### PR TITLE
Fix duplicate column error in migrations

### DIFF
--- a/database/migrations/2025_05_22_115908_add_threading_and_user_fields_to_kontakt_messages_table.php
+++ b/database/migrations/2025_05_22_115908_add_threading_and_user_fields_to_kontakt_messages_table.php
@@ -11,20 +11,44 @@ return new class extends Migration
      */
     public function up()
      {
-         Schema::table('kontakt_messages', function (Blueprint $table) {
-             $table->unsignedBigInteger('user_id')->nullable()->after('id');
-             $table->unsignedBigInteger('admin_id')->nullable()->after('user_id');
-             $table->unsignedBigInteger('reply_to_id')->nullable()->after('admin_id');
-             $table->boolean('is_from_admin')->default(false)->after('reply_to_id');
-             $table->boolean('is_read')->default(false)->after('is_from_admin');
-         });
+        Schema::table('kontakt_messages', function (Blueprint $table) {
+            if (!Schema::hasColumn('kontakt_messages', 'user_id')) {
+                $table->unsignedBigInteger('user_id')->nullable()->after('id');
+            }
+            if (!Schema::hasColumn('kontakt_messages', 'admin_id')) {
+                $table->unsignedBigInteger('admin_id')->nullable()->after('user_id');
+            }
+            if (!Schema::hasColumn('kontakt_messages', 'reply_to_id')) {
+                $table->unsignedBigInteger('reply_to_id')->nullable()->after('admin_id');
+            }
+            if (!Schema::hasColumn('kontakt_messages', 'is_from_admin')) {
+                $table->boolean('is_from_admin')->default(false)->after('reply_to_id');
+            }
+            if (!Schema::hasColumn('kontakt_messages', 'is_read')) {
+                $table->boolean('is_read')->default(false)->after('is_from_admin');
+            }
+        });
      }
 
      public function down()
      {
-         Schema::table('kontakt_messages', function (Blueprint $table) {
-             $table->dropColumn(['user_id', 'admin_id', 'reply_to_id', 'is_from_admin', 'is_read']);
-         });
+        Schema::table('kontakt_messages', function (Blueprint $table) {
+            if (Schema::hasColumn('kontakt_messages', 'user_id')) {
+                $table->dropColumn('user_id');
+            }
+            if (Schema::hasColumn('kontakt_messages', 'admin_id')) {
+                $table->dropColumn('admin_id');
+            }
+            if (Schema::hasColumn('kontakt_messages', 'reply_to_id')) {
+                $table->dropColumn('reply_to_id');
+            }
+            if (Schema::hasColumn('kontakt_messages', 'is_from_admin')) {
+                $table->dropColumn('is_from_admin');
+            }
+            if (Schema::hasColumn('kontakt_messages', 'is_read')) {
+                $table->dropColumn('is_read');
+            }
+        });
      }
 
 };


### PR DESCRIPTION
## Summary
- check for column existence before adding or dropping columns in the `kontakt_messages` migration

## Testing
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0afe0c88329a92f876387291137