### PR TITLE
Fix pointer events and z-index for calendar modals

### DIFF
--- a/resources/css/modal-fix.css
+++ b/resources/css/modal-fix.css
@@ -16,6 +16,15 @@
   pointer-events: auto !important;
 }
 
+/* Ustawienia dla modali wykorzystywanych na stronie kalendarza */
+#appointmentModal,
+#adminEditModal,
+#adminCreateModal,
+#adminEditFullModal,
+#realizeModal {
+  z-index: 10000 !important;
+}
+
 /* Zapewnienie, że zawartość modalu przechwytuje wszystkie zdarzenia */
 [x-data][x-show="show"] .bg-white {
   position: relative;
@@ -40,6 +49,7 @@ body.modal-open .fc-view-harness.fc-view-harness-active::after {
   pointer-events: auto;
 }
 
+body.modal-open #calendar,
 body.modal-open .fc-event {
   pointer-events: none !important;
 }


### PR DESCRIPTION
## Summary
- update `modal-fix.css` so calendar and events ignore clicks when a modal is open
- ensure calendar modals get a very high z-index
- rebuild assets

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851f29612ec8329920ec7a7d5e10299