### PR TITLE
Delay calendar until variant selected

### DIFF
--- a/resources/js/appointmentForm.js
+++ b/resources/js/appointmentForm.js
@@ -7,6 +7,7 @@ export function appointmentForm(services, initialVariantId = null) {
         variants: [],
         variant_id: '',
         calendar: null,
+        calendarReady: false,
         init() {
             if (initialVariantId) {
                 for (const s of this.services) {
@@ -28,11 +29,23 @@ export function appointmentForm(services, initialVariantId = null) {
             });
 
             this.calendar = initUserCalendar(60);
-            this.calendar.init();
             this.$watch('variant_id', id => {
                 const d = this.variants.find(v => v.id == id)?.duration_minutes || 60;
-                this.calendar.setDuration(d);
+                if (id && !this.calendarReady) {
+                    this.calendar.init();
+                    this.calendarReady = true;
+                }
+                if (this.calendarReady) {
+                    this.calendar.setDuration(d);
+                }
             });
+
+            if (this.variant_id) {
+                const d = this.variants.find(v => v.id == this.variant_id)?.duration_minutes || 60;
+                this.calendar.init();
+                this.calendar.setDuration(d);
+                this.calendarReady = true;
+            }
         }
     };
 }

--- a/resources/js/userCalendar.js
+++ b/resources/js/userCalendar.js
@@ -6,10 +6,13 @@ export function initUserCalendar(duration) {
     return {
         duration,
         events: [],
+        initialized: false,
+        calendar: null,
         setDuration(value) {
             this.duration = value;
         },
         init() {
+            if (this.initialized) return;
             const el = document.getElementById('user-calendar');
             if (!el) return;
             const url = el.dataset.busyUrl;
@@ -45,6 +48,8 @@ export function initUserCalendar(duration) {
                         }
                     });
                     calendar.render();
+                    this.calendar = calendar;
+                    this.initialized = true;
                 });
         }
     }

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -38,7 +38,7 @@
                                 </select>
                         </div>
 
-                        <div>
+                        <div x-show="variant_id" x-cloak>
                                 <label class="block font-medium mb-1">Wybierz termin</label>
                                 <div id="user-calendar" data-busy-url="{{ route('appointments.busy') }}" class="mb-4 h-96 border rounded"></div>
                                 <input type="hidden" name="appointment_at" required>


### PR DESCRIPTION
## Summary
- add state tracking for calendar initialization
- initialize calendar only after selecting service variant
- hide the appointment calendar until a variant is chosen

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfb05ed50832989fb3f974e8474fe