### PR TITLE
Update locale and timezone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+# Default timezone is Europe/Warsaw
 
-APP_LOCALE=en
+APP_LOCALE=pl
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
 

--- a/config/app.php
+++ b/config/app.php
@@ -65,7 +65,7 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => 'Europe/Warsaw',
 
     /*
     |--------------------------------------------------------------------------
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'locale' => env('APP_LOCALE', 'en'),
+    'locale' => env('APP_LOCALE', 'pl'),
 
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
 


### PR DESCRIPTION
## Summary
- set default timezone to `Europe/Warsaw`
- default locale now Polish and set `APP_LOCALE=pl` in `.env.example`
- note the timezone in the example environment file

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c5ea134c8329808227e01ce972c2