### PR TITLE
Add Leaflet map support

### DIFF
--- a/app/Http/Controllers/AdminKontaktController.php
+++ b/app/Http/Controllers/AdminKontaktController.php
@@ -91,6 +91,8 @@ class AdminKontaktController extends Controller
             'facebook_url' => 'nullable|url|max:255',
             'instagram_url' => 'nullable|url|max:255',
             'google_maps_url' => 'nullable|url|max:255',
+            'latitude' => 'nullable|numeric|between:-90,90',
+            'longitude' => 'nullable|numeric|between:-180,180',
             'working_hours.*.0' => 'nullable|date_format:H:i',
             'working_hours.*.1' => 'nullable|date_format:H:i|after:working_hours.*.0',
         ], [
@@ -132,6 +134,8 @@ class AdminKontaktController extends Controller
             'facebook_url' => $request->facebook_url,
             'instagram_url' => $request->instagram_url,
             'google_maps_url' => $request->google_maps_url,
+            'latitude' => $request->latitude,
+            'longitude' => $request->longitude,
         ]);
 
         return redirect()->route('admin.kontakt.edit')->with('success', 'Dane kontaktowe zostały zaktualizowane.');

--- a/app/Models/ContactInfo.php
+++ b/app/Models/ContactInfo.php
@@ -34,6 +34,8 @@ class ContactInfo extends Model
         'facebook_url',
         'instagram_url',
         'google_maps_url',
+        'latitude',
+        'longitude',
     ];
 
     /**
@@ -63,6 +65,8 @@ class ContactInfo extends Model
                 'phone' => '+48 123 456 789',
                 'email' => 'kontakt@salon-bw.pl',
                 'google_maps_url' => 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2563.0658784063153!2d18.91093751598082!3d50.34623847946937!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47113061f0f77f11%3A0x39e236ec244bcabb!2sBytom!5e0!3m2!1spl!2spl!4v1618312782107!5m2!1spl!2spl',
+                'latitude' => 50.346238,
+                'longitude' => 18.910938,
                 'working_hours' => [
                     'monday' => ['09:00', '18:00'],
                     'tuesday' => ['09:00', '18:00'],

--- a/database/migrations/2025_05_28_000000_create_contact_info_table.php
+++ b/database/migrations/2025_05_28_000000_create_contact_info_table.php
@@ -25,6 +25,8 @@ return new class extends Migration
             $table->string('facebook_url')->nullable();
             $table->string('instagram_url')->nullable();
             $table->string('google_maps_url')->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/admin/kontakt/edit.blade.php
+++ b/resources/views/admin/kontakt/edit.blade.php
@@ -199,11 +199,37 @@
                         <div class="sm:col-span-6">
                             <label for="google_maps_url" class="block text-sm font-medium text-gray-700">Google Maps URL</label>
                             <div class="mt-1">
-                                <input type="url" name="google_maps_url" id="google_maps_url" 
-                                    value="{{ old('google_maps_url', $contactInfo->google_maps_url) }}" 
+                                <input type="url" name="google_maps_url" id="google_maps_url"
+                                    value="{{ old('google_maps_url', $contactInfo->google_maps_url) }}"
                                     class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md">
                             </div>
                             @error('google_maps_url')
+                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <!-- Latitude -->
+                        <div class="sm:col-span-3">
+                            <label for="latitude" class="block text-sm font-medium text-gray-700">Szerokość (lat)</label>
+                            <div class="mt-1">
+                                <input type="text" name="latitude" id="latitude"
+                                    value="{{ old('latitude', $contactInfo->latitude) }}"
+                                    class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md">
+                            </div>
+                            @error('latitude')
+                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <!-- Longitude -->
+                        <div class="sm:col-span-3">
+                            <label for="longitude" class="block text-sm font-medium text-gray-700">Długość (lng)</label>
+                            <div class="mt-1">
+                                <input type="text" name="longitude" id="longitude"
+                                    value="{{ old('longitude', $contactInfo->longitude) }}"
+                                    class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md">
+                            </div>
+                            @error('longitude')
                                 <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                             @enderror
                         </div>

--- a/resources/views/kontakt.blade.php
+++ b/resources/views/kontakt.blade.php
@@ -143,17 +143,33 @@
                         </div>
                     </div>
                     
-                    <!-- Mapa Google -->
-                    @if($contactInfo->google_maps_url)
-                        <div class="mt-8">
-                            <h3 class="text-lg font-semibold mb-2">Jak do nas trafić</h3>
-                            <div class="aspect-w-16 aspect-h-9">
-                                <iframe src="{{ $contactInfo->google_maps_url }}" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                            </div>
+                    <!-- Mapa -->
+                    <div class="mt-8">
+                        <h3 class="text-lg font-semibold mb-2">Jak do nas trafić</h3>
+                        <div class="aspect-w-16 aspect-h-9">
+                            <div id="map" class="w-full h-full rounded"></div>
                         </div>
-                    @endif
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 </x-app-layout>
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const lat = {{ $contactInfo->latitude ?? 'null' }};
+            const lng = {{ $contactInfo->longitude ?? 'null' }};
+            if (lat && lng && L) {
+                const map = L.map('map').setView([lat, lng], 14);
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; OpenStreetMap contributors'
+                }).addTo(map);
+                L.marker([lat, lng]).addTo(map)
+                    .bindPopup(@json($contactInfo->address_line1))
+                    .openPopup();
+            }
+        });
+    </script>
+@endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,6 +7,17 @@
   <title>{{ config('app.name', 'Salon Black&White') }}</title>
 
   @vite(['resources/css/app.css', 'resources/js/app.js'])
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""
+  ></script>
   <style>
     [x-cloak] { display: none !important; }
   </style>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config('app.name', 'Salon Black&White') }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <link
+        rel="stylesheet"
+        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+        crossorigin=""
+    />
+    <script
+        src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""
+    ></script>
     @stack('styles')
     @stack('head')
 </head>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -147,12 +147,26 @@
                 <a href="{{ route('kontakt') }}" class="text-indigo-600 hover:underline">Więcej informacji</a>
             </div>
             <div>
-                @if($contactInfo->google_maps_url)
-                    <iframe src="{{ $contactInfo->google_maps_url }}" width="100%" height="256" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade" class="w-full h-64 object-cover rounded"></iframe>
-                @else
-                    <img src="https://source.unsplash.com/random/600x400?map" alt="Mapa" class="w-full h-64 object-cover rounded" loading="lazy">
-                @endif
+                <div id="map" class="w-full h-64 rounded"></div>
             </div>
         </div>
     </section>
+
+    @push('scripts')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const lat = {{ $contactInfo->latitude ?? 'null' }};
+                const lng = {{ $contactInfo->longitude ?? 'null' }};
+                if (lat && lng && L) {
+                    const map = L.map('map').setView([lat, lng], 14);
+                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                        attribution: '&copy; OpenStreetMap contributors'
+                    }).addTo(map);
+                    L.marker([lat, lng]).addTo(map)
+                        .bindPopup(@json($contactInfo->address_line1))
+                        .openPopup();
+                }
+            });
+        </script>
+    @endpush
 </x-guest-layout>


### PR DESCRIPTION
## Summary
- include Leaflet assets on frontend layouts
- store `latitude` and `longitude` for contact info
- allow editing and validation of coordinates
- replace Google Maps iframes with Leaflet maps
- seed default coordinates

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b26268bd88329b7d31b4e584efacf