### PR TITLE
Extend appointment history tooltip

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -254,12 +254,24 @@ class AdminAppointmentController extends Controller
         $appointments = Appointment::where('user_id', $appointment->user_id)
             ->with('serviceVariant.service')
             ->orderByDesc('appointment_at')
-            ->get(['id', 'appointment_at', 'service_variant_id'])
+            ->get([
+                'id',
+                'appointment_at',
+                'service_variant_id',
+                'note_client',
+                'note_internal',
+                'service_description',
+                'products_used',
+            ])
             ->map(function ($a) {
                 return [
                     'id' => $a->id,
                     'appointment_at' => $a->appointment_at->format('Y-m-d H:i'),
                     'service_name' => optional($a->serviceVariant->service)->name,
+                    'note_client' => $a->note_client,
+                    'note_internal' => $a->note_internal,
+                    'service_description' => $a->service_description,
+                    'products_used' => $a->products_used,
                 ];
             });
 

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -249,7 +249,15 @@
         <h3 class="font-semibold mb-2">Historia wizyt</h3>
         <ul class="text-sm max-h-32 overflow-y-auto list-disc list-inside" >
           <template x-for="h in history" :key="h.id">
-            <li x-text="h.appointment_at + ' - ' + (h.service_name || '')"></li>
+            <li
+              x-text="h.appointment_at + ' - ' + (h.service_name || '')"
+              :title="
+                (h.note_client ? 'Zalecenia: ' + h.note_client + '\n' : '') +
+                (h.note_internal ? 'Notatka: ' + h.note_internal + '\n' : '') +
+                (h.service_description ? 'Opis: ' + h.service_description + '\n' : '') +
+                (h.products_used ? 'Produkty: ' + h.products_used : '')
+              ">
+            </li>
           </template>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- include more fields in appointment history API
- show note information in history hover tooltip

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527bc91c6c832985eb77b704270117