### PR TITLE
Fix history API query

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -252,8 +252,9 @@ class AdminAppointmentController extends Controller
     public function history(Appointment $appointment)
     {
         $appointments = Appointment::where('user_id', $appointment->user_id)
+            ->with('serviceVariant.service')
             ->orderByDesc('appointment_at')
-            ->get(['id', 'appointment_at'])
+            ->get(['id', 'appointment_at', 'service_variant_id'])
             ->map(function ($a) {
                 return [
                     'id' => $a->id,


### PR DESCRIPTION
## Summary
- load service data when listing appointment history

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852776a23d8832987392ad471b4b6ae