### PR TITLE
Fix calendar modal overlay pointer events

### DIFF
--- a/resources/css/modal-fix.css
+++ b/resources/css/modal-fix.css
@@ -37,7 +37,7 @@ body.modal-open .fc-view-harness.fc-view-harness-active::after {
   bottom: 0;
   background-color: transparent;
   z-index: 8000;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 body.modal-open .fc-event {


### PR DESCRIPTION
## Summary
- allow pointer events on the calendar overlay so modals are clickable
- run vite build to regenerate assets

## Testing
- `npm run build`
- ❌ `phpunit` *(failed: `phpunit` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c16c1333c83298aae73f56eb38908