### PR TITLE
Fix create modal default options

### DIFF
--- a/resources/js/createModal.js
+++ b/resources/js/createModal.js
@@ -3,8 +3,8 @@ export function createModal() {
 	open: false,
         date: '',
         user_id: null,
-        service_id: null,
-        variant_id: null,
+        service_id: '',
+        variant_id: '',
         users: [],
         services: [],
         variants: [],
@@ -35,7 +35,7 @@ export function createModal() {
         loadVariants() {
           if (!this.service_id) {
                 this.variants = [];
-                this.variant_id = null;
+                this.variant_id = '';
                 return;
           }
           fetch(`/admin/api/services/${this.service_id}/variants`)

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -114,6 +114,7 @@
 
         <label class="block mb-2 text-sm font-medium">Wariant usługi:</label>
         <select x-model="variant_id" :disabled="!service_id" class="w-full mb-4 border rounded px-2 py-1">
+          <option value="" disabled selected>Wybierz wariant</option>
           <template x-for="v in variants" :key="v.id">
             <option :value="v.id" x-text="v.variant_name"></option>
           </template>


### PR DESCRIPTION
## Summary
- default service/variant IDs to empty string so placeholder option shows
- add placeholder option for variant select
- build assets

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df62a4e2c8329a18deeb135ac82e4