### PR TITLE
Add discount handling during appointment scheduling

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -44,6 +44,7 @@ class AdminAppointmentController extends Controller
                     'service_id' => $appointment->service_id,
                     'service_variant_id' => $appointment->service_variant_id,
                     'price_pln' => $appointment->price_pln,
+                    'discount_percent' => $appointment->discount_percent,
                 ],
             ];
         });
@@ -104,6 +105,7 @@ class AdminAppointmentController extends Controller
             'service_variant_id' => 'required|exists:service_variants,id',
             'appointment_at' => 'required|date',
             'price_pln' => 'required|integer|min:0',
+            'discount_percent' => 'nullable|integer|min:0|max:100',
         ]);
         
         // Sprawdzenie czy termin jest w godzinach pracy
@@ -131,11 +133,16 @@ class AdminAppointmentController extends Controller
         }
         
         $variant = ServiceVariant::with('service')->findOrFail($request->service_variant_id);
+        $discount = $request->discount_percent ?? 0;
+        $price    = $request->price_pln ?? $variant->price_pln;
+        $price    = round($price * (100 - $discount) / 100);
+
         $appointment = Appointment::create([
             'user_id' => $request->user_id,
             'service_id' => $variant->service_id,
             'service_variant_id' => $variant->id,
-            'price_pln' => $request->price_pln ?? $variant->price_pln,
+            'price_pln' => $price,
+            'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
             'status' => 'zaplanowana',
         ]);
@@ -150,6 +157,7 @@ class AdminAppointmentController extends Controller
             'appointment_at' => 'required|date',
             'status' => 'required|in:zaplanowana,odbyta,odwołana,nieodbyta',
             'price_pln' => 'required|integer|min:0',
+            'discount_percent' => 'nullable|integer|min:0|max:100',
         ]);
 
         $newDateTime = Carbon::parse($request->appointment_at);
@@ -165,11 +173,16 @@ class AdminAppointmentController extends Controller
         }
 
         $variant = ServiceVariant::with('service')->findOrFail($request->service_variant_id);
+        $discount = $request->discount_percent ?? 0;
+        $price    = $request->price_pln ?? $variant->price_pln;
+        $price    = round($price * (100 - $discount) / 100);
+
         $appointment->update([
             'user_id' => $request->user_id,
             'service_id' => $variant->service_id,
             'service_variant_id' => $variant->id,
-            'price_pln' => $request->price_pln ?? $variant->price_pln,
+            'price_pln' => $price,
+            'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
             'status' => $request->status,
         ]);

--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -41,15 +41,20 @@ class AppointmentController extends Controller
         $validated = $request->validate([
             'service_variant_id' => 'required|exists:service_variants,id',
             'appointment_at'     => 'required|date|after:now',
+            'discount_percent'   => 'nullable|integer|min:0|max:100',
         ]);
 
         $variant = ServiceVariant::with('service')->findOrFail($validated['service_variant_id']);
+
+        $discount = $validated['discount_percent'] ?? 0;
+        $price    = round($variant->price_pln * (100 - $discount) / 100);
 
         Appointment::create([
             'user_id'            => Auth::id(),
             'service_id'         => $variant->service->id,
             'service_variant_id' => $variant->id,
-            'price_pln'          => $variant->price_pln,
+            'price_pln'          => $price,
+            'discount_percent'   => $discount,
             'appointment_at'     => $validated['appointment_at'],
             'status'             => 'zaplanowana',
         ]);

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -11,6 +11,7 @@ class Appointment extends Model
         'service_id',
         'service_variant_id',
         'price_pln',
+        'discount_percent',
         'appointment_at',
         'status',
         'note_client',
@@ -20,6 +21,7 @@ class Appointment extends Model
     protected $casts = [
         'appointment_at' => 'datetime',
         'price_pln' => 'integer',
+        'discount_percent' => 'integer',
     ];
 
     public function user()

--- a/database/migrations/2025_06_02_000000_add_discount_percent_to_appointments_table.php
+++ b/database/migrations/2025_06_02_000000_add_discount_percent_to_appointments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->unsignedTinyInteger('discount_percent')->default(0)->after('price_pln');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn('discount_percent');
+        });
+    }
+};

--- a/resources/js/createModal.js
+++ b/resources/js/createModal.js
@@ -6,6 +6,7 @@ export function createModal() {
         service_id: '',
         variant_id: '',
         price: 0,
+        discount_percent: 0,
         users: [],
         services: [],
         variants: [],
@@ -32,6 +33,7 @@ export function createModal() {
 
           this.$watch('service_id', () => this.loadVariants());
           this.$watch('variant_id', () => this.setPrice());
+          this.$watch('discount_percent', () => this.setPrice());
        },
 
         loadVariants() {
@@ -55,7 +57,8 @@ export function createModal() {
 
         setPrice() {
           const v = this.variants.find(v => v.id == this.variant_id);
-          this.price = v ? v.price_pln : 0;
+          const base = v ? v.price_pln : 0;
+          this.price = Math.round(base * (100 - this.discount_percent) / 100);
         },
 
 	close() {
@@ -79,6 +82,7 @@ export function createModal() {
                         user_id: this.user_id,
                         service_variant_id: this.variant_id,
                         price_pln: this.price,
+                        discount_percent: this.discount_percent,
                         appointment_at: this.date,
                   })
                 });

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -120,8 +120,11 @@
           </template>
         </select>
 
+        <label class="block mb-2 text-sm font-medium">Rabat (%):</label>
+        <input type="number" x-model="discount_percent" min="0" max="100" class="w-full mb-4 border rounded px-2 py-1">
+
         <label class="block mb-2 text-sm font-medium">Cena (zł):</label>
-        <input type="number" x-model="price" class="w-full mb-4 border rounded px-2 py-1">
+        <input type="number" x-model="price" class="w-full mb-4 border rounded px-2 py-1" readonly>
 
         <div class="flex justify-end gap-2">
           <button

--- a/resources/views/admin/appointments/show.blade.php
+++ b/resources/views/admin/appointments/show.blade.php
@@ -4,6 +4,9 @@
         <ul>
             <li><b>Usługa:</b> {{ $appointment->service->name }} – {{ $appointment->variant->variant_name }}</li>
             <li><b>Cena:</b> {{ number_format($appointment->price_pln, 2) }} zł</li>
+            @if($appointment->discount_percent)
+                <li><b>Rabat:</b> {{ $appointment->discount_percent }}%</li>
+            @endif
             <li><b>Data:</b> {{ $appointment->appointment_at }}</li>
             <li><b>Status:</b> {{ $appointment->status }}</li>
         </ul>

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -41,10 +41,15 @@
 
 			</div>
 
-			<div>
-				<label class="block font-medium mb-1">Data i godzina wizyty</label>
-				<input type="datetime-local" name="appointment_at" class="w-full border rounded px-4 py-2" required>
-			</div>
+                        <div>
+                                <label class="block font-medium mb-1">Data i godzina wizyty</label>
+                                <input type="datetime-local" name="appointment_at" class="w-full border rounded px-4 py-2" required>
+                        </div>
+
+                        <div>
+                                <label class="block font-medium mb-1">Rabat (%)</label>
+                                <input type="number" name="discount_percent" min="0" max="100" value="0" class="w-full border rounded px-4 py-2">
+                        </div>
 
 			<div class="pt-4">
 				<button type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">


### PR DESCRIPTION
## Summary
- allow storing discount_percent on appointments
- adjust controllers to process discount percent and compute price
- update admin create modal logic and UI for discount field
- show discount information in admin views
- add migration for new column
- include optional discount input on user booking form

## Testing
- `npm run build` *(fails: vite not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df955430c8329babab8d9812e5d5b