### PR TITLE
Improve reservation contact flow

### DIFF
--- a/app/Http/Controllers/KontaktController.php
+++ b/app/Http/Controllers/KontaktController.php
@@ -26,9 +26,20 @@ class KontaktController extends Controller
         return view('messages.show', compact('message'));
     }
 
-    public function create()
+    public function create(Request $request)
     {
-        return view('messages.create');
+        $variantId = $request->query('variant_id');
+        $selectedVariant = null;
+        $prefill = '';
+
+        if ($variantId) {
+            $selectedVariant = \App\Models\ServiceVariant::with('service')->find($variantId);
+            if ($selectedVariant) {
+                $prefill = "Interesuje mnie termin dla us\u0142ugi: {$selectedVariant->service->name} – {$selectedVariant->variant_name}. Preferowane daty: ";
+            }
+        }
+
+        return view('messages.create', compact('selectedVariant', 'prefill'));
     }
 
     public function store(Request $request)

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -54,7 +54,12 @@
                                 <button type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
                                         Zarezerwuj
                                 </button>
-                                <a href="{{ route('messages.create', ['category' => 'rezerwacja']) }}" class="ml-4 text-blue-600 hover:underline">Nie widzisz terminu? Napisz do nas</a>
+                                @php $msgUrl = route('messages.create'); @endphp
+                                <a
+                                    :href="variant_id ? '{{ $msgUrl }}?category=rezerwacja&variant_id=' + variant_id : '{{ $msgUrl }}?category=rezerwacja'"
+                                    class="ml-4 text-blue-600 hover:underline">
+                                    Nie widzisz terminu? Napisz do nas
+                                </a>
                         </div>
                 </form>
         </div>

--- a/resources/views/messages/create.blade.php
+++ b/resources/views/messages/create.blade.php
@@ -49,11 +49,20 @@
                     @error('category')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
                 </div>
 
+                @isset($selectedVariant)
+                    <div class="mb-4 p-4 bg-gray-100 rounded">
+                        <p class="text-sm text-gray-700">
+                            Wybrana usługa:
+                            <strong>{{ $selectedVariant->service->name }} – {{ $selectedVariant->variant_name }}</strong>
+                        </p>
+                    </div>
+                @endisset
+
                 {{-- Wiadomość --}}
                 <div class="mb-4">
                     <label for="message" class="block font-medium text-sm text-gray-700">Wiadomość</label>
                     <textarea id="message" name="message" rows="6" required
-                        class="mt-1 block w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">{{ old('message') }}</textarea>
+                        class="mt-1 block w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">{{ old('message', $prefill) }}</textarea>
                     @error('message')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
                 </div>
 


### PR DESCRIPTION
## Summary
- add service variant info to contact link on reservation form
- prefill contact message with selected service variant
- show service/variant info in the message form

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c6862f3d8832980192363e529d192