### PR TITLE
Restore hero-swiper markup on homepage

### DIFF
--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -26,13 +26,23 @@
         </script>
     @endpush
 
-    <section class="relative bg-cover bg-center" style="background-image:url('{{ asset('img/slider/slider1.jpg') }}');">
-        <div class="bg-black/50">
-            <div class="max-w-7xl mx-auto px-4 py-32 text-center text-white">
-                <h1 class="text-4xl md:text-5xl font-bold mb-4">Zadbaj o swoje włosy</h1>
-                <p class="mb-6">Profesjonalne usługi fryzjerskie i kosmetyczne w przyjaznej atmosferze.</p>
-                <a href="{{ route('reservation.entry') }}" class="inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded shadow transition">Umów wizytę</a>
+    <!-- Hero Slider -->
+    <section class="mb-10">
+        <div class="hero-swiper relative overflow-hidden rounded-lg shadow-lg">
+            <div class="swiper-wrapper">
+                @foreach(['slider1.jpg', 'slider2.jpg', 'slider3.jpg'] as $slide)
+                <div class="swiper-slide">
+                    <img src="{{ asset('img/slider/'.$slide) }}" alt="Salon Black&White" class="w-full h-96 object-cover">
+                    <div class="absolute top-0 left-0 w-full h-full flex items-center justify-center bg-black bg-opacity-30">
+                        <div class="text-center text-white px-4">
+                            <h2 class="text-3xl font-bold mb-2">Witamy w Akademii Zdrowych Włosów <span class="text-black bg-white px-2">Black</span> & <span class="bg-black text-white px-2">White</span></h2>
+                            <p class="max-w-xl mx-auto">Naszym celem jest dostarczanie najwyższej jakości usług i zadowolenia klienta. Rozumiemy indywidualne potrzeby każdego.</p>
+                        </div>
+                    </div>
+                </div>
+                @endforeach
             </div>
+            <div class="swiper-pagination"></div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- restore Swiper markup for the hero section of the home page

## Testing
- `npm install`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_685c0a2a57d083298c53fcd10a9073da