### PR TITLE
Improve calendar slot selection

### DIFF
--- a/resources/js/userCalendar.js
+++ b/resources/js/userCalendar.js
@@ -8,6 +8,7 @@ export function initUserCalendar(duration) {
         events: [],
         initialized: false,
         calendar: null,
+        tempEvent: null,
         setDuration(value) {
             this.duration = value;
         },
@@ -16,7 +17,10 @@ export function initUserCalendar(duration) {
             const el = document.getElementById('user-calendar');
             if (!el) return;
             const url = el.dataset.busyUrl;
+            const msgUrl = el.dataset.msgUrl;
             const input = document.querySelector('input[name="appointment_at"]');
+            const notice = document.getElementById('calendar-notice');
+            const submitBtn = document.getElementById('submit-appointment');
             fetch(url)
                 .then(r => r.ok ? r.json() : [])
                 .then(events => {
@@ -35,16 +39,52 @@ export function initUserCalendar(duration) {
                         selectOverlap: false,
                         select: info => {
                             const start = info.start;
-                            const end = new Date(start.getTime() + this.duration*60000);
+                            const end = new Date(start.getTime() + this.duration * 60000);
+
+                            if (this.tempEvent) {
+                                this.tempEvent.remove();
+                                this.tempEvent = null;
+                            }
+
+                            let overlap = false;
                             for (const e of this.events) {
                                 const estart = new Date(e.start);
                                 const eend = new Date(e.end);
                                 if (start < eend && end > estart) {
-                                    calendar.unselect();
-                                    return alert('Wybrany termin jest zajęty.');
+                                    overlap = true;
+                                    break;
                                 }
                             }
-                            input.value = start.toISOString().slice(0,16);
+
+                            const color = overlap ? 'red' : 'green';
+                            this.tempEvent = calendar.addEvent({
+                                id: 'temp-selection',
+                                start,
+                                end,
+                                backgroundColor: color,
+                                borderColor: color,
+                            });
+
+                            if (overlap) {
+                                input.value = '';
+                                if (notice) {
+                                    notice.classList.remove('hidden');
+                                    notice.classList.remove('bg-green-100', 'text-green-700');
+                                    notice.classList.add('bg-red-100', 'text-red-700');
+                                    const href = `${msgUrl}?category=rezerwacja&datetime=${start.toISOString()}`;
+                                    notice.innerHTML = `Wybrany termin jest zaj\u0119ty. <a href="${href}" class="underline">Wy\u015blij wiadomo\u015b\u0107</a>`;
+                                }
+                                if (submitBtn) submitBtn.disabled = true;
+                            } else {
+                                input.value = start.toISOString().slice(0,16);
+                                if (notice) {
+                                    notice.classList.remove('hidden');
+                                    notice.classList.remove('bg-red-100', 'text-red-700');
+                                    notice.classList.add('bg-green-100', 'text-green-700');
+                                    notice.textContent = 'Termin wolny. Mo\u017cesz zarezerwowa\u0107.';
+                                }
+                                if (submitBtn) submitBtn.disabled = false;
+                            }
                         }
                     });
                     calendar.render();

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -40,7 +40,8 @@
 
                         <div x-show="variant_id" x-cloak>
                                 <label class="block font-medium mb-1">Wybierz termin</label>
-                                <div id="user-calendar" data-busy-url="{{ route('appointments.busy') }}" class="mb-4 h-96 border rounded"></div>
+                                <div id="user-calendar" data-busy-url="{{ route('appointments.busy') }}" data-msg-url="{{ route('messages.create') }}" class="mb-4 h-96 border rounded"></div>
+                                <div id="calendar-notice" class="hidden mb-2 p-2 rounded text-sm"></div>
                                 <input type="hidden" name="appointment_at" required>
                         </div>
 
@@ -51,7 +52,7 @@
                         </div>
 
                         <div class="pt-4">
-                                <button type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
+                                <button id="submit-appointment" type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
                                         Zarezerwuj
                                 </button>
                                 @php $msgUrl = route('messages.create'); @endphp


### PR DESCRIPTION
## Summary
- show selected time slot on calendar and highlight conflicts
- allow sending a message if the chosen slot is busy
- add notice placeholder in appointment form

## Testing
- `npm run build`
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a713ff88329939ea9279f0e17ad