### PR TITLE
Add client calendar booking

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,7 @@ import { editFullModal } from './editFullModal';
 import { realizeModal } from './realizeModal';
 import { initMap } from './map';
 import { appointmentForm } from './appointmentForm';
+import { initUserCalendar } from './userCalendar';
 
 // Uniwersalna funkcja zamykająca oba modale
 window.closeAllModals = function() {
@@ -29,6 +30,7 @@ Alpine.data('editModal', editModal);
 Alpine.data('editFullModal', editFullModal);
 Alpine.data('realizeModal', realizeModal);
 Alpine.data('appointmentForm', appointmentForm);
+Alpine.data('userCalendar', initUserCalendar);
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/resources/js/appointmentForm.js
+++ b/resources/js/appointmentForm.js
@@ -1,9 +1,12 @@
+import { initUserCalendar } from './userCalendar';
+
 export function appointmentForm(services, initialVariantId = null) {
     return {
         services,
         service_id: '',
         variants: [],
         variant_id: '',
+        calendar: null,
         init() {
             if (initialVariantId) {
                 for (const s of this.services) {
@@ -22,6 +25,13 @@ export function appointmentForm(services, initialVariantId = null) {
                 if (!this.variants.some(v => v.id == this.variant_id)) {
                     this.variant_id = '';
                 }
+            });
+
+            this.calendar = initUserCalendar(60);
+            this.calendar.init();
+            this.$watch('variant_id', id => {
+                const d = this.variants.find(v => v.id == id)?.duration_minutes || 60;
+                this.calendar.setDuration(d);
             });
         }
     };

--- a/resources/js/userCalendar.js
+++ b/resources/js/userCalendar.js
@@ -1,0 +1,51 @@
+import { Calendar } from '@fullcalendar/core';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+
+export function initUserCalendar(duration) {
+    return {
+        duration,
+        events: [],
+        setDuration(value) {
+            this.duration = value;
+        },
+        init() {
+            const el = document.getElementById('user-calendar');
+            if (!el) return;
+            const url = el.dataset.busyUrl;
+            const input = document.querySelector('input[name="appointment_at"]');
+            fetch(url)
+                .then(r => r.ok ? r.json() : [])
+                .then(events => {
+                    this.events = events;
+                    const calendar = new Calendar(el, {
+                        plugins: [timeGridPlugin, interactionPlugin],
+                        initialView: 'timeGridWeek',
+                        locale: 'pl',
+                        selectable: true,
+                        events,
+                        businessHours: {
+                            startTime: '09:00',
+                            endTime: '18:00',
+                            daysOfWeek: [1,2,3,4,5,6],
+                        },
+                        selectOverlap: false,
+                        select: info => {
+                            const start = info.start;
+                            const end = new Date(start.getTime() + this.duration*60000);
+                            for (const e of this.events) {
+                                const estart = new Date(e.start);
+                                const eend = new Date(e.end);
+                                if (start < eend && end > estart) {
+                                    calendar.unselect();
+                                    return alert('Wybrany termin jest zajęty.');
+                                }
+                            }
+                            input.value = start.toISOString().slice(0,16);
+                        }
+                    });
+                    calendar.render();
+                });
+        }
+    }
+}

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -39,8 +39,9 @@
                         </div>
 
                         <div>
-                                <label class="block font-medium mb-1">Data i godzina wizyty</label>
-                                <input type="datetime-local" name="appointment_at" class="w-full border rounded px-4 py-2" required>
+                                <label class="block font-medium mb-1">Wybierz termin</label>
+                                <div id="user-calendar" data-busy-url="{{ route('appointments.busy') }}" class="mb-4 h-96 border rounded"></div>
+                                <input type="hidden" name="appointment_at" required>
                         </div>
 
 
@@ -49,11 +50,12 @@
                                 <textarea name="note_user" class="w-full border rounded px-4 py-2" rows="3">{{ old('note_user') }}</textarea>
                         </div>
 
-			<div class="pt-4">
-				<button type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
-					Zarezerwuj
-				</button>
-			</div>
-		</form>
-	</div>
+                        <div class="pt-4">
+                                <button type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
+                                        Zarezerwuj
+                                </button>
+                                <a href="{{ route('messages.create', ['category' => 'rezerwacja']) }}" class="ml-4 text-blue-600 hover:underline">Nie widzisz terminu? Napisz do nas</a>
+                        </div>
+                </form>
+        </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/moje-wizyty/{id}', [AppointmentController::class, 'show'])->name('appointments.show');
     Route::get('/rezerwacje/dodaj', [AppointmentController::class, 'create'])->name('appointments.create');
     Route::post('/rezerwacje', [AppointmentController::class, 'store'])->name('appointments.store');
+    Route::get('/rezerwacje/busy', [AppointmentController::class, 'busyTimes'])->name('appointments.busy');
     Route::get('/moje-wiadomosci', [KontaktController::class, 'myMessages'])->name('messages.index');
     Route::get('/moje-wiadomosci/nowa', [KontaktController::class, 'create'])->name('messages.create');
     Route::post('/moje-wiadomosci', [KontaktController::class, 'store'])->name('messages.store');

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,12 @@ import path from 'path';
 export default defineConfig({
   plugins: [
     laravel({
-      input: ['resources/css/app.css','resources/js/app.js','resources/js/calendar.js'],
+      input: [
+        'resources/css/app.css',
+        'resources/js/app.js',
+        'resources/js/calendar.js',
+        'resources/js/userCalendar.js',
+      ],
       refresh: true,
     }),
   ],


### PR DESCRIPTION
## Summary
- add appointment overlap check
- expose busy appointments API
- wire up front-end calendar for users
- include calendar assets in Vite
- provide contact link when no slots are free

## Testing
- `npm run build`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c416f6354832987461008c0f3ac7d