### PR TITLE
Show tooltip even when visit notes missing

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -45,6 +45,12 @@ class AdminAppointmentController extends Controller
                     'service_variant_id' => $appointment->service_variant_id,
                     'price_pln' => $appointment->price_pln,
                     'discount_percent' => $appointment->discount_percent,
+                    'note_client' => $appointment->note_client,
+                    'note_internal' => $appointment->note_internal,
+                    'service_description' => $appointment->service_description,
+                    'products_used' => $appointment->products_used,
+                    'amount_paid_pln' => $appointment->amount_paid_pln,
+                    'payment_method' => $appointment->payment_method,
                 ],
             ];
         });

--- a/resources/js/realizeModal.js
+++ b/resources/js/realizeModal.js
@@ -31,7 +31,15 @@ export function realizeModal() {
       try {
         const res = await fetch(`/admin/kalendarz/appointments/${this.appointment.id}/history`);
         if (res.ok) {
-          this.history = await res.json();
+          const data = await res.json();
+          this.history = data.map(h => {
+            const parts = [];
+            if (h.note_client) parts.push('Zalecenia: ' + h.note_client);
+            if (h.note_internal) parts.push('Notatka: ' + h.note_internal);
+            if (h.service_description) parts.push('Opis: ' + h.service_description);
+            if (h.products_used) parts.push('Produkty: ' + h.products_used);
+            return { ...h, tooltip: parts.join('\n') || 'Brak dodatkowych informacji' };
+          });
         }
       } catch {
         this.history = [];

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -251,13 +251,8 @@
           <template x-for="h in history" :key="h.id">
             <li
               x-text="h.appointment_at + ' - ' + (h.service_name || '')"
-              :title="
-                (h.note_client ? 'Zalecenia: ' + h.note_client + '\n' : '') +
-                (h.note_internal ? 'Notatka: ' + h.note_internal + '\n' : '') +
-                (h.service_description ? 'Opis: ' + h.service_description + '\n' : '') +
-                (h.products_used ? 'Produkty: ' + h.products_used : '')
-              ">
-            </li>
+              :title="h.tooltip"
+            ></li>
           </template>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- compute tooltip text when loading visit history
- update history list to bind `:title` to this tooltip

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532f8fa8c083298d8e68f07e75fa0a