### PR TITLE
Fix calendar updating and add edit modal

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,17 +3,21 @@ import './bootstrap';
 import Alpine from 'alpinejs';
 import { createModal } from './createModal';
 import { viewModal }   from './viewModal';
+import { editModal }   from './editModal';
 
 // Uniwersalna funkcja zamykająca oba modale
 window.closeAllModals = function() {
-	const event1 = new CustomEvent('force-close-appointment-modal');
-	const event2 = new CustomEvent('force-close-admin-create-modal');
-	window.dispatchEvent(event1);
-	window.dispatchEvent(event2);
+        const event1 = new CustomEvent('force-close-appointment-modal');
+        const event2 = new CustomEvent('force-close-admin-create-modal');
+        const event3 = new CustomEvent('force-close-edit-modal');
+        window.dispatchEvent(event1);
+        window.dispatchEvent(event2);
+        window.dispatchEvent(event3);
 };
 
 Alpine.data('createModal', createModal);
 Alpine.data('viewModal', viewModal);
+Alpine.data('editModal', editModal);
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -82,7 +82,8 @@ function initializeCalendar() {
         // Dodajemy klasę do body, aby zablokować interakcje z kalendarzem
         document.body.classList.add('modal-open');
         
-        window.dispatchEvent(new CustomEvent('open-view-modal', { detail: info.event.extendedProps }));
+        const data = { ...info.event.extendedProps, id: info.event.id };
+        window.dispatchEvent(new CustomEvent('open-edit-modal', { detail: data }));
       },
       editable: true,
       eventDrop: function(info) {

--- a/resources/js/editModal.js
+++ b/resources/js/editModal.js
@@ -1,0 +1,45 @@
+export function editModal() {
+  return {
+    open: false,
+    appointment: {},
+    date: '',
+    init() {
+      window.addEventListener('open-edit-modal', e => {
+        if (window.modalIsOpen) return;
+        this.appointment = e.detail;
+        this.date = e.detail.datetime.replace(' ', 'T');
+        this.open = true;
+        window.modalIsOpen = true;
+        document.body.classList.add('modal-open');
+      });
+      window.addEventListener('force-close-edit-modal', () => this.close());
+    },
+    close() {
+      this.open = false;
+      window.modalIsOpen = false;
+      document.body.classList.remove('modal-open');
+    },
+    async save() {
+      if (!this.date || !this.appointment.id) {
+        return alert('Uzupełnij wszystkie pola');
+      }
+      try {
+        const res = await fetch(`/admin/kalendarz/appointments/${this.appointment.id}/update-time`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+          },
+          body: JSON.stringify({
+            appointment_at: this.date,
+          }),
+        });
+        if (!res.ok) throw new Error();
+        this.close();
+        window.location.reload();
+      } catch {
+        alert('Nie udało się zaktualizować rezerwacji');
+      }
+    },
+  }
+}

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -65,6 +65,35 @@
       </div>
     </div>
 
+    {{-- Modal edycji rezerwacji --}}
+    <div
+      id="adminEditModal"
+      x-data="editModal()"
+      x-init="init()"
+      x-show="open"
+      x-cloak
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div class="bg-white rounded-lg p-6 shadow-lg w-full max-w-md">
+        <h2 class="text-lg font-bold mb-4">Edytuj rezerwację</h2>
+
+        <label class="block mb-2 text-sm font-medium">Data i godzina:</label>
+        <input type="datetime-local" x-model="date" class="w-full mb-4 border rounded px-2 py-1">
+
+        <div class="flex justify-end gap-2">
+          <button
+            @click="close()"
+            class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700">
+            Anuluj
+          </button>
+          <button
+            @click="save()"
+            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+            Zapisz
+          </button>
+        </div>
+      </div>
+    </div>
+
     {{-- Modal dodawania rezerwacji --}}
     <div
       id="adminCreateModal"


### PR DESCRIPTION
## Summary
- add modal for editing appointments
- dispatch new event with id when clicking calendar entry
- wire up edit modal in app.js

## Testing
- `npm run build`
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c42f067d88329bf962721eaccda84