### PR TITLE
Fix admin reply message fields

### DIFF
--- a/app/Http/Controllers/AdminKontaktController.php
+++ b/app/Http/Controllers/AdminKontaktController.php
@@ -35,6 +35,9 @@ class AdminKontaktController extends Controller
         KontaktMessage::create([
             'user_id'      => $parent->user_id,
             'admin_id'     => auth()->id(),
+            'name'         => auth()->user()->name,
+            'email'        => auth()->user()->email,
+            'phone'        => auth()->user()->phone ?? null,
             'message'      => $request->message,
             'reply_to_id'  => $parent->id,
             'is_from_admin'=> true,


### PR DESCRIPTION
## Summary
- ensure admin reply includes name, email, and phone to satisfy DB constraints

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b24a49584832993eb4599620326d2