### PR TITLE
Add tailwind aspect ratio plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "swiper": "^11.0.0"
             },
             "devDependencies": {
+                "@tailwindcss/aspect-ratio": "^0.4.2",
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.1.7",
                 "alpinejs": "^3.14.9",
@@ -941,6 +942,16 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@tailwindcss/aspect-ratio": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
+            "integrity": "sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+            }
         },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.10",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
+        "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/vite": "^4.1.7",
         "alpinejs": "^3.14.9",
         "autoprefixer": "^10.4.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 import defaultTheme from 'tailwindcss/defaultTheme';
 import forms from '@tailwindcss/forms';
+import aspectRatio from '@tailwindcss/aspect-ratio';
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -17,5 +18,5 @@ export default {
         },
     },
 
-    plugins: [forms],
+    plugins: [forms, aspectRatio],
 };


### PR DESCRIPTION
## Summary
- add @tailwindcss/aspect-ratio dev dependency
- enable aspect ratio plugin in Tailwind config
- rebuild assets to include aspect ratio utilities

## Testing
- `npm run build`
- `php artisan test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685bc13e26348329b3164c8b86133eec