### PR TITLE
Update WhatsAppChannelTest

### DIFF
--- a/tests/Feature/WhatsAppChannelTest.php
+++ b/tests/Feature/WhatsAppChannelTest.php
@@ -7,24 +7,18 @@ use App\Notifications\Channels\WhatsAppChannel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class WhatsAppChannelTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_channel_sends_payload_and_logs(): void
+    public function test_channel_sends_payload(): void
     {
         Http::fake();
-        Log::shouldReceive('info')->once()->with('WhatsApp message sent', [
-            'to' => '5551234',
-            'body' => 'Test Body',
-        ]);
 
-        config()->set('services.twilio.sid', 'ACXXXXX');
-        config()->set('services.twilio.token', 'token');
-        config()->set('services.twilio.whatsapp_from', '12345');
+        config()->set('services.whatsapp.token', 'token');
+        config()->set('services.whatsapp.phone_id', '12345');
 
         $user = User::factory()->create(['phone' => '5551234']);
 
@@ -38,7 +32,8 @@ class WhatsAppChannelTest extends TestCase
             {
                 return [
                     'to' => $notifiable->phone,
-                    'body' => 'Test Body',
+                    'template_name' => 'test_template',
+                    'parameters' => ['foo', 'bar'],
                 ];
             }
         };
@@ -46,10 +41,14 @@ class WhatsAppChannelTest extends TestCase
         $user->notify($notification);
 
         Http::assertSent(function ($request) {
-            return $request->url() === 'https://api.twilio.com/2010-04-01/Accounts/'.config('services.twilio.sid').'/Messages.json'
-                && $request['From'] === 'whatsapp:'.config('services.twilio.whatsapp_from')
-                && $request['To'] === 'whatsapp:5551234'
-                && $request['Body'] === 'Test Body';
+            $data = $request->data();
+
+            return $request->url() === 'https://graph.facebook.com/v18.0/'.config('services.whatsapp.phone_id').'/messages'
+                && $data['messaging_product'] === 'whatsapp'
+                && $data['type'] === 'template'
+                && $data['template']['name'] === 'test_template'
+                && $data['template']['components'][0]['parameters'][0]['text'] === 'foo'
+                && $data['template']['components'][0]['parameters'][1]['text'] === 'bar';
         });
     }
 }


### PR DESCRIPTION
## Summary
- adjust WhatsAppChannelTest to assert Graph API call

## Testing
- `php artisan test tests/Feature/WhatsAppChannelTest.php` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6862a066f7e08329a0f5ac1522094097