### PR TITLE
Remove video controls in gallery

### DIFF
--- a/resources/views/pages/gallery.blade.php
+++ b/resources/views/pages/gallery.blade.php
@@ -5,7 +5,7 @@
             @foreach($media as $item)
                 <a href="{{ $item['permalink'] }}" target="_blank">
                     @if(($item['media_type'] ?? '') === 'VIDEO')
-                        <video controls autoplay poster="{{ $item['thumbnail_url'] ?? '' }}" class="w-full h-60 object-cover rounded" preload="none">
+                        <video autoplay poster="{{ $item['thumbnail_url'] ?? '' }}" class="w-full h-60 object-cover rounded" preload="none">
                             <source src="{{ $item['media_url'] }}" type="video/mp4">
                             <img src="{{ $item['thumbnail_url'] ?? '' }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded">
                         </video>
@@ -38,7 +38,7 @@
                                         a.target = '_blank';
                                         if (item.media_type === 'VIDEO') {
                                             const video = document.createElement('video');
-                                            video.controls = true;
+                                            video.controls = false;
                                             video.autoplay = true;
                                             video.poster = item.thumbnail_url || '';
                                             video.className = 'w-full h-60 object-cover rounded';

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -81,7 +81,7 @@
                 @forelse($instagramPhotos ?? [] as $photo)
                     <a href="{{ $photo['permalink'] }}" target="_blank">
                         @if(($photo['media_type'] ?? '') === 'VIDEO')
-                            <video controls autoplay poster="{{ $photo['thumbnail_url'] ?? '' }}" class="w-full h-48 object-cover rounded" preload="none">
+                            <video autoplay poster="{{ $photo['thumbnail_url'] ?? '' }}" class="w-full h-48 object-cover rounded" preload="none">
                                 <source src="{{ $photo['media_url'] }}" type="video/mp4">
                                 <img src="{{ $photo['thumbnail_url'] ?? '' }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded">
                             </video>


### PR DESCRIPTION
## Summary
- hide video player controls on the home page and gallery page
- keep autoplay when dynamically adding videos

## Testing
- `npm test` *(fails: Missing script)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1d832a748329ba96b6b75cadbb45