### PR TITLE
Add expandable pending list on calendar

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -12,11 +12,21 @@ class AdminAppointmentController extends Controller
 {
     public function calendar()
     {
-        $pendingCount   = Appointment::where('status', 'oczekuje')->count();
-        $proposedCount  = Appointment::where('status', 'proponowana')->count();
+        $pendingAppointments  = Appointment::with(['user', 'serviceVariant.service'])
+            ->where('status', 'oczekuje')
+            ->orderBy('appointment_at')
+            ->get();
+
+        $proposedAppointments = Appointment::with(['user', 'serviceVariant.service'])
+            ->where('status', 'proponowana')
+            ->orderBy('appointment_at')
+            ->get();
+
         return view('admin.appointments.calendar', [
-            'pendingCount'  => $pendingCount,
-            'proposedCount' => $proposedCount,
+            'pendingCount'   => $pendingAppointments->count(),
+            'proposedCount'  => $proposedAppointments->count(),
+            'pendingList'    => $pendingAppointments,
+            'proposedList'   => $proposedAppointments,
         ]);
     }
     

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -197,6 +197,7 @@ function initializeCalendar() {
     
     // Zapisujemy instancję kalendarza do elementu DOM dla łatwiejszego debugowania
     el._fullCalendar = calendar;
+    window.calendar = calendar;
     
     // Dodajemy wizualną wskazówkę, że kalendarz jest gotowy
     el.classList.add('calendar-initialized');
@@ -299,6 +300,22 @@ function initializeCalendar() {
 document.addEventListener('DOMContentLoaded', function() {
   // console.log('DOMContentLoaded event fired');
   initializeCalendar();
+
+  document.addEventListener('click', function(e) {
+    const link = e.target.closest('.jump-to-appointment');
+    if (!link) return;
+    e.preventDefault();
+    const id = link.dataset.appointmentId;
+    const el = document.getElementById('calendar');
+    const calendar = el ? el._fullCalendar || window.initCalendar() : null;
+    if (!calendar) return;
+    const event = calendar.getEventById(id);
+    if (event) {
+      calendar.gotoDate(event.start);
+      const data = { ...event.extendedProps, id: event.id };
+      window.dispatchEvent(new CustomEvent('open-view-modal', { detail: data }));
+    }
+  });
   
   // Dodajemy nasłuchiwanie na zdarzenie zamknięcia modala
   window.addEventListener('close-modal', function() {

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -35,10 +35,37 @@
     @endpush
 
     @if($pendingCount > 0 || $proposedCount > 0)
-    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 py-2">
-        <div class="bg-yellow-100 text-yellow-800 p-4 rounded mb-4">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 py-2" x-data="{open:false}">
+        <div class="bg-yellow-100 text-yellow-800 p-4 rounded mb-4 cursor-pointer" @click="open = !open">
             <p><strong>Oczekujące zgłoszenia:</strong> {{ $pendingCount }}</p>
             <p><strong>Proponowane terminy:</strong> {{ $proposedCount }}</p>
+            <p class="text-sm" x-show="!open" x-cloak>Kliknij, aby rozwinąć listę</p>
+        </div>
+        <div class="bg-yellow-50 text-yellow-800 p-4 rounded mb-4" x-show="open" x-cloak>
+            @if($pendingList->count())
+                <p class="font-semibold mb-2">Oczekujące zgłoszenia</p>
+                <ul class="list-disc list-inside mb-4">
+                    @foreach($pendingList as $a)
+                        <li>
+                            <a href="#" class="text-blue-600 hover:underline jump-to-appointment" data-appointment-id="{{ $a->id }}">
+                                {{ $a->appointment_at->format('Y-m-d H:i') }} – {{ $a->user->name }} ({{ $a->serviceVariant->service->name }})
+                            </a>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+            @if($proposedList->count())
+                <p class="font-semibold mb-2">Proponowane terminy</p>
+                <ul class="list-disc list-inside">
+                    @foreach($proposedList as $a)
+                        <li>
+                            <a href="#" class="text-blue-600 hover:underline jump-to-appointment" data-appointment-id="{{ $a->id }}">
+                                {{ $a->appointment_at->format('Y-m-d H:i') }} – {{ $a->user->name }} ({{ $a->serviceVariant->service->name }})
+                            </a>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
         </div>
     </div>
     @endif


### PR DESCRIPTION
## Summary
- show pending/proposed appointment details on admin calendar
- fetch lists of pending/proposed appointments
- allow jumping to appointment from list

## Testing
- `npm run build` *(fails: vite not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e47297ad8832985b95b1ea89e6536