### PR TITLE
Add WhatsApp opt‑in check

### DIFF
--- a/app/Notifications/NewMessageNotification.php
+++ b/app/Notifications/NewMessageNotification.php
@@ -18,10 +18,17 @@ class NewMessageNotification extends Notification implements ShouldQueue
 
     public function via(object $notifiable): array
     {
-        $channel = \App\Notifications\Channels\WhatsAppChannel::class;
+        $whatsAppChannel = \App\Notifications\Channels\WhatsAppChannel::class;
+
+        $sendWhatsApp = in_array($notifiable->notification_preference, ['whatsapp', 'both']);
+
+        if (property_exists($notifiable, 'whatsapp_opt_in')) {
+            $sendWhatsApp = $sendWhatsApp && (bool) $notifiable->whatsapp_opt_in;
+        }
+
         return match ($notifiable->notification_preference) {
-            'whatsapp' => [$channel],
-            'both' => ['mail', $channel],
+            'whatsapp' => $sendWhatsApp ? [$whatsAppChannel] : ['mail'],
+            'both' => $sendWhatsApp ? ['mail', $whatsAppChannel] : ['mail'],
             default => ['mail'],
         };
     }

--- a/app/Notifications/StatusChangeNotification.php
+++ b/app/Notifications/StatusChangeNotification.php
@@ -18,10 +18,17 @@ class StatusChangeNotification extends Notification implements ShouldQueue
 
     public function via(object $notifiable): array
     {
-        $channel = \App\Notifications\Channels\WhatsAppChannel::class;
+        $whatsAppChannel = \App\Notifications\Channels\WhatsAppChannel::class;
+
+        $sendWhatsApp = in_array($notifiable->notification_preference, ['whatsapp', 'both']);
+
+        if (property_exists($notifiable, 'whatsapp_opt_in')) {
+            $sendWhatsApp = $sendWhatsApp && (bool) $notifiable->whatsapp_opt_in;
+        }
+
         return match ($notifiable->notification_preference) {
-            'whatsapp' => [$channel],
-            'both' => ['mail', $channel],
+            'whatsapp' => $sendWhatsApp ? [$whatsAppChannel] : ['mail'],
+            'both' => $sendWhatsApp ? ['mail', $whatsAppChannel] : ['mail'],
             default => ['mail'],
         };
     }


### PR DESCRIPTION
## Summary
- respect user preference for WhatsApp in notifications

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610610db2883298a2e0d350296c754