### PR TITLE
Fix syntax error in ContactInfo model

### DIFF
--- a/app/Models/ContactInfo.php
+++ b/app/Models/ContactInfo.php
@@ -78,7 +78,7 @@ class ContactInfo extends Model
                     'sunday' => null,
                 ],
             ]);
-        }
+        } else {
             $contactInfo->update([
                 'latitude' => 50.346238,
                 'longitude' => 18.910938,


### PR DESCRIPTION
## Summary
- fix mismatched closing bracket in ContactInfo
- ensure PHP parses the file correctly

## Testing
- `php -l app/Models/ContactInfo.php`


------
https://chatgpt.com/codex/tasks/task_e_685ba85064808329839182f9e8a67600