### PR TITLE
Fix duplicate drag-drop info on admin calendar

### DIFF
--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -10,9 +10,14 @@ import listPlugin from '@fullcalendar/list';
 // Funkcja inicjalizująca kalendarz
 function initializeCalendar() {
   // console.log('Inicjalizacja kalendarza rozpoczęta');
-  
+
   const el = document.getElementById('calendar');
   // console.log('Element kalendarza:', el);
+
+  // Zapobiegamy wielokrotnej inicjalizacji
+  if (el && el._fullCalendar) {
+    return el._fullCalendar;
+  }
   
   if (!el) {
     console.error('Element kalendarza nie został znaleziony! Sprawdź czy jesteś na właściwej stronie.');


### PR DESCRIPTION
## Summary
- avoid reinitializing FullCalendar

## Testing
- `composer test` *(fails: composer not installed)*
- `php -v` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e4382b3d483298ed280a453efc966