### PR TITLE
Fix variant filtering in admin booking modal

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -160,6 +160,11 @@ class AdminAppointmentController extends Controller
     {
         return Service::select('id', 'name')->orderBy('name')->get();
     }
+
+    public function variantsForService(Service $service)
+    {
+        return $service->variants()->select('id', 'service_id', 'variant_name', 'duration_minutes')->get();
+    }
     
     // Pobieranie godzin pracy
     public function workingHours()

--- a/resources/js/createModal.js
+++ b/resources/js/createModal.js
@@ -8,7 +8,6 @@ export function createModal() {
         users: [],
         services: [],
         variants: [],
-        allVariants: [],
 
 	init() {
 	  window.addEventListener('open-create-modal', e => {
@@ -29,21 +28,22 @@ export function createModal() {
                 .then(data => this.services = data)
                 .catch(() => console.error('Services load error'));
 
-          fetch('/admin/api/variants')
-                .then(r => r.ok ? r.json() : [])
-                .then(data => { this.allVariants = data; this.filterVariants(); })
-                .catch(() => console.error('Variants load error'));
-
-          this.$watch('service_id', () => this.filterVariants());
+          this.$watch('service_id', () => this.loadVariants());
        },
 
-        filterVariants() {
+        loadVariants() {
           if (!this.service_id) {
                 this.variants = [];
                 this.variant_id = null;
                 return;
           }
-          this.variants = this.allVariants.filter(v => v.service_id === Number(this.service_id));
+          fetch(`/admin/api/services/${this.service_id}/variants`)
+                .then(r => r.ok ? r.json() : [])
+                .then(data => this.variants = data)
+                .catch(() => {
+                      console.error('Variants load error');
+                      this.variants = [];
+                });
         },
 
 	close() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,7 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
     Route::get('/api/users', [AdminAppointmentController::class, 'users'])->name('appointments.users');
     Route::get('/api/variants', [AdminAppointmentController::class, 'variants'])->name('appointments.variants');
     Route::get('/api/services', [AdminAppointmentController::class, 'services'])->name('appointments.services');
+    Route::get('/api/services/{service}/variants', [AdminAppointmentController::class, 'variantsForService'])->name('appointments.serviceVariants');
     Route::get('/api/working-hours', [AdminAppointmentController::class, 'workingHours'])->name('appointments.workingHours');
     
     // Wiadomości


### PR DESCRIPTION
## Summary
- serve variants based on selected service
- fetch filtered variants in admin booking modal
- add API route for variants filtered by service

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c290dfee483298ec05e6f363b2399