### PR TITLE
Add service note fields

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -106,6 +106,8 @@ class AdminAppointmentController extends Controller
             'appointment_at' => 'required|date',
             'price_pln' => 'required|integer|min:0',
             'discount_percent' => 'nullable|integer|min:0|max:100',
+            'service_description' => 'nullable|string',
+            'products_used' => 'nullable|string',
         ]);
         
         // Sprawdzenie czy termin jest w godzinach pracy
@@ -145,6 +147,8 @@ class AdminAppointmentController extends Controller
             'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
             'status' => 'zaplanowana',
+            'service_description' => $request->service_description,
+            'products_used' => $request->products_used,
         ]);
         return response()->json(['success' => true, 'id' => $appointment->id]);
     }
@@ -158,6 +162,8 @@ class AdminAppointmentController extends Controller
             'status' => 'required|in:zaplanowana,odbyta,odwołana,nieodbyta',
             'price_pln' => 'required|integer|min:0',
             'discount_percent' => 'nullable|integer|min:0|max:100',
+            'service_description' => 'nullable|string',
+            'products_used' => 'nullable|string',
         ]);
 
         $newDateTime = Carbon::parse($request->appointment_at);
@@ -185,6 +191,8 @@ class AdminAppointmentController extends Controller
             'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
             'status' => $request->status,
+            'service_description' => $request->service_description,
+            'products_used' => $request->products_used,
         ]);
 
         return response()->json(['success' => true]);

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -16,6 +16,8 @@ class Appointment extends Model
         'status',
         'note_client',
         'note_internal',
+        'service_description',
+        'products_used',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_06_03_000000_add_service_notes_to_appointments_table.php
+++ b/database/migrations/2025_06_03_000000_add_service_notes_to_appointments_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->text('service_description')->nullable()->after('note_internal');
+            $table->text('products_used')->nullable()->after('service_description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn(['service_description', 'products_used']);
+        });
+    }
+};

--- a/resources/views/admin/appointments/edit.blade.php
+++ b/resources/views/admin/appointments/edit.blade.php
@@ -13,6 +13,14 @@
                 <textarea name="note_internal" id="note_internal" class="w-full p-2 border rounded">{{ old('note_internal', $appointment->note_internal) }}</textarea>
             </div>
             <div class="mb-4">
+                <label for="service_description" class="block font-medium mb-2">Opis usługi:</label>
+                <textarea name="service_description" id="service_description" class="w-full p-2 border rounded">{{ old('service_description', $appointment->service_description) }}</textarea>
+            </div>
+            <div class="mb-4">
+                <label for="products_used" class="block font-medium mb-2">Użyte produkty i proporcje:</label>
+                <textarea name="products_used" id="products_used" class="w-full p-2 border rounded">{{ old('products_used', $appointment->products_used) }}</textarea>
+            </div>
+            <div class="mb-4">
                 <label for="status" class="block font-medium mb-2">Status:</label>
                 <select name="status" id="status" class="w-full p-2 border rounded">
                     <option value="zaplanowana" @selected($appointment->status === 'zaplanowana')>Zaplanowana</option>

--- a/resources/views/admin/appointments/show.blade.php
+++ b/resources/views/admin/appointments/show.blade.php
@@ -16,5 +16,23 @@
                 {{ $appointment->note_client }}
             </div>
         @endif
+        @if($appointment->service_description)
+            <div class="my-4 p-4 rounded bg-blue-100 border-l-4 border-blue-500">
+                <b>Opis usługi:</b><br>
+                {{ $appointment->service_description }}
+            </div>
+        @endif
+        @if($appointment->products_used)
+            <div class="my-4 p-4 rounded bg-purple-100 border-l-4 border-purple-500">
+                <b>Użyte produkty:</b><br>
+                {{ $appointment->products_used }}
+            </div>
+        @endif
+        @if($appointment->note_internal)
+            <div class="my-4 p-4 rounded bg-gray-100 border-l-4 border-gray-500">
+                <b>Notatka fryzjera:</b><br>
+                {{ $appointment->note_internal }}
+            </div>
+        @endif
     </div>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- add new migration to store `service_description` and `products_used`
- allow mass assignment of new fields in `Appointment`
- support new fields in `AdminAppointmentController`
- extend admin appointment edit and show pages to view and edit these notes

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edc38bea483298b5369bd378406fd