### PR TITLE
Add two-step service/variant selection

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,7 @@ import { editModal }   from './editModal';
 import { editFullModal } from './editFullModal';
 import { realizeModal } from './realizeModal';
 import { initMap } from './map';
+import { appointmentForm } from './appointmentForm';
 
 // Uniwersalna funkcja zamykająca oba modale
 window.closeAllModals = function() {
@@ -27,6 +28,7 @@ Alpine.data('viewModal', viewModal);
 Alpine.data('editModal', editModal);
 Alpine.data('editFullModal', editFullModal);
 Alpine.data('realizeModal', realizeModal);
+Alpine.data('appointmentForm', appointmentForm);
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/resources/js/appointmentForm.js
+++ b/resources/js/appointmentForm.js
@@ -1,0 +1,28 @@
+export function appointmentForm(services, initialVariantId = null) {
+    return {
+        services,
+        service_id: '',
+        variants: [],
+        variant_id: '',
+        init() {
+            if (initialVariantId) {
+                for (const s of this.services) {
+                    const match = s.variants.find(v => v.id == initialVariantId);
+                    if (match) {
+                        this.service_id = s.id;
+                        this.variants = s.variants;
+                        this.variant_id = initialVariantId;
+                        break;
+                    }
+                }
+            }
+            this.$watch('service_id', (value) => {
+                const s = this.services.find(s => s.id == value);
+                this.variants = s ? s.variants : [];
+                if (!this.variants.some(v => v.id == this.variant_id)) {
+                    this.variant_id = '';
+                }
+            });
+        }
+    };
+}

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -3,7 +3,9 @@
 		<h2 class="text-xl font-semibold text-gray-800">Nowa rezerwacja</h2>
 	</x-slot>
 
-	<div class="max-w-2xl mx-auto mt-8">
+        <div class="max-w-2xl mx-auto mt-8"
+             x-data="appointmentForm(@js($services), @js(old('service_variant_id', $preselectedVariant)) )"
+             x-init="init()">
 		@if ($errors->any())
 			<div class="bg-red-100 text-red-700 px-4 py-2 rounded mb-4">
 				<ul class="list-disc list-inside">
@@ -17,29 +19,24 @@
 		<form method="POST" action="{{ route('appointments.store') }}" class="space-y-6">
 			@csrf
 
-			<div>
-				<label class="block font-medium mb-1">Wybierz usługę i wariant</label>
-                <select name="service_variant_id" id="service_variant_id" class="w-full p-2 border rounded" required>
-                    @foreach($services as $service)
-                        <optgroup label="{{ $service->name }}">
-                            @foreach($service->variants as $variant)
-                                <option value="{{ $variant->id }}"
-                                    @if(
-                                        (old('service_variant_id') && old('service_variant_id') == $variant->id) ||
-                                        (isset($preselectedVariant) && !$errors->any() && $preselectedVariant == $variant->id)
-                                    ) selected @endif>
-                                    {{ $variant->variant_name }}
-                                    @if($variant->price)
-                                        – {{ number_format($variant->price, 2) }} zł
-                                    @endif
-                                </option>
-                            @endforeach
-                        </optgroup>
-                    @endforeach
-                </select>
-
-
-			</div>
+                        <div>
+                                <label class="block font-medium mb-1">Usługa</label>
+                                <select x-model="service_id" class="w-full p-2 border rounded" required>
+                                        <option value="" disabled selected>Wybierz usługę</option>
+                                        <template x-for="s in services" :key="s.id">
+                                                <option :value="s.id" x-text="s.name"></option>
+                                        </template>
+                                </select>
+                        </div>
+                        <div>
+                                <label class="block font-medium mb-1">Wariant usługi</label>
+                                <select name="service_variant_id" x-model="variant_id" :disabled="!service_id" class="w-full p-2 border rounded" required>
+                                        <option value="" disabled selected>Wybierz wariant</option>
+                                        <template x-for="v in variants" :key="v.id">
+                                                <option :value="v.id" x-text="v.variant_name + (v.price_pln ? ' – ' + Number(v.price_pln).toFixed(2) + ' zł' : '')"></option>
+                                        </template>
+                                </select>
+                        </div>
 
                         <div>
                                 <label class="block font-medium mb-1">Data i godzina wizyty</label>


### PR DESCRIPTION
## Summary
- create appointmentForm Alpine component
- register `appointmentForm` in app.js
- update booking view to select service first then variant

## Testing
- `npm run build`
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c34c7e8bc8329ab33a262bb29f9ba