### PR TITLE
Fix admin calendar modal style inclusion

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -2,6 +2,7 @@
 namespace App\Http\Controllers;
 use App\Models\Appointment;
 use App\Models\ServiceVariant;
+use App\Models\Service;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -148,10 +149,16 @@ class AdminAppointmentController extends Controller
             ->map(function ($variant) {
                 return [
                     'id' => $variant->id,
-                    'name' => $variant->service->name . ' – ' . $variant->name,
-                    'duration' => $variant->duration ?? 60,
+                    'service_id' => $variant->service_id,
+                    'variant_name' => $variant->variant_name,
+                    'duration_minutes' => $variant->duration_minutes,
                 ];
             });
+    }
+
+    public function services()
+    {
+        return Service::select('id', 'name')->orderBy('name')->get();
     }
     
     // Pobieranie godzin pracy

--- a/resources/js/createModal.js
+++ b/resources/js/createModal.js
@@ -1,31 +1,50 @@
 export function createModal() {
   return {
 	open: false,
-	date: '',
-	user_id: null,
-	variant_id: null,
-	users: [],
-	variants: [],
+        date: '',
+        user_id: null,
+        service_id: null,
+        variant_id: null,
+        users: [],
+        services: [],
+        variants: [],
+        allVariants: [],
 
 	init() {
 	  window.addEventListener('open-create-modal', e => {
 		if (window.modalIsOpen) return;
-		this.date = e.detail;
+                this.date = e.detail.substring(0,16);
 		this.open = true;
 		window.modalIsOpen = true; // modal otwarty
 		document.body.classList.add('modal-open');
 	  });
 
-	  fetch('/admin/api/users')
-		.then(r => r.ok ? r.json() : [])
-		.then(data => this.users = data)
-		.catch(() => console.error('Users load error'));
+          fetch('/admin/api/users')
+                .then(r => r.ok ? r.json() : [])
+                .then(data => this.users = data)
+                .catch(() => console.error('Users load error'));
 
-	  fetch('/admin/api/variants')
-		.then(r => r.ok ? r.json() : [])
-		.then(data => this.variants = data)
-		.catch(() => console.error('Variants load error'));
-	},
+          fetch('/admin/api/services')
+                .then(r => r.ok ? r.json() : [])
+                .then(data => this.services = data)
+                .catch(() => console.error('Services load error'));
+
+          fetch('/admin/api/variants')
+                .then(r => r.ok ? r.json() : [])
+                .then(data => { this.allVariants = data; this.filterVariants(); })
+                .catch(() => console.error('Variants load error'));
+
+          this.$watch('service_id', () => this.filterVariants());
+       },
+
+        filterVariants() {
+          if (!this.service_id) {
+                this.variants = [];
+                this.variant_id = null;
+                return;
+          }
+          this.variants = this.allVariants.filter(v => v.service_id === Number(this.service_id));
+        },
 
 	close() {
 	  this.open = false;
@@ -34,11 +53,11 @@ export function createModal() {
 	},
 
 	async save() {
-	  if (!this.user_id || !this.variant_id) {
-		return alert('Wybierz klienta oraz wariant usługi');
-	  }
-	  try {
-		const res = await fetch('/admin/kalendarz/store', {
+          if (!this.user_id || !this.variant_id || !this.date) {
+                return alert('Uzupełnij wszystkie pola');
+          }
+          try {
+                const res = await fetch('/admin/kalendarz/store', {
 		  method: 'POST',
 		  headers: {
 			'Content-Type': 'application/json',

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -75,7 +75,9 @@
       class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
       <div class="bg-white rounded-lg p-6 shadow-lg w-full max-w-md">
         <h2 class="text-lg font-bold mb-4">Nowa rezerwacja</h2>
-        <p class="text-sm mb-4">Data i godzina: <span x-text="date"></span></p>
+
+        <label class="block mb-2 text-sm font-medium">Data i godzina:</label>
+        <input type="datetime-local" x-model="date" class="w-full mb-4 border rounded px-2 py-1">
 
         <label class="block mb-2 text-sm font-medium">Klient:</label>
         <select x-model="user_id" class="w-full mb-4 border rounded px-2 py-1">
@@ -84,10 +86,18 @@
           </template>
         </select>
 
+        <label class="block mb-2 text-sm font-medium">Usługa:</label>
+        <select x-model="service_id" class="w-full mb-4 border rounded px-2 py-1">
+          <option value="" disabled selected>Wybierz usługę</option>
+          <template x-for="s in services" :key="s.id">
+            <option :value="s.id" x-text="s.name"></option>
+          </template>
+        </select>
+
         <label class="block mb-2 text-sm font-medium">Wariant usługi:</label>
-        <select x-model="variant_id" class="w-full mb-4 border rounded px-2 py-1">
+        <select x-model="variant_id" :disabled="!service_id" class="w-full mb-4 border rounded px-2 py-1">
           <template x-for="v in variants" :key="v.id">
-            <option :value="v.id" x-text="v.name"></option>
+            <option :value="v.id" x-text="v.variant_name"></option>
           </template>
         </select>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,6 +7,7 @@
   <title>{{ config('app.name', 'Salon Black&White') }}</title>
 
   @vite(['resources/css/app.css', 'resources/js/app.js'])
+  @stack('styles')
   @stack('head')
 </head>
 <body class="bg-gray-50 antialiased">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config('app.name', 'Salon Black&White') }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @stack('styles')
     @stack('head')
 </head>
 <body class="bg-gray-50 min-h-screen antialiased">

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,7 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
     // API do dropdownów i godzin pracy
     Route::get('/api/users', [AdminAppointmentController::class, 'users'])->name('appointments.users');
     Route::get('/api/variants', [AdminAppointmentController::class, 'variants'])->name('appointments.variants');
+    Route::get('/api/services', [AdminAppointmentController::class, 'services'])->name('appointments.services');
     Route::get('/api/working-hours', [AdminAppointmentController::class, 'workingHours'])->name('appointments.workingHours');
     
     // Wiadomości


### PR DESCRIPTION
## Summary
- ensure pushed styles render in page head
- allow service and variant selection in admin calendar modal
- add date/time field for new appointments

## Testing
- `npm install`
- `npm run build`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c10102fb48329b38f9241a6b316ae