### PR TITLE
Modern chat view

### DIFF
--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -2,11 +2,11 @@
 <x-app-layout>
     <h2 class="text-2xl font-bold mb-6">Wiadomości od klientów</h2>
     @foreach($messages as $msg)
-        <div class="mb-4 border-b pb-2">
-            <a href="{{ route('admin.messages.show', $msg->id) }}" class="text-lg font-semibold">
-                {{ $msg->user->name }}: {{ Str::limit($msg->message, 60) }}
-            </a>
-            <div class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</div>
-        </div>
+        <a href="{{ route('admin.messages.show', $msg->id) }}" class="block bg-white p-4 rounded-lg shadow mb-4 hover:bg-gray-50">
+            <div class="flex items-start justify-between">
+                <span class="font-semibold">{{ $msg->user->name }}: {{ Str::limit($msg->message, 60) }}</span>
+                <span class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</span>
+            </div>
+        </a>
     @endforeach
 </x-app-layout>

--- a/resources/views/admin/messages/show.blade.php
+++ b/resources/views/admin/messages/show.blade.php
@@ -2,26 +2,32 @@
     <div class="max-w-2xl mx-auto py-12">
         <a href="{{ route('admin.messages.index') }}" class="text-blue-600 hover:underline">&larr; Wróć do listy</a>
 
-        <div class="bg-white shadow p-4 rounded my-4">
-            <div class="text-xs text-gray-500 mb-2">
-                {{ $message->user->name ?? 'Klient' }} &mdash; {{ $message->created_at->format('d.m.Y H:i') }}
-            </div>
-            <p>{{ $message->message }}</p>
-        </div>
-
-        @foreach ($message->replies as $reply)
-            <div class="bg-gray-50 p-4 rounded mb-4">
-                <div class="text-xs text-gray-500 mb-1">
-                    @if($reply->is_from_admin)
-                        {{ $reply->admin->name ?? 'Admin' }}
-                    @else
-                        {{ $reply->user->name ?? 'Klient' }}
-                    @endif
-                    &mdash; {{ $reply->created_at->format('d.m.Y H:i') }}
+        <div class="space-y-4 my-4">
+            <div class="flex justify-start">
+                <div class="bg-gray-200 text-gray-800 p-3 rounded-lg shadow max-w-xs">
+                    <div class="text-xs text-gray-600 mb-1">
+                        {{ $message->user->name ?? 'Klient' }} — {{ $message->created_at->format('d.m.Y H:i') }}
+                    </div>
+                    <p>{{ $message->message }}</p>
                 </div>
-                <p>{{ $reply->message }}</p>
             </div>
-        @endforeach
+
+            @foreach ($message->replies as $reply)
+                <div class="flex {{ $reply->is_from_admin ? 'justify-end' : 'justify-start' }}">
+                    <div class="p-3 rounded-lg shadow max-w-xs {{ $reply->is_from_admin ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-800' }}">
+                        <div class="text-xs mb-1 {{ $reply->is_from_admin ? 'text-white/80' : 'text-gray-600' }}">
+                            @if($reply->is_from_admin)
+                                {{ $reply->admin->name ?? 'Admin' }}
+                            @else
+                                {{ $reply->user->name ?? 'Klient' }}
+                            @endif
+                            — {{ $reply->created_at->format('d.m.Y H:i') }}
+                        </div>
+                        <p>{{ $reply->message }}</p>
+                    </div>
+                </div>
+            @endforeach
+        </div>
 
         <form method="POST" action="{{ route('admin.messages.reply', $message->id) }}" class="mt-6">
             @csrf

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -11,15 +11,15 @@
         @endif
 
         @forelse($messages as $msg)
-            <div class="mb-4 border-b pb-2">
-                <a href="{{ route('messages.show', $msg->id) }}" class="text-lg font-semibold">
-                    {{ Str::limit($msg->message, 60) }}
-                </a>
-                <div class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</div>
+            <a href="{{ route('messages.show', $msg->id) }}" class="block bg-white p-4 rounded-lg shadow mb-4 hover:bg-gray-50">
+                <div class="flex items-start justify-between">
+                    <span class="font-semibold">{{ Str::limit($msg->message, 60) }}</span>
+                    <span class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</span>
+                </div>
                 @if($msg->replies->contains('is_from_admin', true))
-                    <span class="text-green-600 text-xs ml-2">Odpowiedź z salonu</span>
+                    <div class="text-green-600 text-xs mt-1">Odpowiedź z salonu</div>
                 @endif
-            </div>
+            </a>
         @empty
             <div class="text-gray-400 italic py-6">Nie masz jeszcze żadnych wiadomości.</div>
         @endforelse

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -4,28 +4,34 @@
             ← Wróć do listy wiadomości
         </a>
 
-        <div class="bg-white shadow p-4 rounded my-4">
-            <div class="text-xs text-gray-500 mb-2">
-                Ty &mdash; {{ $message->created_at->format('d.m.Y H:i') }}
-            </div>
-            <p>{{ $message->message }}</p>
-        </div>
-
-        @forelse ($message->replies as $reply)
-            <div class="bg-gray-50 p-4 rounded mb-4">
-                <div class="text-xs text-gray-500 mb-1">
-                    @if($reply->is_from_admin)
-                        {{ $reply->admin->name ?? 'Admin' }}
-                    @else
-                        Ty
-                    @endif
-                    — {{ $reply->created_at->format('d.m.Y H:i') }}
+        <div class="space-y-4 my-4">
+            <div class="flex justify-end">
+                <div class="bg-blue-500 text-white p-3 rounded-lg shadow max-w-xs">
+                    <div class="text-xs text-white/80 mb-1">
+                        Ty — {{ $message->created_at->format('d.m.Y H:i') }}
+                    </div>
+                    <p>{{ $message->message }}</p>
                 </div>
-                <p>{{ $reply->message }}</p>
             </div>
-        @empty
-            <p class="text-gray-500 italic">Brak odpowiedzi.</p>
-        @endforelse
+
+            @forelse ($message->replies as $reply)
+                <div class="flex {{ $reply->is_from_admin ? 'justify-start' : 'justify-end' }}">
+                    <div class="p-3 rounded-lg shadow max-w-xs {{ $reply->is_from_admin ? 'bg-gray-200 text-gray-800' : 'bg-blue-500 text-white' }}">
+                        <div class="text-xs mb-1 {{ $reply->is_from_admin ? 'text-gray-600' : 'text-white/80' }}">
+                            @if($reply->is_from_admin)
+                                {{ $reply->admin->name ?? 'Admin' }}
+                            @else
+                                Ty
+                            @endif
+                            — {{ $reply->created_at->format('d.m.Y H:i') }}
+                        </div>
+                        <p>{{ $reply->message }}</p>
+                    </div>
+                </div>
+            @empty
+                <p class="text-gray-500 italic">Brak odpowiedzi.</p>
+            @endforelse
+        </div>
 
         <form method="POST" action="{{ route('messages.reply', $message->id) }}" class="mt-6">
             @csrf


### PR DESCRIPTION
## Summary
- refresh message view markup with chat-style bubbles
- update list of messages to use card styling for admins and users

## Testing
- `php artisan --version` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b2cb9c3548329b8de626bd92a1f31