### PR TITLE
Fix ContactInfo coordinates when missing

### DIFF
--- a/app/Models/ContactInfo.php
+++ b/app/Models/ContactInfo.php
@@ -78,6 +78,14 @@ class ContactInfo extends Model
                 ],
             ]);
         }
+
+        // Ensure existing record has coordinates
+        elseif (is_null($contactInfo->latitude) || is_null($contactInfo->longitude)) {
+            $contactInfo->update([
+                'latitude' => 50.346238,
+                'longitude' => 18.910938,
+            ]);
+        }
         
         return $contactInfo;
     }


### PR DESCRIPTION
## Summary
- ensure `ContactInfo::getDefault()` fills latitude and longitude if they are null

## Testing
- `php artisan migrate:fresh --seed`
- `php artisan test` *(fails: no such table: services)*

------
https://chatgpt.com/codex/tasks/task_e_685b297e1890832990b1ff110743e56b