### PR TITLE
Fix reply bug requiring name/email

### DIFF
--- a/app/Http/Controllers/KontaktController.php
+++ b/app/Http/Controllers/KontaktController.php
@@ -86,6 +86,9 @@ class KontaktController extends Controller
         abort_if($parent->user_id !== auth()->id(), 403);
 
         KontaktMessage::create([
+            'name'          => auth()->user()->name ?? 'Użytkownik',
+            'email'         => auth()->user()->email,
+            'phone'         => auth()->user()->phone ?? null,
             'message'       => $request->message,
             'reply_to_id'   => $parent->id,
             'user_id'       => auth()->id(),


### PR DESCRIPTION
## Summary
- include user's name, email and phone when creating reply messages

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1f058ef88329b7096429ceba7a2b