### PR TITLE
Fix admin calendar modal style inclusion

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,6 +7,7 @@
   <title>{{ config('app.name', 'Salon Black&White') }}</title>
 
   @vite(['resources/css/app.css', 'resources/js/app.js'])
+  @stack('styles')
   @stack('head')
 </head>
 <body class="bg-gray-50 antialiased">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config('app.name', 'Salon Black&White') }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @stack('styles')
     @stack('head')
 </head>
 <body class="bg-gray-50 min-h-screen antialiased">


### PR DESCRIPTION
## Summary
- ensure pushed styles render in page head

## Testing
- `npm install`
- `npm run build`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c10102fb48329b38f9241a6b316ae