### PR TITLE
Improve realize modal layout

### DIFF
--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -235,8 +235,8 @@
     x-init="init()"
     x-show="open"
     x-cloak
-    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-    <div class="bg-white rounded-lg p-6 shadow-lg w-full max-w-lg overflow-y-auto max-h-full">
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 sm:p-6">
+    <div class="bg-white rounded-lg p-6 shadow-lg w-full max-w-lg overflow-y-auto max-h-[90vh]">
       <h2 class="text-lg font-bold mb-4">Realizacja wizyty</h2>
 
       <div class="mb-4">


### PR DESCRIPTION
## Summary
- adjust the `realizeModal` container to use padding and a max height
- cap the modal height to 90vh so it doesn't occupy the full screen

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685949edc96c83298ba7ad5adcb78eed