### PR TITLE
Add calendar link from edit page

### DIFF
--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -301,6 +301,23 @@ document.addEventListener('DOMContentLoaded', function() {
   // console.log('DOMContentLoaded event fired');
   initializeCalendar();
 
+  const params = new URLSearchParams(window.location.search);
+  const jumpId = params.get('jump');
+  if (jumpId) {
+    const showAppointment = () => {
+      const el = document.getElementById('calendar');
+      const calendar = el ? el._fullCalendar || window.initCalendar() : null;
+      if (!calendar) return;
+      const event = calendar.getEventById(jumpId);
+      if (event) {
+        calendar.gotoDate(event.start);
+        const data = { ...event.extendedProps, id: event.id };
+        window.dispatchEvent(new CustomEvent('open-view-modal', { detail: data }));
+      }
+    };
+    setTimeout(showAppointment, 800);
+  }
+
   document.addEventListener('click', function(e) {
     const link = e.target.closest('.jump-to-appointment');
     if (!link) return;

--- a/resources/views/admin/appointments/edit.blade.php
+++ b/resources/views/admin/appointments/edit.blade.php
@@ -5,6 +5,13 @@
             @csrf
             @method('PUT')
             <div class="mb-4">
+                <label class="block font-medium mb-2">Termin wizyty:</label>
+                <a href="{{ route('calendar', ['jump' => $appointment->id]) }}" class="text-blue-600 underline">
+                    {{ $appointment->appointment_at->format('Y-m-d H:i') }}
+                </a>
+                <p class="text-sm text-gray-500">Kliknij datę, aby otworzyć kalendarz i zmienić termin przez przeciąganie.</p>
+            </div>
+            <div class="mb-4">
                 <label for="note_client" class="block font-medium mb-2">Zalecenia dla klienta:</label>
                 <textarea name="note_client" id="note_client" class="w-full p-2 border rounded">{{ old('note_client', $appointment->note_client) }}</textarea>
             </div>


### PR DESCRIPTION
## Summary
- show appointment date as a link on edit page
- when calendar page is opened with `?jump={id}` focus on that appointment

## Testing
- `npm run build` *(fails: vite not found)*
- `./vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_685e76234d708329b567ef55c1efe21c