### PR TITLE
Remove Instagram carousel

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -10,7 +10,7 @@ class GalleryController extends Controller
     private function fetchMedia(?string $after = null, int $limit = 9)
     {
         $params = [
-            'fields' => 'id,caption,media_url,permalink,thumbnail_url,media_type,children',
+            'fields' => 'id,caption,media_url,permalink,thumbnail_url,media_type',
             'access_token' => config('services.instagram.token'),
             'limit' => $limit,
         ];
@@ -26,19 +26,6 @@ class GalleryController extends Controller
 
         $data = $response->json();
 
-        foreach (($data['data'] ?? []) as &$item) {
-            if (($item['media_type'] ?? '') === 'CAROUSEL_ALBUM' && isset($item['id'])) {
-                $childRes = Http::get("https://graph.instagram.com/{$item['id']}/children", [
-                    'fields' => 'id,media_type,media_url,thumbnail_url',
-                    'access_token' => config('services.instagram.token'),
-                ]);
-                if ($childRes->ok()) {
-                    $item['children'] = $childRes->json('data') ?? [];
-                } else {
-                    $item['children'] = [];
-                }
-            }
-        }
 
         return $data;
     }

--- a/resources/views/pages/gallery.blade.php
+++ b/resources/views/pages/gallery.blade.php
@@ -4,24 +4,7 @@
         <div id="gallery" class="grid grid-cols-2 md:grid-cols-3 gap-4">
             @foreach($media as $item)
                 <a href="{{ $item['permalink'] }}" target="_blank">
-                    @if(!empty($item['children']))
-                        <div class="carousel-swiper swiper h-60">
-                            <div class="swiper-wrapper">
-                                @foreach($item['children'] as $child)
-                                    <div class="swiper-slide">
-                                        @if(($child['media_type'] ?? '') === 'VIDEO')
-                                            <video autoplay muted loop playsinline class="w-full h-60 object-cover rounded" preload="none">
-                                                <source src="{{ $child['media_url'] ?? '' }}" type="video/mp4">
-                                                <img src="{{ $child['thumbnail_url'] ?? '' }}" alt="" class="w-full h-60 object-cover rounded">
-                                            </video>
-                                        @else
-                                            <img src="{{ $child['media_url'] ?? '' }}" alt="" class="w-full h-60 object-cover rounded" loading="lazy">
-                                        @endif
-                                    </div>
-                                @endforeach
-                            </div>
-                        </div>
-                    @elseif(($item['media_type'] ?? '') === 'VIDEO')
+                    @if(($item['media_type'] ?? '') === 'VIDEO')
                         <video autoplay muted loop playsinline class="w-full h-60 object-cover rounded" preload="none">
                             <source src="{{ $item['media_url'] ?? '' }}" type="video/mp4">
                             <img src="{{ $item['thumbnail_url'] ?? '' }}" alt="{{ $item['caption'] ?? '' }}" class="w-full h-60 object-cover rounded">
@@ -38,14 +21,6 @@
     @push('scripts')
         <script>
             document.addEventListener('DOMContentLoaded', function () {
-                function initCarousel(el) {
-                    new Swiper(el, {
-                        loop: true,
-                        autoplay: { delay: 3000 },
-                    });
-                }
-
-                document.querySelectorAll('.carousel-swiper').forEach(initCarousel);
 
                 let next = @json($next);
                 const gallery = document.getElementById('gallery');
@@ -62,48 +37,7 @@
                                         const a = document.createElement('a');
                                         a.href = item.permalink;
                                         a.target = '_blank';
-                                        if (Array.isArray(item.children) && item.children.length) {
-                                            const swiper = document.createElement('div');
-                                            swiper.className = 'carousel-swiper swiper h-60';
-                                            const wrapper = document.createElement('div');
-                                            wrapper.className = 'swiper-wrapper';
-                                            item.children.forEach(child => {
-                                                const slide = document.createElement('div');
-                                                slide.className = 'swiper-slide';
-                                                if (child.media_type === 'VIDEO') {
-                                                    const video = document.createElement('video');
-                                                    video.controls = false;
-                                                    video.autoplay = true;
-                                                    video.muted = true;
-                                                    video.loop = true;
-                                                    video.playsInline = true;
-                                                    video.poster = child.thumbnail_url || '';
-                                                    video.className = 'w-full h-60 object-cover rounded';
-                                                    const source = document.createElement('source');
-                                                    source.src = child.media_url;
-                                                    source.type = 'video/mp4';
-                                                    video.appendChild(source);
-                                                    const imgFallback = document.createElement('img');
-                                                    imgFallback.src = child.thumbnail_url || '';
-                                                    imgFallback.alt = '';
-                                                    imgFallback.className = 'w-full h-60 object-cover rounded';
-                                                    video.appendChild(imgFallback);
-                                                    slide.appendChild(video);
-                                                } else {
-                                                    const img = document.createElement('img');
-                                                    img.src = child.media_url;
-                                                    img.alt = '';
-                                                    img.className = 'w-full h-60 object-cover rounded';
-                                                    img.loading = 'lazy';
-                                                    slide.appendChild(img);
-                                                }
-                                                wrapper.appendChild(slide);
-                                            });
-                                            swiper.appendChild(wrapper);
-                                            a.appendChild(swiper);
-                                            gallery.appendChild(a);
-                                            initCarousel(swiper);
-                                        } else if (item.media_type === 'VIDEO') {
+                                        if (item.media_type === 'VIDEO') {
                                             const video = document.createElement('video');
                                             video.controls = false;
                                             video.autoplay = true;

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -80,24 +80,7 @@
             <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
                 @forelse($instagramPhotos ?? [] as $photo)
                     <a href="{{ $photo['permalink'] }}" target="_blank">
-                        @if(!empty($photo['children']))
-                            <div class="carousel-swiper swiper h-48">
-                                <div class="swiper-wrapper">
-                                    @foreach($photo['children'] as $child)
-                                        <div class="swiper-slide">
-                                            @if(($child['media_type'] ?? '') === 'VIDEO')
-                                                <video autoplay muted loop playsinline class="w-full h-48 object-cover rounded" preload="none">
-                                                    <source src="{{ $child['media_url'] ?? '' }}" type="video/mp4">
-                                                    <img src="{{ $child['thumbnail_url'] ?? '' }}" alt="" class="w-full h-48 object-cover rounded">
-                                                </video>
-                                            @else
-                                                <img src="{{ $child['media_url'] ?? '' }}" alt="" class="w-full h-48 object-cover rounded" loading="lazy">
-                                            @endif
-                                        </div>
-                                    @endforeach
-                                </div>
-                            </div>
-                        @elseif(($photo['media_type'] ?? '') === 'VIDEO')
+                        @if(($photo['media_type'] ?? '') === 'VIDEO')
                             <video autoplay muted loop playsinline class="w-full h-48 object-cover rounded" preload="none">
                                 <source src="{{ $photo['media_url'] ?? '' }}" type="video/mp4">
                                 <img src="{{ $photo['thumbnail_url'] ?? '' }}" alt="{{ $photo['caption'] ?? '' }}" class="w-full h-48 object-cover rounded">
@@ -194,12 +177,6 @@
                     window.initMap(lat, lng, @json($contactInfo->address_line1));
                 }
 
-                document.querySelectorAll('.carousel-swiper').forEach(el => {
-                    new Swiper(el, {
-                        loop: true,
-                        autoplay: { delay: 3000 },
-                    });
-                });
             });
         </script>
     @endpush


### PR DESCRIPTION
## Summary
- remove carousel display logic from Home and Gallery views
- drop children fetch from `GalleryController`

## Testing
- `composer install` *(fails: ext-dom missing, resolved by installing php-xml)*
- `composer test` *(fails: could not find driver sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_685c308b7a448329b986d9f4bc4391fe