### PR TITLE
Modern home page design

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -48,4 +48,15 @@ document.addEventListener('DOMContentLoaded', () => {
             clickable: true,
         },
     });
+
+    new Swiper('.testimonial-swiper', {
+        loop: true,
+        autoplay: {
+            delay: 7000,
+        },
+        pagination: {
+            el: '.testimonial-swiper .swiper-pagination',
+            clickable: true,
+        },
+    });
 });

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,26 +1,28 @@
-<nav class="bg-white border-b">
-    <div class="max-w-7xl mx-auto px-4 py-3">
-        <div class="flex flex-wrap items-center justify-between gap-4">
-            {{-- Lewa sekcja --}}
-            <div class="flex flex-wrap items-center gap-6">
+<nav x-data="{ open: false }" class="bg-white border-b sticky top-0 z-50">
+    <div class="max-w-7xl mx-auto px-4">
+        <div class="flex justify-between items-center py-4">
+            <div class="flex items-center">
                 <a href="{{ route('home') }}" class="font-bold text-lg flex items-center">
                     <x-heroicon-o-home class="w-5 h-5 mr-1 text-gray-700" />
                     Salon Black&White
                 </a>
-                <a href="{{ route('uslugi') }}" class="flex items-center text-gray-700 hover:underline">
-                    <x-heroicon-o-scissors class="w-5 h-5 mr-1 text-gray-500" />
-                    Usługi
-                </a>
-                <a href="{{ route('kontakt') }}" class="flex items-center text-gray-700 hover:underline">
-                    <x-heroicon-o-envelope class="w-5 h-5 mr-1 text-gray-500" />
-                    Kontakt
-                </a>
+                <div class="hidden md:flex space-x-6 ml-6">
+                    <a href="{{ route('uslugi') }}" class="text-gray-700 hover:text-indigo-600">Usługi</a>
+                    <a href="{{ route('team') }}" class="text-gray-700 hover:text-indigo-600">Zespół</a>
+                    <a href="{{ route('gallery') }}" class="text-gray-700 hover:text-indigo-600">Galeria</a>
+                    <a href="{{ route('faq') }}" class="text-gray-700 hover:text-indigo-600">FAQ</a>
+                    <a href="{{ route('kontakt') }}" class="text-gray-700 hover:text-indigo-600">Kontakt</a>
+                </div>
             </div>
-
-            {{-- Prawa sekcja --}}
-            <div class="flex items-center gap-4">
+            <div class="flex items-center space-x-4">
+                <a href="{{ route('reservation.entry') }}" class="hidden md:inline-block bg-indigo-600 text-white px-4 py-2 rounded shadow hover:bg-indigo-700 transition">Rezerwuj</a>
+                <button @click="open = !open" class="md:hidden focus:outline-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 6h16.5m-16.5 6h16.5" />
+                    </svg>
+                </button>
                 @auth
-                    <form method="POST" action="{{ route('logout') }}" class="flex items-center">
+                    <form method="POST" action="{{ route('logout') }}" class="hidden md:inline-flex items-center">
                         @csrf
                         <button type="submit" class="text-red-600 hover:underline flex items-center">
                             <x-heroicon-o-arrow-left-on-rectangle class="w-5 h-5 mr-1" />
@@ -28,21 +30,36 @@
                         </button>
                     </form>
                 @else
-                    <a href="{{ route('register') }}" class="hover:underline flex items-center">
+                    <a href="{{ route('register') }}" class="hidden md:inline-flex hover:underline items-center">
                         <x-heroicon-o-user-plus class="w-5 h-5 mr-1" />
-                        Zarejestruj się
+                        Rejestracja
                     </a>
-                    <a href="{{ route('login') }}" class="hover:underline flex items-center">
+                    <a href="{{ route('login') }}" class="hidden md:inline-flex hover:underline items-center">
                         <x-heroicon-o-arrow-right-on-rectangle class="w-5 h-5 mr-1" />
-                        Zaloguj się
+                        Logowanie
                     </a>
                 @endauth
             </div>
         </div>
-
-        {{-- Linki użytkownika/admina --}}
+        <div x-show="open" class="md:hidden pb-4 space-y-2">
+            <a href="{{ route('uslugi') }}" class="block text-gray-700">Usługi</a>
+            <a href="{{ route('team') }}" class="block text-gray-700">Zespół</a>
+            <a href="{{ route('gallery') }}" class="block text-gray-700">Galeria</a>
+            <a href="{{ route('faq') }}" class="block text-gray-700">FAQ</a>
+            <a href="{{ route('kontakt') }}" class="block text-gray-700">Kontakt</a>
+            <a href="{{ route('reservation.entry') }}" class="block text-indigo-600 font-semibold">Rezerwuj</a>
+            @auth
+                <form method="POST" action="{{ route('logout') }}" class="block">
+                    @csrf
+                    <button type="submit" class="text-red-600 underline">Wyloguj</button>
+                </form>
+            @else
+                <a href="{{ route('register') }}" class="block">Rejestracja</a>
+                <a href="{{ route('login') }}" class="block">Logowanie</a>
+            @endauth
+        </div>
         @auth
-        <div class="mt-4 pt-2 border-t flex flex-wrap gap-6 text-sm">
+        <div class="hidden md:flex mt-4 pt-2 border-t flex-wrap gap-6 text-sm">
             @if(Auth::user()->role === 'admin')
                 <a href="{{ route('admin.services.index') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-cog class="w-4 h-4 mr-1 text-gray-500" />

--- a/resources/views/pages/faq.blade.php
+++ b/resources/views/pages/faq.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto text-center py-20">
+        <h1 class="text-3xl font-bold mb-6">FAQ</h1>
+        <p>Najczęściej zadawane pytania wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/resources/views/pages/gallery.blade.php
+++ b/resources/views/pages/gallery.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto text-center py-20">
+        <h1 class="text-3xl font-bold mb-6">Galeria</h1>
+        <p>Zdjęcia wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -1,33 +1,160 @@
 <x-guest-layout>
+    @push('head')
+        <title>Salon Black&White – Profesjonalna pielęgnacja włosów</title>
+        <meta name="description" content="Nowoczesny salon fryzjerski w centrum miasta. Umów wizytę online i zadbaj o swoje włosy." />
+        <meta property="og:title" content="Salon Black&White" />
+        <meta property="og:description" content="Profesjonalna pielęgnacja i stylizacja włosów." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="{{ url('/') }}" />
+        <meta property="og:image" content="{{ asset('img/slider/slider1.jpg') }}" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "HairSalon",
+            "name": "Salon Black&White",
+            "image": "{{ asset('img/slider/slider1.jpg') }}",
+            "url": "{{ url('/') }}",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "Przykładowa 1",
+                "addressLocality": "Miasto",
+                "postalCode": "00-000",
+                "addressCountry": "PL"
+            }
+        }
+        </script>
+    @endpush
 
-	<!-- Hero Slider -->
-        <section class="mb-10">
-                <div class="hero-swiper relative overflow-hidden rounded-lg shadow-lg">
-                        <div class="swiper-wrapper">
-                                @foreach(['slider1.jpg', 'slider2.jpg', 'slider3.jpg'] as $slide)
-                                <div class="swiper-slide">
-                                        <img src="{{ asset('img/slider/'.$slide) }}" alt="Salon Black&White" class="w-full h-96 object-cover">
-                                        <div class="absolute top-0 left-0 w-full h-full flex items-center justify-center bg-black bg-opacity-30">
-                                                <div class="text-center text-white px-4">
-                                                        <h2 class="text-3xl font-bold mb-2">Witamy w Akademii Zdrowych Włosów <span class="text-black bg-white px-2">Black</span> & <span class="bg-black text-white px-2">White</span></h2>
-                                                        <p class="max-w-xl mx-auto">Naszym celem jest dostarczanie najwyższej jakości usług i zadowolenia klienta. Rozumiemy indywidualne potrzeby każdego.</p>
-                                                </div>
-                                        </div>
-                                </div>
-                                @endforeach
+    <section class="relative bg-cover bg-center" style="background-image:url('{{ asset('img/slider/slider1.jpg') }}');">
+        <div class="bg-black/50">
+            <div class="max-w-7xl mx-auto px-4 py-32 text-center text-white">
+                <h1 class="text-4xl md:text-5xl font-bold mb-4">Zadbaj o swoje włosy</h1>
+                <p class="mb-6">Profesjonalne usługi fryzjerskie i kosmetyczne w przyjaznej atmosferze.</p>
+                <a href="{{ route('reservation.entry') }}" class="inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded shadow transition">Umów wizytę</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-gray-50">
+        <div class="max-w-5xl mx-auto px-4 text-center">
+            <h2 class="text-3xl font-bold mb-4">Witamy w Salon Black&White</h2>
+            <p class="text-gray-700 mb-6">Naszą pasją jest dbanie o Twoje włosy i dobre samopoczucie. Poznaj nasz zespół doświadczonych specjalistów.</p>
+        </div>
+    </section>
+
+    @php
+        $servicePreview = \App\Models\Service::take(3)->get();
+    @endphp
+    <section class="py-16">
+        <div class="max-w-7xl mx-auto px-4">
+            <h2 class="text-3xl font-bold text-center mb-8">Popularne usługi</h2>
+            <div class="grid md:grid-cols-3 gap-6">
+                @forelse($servicePreview as $service)
+                    <div class="bg-white shadow rounded-lg p-6 text-center">
+                        <h3 class="font-semibold text-lg mb-2">{{ $service->name }}</h3>
+                        <p class="text-sm text-gray-500 mb-4">Profesjonalna usługa dopasowana do Twoich potrzeb.</p>
+                        <a href="{{ route('uslugi') }}" class="text-indigo-600 hover:underline">Zobacz więcej</a>
+                    </div>
+                @empty
+                    <p class="col-span-3 text-center text-gray-500">Brak usług do wyświetlenia.</p>
+                @endforelse
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4">
+            <h2 class="text-3xl font-bold text-center mb-8">Nasz zespół</h2>
+            <div class="grid md:grid-cols-3 gap-6 text-center">
+                @foreach(range(1,3) as $i)
+                    <div>
+                        <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=300&q=60" alt="Pracownik" class="mx-auto rounded-full w-40 h-40 object-cover mb-4" loading="lazy">
+                        <h3 class="font-semibold">Imię Nazwisko</h3>
+                        <p class="text-sm text-gray-500">Stylista</p>
+                    </div>
+                @endforeach
+            </div>
+            <div class="text-center mt-8">
+                <a href="{{ route('team') }}" class="text-indigo-600 hover:underline">Poznaj cały zespół</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16">
+        <div class="max-w-7xl mx-auto px-4">
+            <h2 class="text-3xl font-bold text-center mb-8">Galeria</h2>
+            <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+                @foreach(range(1,6) as $i)
+                    <a href="https://source.unsplash.com/random/800x600?hair,{{ $i }}" target="_blank">
+                        <img src="https://source.unsplash.com/random/400x300?hair,{{ $i }}" alt="Galeria" class="w-full h-48 object-cover rounded" loading="lazy">
+                    </a>
+                @endforeach
+            </div>
+            <div class="text-center mt-8">
+                <a href="{{ route('gallery') }}" class="text-indigo-600 hover:underline">Zobacz więcej zdjęć</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16 bg-gray-50">
+        <div class="max-w-3xl mx-auto px-4 text-center">
+            <h2 class="text-3xl font-bold mb-6">Opinie klientów</h2>
+            <div class="swiper testimonial-swiper">
+                <div class="swiper-wrapper">
+                    @foreach(['Fantastyczna obsługa!', 'Polecam w 100%', 'Najlepszy salon w mieście'] as $review)
+                        <div class="swiper-slide p-6">
+                            <p class="italic">"{{ $review }}"</p>
                         </div>
-                        <div class="swiper-pagination"></div>
+                    @endforeach
                 </div>
-        </section>
+                <div class="swiper-pagination"></div>
+            </div>
+        </div>
+    </section>
 
-	<!-- Main Info -->
-	<section class="text-center">
-		<div class="max-w-4xl mx-auto">
-			<h2 class="text-2xl font-bold mb-4">Nowoczesna Stylizacja</h2>
-			<p class="mb-6">Różnorodność fryzur, zabiegów skóry głowy oraz usług kosmetycznych sprawia, że Salon Black&White stanie się Twoim miejscem piękna i relaksu.</p>
+    <section class="py-16">
+        <div class="max-w-7xl mx-auto px-4 text-center">
+            <h2 class="text-3xl font-bold mb-4">Zarezerwuj wizytę już dziś!</h2>
+            <p class="mb-6">Rezerwacje online dostępne 24/7.</p>
+            <a href="{{ route('reservation.entry') }}" class="bg-indigo-600 text-white px-6 py-3 rounded shadow hover:bg-indigo-700 transition">Umów wizytę</a>
+        </div>
+    </section>
 
-			<h2 class="text-2xl font-bold mb-4">Serdecznie Zapraszamy</h2>
-			<p>Zapoznaj się z naszą <a href="{{ route('uslugi') }}" class="text-blue-600 underline">ofertą</a>. Masz pytania? <a href="{{ route('kontakt') }}" class="text-blue-600 underline">Skontaktuj się z nami</a>.</p>
-		</div>
-	</section>
+    <section class="py-16 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4">
+            <h2 class="text-3xl font-bold text-center mb-8">Najczęstsze pytania</h2>
+            <div class="space-y-4" x-data="{selected:null}">
+                @foreach(['Jak umówić wizytę?', 'Czy można odwołać rezerwację?', 'Jak przygotować się do wizyty?'] as $idx => $question)
+                    <div class="border rounded-lg overflow-hidden">
+                        <button class="w-full px-4 py-3 text-left font-medium bg-white" @click="selected === {{ $idx }} ? selected = null : selected = {{ $idx }}">
+                            {{ $question }}
+                        </button>
+                        <div x-show="selected === {{ $idx }}" class="px-4 py-3 text-gray-700 bg-gray-50">
+                            Odpowiedź przykładowa na pytanie.
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+            <div class="text-center mt-8">
+                <a href="{{ route('faq') }}" class="text-indigo-600 hover:underline">Więcej pytań</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16">
+        <div class="max-w-7xl mx-auto px-4 grid md:grid-cols-2 gap-8">
+            <div>
+                <h2 class="text-3xl font-bold mb-4">Kontakt</h2>
+                <p class="mb-2">Przykładowa 1</p>
+                <p class="mb-2">00-000 Miasto</p>
+                <p class="mb-2">Tel: <a href="tel:+48111222333" class="text-indigo-600 hover:underline">+48 111 222 333</a></p>
+                <p class="mb-2">Godziny otwarcia: 9:00-18:00</p>
+                <a href="{{ route('kontakt') }}" class="text-indigo-600 hover:underline">Więcej informacji</a>
+            </div>
+            <div>
+                <img src="https://source.unsplash.com/random/600x400?map" alt="Mapa" class="w-full h-64 object-cover rounded" loading="lazy">
+            </div>
+        </div>
+    </section>
 </x-guest-layout>

--- a/resources/views/pages/team.blade.php
+++ b/resources/views/pages/team.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto text-center py-20">
+        <h1 class="text-3xl font-bold mb-6">Nasz Zespół</h1>
+        <p>Ta sekcja jest w przygotowaniu.</p>
+    </div>
+</x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,10 @@ Route::get('/uslugi', function () {
     return view('pages.uslugi', compact('services'));
 })->name('uslugi');
 
+Route::view('/team', 'pages.team')->name('team');
+Route::view('/galeria', 'pages.gallery')->name('gallery');
+Route::view('/faq', 'pages.faq')->name('faq');
+
 Route::get('/kontakt', function () {
     return view('kontakt');
 })->name('kontakt');


### PR DESCRIPTION
## Summary
- add placeholder pages (team, gallery, faq)
- modernize the navigation with responsive menu and sticky header
- redesign the home page with modern sections and SEO meta tags
- initialize testimonial swiper
- expose new routes for the extra pages

## Testing
- `npm install`
- `npm run build`
- ❌ `php artisan test` *(command failed: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cbedf73c8329a03975bcfda5f949