### PR TITLE
Load calendar.js only when needed

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,8 +30,6 @@ Alpine.data('realizeModal', realizeModal);
 window.Alpine = Alpine;
 Alpine.start();
 
-// Calendar po Alpine!
-import './calendar';
 
 import Swiper from 'swiper/bundle';
 import 'swiper/css/bundle';

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -288,6 +288,6 @@
   </div>
 
   @push('scripts')
-    @vite(['resources/css/app.css','resources/js/app.js'])
+    @vite('resources/js/calendar.js')
   @endpush
 </x-app-layout>


### PR DESCRIPTION
## Summary
- remove global `calendar.js` import
- load `calendar.js` only on the admin calendar page
- rebuild assets

## Testing
- `npm install`
- `npm run build`
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd725e08c8329ada06caf5a456689