### PR TITLE
Allow calendar slot selection overlaps

### DIFF
--- a/resources/js/userCalendar.js
+++ b/resources/js/userCalendar.js
@@ -36,7 +36,9 @@ export function initUserCalendar(duration) {
                             endTime: '18:00',
                             daysOfWeek: [1,2,3,4,5,6],
                         },
-                        selectOverlap: false,
+                        // Allow selection even when the slot overlaps an existing event so
+                        // we can display a notice about the conflict.
+                        selectOverlap: true,
                         select: info => {
                             const start = info.start;
                             const end = new Date(start.getTime() + this.duration * 60000);


### PR DESCRIPTION
## Summary
- allow selecting busy slots in the user calendar
- rebuild assets

## Testing
- `npm run build`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d50f38cdc8329b531696d1e7acdb4