### PR TITLE
Add note field for users and admin-only discount

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -45,6 +45,7 @@ class AdminAppointmentController extends Controller
                     'service_variant_id' => $appointment->service_variant_id,
                     'price_pln' => $appointment->price_pln,
                     'discount_percent' => $appointment->discount_percent,
+                    'note_user' => $appointment->note_user,
                     'note_client' => $appointment->note_client,
                     'note_internal' => $appointment->note_internal,
                     'service_description' => $appointment->service_description,
@@ -112,6 +113,7 @@ class AdminAppointmentController extends Controller
             'appointment_at' => 'required|date',
             'price_pln' => 'required|integer|min:0',
             'discount_percent' => 'nullable|integer|min:0|max:100',
+            'note_user' => 'nullable|string',
             'service_description' => 'nullable|string',
             'products_used' => 'nullable|string',
         ]);
@@ -153,6 +155,7 @@ class AdminAppointmentController extends Controller
             'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
             'status' => 'zaplanowana',
+            'note_user' => $request->note_user,
             'service_description' => $request->service_description,
             'products_used' => $request->products_used,
         ]);
@@ -168,6 +171,7 @@ class AdminAppointmentController extends Controller
             'status' => 'required|in:zaplanowana,odbyta,odwołana,nieodbyta',
             'price_pln' => 'required|integer|min:0',
             'discount_percent' => 'nullable|integer|min:0|max:100',
+            'note_user' => 'nullable|string',
             'service_description' => 'nullable|string',
             'products_used' => 'nullable|string',
         ]);
@@ -197,6 +201,7 @@ class AdminAppointmentController extends Controller
             'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
             'status' => $request->status,
+            'note_user' => $request->note_user,
             'service_description' => $request->service_description,
             'products_used' => $request->products_used,
         ]);

--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -41,22 +41,21 @@ class AppointmentController extends Controller
         $validated = $request->validate([
             'service_variant_id' => 'required|exists:service_variants,id',
             'appointment_at'     => 'required|date|after:now',
-            'discount_percent'   => 'nullable|integer|min:0|max:100',
+            'note_user'          => 'nullable|string',
         ]);
 
         $variant = ServiceVariant::with('service')->findOrFail($validated['service_variant_id']);
 
-        $discount = $validated['discount_percent'] ?? 0;
-        $price    = round($variant->price_pln * (100 - $discount) / 100);
+        $price = $variant->price_pln;
 
         Appointment::create([
             'user_id'            => Auth::id(),
             'service_id'         => $variant->service->id,
             'service_variant_id' => $variant->id,
             'price_pln'          => $price,
-            'discount_percent'   => $discount,
             'appointment_at'     => $validated['appointment_at'],
             'status'             => 'zaplanowana',
+            'note_user'          => $validated['note_user'] ?? null,
         ]);
 
         return redirect()->route('dashboard')->with('success', 'Rezerwacja została zapisana.');

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -12,6 +12,7 @@ class Appointment extends Model
         'service_variant_id',
         'price_pln',
         'discount_percent',
+        'note_user',
         'appointment_at',
         'status',
         'note_client',

--- a/database/migrations/2025_06_05_000000_add_user_note_to_appointments_table.php
+++ b/database/migrations/2025_06_05_000000_add_user_note_to_appointments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->text('note_user')->nullable()->after('discount_percent');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn('note_user');
+        });
+    }
+};

--- a/resources/js/createModal.js
+++ b/resources/js/createModal.js
@@ -7,6 +7,7 @@ export function createModal() {
         variant_id: '',
         price: 0,
         discount_percent: 0,
+        note_user: '',
         users: [],
         services: [],
         variants: [],
@@ -83,6 +84,7 @@ export function createModal() {
                         service_variant_id: this.variant_id,
                         price_pln: this.price,
                         discount_percent: this.discount_percent,
+                        note_user: this.note_user,
                         appointment_at: this.date,
                   })
                 });

--- a/resources/js/editFullModal.js
+++ b/resources/js/editFullModal.js
@@ -6,9 +6,10 @@ export function editFullModal() {
     user_id: null,
     service_id: '',
     variant_id: '',
-    price: 0,
-    discount_percent: 0,
-    note_client: '',
+   price: 0,
+   discount_percent: 0,
+    note_user: '',
+   note_client: '',
     note_internal: '',
     status: '',
     service_description: '',
@@ -27,6 +28,7 @@ export function editFullModal() {
         this.variant_id = data.service_variant_id;
         this.price = data.price_pln;
         this.discount_percent = data.discount_percent;
+        this.note_user = data.note_user || '';
         this.note_client = data.note_client || '';
         this.note_internal = data.note_internal || '';
         this.status = data.status || 'zaplanowana';
@@ -99,6 +101,7 @@ export function editFullModal() {
             status: this.status,
             price_pln: this.price,
             discount_percent: this.discount_percent,
+            note_user: this.note_user,
             note_client: this.note_client,
             note_internal: this.note_internal,
             service_description: this.service_description,

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -59,6 +59,9 @@
             <p class="mb-2"><strong>Wariant:</strong>  <span x-text="appointment.variant"></span></p>
             <p class="mb-2"><strong>Termin:</strong>   <span x-text="appointment.datetime"></span></p>
             <p class="mb-2"><strong>Status:</strong>   <span x-text="appointment.status"></span></p>
+            <template x-if="appointment.note_user">
+              <p class="mb-2"><strong>Uwagi klienta:</strong> <span x-text="appointment.note_user"></span></p>
+            </template>
           </div>
         </template>
         <div class="mt-4 text-right">
@@ -139,6 +142,9 @@
         <label class="block mb-2 text-sm font-medium">Rabat (%):</label>
         <input type="number" x-model="discount_percent" min="0" max="100" class="w-full mb-4 border rounded px-2 py-1">
 
+        <label class="block mb-2 text-sm font-medium">Uwagi klienta:</label>
+        <textarea x-model="note_user" class="w-full mb-4 border rounded px-2 py-1"></textarea>
+
         <label class="block mb-2 text-sm font-medium">Cena (zł):</label>
         <input type="number" x-model="price" class="w-full mb-4 border rounded px-2 py-1" readonly>
 
@@ -197,6 +203,9 @@
       <label class="block mb-2 text-sm font-medium">Rabat (%):</label>
       <input type="number" x-model="discount_percent" min="0" max="100" class="w-full mb-4 border rounded px-2 py-1">
 
+      <label class="block mb-2 text-sm font-medium">Uwagi klienta:</label>
+      <textarea x-model="note_user" class="w-full mb-4 border rounded px-2 py-1"></textarea>
+
       <label class="block mb-2 text-sm font-medium">Cena (zł):</label>
       <input type="number" x-model="price" class="w-full mb-4 border rounded px-2 py-1" readonly>
 
@@ -243,6 +252,9 @@
         <p><strong>Klient:</strong> <span x-text="appointment.user"></span></p>
         <p><strong>Usługa:</strong> <span x-text="appointment.service"></span> - <span x-text="appointment.variant"></span></p>
         <p><strong>Termin:</strong> <span x-text="appointment.datetime"></span></p>
+        <template x-if="appointment.note_user">
+          <p><strong>Uwagi klienta:</strong> <span x-text="appointment.note_user"></span></p>
+        </template>
       </div>
 
       <div class="mb-4">

--- a/resources/views/admin/appointments/show.blade.php
+++ b/resources/views/admin/appointments/show.blade.php
@@ -9,6 +9,9 @@
             @endif
             <li><b>Data:</b> {{ $appointment->appointment_at }}</li>
             <li><b>Status:</b> {{ $appointment->status }}</li>
+            @if($appointment->note_user)
+                <li><b>Uwagi klienta:</b> {{ $appointment->note_user }}</li>
+            @endif
         </ul>
         @if($appointment->note_client)
             <div class="my-4 p-4 rounded bg-green-100 border-l-4 border-green-500">

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -43,9 +43,10 @@
                                 <input type="datetime-local" name="appointment_at" class="w-full border rounded px-4 py-2" required>
                         </div>
 
+
                         <div>
-                                <label class="block font-medium mb-1">Rabat (%)</label>
-                                <input type="number" name="discount_percent" min="0" max="100" value="0" class="w-full border rounded px-4 py-2">
+                                <label class="block font-medium mb-1">Uwagi / specjalne wymagania</label>
+                                <textarea name="note_user" class="w-full border rounded px-4 py-2" rows="3">{{ old('note_user') }}</textarea>
                         </div>
 
 			<div class="pt-4">


### PR DESCRIPTION
## Summary
- allow appointments to contain `note_user`
- hide discount percent on user side
- show and edit client note for admins
- add migration for `note_user` field

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3c57fadc8329a0961636d091934e