### PR TITLE
Fix Instagram video display

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -10,7 +10,7 @@ class GalleryController extends Controller
     private function fetchMedia(?string $after = null, int $limit = 9)
     {
         $params = [
-            'fields' => 'id,caption,media_url,permalink,thumbnail_url',
+            'fields' => 'id,caption,media_url,permalink,thumbnail_url,media_type',
             'access_token' => config('services.instagram.token'),
             'limit' => $limit,
         ];

--- a/resources/views/pages/gallery.blade.php
+++ b/resources/views/pages/gallery.blade.php
@@ -4,7 +4,14 @@
         <div id="gallery" class="grid grid-cols-2 md:grid-cols-3 gap-4">
             @foreach($media as $item)
                 <a href="{{ $item['permalink'] }}" target="_blank">
-                    <img src="{{ $item['media_url'] }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded" loading="lazy">
+                    @if(($item['media_type'] ?? '') === 'VIDEO')
+                        <video controls poster="{{ $item['thumbnail_url'] ?? '' }}" class="w-full h-60 object-cover rounded" preload="none">
+                            <source src="{{ $item['media_url'] }}" type="video/mp4">
+                            <img src="{{ $item['thumbnail_url'] ?? '' }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded">
+                        </video>
+                    @else
+                        <img src="{{ $item['media_url'] }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded" loading="lazy">
+                    @endif
                 </a>
             @endforeach
         </div>
@@ -29,12 +36,29 @@
                                         const a = document.createElement('a');
                                         a.href = item.permalink;
                                         a.target = '_blank';
-                                        const img = document.createElement('img');
-                                        img.src = item.media_url;
-                                        img.alt = item.caption || '';
-                                        img.className = 'w-full h-60 object-cover rounded';
-                                        img.loading = 'lazy';
-                                        a.appendChild(img);
+                                        if (item.media_type === 'VIDEO') {
+                                            const video = document.createElement('video');
+                                            video.controls = true;
+                                            video.poster = item.thumbnail_url || '';
+                                            video.className = 'w-full h-60 object-cover rounded';
+                                            const source = document.createElement('source');
+                                            source.src = item.media_url;
+                                            source.type = 'video/mp4';
+                                            video.appendChild(source);
+                                            const imgFallback = document.createElement('img');
+                                            imgFallback.src = item.thumbnail_url || '';
+                                            imgFallback.alt = item.caption || '';
+                                            imgFallback.className = 'w-full h-60 object-cover rounded';
+                                            video.appendChild(imgFallback);
+                                            a.appendChild(video);
+                                        } else {
+                                            const img = document.createElement('img');
+                                            img.src = item.media_url;
+                                            img.alt = item.caption || '';
+                                            img.className = 'w-full h-60 object-cover rounded';
+                                            img.loading = 'lazy';
+                                            a.appendChild(img);
+                                        }
                                         gallery.appendChild(a);
                                     });
                                 });

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -80,7 +80,14 @@
             <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
                 @forelse($instagramPhotos ?? [] as $photo)
                     <a href="{{ $photo['permalink'] }}" target="_blank">
-                        <img src="{{ $photo['media_url'] }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded" loading="lazy">
+                        @if(($photo['media_type'] ?? '') === 'VIDEO')
+                            <video controls poster="{{ $photo['thumbnail_url'] ?? '' }}" class="w-full h-48 object-cover rounded" preload="none">
+                                <source src="{{ $photo['media_url'] }}" type="video/mp4">
+                                <img src="{{ $photo['thumbnail_url'] ?? '' }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded">
+                            </video>
+                        @else
+                            <img src="{{ $photo['media_url'] }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded" loading="lazy">
+                        @endif
                     </a>
                 @empty
                     <p class="col-span-3 text-center text-gray-500">Zdjęcia wkrótce.</p>


### PR DESCRIPTION
## Summary
- include media_type when fetching Instagram media
- display videos correctly in gallery and homepage preview
- render videos in JS when scrolling gallery

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1942c8788329a05d85a71d7c95db