### PR TITLE
Add price editing in admin reservation modal

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -43,6 +43,7 @@ class AdminAppointmentController extends Controller
                     'user_id' => $appointment->user_id,
                     'service_id' => $appointment->service_id,
                     'service_variant_id' => $appointment->service_variant_id,
+                    'price_pln' => $appointment->price_pln,
                 ],
             ];
         });
@@ -102,6 +103,7 @@ class AdminAppointmentController extends Controller
             'user_id' => 'required|exists:users,id',
             'service_variant_id' => 'required|exists:service_variants,id',
             'appointment_at' => 'required|date',
+            'price_pln' => 'required|integer|min:0',
         ]);
         
         // Sprawdzenie czy termin jest w godzinach pracy
@@ -133,6 +135,7 @@ class AdminAppointmentController extends Controller
             'user_id' => $request->user_id,
             'service_id' => $variant->service_id,
             'service_variant_id' => $variant->id,
+            'price_pln' => $request->price_pln ?? $variant->price_pln,
             'appointment_at' => $request->appointment_at,
             'status' => 'zaplanowana',
         ]);
@@ -146,6 +149,7 @@ class AdminAppointmentController extends Controller
             'service_variant_id' => 'required|exists:service_variants,id',
             'appointment_at' => 'required|date',
             'status' => 'required|in:zaplanowana,odbyta,odwołana,nieodbyta',
+            'price_pln' => 'required|integer|min:0',
         ]);
 
         $newDateTime = Carbon::parse($request->appointment_at);
@@ -165,6 +169,7 @@ class AdminAppointmentController extends Controller
             'user_id' => $request->user_id,
             'service_id' => $variant->service_id,
             'service_variant_id' => $variant->id,
+            'price_pln' => $request->price_pln ?? $variant->price_pln,
             'appointment_at' => $request->appointment_at,
             'status' => $request->status,
         ]);
@@ -194,6 +199,7 @@ class AdminAppointmentController extends Controller
                     'service_id' => $variant->service_id,
                     'variant_name' => $variant->variant_name,
                     'duration_minutes' => $variant->duration_minutes,
+                    'price_pln' => $variant->price_pln,
                 ];
             });
     }
@@ -205,7 +211,7 @@ class AdminAppointmentController extends Controller
 
     public function variantsForService(Service $service)
     {
-        return $service->variants()->select('id', 'service_id', 'variant_name', 'duration_minutes')->get();
+        return $service->variants()->select('id', 'service_id', 'variant_name', 'duration_minutes', 'price_pln')->get();
     }
     
     // Pobieranie godzin pracy

--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -49,6 +49,7 @@ class AppointmentController extends Controller
             'user_id'            => Auth::id(),
             'service_id'         => $variant->service->id,
             'service_variant_id' => $variant->id,
+            'price_pln'          => $variant->price_pln,
             'appointment_at'     => $validated['appointment_at'],
             'status'             => 'zaplanowana',
         ]);

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -10,6 +10,7 @@ class Appointment extends Model
         'user_id',
         'service_id',
         'service_variant_id',
+        'price_pln',
         'appointment_at',
         'status',
         'note_client',
@@ -18,6 +19,7 @@ class Appointment extends Model
 
     protected $casts = [
         'appointment_at' => 'datetime',
+        'price_pln' => 'integer',
     ];
 
     public function user()

--- a/database/migrations/2025_06_01_000000_add_price_pln_to_appointments_table.php
+++ b/database/migrations/2025_06_01_000000_add_price_pln_to_appointments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->unsignedInteger('price_pln')->default(0)->after('service_variant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn('price_pln');
+        });
+    }
+};

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -120,6 +120,9 @@
           </template>
         </select>
 
+        <label class="block mb-2 text-sm font-medium">Cena (zł):</label>
+        <input type="number" x-model="price" class="w-full mb-4 border rounded px-2 py-1">
+
         <div class="flex justify-end gap-2">
           <button
             @click="close()"

--- a/resources/views/admin/appointments/show.blade.php
+++ b/resources/views/admin/appointments/show.blade.php
@@ -3,6 +3,7 @@
         <h2 class="text-xl font-bold mb-6">Szczegóły wizyty</h2>
         <ul>
             <li><b>Usługa:</b> {{ $appointment->service->name }} – {{ $appointment->variant->variant_name }}</li>
+            <li><b>Cena:</b> {{ number_format($appointment->price_pln, 2) }} zł</li>
             <li><b>Data:</b> {{ $appointment->appointment_at }}</li>
             <li><b>Status:</b> {{ $appointment->status }}</li>
         </ul>


### PR DESCRIPTION
## Summary
- allow storing appointment price
- update APIs to return service variant pricing
- show/edit price when booking an appointment in admin calendar
- persist price on appointment create/update

## Testing
- `npm run build`
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df73ace188329ad2d0887682e2481