### PR TITLE
Handle forced closing of admin create modal

### DIFF
--- a/resources/js/createModal.js
+++ b/resources/js/createModal.js
@@ -17,6 +17,7 @@ export function createModal() {
 		window.modalIsOpen = true; // modal otwarty
 		document.body.classList.add('modal-open');
 	  });
+          window.addEventListener('force-close-admin-create-modal', () => this.close());
 
           fetch('/admin/api/users')
                 .then(r => r.ok ? r.json() : [])


### PR DESCRIPTION
## Summary
- listen for `force-close-admin-create-modal` in `createModal.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c3ed8b3dc8329997bfe79c07b485f