### PR TITLE
Add fallback route and tests

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -120,3 +120,18 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
 Route::get('/zarezerwuj', [ReservationEntryController::class, 'index'])->name('reservation.entry');
 
 require __DIR__ . '/auth.php';
+
+/*
+|--------------------------------------------------------------------------
+| Fallback Route
+|--------------------------------------------------------------------------
+*/
+Route::fallback(function () {
+    if (auth()->check()) {
+        return redirect()->route(
+            auth()->user()->role === 'admin' ? 'admin.calendar' : 'dashboard'
+        );
+    }
+
+    return redirect('/');
+});

--- a/tests/Feature/FallbackRedirectTest.php
+++ b/tests/Feature/FallbackRedirectTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FallbackRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invalid_url_redirects_user_to_dashboard(): void
+    {
+        $user = User::factory()->create(['role' => 'user']);
+
+        $response = $this->actingAs($user)->get('/nonexistent');
+
+        $response->assertRedirect(route('dashboard', absolute: false));
+    }
+
+    public function test_invalid_url_redirects_admin_to_calendar(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($admin)->get('/some/invalid/path');
+
+        $response->assertRedirect(route('admin.calendar', absolute: false));
+    }
+
+    public function test_invalid_url_redirects_guest_home(): void
+    {
+        $response = $this->get('/invalid');
+
+        $response->assertRedirect('/');
+    }
+}
+


### PR DESCRIPTION
## Summary
- add fallback route redirecting logged-in users to dashboard or admin calendar
- cover fallback behaviour with new feature tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6851f3ee8f3c832990c02ec3e2610439