### PR TITLE
Fix sed inline editing flags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,13 +60,13 @@ jobs:
             fi
             cd $REMOTE_PATH
             grep -q '^APP_URL=' .env || echo 'APP_URL=https://dev.salon-bw.pl' >> .env
-            sed -i 's|^APP_URL=.*|APP_URL=https://dev.salon-bw.pl|' .env
+            sed -i'' 's|^APP_URL=.*|APP_URL=https://dev.salon-bw.pl|' .env
             grep -q '^SESSION_DOMAIN=' .env || echo 'SESSION_DOMAIN=dev.salon-bw.pl' >> .env
-            sed -i 's|^SESSION_DOMAIN=.*|SESSION_DOMAIN=dev.salon-bw.pl|' .env
+            sed -i'' 's|^SESSION_DOMAIN=.*|SESSION_DOMAIN=dev.salon-bw.pl|' .env
             grep -q '^SESSION_SECURE_COOKIE=' .env || echo 'SESSION_SECURE_COOKIE=true' >> .env
-            sed -i 's|^SESSION_SECURE_COOKIE=.*|SESSION_SECURE_COOKIE=true|' .env
+            sed -i'' 's|^SESSION_SECURE_COOKIE=.*|SESSION_SECURE_COOKIE=true|' .env
             grep -q '^SESSION_SAME_SITE=' .env || echo 'SESSION_SAME_SITE=lax' >> .env
-            sed -i 's|^SESSION_SAME_SITE=.*|SESSION_SAME_SITE=lax|' .env
+            sed -i'' 's|^SESSION_SAME_SITE=.*|SESSION_SAME_SITE=lax|' .env
             /home/vetternkraft/bin/php /usr/local/bin/composer dump-autoload
             /home/vetternkraft/bin/php artisan optimize:clear
             /home/vetternkraft/bin/php artisan config:clear

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -53,13 +53,13 @@ pipelines:
             - echo "Sprawdzanie i naprawa konfiguracji sesji..."
             - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && echo 'Aktualna konfiguracja sesji:' && cat .env | grep -E '(APP_URL|SESSION_|COOKIE_)' || echo 'Brak konfiguracji sesji'"
             - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && grep -q '^APP_URL=' .env || echo 'APP_URL=https://dev.salon-bw.pl' >> .env"
-            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i 's|^APP_URL=.*|APP_URL=https://dev.salon-bw.pl|' .env"
+            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i'' 's|^APP_URL=.*|APP_URL=https://dev.salon-bw.pl|' .env"
             - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && grep -q '^SESSION_DOMAIN=' .env || echo 'SESSION_DOMAIN=dev.salon-bw.pl' >> .env"
-            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i 's|^SESSION_DOMAIN=.*|SESSION_DOMAIN=dev.salon-bw.pl|' .env"
+            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i'' 's|^SESSION_DOMAIN=.*|SESSION_DOMAIN=dev.salon-bw.pl|' .env"
             - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && grep -q '^SESSION_SECURE_COOKIE=' .env || echo 'SESSION_SECURE_COOKIE=true' >> .env"
-            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i 's|^SESSION_SECURE_COOKIE=.*|SESSION_SECURE_COOKIE=true|' .env"
+            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i'' 's|^SESSION_SECURE_COOKIE=.*|SESSION_SECURE_COOKIE=true|' .env"
             - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && grep -q '^SESSION_SAME_SITE=' .env || echo 'SESSION_SAME_SITE=lax' >> .env"
-            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i 's|^SESSION_SAME_SITE=.*|SESSION_SAME_SITE=lax|' .env"
+            - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && sed -i'' 's|^SESSION_SAME_SITE=.*|SESSION_SAME_SITE=lax|' .env"
             - ssh vetternkraft@s0.mydevil.net "cd /home/vetternkraft/domains/dev.salon-bw.pl/salonbw && echo 'Zaktualizowana konfiguracja sesji:' && cat .env | grep -E '(APP_URL|SESSION_|COOKIE_)'"
 
             # Naprawa uprawnień do katalogów sesji


### PR DESCRIPTION
## Summary
- use `-i''` for sed inline editing in GitHub workflow
- apply the same change for the Bitbucket pipeline

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0181a1888329ae0107983d7e1d26