### PR TITLE
Update admin message sender info

### DIFF
--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -5,7 +5,9 @@
         @foreach($messages as $msg)
             <a href="{{ route('admin.messages.show', $msg->id) }}" class="block bg-white p-4 rounded-lg shadow mb-4 hover:bg-gray-50">
                 <div class="flex items-start justify-between">
-                    <span class="font-semibold">{{ $msg->user->name }}: {{ Str::limit($msg->message, 60) }}</span>
+                    <span class="font-semibold">
+                        {{ optional($msg->user)->name ?? $msg->name }}: {{ Str::limit($msg->message, 60) }}
+                    </span>
                     <span class="text-xs text-gray-500">{{ $msg->created_at->diffForHumans() }}</span>
                 </div>
                 @php

--- a/resources/views/admin/messages/show.blade.php
+++ b/resources/views/admin/messages/show.blade.php
@@ -6,7 +6,7 @@
             <div class="flex justify-start">
                 <div class="bg-gray-200 text-gray-800 p-3 rounded-lg shadow max-w-xs">
                     <div class="text-xs text-gray-600 mb-1">
-                        {{ $message->user->name ?? 'Klient' }} — {{ $message->created_at->format('d.m.Y H:i') }}
+                        {{ optional($message->user)->name ?? $message->name ?? 'Klient' }} — {{ $message->created_at->format('d.m.Y H:i') }}
                     </div>
                     <p>{{ $message->message }}</p>
                 </div>
@@ -19,7 +19,7 @@
                             @if($reply->is_from_admin)
                                 {{ $reply->admin->name ?? 'Admin' }}
                             @else
-                                {{ $reply->user->name ?? 'Klient' }}
+                                {{ optional($reply->user)->name ?? $reply->name ?? 'Klient' }}
                             @endif
                             — {{ $reply->created_at->format('d.m.Y H:i') }}
                         </div>


### PR DESCRIPTION
## Summary
- display sender's name in admin message list
- show sender information in message thread view

## Testing
- `composer install`
- `php artisan key:generate`
- `php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0bc5a0f483298de5897b039a5979