### PR TITLE
Add map initialization logs

### DIFF
--- a/resources/views/kontakt.blade.php
+++ b/resources/views/kontakt.blade.php
@@ -154,9 +154,11 @@
 @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+            console.log('DOMContentLoaded fired');
             const lat = {{ $contactInfo->latitude ?? 'null' }};
             const lng = {{ $contactInfo->longitude ?? 'null' }};
-            if (lat && lng && L) {
+            console.log('lat:', lat, 'lng:', lng, 'window.L:', window.L);
+            if (lat && lng && window.L) {
                 const map = L.map('map').setView([lat, lng], 14);
                 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                     attribution: '&copy; OpenStreetMap contributors'
@@ -164,6 +166,8 @@
                 L.marker([lat, lng]).addTo(map)
                     .bindPopup(@json($contactInfo->address_line1))
                     .openPopup();
+            } else {
+                console.error('Missing latitude, longitude or Leaflet library', { lat, lng, L: window.L });
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- log DOMContentLoaded and map initialization details on `/kontakt`
- show error when Leaflet library or coordinates are missing
- include a failing attempt to run PHP tests

## Testing
- `npm install`
- `npm run build`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be9ebad848329b846300fd7672fde