### PR TITLE
Fix migration rollback for service variant

### DIFF
--- a/database/migrations/2025_05_19_185054_add_service_variant_id_to_appointments_table.php
+++ b/database/migrations/2025_05_19_185054_add_service_variant_id_to_appointments_table.php
@@ -22,7 +22,8 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('appointments', function (Blueprint $table) {
-            //
+            $table->dropForeign(['service_variant_id']);
+            $table->dropColumn('service_variant_id');
         });
     }
 };


### PR DESCRIPTION
## Summary
- properly drop `service_variant_id` and its foreign key in the `down()` method

## Testing
- `php -l database/migrations/2025_05_19_185054_add_service_variant_id_to_appointments_table.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849f299ba048329a73e7b3edd048993