### PR TITLE
Display admin reply status in message list

### DIFF
--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -8,6 +8,14 @@
                     <span class="font-semibold">{{ $msg->user->name }}: {{ Str::limit($msg->message, 60) }}</span>
                     <span class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</span>
                 </div>
+                @php
+                    $last = $msg->replies->sortByDesc('created_at')->first();
+                @endphp
+                @if(!$last || !$last->is_from_admin)
+                    <div class="text-red-600 text-xs mt-1">Wymaga odpowiedzi</div>
+                @else
+                    <div class="text-green-600 text-xs mt-1">Odpowiedź udzielona</div>
+                @endif
             </a>
         @endforeach
     </div>


### PR DESCRIPTION
## Summary
- show whether client messages require an admin reply

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c09be7c8483299a615711bb7574ed