### PR TITLE
Improve admin messages UI

### DIFF
--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -1,12 +1,14 @@
 {{-- resources/views/admin/messages/index.blade.php --}}
 <x-app-layout>
-    <h2 class="text-2xl font-bold mb-6">Wiadomości od klientów</h2>
-    @foreach($messages as $msg)
-        <a href="{{ route('admin.messages.show', $msg->id) }}" class="block bg-white p-4 rounded-lg shadow mb-4 hover:bg-gray-50">
-            <div class="flex items-start justify-between">
-                <span class="font-semibold">{{ $msg->user->name }}: {{ Str::limit($msg->message, 60) }}</span>
-                <span class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</span>
-            </div>
-        </a>
-    @endforeach
+    <div class="max-w-2xl mx-auto py-12">
+        <h2 class="text-2xl font-bold mb-6">Wiadomości od klientów</h2>
+        @foreach($messages as $msg)
+            <a href="{{ route('admin.messages.show', $msg->id) }}" class="block bg-white p-4 rounded-lg shadow mb-4 hover:bg-gray-50">
+                <div class="flex items-start justify-between">
+                    <span class="font-semibold">{{ $msg->user->name }}: {{ Str::limit($msg->message, 60) }}</span>
+                    <span class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</span>
+                </div>
+            </a>
+        @endforeach
+    </div>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- wrap admin messages list with a centered container so the page has margins

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_684c030d19788329aa0dfdabaa7b041a