### PR TITLE
Fix calendar jump sync

### DIFF
--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -299,23 +299,24 @@ function initializeCalendar() {
 // Standardowa inicjalizacja przy załadowaniu DOM
 document.addEventListener('DOMContentLoaded', function() {
   // console.log('DOMContentLoaded event fired');
-  initializeCalendar();
+  const calendar = initializeCalendar();
 
   const params = new URLSearchParams(window.location.search);
   const jumpId = params.get('jump');
-  if (jumpId) {
-    const showAppointment = () => {
-      const el = document.getElementById('calendar');
-      const calendar = el ? el._fullCalendar || window.initCalendar() : null;
-      if (!calendar) return;
+  if (jumpId && calendar) {
+    const handleEventsSet = () => {
       const event = calendar.getEventById(jumpId);
       if (event) {
         calendar.gotoDate(event.start);
         const data = { ...event.extendedProps, id: event.id };
         window.dispatchEvent(new CustomEvent('open-view-modal', { detail: data }));
+        calendar.off('eventsSet', handleEventsSet);
       }
     };
-    setTimeout(showAppointment, 800);
+
+    // In case events are already loaded
+    handleEventsSet();
+    calendar.on('eventsSet', handleEventsSet);
   }
 
   document.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary
- call initializeCalendar once and capture the calendar object
- jump to appointment when `eventsSet` fires instead of using a delay

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7fcee1088329b2d62cba50922867