### PR TITLE
Fix message threading bug and show author

### DIFF
--- a/app/Http/Controllers/KontaktController.php
+++ b/app/Http/Controllers/KontaktController.php
@@ -47,6 +47,7 @@ class KontaktController extends Controller
                 'phone'         => auth()->user()->phone ?? null, // dodane
                 'message'       => $request->message,
                 'category'      => $request->category,
+                'reply_to_id'   => null, // ensure new thread
                 'is_from_admin' => false,
                 'is_read'       => false,
                 'status'        => 'nowa',
@@ -66,6 +67,7 @@ class KontaktController extends Controller
                 'phone'          => $request->phone,
                 'message'        => $request->message,
                 'category'       => $request->category,
+                'reply_to_id'    => null, // ensure new thread for guests
                 'is_from_admin'  => false,
                 'is_read'        => false,
                 'status'         => 'nowa',

--- a/resources/views/admin/messages/show.blade.php
+++ b/resources/views/admin/messages/show.blade.php
@@ -4,7 +4,7 @@
 
         <div class="bg-white shadow p-4 rounded my-4">
             <div class="text-xs text-gray-500 mb-2">
-                {{ $message->created_at->format('d.m.Y H:i') }}
+                {{ $message->user->name ?? 'Klient' }} &mdash; {{ $message->created_at->format('d.m.Y H:i') }}
             </div>
             <p>{{ $message->message }}</p>
         </div>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -6,7 +6,7 @@
 
         <div class="bg-white shadow p-4 rounded my-4">
             <div class="text-xs text-gray-500 mb-2">
-                {{ $message->created_at->format('d.m.Y H:i') }}
+                Ty &mdash; {{ $message->created_at->format('d.m.Y H:i') }}
             </div>
             <p>{{ $message->message }}</p>
         </div>


### PR DESCRIPTION
## Summary
- ensure new messages start new threads instead of being replies
- display who wrote each message in both user and admin thread views

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit --version` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b20570dcc8329a66be5d8efd8d159