### PR TITLE
Add ContactInfo default location test

### DIFF
--- a/tests/Feature/ContactInfoTest.php
+++ b/tests/Feature/ContactInfoTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ContactInfo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ContactInfoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_default_sets_missing_coordinates(): void
+    {
+        ContactInfo::create([
+            'salon_name' => 'Test Salon',
+            'address_line1' => 'Address 1',
+            'city' => 'City',
+            'postal_code' => '00-000',
+            'phone' => '123456789',
+            'email' => 'test@example.com',
+            'latitude' => null,
+            'longitude' => null,
+        ]);
+
+        $contactInfo = ContactInfo::getDefault();
+
+        $this->assertNotNull($contactInfo->latitude);
+        $this->assertNotNull($contactInfo->longitude);
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,16 +2,21 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * A basic test example.
      */
     public function test_the_application_returns_a_successful_response(): void
     {
+        Http::fake();
+
         $response = $this->get('/');
 
         $response->assertStatus(200);


### PR DESCRIPTION
## Summary
- ensure ContactInfo::getDefault sets coordinates
- prevent network failures in ExampleTest

## Testing
- `php artisan test --filter=ContactInfoTest`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_685ba9fb9a688329ab0a37211867e625