### PR TITLE
Remove unused session flush in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,6 @@ jobs:
             /home/vetternkraft/bin/php artisan route:clear
             /home/vetternkraft/bin/php artisan cache:clear
             /home/vetternkraft/bin/php artisan view:clear
-            /home/vetternkraft/bin/php artisan session:flush
             /home/vetternkraft/bin/php artisan queue:restart
             rm -rf bootstrap/cache/*.php
             rm -rf storage/framework/sessions/*


### PR DESCRIPTION
## Summary
- trim deploy workflow by dropping `session:flush` step

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685b00ab94888329b71b130997d61c76