### PR TITLE
Remove team page references

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -8,7 +8,6 @@
                 </a>
                 <div class="hidden md:flex space-x-6 ml-6">
                     <a href="{{ route('uslugi') }}" class="text-gray-700 hover:text-indigo-600">Usługi</a>
-                    <a href="{{ route('team') }}" class="text-gray-700 hover:text-indigo-600">Zespół</a>
                     <a href="{{ route('gallery') }}" class="text-gray-700 hover:text-indigo-600">Galeria</a>
                     <a href="{{ route('faq') }}" class="text-gray-700 hover:text-indigo-600">FAQ</a>
                     <a href="{{ route('kontakt') }}" class="text-gray-700 hover:text-indigo-600">Kontakt</a>
@@ -43,7 +42,6 @@
         </div>
         <div x-show="open" class="md:hidden pb-4 space-y-2">
             <a href="{{ route('uslugi') }}" class="block text-gray-700">Usługi</a>
-            <a href="{{ route('team') }}" class="block text-gray-700">Zespół</a>
             <a href="{{ route('gallery') }}" class="block text-gray-700">Galeria</a>
             <a href="{{ route('faq') }}" class="block text-gray-700">FAQ</a>
             <a href="{{ route('kontakt') }}" class="block text-gray-700">Kontakt</a>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -75,9 +75,6 @@
                     </div>
                 @endforeach
             </div>
-            <div class="text-center mt-8">
-                <a href="{{ route('team') }}" class="text-indigo-600 hover:underline">Poznaj cały zespół</a>
-            </div>
         </div>
     </section>
 

--- a/resources/views/pages/team.blade.php
+++ b/resources/views/pages/team.blade.php
@@ -1,6 +1,0 @@
-<x-guest-layout>
-    <div class="max-w-3xl mx-auto text-center py-20">
-        <h1 class="text-3xl font-bold mb-6">Nasz Zespół</h1>
-        <p>Ta sekcja jest w przygotowaniu.</p>
-    </div>
-</x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,6 @@ Route::get('/uslugi', function () {
     return view('pages.uslugi', compact('services'));
 })->name('uslugi');
 
-Route::view('/team', 'pages.team')->name('team');
 Route::view('/galeria', 'pages.gallery')->name('gallery');
 Route::view('/faq', 'pages.faq')->name('faq');
 


### PR DESCRIPTION
## Summary
- delete `pages/team` and route
- remove "Zespół" nav links
- drop "Poznaj cały zespół" link from homepage

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b125ec6488329a11592b7fc028501