### PR TITLE
Fix reply indicator for client messages

### DIFF
--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -16,7 +16,7 @@
                     {{ Str::limit($msg->message, 60) }}
                 </a>
                 <div class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</div>
-                @if($msg->replies->count())
+                @if($msg->replies->contains('is_from_admin', true))
                     <span class="text-green-600 text-xs ml-2">Odpowiedź z salonu</span>
                 @endif
             </div>


### PR DESCRIPTION
## Summary
- show the "Odpowiedź z salonu" indicator only when a thread has a reply from an admin

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b223d6bd48329a1a770d0ef817871