### PR TITLE
Add show view for user messages

### DIFF
--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -1,0 +1,26 @@
+<x-app-layout>
+    <div class="max-w-2xl mx-auto py-12">
+        <a href="{{ route('messages.index') }}" class="text-blue-600 hover:underline">
+            ← Wróć do listy wiadomości
+        </a>
+
+        <div class="bg-white shadow p-4 rounded my-4">
+            <div class="text-xs text-gray-500 mb-2">
+                {{ $message->created_at->format('d.m.Y H:i') }}
+            </div>
+            <p>{{ $message->message }}</p>
+        </div>
+
+        @forelse ($message->replies as $reply)
+            <div class="bg-gray-50 p-4 rounded mb-4">
+                <div class="text-xs text-gray-500 mb-1">
+                    {{ $reply->admin->name ?? 'Admin' }} —
+                    {{ $reply->created_at->format('d.m.Y H:i') }}
+                </div>
+                <p>{{ $reply->message }}</p>
+            </div>
+        @empty
+            <p class="text-gray-500 italic">Brak odpowiedzi.</p>
+        @endforelse
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- add missing `show.blade.php` under `resources/views/messages` so message details render correctly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ab4d91d6883298bf9fdd16f112a26