### PR TITLE
Fix missing variant relation for appointments

### DIFF
--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -34,4 +34,12 @@ class Appointment extends Model
     {
         return $this->belongsTo(ServiceVariant::class, 'service_variant_id');
     }
+
+    /**
+     * Alias for the serviceVariant relationship used in views/controllers.
+     */
+    public function variant()
+    {
+        return $this->serviceVariant();
+    }
 }


### PR DESCRIPTION
## Summary
- expose an alias `variant` relation in `Appointment`

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab280341c8329887fdb44f0140e3b