### PR TITLE
Add limited history loading in realization modal

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -255,12 +255,19 @@ class AdminAppointmentController extends Controller
     }
 
     // Historia wizyt klienta dla danej wizyty
-    public function history(Appointment $appointment)
+    public function history(Request $request, Appointment $appointment)
     {
-        $appointments = Appointment::where('user_id', $appointment->user_id)
+        $limit = (int) $request->query('limit', 5);
+
+        $query = Appointment::where('user_id', $appointment->user_id)
             ->with('serviceVariant.service')
-            ->orderByDesc('appointment_at')
-            ->get([
+            ->orderByDesc('appointment_at');
+
+        if ($limit > 0) {
+            $query->limit($limit);
+        }
+
+        $appointments = $query->get([
                 'id',
                 'appointment_at',
                 'service_variant_id',

--- a/resources/js/realizeModal.js
+++ b/resources/js/realizeModal.js
@@ -3,6 +3,7 @@ export function realizeModal() {
     open: false,
     appointment: {},
     history: [],
+    loadedAllHistory: false,
     note_client: '',
     note_internal: '',
     amount_paid_pln: '',
@@ -23,13 +24,15 @@ export function realizeModal() {
         this.open = true;
         window.modalIsOpen = true;
         document.body.classList.add('modal-open');
+        this.loadedAllHistory = false;
         this.loadHistory();
       });
       window.addEventListener('force-close-realize-modal', () => this.close());
     },
-    async loadHistory() {
+    async loadHistory(all = false) {
       try {
-        const res = await fetch(`/admin/kalendarz/appointments/${this.appointment.id}/history`);
+        const url = `/admin/kalendarz/appointments/${this.appointment.id}/history` + (all ? '' : '?limit=5');
+        const res = await fetch(url);
         if (res.ok) {
           const data = await res.json();
           this.history = data.map(h => {
@@ -41,9 +44,14 @@ export function realizeModal() {
             return { ...h, tooltip: parts.join('\n') || 'Brak dodatkowych informacji' };
           });
         }
+        this.loadedAllHistory = all;
       } catch {
         this.history = [];
       }
+    },
+
+    viewAllHistory() {
+      this.loadHistory(true);
     },
     close() {
       this.open = false;

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -255,6 +255,11 @@
             ></li>
           </template>
         </ul>
+        <button
+          x-show="!loadedAllHistory"
+          @click="viewAllHistory()"
+          class="mt-2 text-blue-600 hover:underline"
+        >Pokaż całą historię</button>
       </div>
 
       <label class="block mb-2 text-sm font-medium">Zalecenia dla klienta:</label>


### PR DESCRIPTION
## Summary
- support optional `limit` parameter in history endpoint
- load only recent history when opening the realization modal
- allow fetching all past visits with *Pokaż całą historię* button

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68594f9c398c8329b047efa7498f3004