### PR TITLE
Add carousel support to Instagram gallery

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -10,7 +10,7 @@ class GalleryController extends Controller
     private function fetchMedia(?string $after = null, int $limit = 9)
     {
         $params = [
-            'fields' => 'id,caption,media_url,permalink,thumbnail_url,media_type',
+            'fields' => 'id,caption,media_url,permalink,thumbnail_url,media_type,children',
             'access_token' => config('services.instagram.token'),
             'limit' => $limit,
         ];
@@ -24,7 +24,23 @@ class GalleryController extends Controller
             return ['data' => [], 'paging' => []];
         }
 
-        return $response->json();
+        $data = $response->json();
+
+        foreach (($data['data'] ?? []) as &$item) {
+            if (($item['media_type'] ?? '') === 'CAROUSEL_ALBUM' && isset($item['id'])) {
+                $childRes = Http::get("https://graph.instagram.com/{$item['id']}/children", [
+                    'fields' => 'id,media_type,media_url,thumbnail_url',
+                    'access_token' => config('services.instagram.token'),
+                ]);
+                if ($childRes->ok()) {
+                    $item['children'] = $childRes->json('data') ?? [];
+                } else {
+                    $item['children'] = [];
+                }
+            }
+        }
+
+        return $data;
     }
 
     public function index(Request $request)
@@ -44,6 +60,8 @@ class GalleryController extends Controller
 
     public function latest(int $limit = 6)
     {
-        return $this->fetchMedia(null, $limit)['data'] ?? [];
+        $result = $this->fetchMedia(null, $limit);
+
+        return $result['data'] ?? [];
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -38,6 +38,9 @@ window.initMap = initMap;
 import Swiper from 'swiper/bundle';
 import 'swiper/css/bundle';
 
+// Make Swiper accessible in inline scripts
+window.Swiper = Swiper;
+
 document.addEventListener('DOMContentLoaded', () => {
     new Swiper('.hero-swiper', {
         loop: true,

--- a/resources/views/pages/gallery.blade.php
+++ b/resources/views/pages/gallery.blade.php
@@ -4,7 +4,24 @@
         <div id="gallery" class="grid grid-cols-2 md:grid-cols-3 gap-4">
             @foreach($media as $item)
                 <a href="{{ $item['permalink'] }}" target="_blank">
-                    @if(($item['media_type'] ?? '') === 'VIDEO')
+                    @if(!empty($item['children']))
+                        <div class="carousel-swiper swiper h-60">
+                            <div class="swiper-wrapper">
+                                @foreach($item['children'] as $child)
+                                    <div class="swiper-slide">
+                                        @if(($child['media_type'] ?? '') === 'VIDEO')
+                                            <video autoplay muted loop playsinline class="w-full h-60 object-cover rounded" preload="none">
+                                                <source src="{{ $child['media_url'] }}" type="video/mp4">
+                                                <img src="{{ $child['thumbnail_url'] ?? '' }}" alt="" class="w-full h-60 object-cover rounded">
+                                            </video>
+                                        @else
+                                            <img src="{{ $child['media_url'] }}" alt="" class="w-full h-60 object-cover rounded" loading="lazy">
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    @elseif(($item['media_type'] ?? '') === 'VIDEO')
                         <video autoplay muted loop playsinline class="w-full h-60 object-cover rounded" preload="none">
                             <source src="{{ $item['media_url'] }}" type="video/mp4">
                             <img src="{{ $item['thumbnail_url'] ?? '' }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded">
@@ -21,6 +38,15 @@
     @push('scripts')
         <script>
             document.addEventListener('DOMContentLoaded', function () {
+                function initCarousel(el) {
+                    new Swiper(el, {
+                        loop: true,
+                        autoplay: { delay: 3000 },
+                    });
+                }
+
+                document.querySelectorAll('.carousel-swiper').forEach(initCarousel);
+
                 let next = @json($next);
                 const gallery = document.getElementById('gallery');
                 const sentinel = document.getElementById('sentinel');
@@ -36,7 +62,48 @@
                                         const a = document.createElement('a');
                                         a.href = item.permalink;
                                         a.target = '_blank';
-                                        if (item.media_type === 'VIDEO') {
+                                        if (Array.isArray(item.children) && item.children.length) {
+                                            const swiper = document.createElement('div');
+                                            swiper.className = 'carousel-swiper swiper h-60';
+                                            const wrapper = document.createElement('div');
+                                            wrapper.className = 'swiper-wrapper';
+                                            item.children.forEach(child => {
+                                                const slide = document.createElement('div');
+                                                slide.className = 'swiper-slide';
+                                                if (child.media_type === 'VIDEO') {
+                                                    const video = document.createElement('video');
+                                                    video.controls = false;
+                                                    video.autoplay = true;
+                                                    video.muted = true;
+                                                    video.loop = true;
+                                                    video.playsInline = true;
+                                                    video.poster = child.thumbnail_url || '';
+                                                    video.className = 'w-full h-60 object-cover rounded';
+                                                    const source = document.createElement('source');
+                                                    source.src = child.media_url;
+                                                    source.type = 'video/mp4';
+                                                    video.appendChild(source);
+                                                    const imgFallback = document.createElement('img');
+                                                    imgFallback.src = child.thumbnail_url || '';
+                                                    imgFallback.alt = '';
+                                                    imgFallback.className = 'w-full h-60 object-cover rounded';
+                                                    video.appendChild(imgFallback);
+                                                    slide.appendChild(video);
+                                                } else {
+                                                    const img = document.createElement('img');
+                                                    img.src = child.media_url;
+                                                    img.alt = '';
+                                                    img.className = 'w-full h-60 object-cover rounded';
+                                                    img.loading = 'lazy';
+                                                    slide.appendChild(img);
+                                                }
+                                                wrapper.appendChild(slide);
+                                            });
+                                            swiper.appendChild(wrapper);
+                                            a.appendChild(swiper);
+                                            gallery.appendChild(a);
+                                            initCarousel(swiper);
+                                        } else if (item.media_type === 'VIDEO') {
                                             const video = document.createElement('video');
                                             video.controls = false;
                                             video.autoplay = true;
@@ -55,6 +122,7 @@
                                             imgFallback.className = 'w-full h-60 object-cover rounded';
                                             video.appendChild(imgFallback);
                                             a.appendChild(video);
+                                            gallery.appendChild(a);
                                         } else {
                                             const img = document.createElement('img');
                                             img.src = item.media_url;
@@ -62,8 +130,8 @@
                                             img.className = 'w-full h-60 object-cover rounded';
                                             img.loading = 'lazy';
                                             a.appendChild(img);
+                                            gallery.appendChild(a);
                                         }
-                                        gallery.appendChild(a);
                                     });
                                 });
                         }

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -80,7 +80,24 @@
             <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
                 @forelse($instagramPhotos ?? [] as $photo)
                     <a href="{{ $photo['permalink'] }}" target="_blank">
-                        @if(($photo['media_type'] ?? '') === 'VIDEO')
+                        @if(!empty($photo['children']))
+                            <div class="carousel-swiper swiper h-48">
+                                <div class="swiper-wrapper">
+                                    @foreach($photo['children'] as $child)
+                                        <div class="swiper-slide">
+                                            @if(($child['media_type'] ?? '') === 'VIDEO')
+                                                <video autoplay muted loop playsinline class="w-full h-48 object-cover rounded" preload="none">
+                                                    <source src="{{ $child['media_url'] }}" type="video/mp4">
+                                                    <img src="{{ $child['thumbnail_url'] ?? '' }}" alt="" class="w-full h-48 object-cover rounded">
+                                                </video>
+                                            @else
+                                                <img src="{{ $child['media_url'] }}" alt="" class="w-full h-48 object-cover rounded" loading="lazy">
+                                            @endif
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @elseif(($photo['media_type'] ?? '') === 'VIDEO')
                             <video autoplay muted loop playsinline class="w-full h-48 object-cover rounded" preload="none">
                                 <source src="{{ $photo['media_url'] }}" type="video/mp4">
                                 <img src="{{ $photo['thumbnail_url'] ?? '' }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded">
@@ -176,6 +193,13 @@
                 if (lat && lng) {
                     window.initMap(lat, lng, @json($contactInfo->address_line1));
                 }
+
+                document.querySelectorAll('.carousel-swiper').forEach(el => {
+                    new Swiper(el, {
+                        loop: true,
+                        autoplay: { delay: 3000 },
+                    });
+                });
             });
         </script>
     @endpush


### PR DESCRIPTION
## Summary
- fetch Instagram carousel child media when `media_type` is `CAROUSEL_ALBUM`
- expose Swiper globally and initialize sliders for carousels
- display carousel posts using Swiper on home and gallery pages
- build assets with Vite

## Testing
- `npm install`
- `npm run build`
- ❌ `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2937a9d08329b0403d9bd8a50b87