### PR TITLE
Fix autoplay for Instagram videos

### DIFF
--- a/resources/views/pages/gallery.blade.php
+++ b/resources/views/pages/gallery.blade.php
@@ -5,6 +5,7 @@
             @foreach($media as $item)
                 <a href="{{ $item['permalink'] }}" target="_blank">
                     @if(($item['media_type'] ?? '') === 'VIDEO')
+                        <video autoplay muted loop playsinline class="w-full h-60 object-cover rounded" preload="none">
                             <source src="{{ $item['media_url'] }}" type="video/mp4">
                             <img src="{{ $item['thumbnail_url'] ?? '' }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded">
                         </video>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -81,7 +81,7 @@
                 @forelse($instagramPhotos ?? [] as $photo)
                     <a href="{{ $photo['permalink'] }}" target="_blank">
                         @if(($photo['media_type'] ?? '') === 'VIDEO')
-
+                            <video autoplay muted loop playsinline class="w-full h-48 object-cover rounded" preload="none">
                                 <source src="{{ $photo['media_url'] }}" type="video/mp4">
                                 <img src="{{ $photo['thumbnail_url'] ?? '' }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded">
                             </video>


### PR DESCRIPTION
## Summary
- show `video` tag again for Instagram videos and enable autoplay

## Testing
- `composer install` *(fails: missing PHP DOM/Xml extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685c2623feb883298b0d0144706c4c23