### PR TITLE
Add phone and notification preference to user factory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,6 +26,8 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'phone' => fake()->e164PhoneNumber(),
+            'notification_preference' => 'email',
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,4 +9,12 @@ use Tests\CreatesApplication;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable Vite during tests to avoid missing manifest errors
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary
- include phone and notification preferences on user factory
- disable Vite in tests so feature tests can run

## Testing
- `composer test` *(fails: WhatsAppChannelTest – expected request not recorded)*

------
https://chatgpt.com/codex/tasks/task_e_686276b5bc108329a8caa668223bbe1d