### PR TITLE
Propose status on reschedule

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -97,9 +97,9 @@ class AdminAppointmentController extends Controller
         ]);
         
         // Sprawdzenie czy nowy termin jest w godzinach pracy
-        $newDateTime = Carbon::parse($request->appointment_at);
-        $dayOfWeek = $newDateTime->dayOfWeek;
-        $timeOfDay = $newDateTime->format('H:i');
+        $newTime = Carbon::parse($request->appointment_at);
+        $dayOfWeek = $newTime->dayOfWeek;
+        $timeOfDay = $newTime->format('H:i');
         
         // Pobierz godziny pracy dla danego dnia tygodnia
         // Domyślne godziny pracy
@@ -121,7 +121,14 @@ class AdminAppointmentController extends Controller
             ]);
         }
         
-        $appointment->update(['appointment_at' => $request->appointment_at]);
+        $fields = ['appointment_at' => $newTime];
+
+        if (!$appointment->appointment_at->equalTo($newTime)) {
+            $fields['status'] = 'proponowana';
+        }
+
+        $appointment->update($fields);
+
         return response()->json(['success' => true]);
     }
     

--- a/app/Models/WhatsAppMessageLog.php
+++ b/app/Models/WhatsAppMessageLog.php
@@ -9,6 +9,8 @@ class WhatsAppMessageLog extends Model
 {
     use HasFactory;
 
+    protected $table = 'whatsapp_message_logs';
+
     protected $fillable = [
         'recipient',
         'template',

--- a/tests/Feature/AppointmentRescheduleTest.php
+++ b/tests/Feature/AppointmentRescheduleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\User;
+use App\Notifications\StatusChangeNotification;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class AppointmentRescheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createService(): array
+    {
+        $service = Service::create(['name' => 'Test Service']);
+        $variant = $service->variants()->create([
+            'variant_name' => 'Basic',
+            'duration_minutes' => 60,
+            'price_pln' => 100,
+        ]);
+        return [$service, $variant];
+    }
+
+    public function test_rescheduling_sets_status_to_proponowana_and_sends_notification(): void
+    {
+        Notification::fake();
+
+        [$service, $variant] = $this->createService();
+        $user = User::factory()->create(['notification_preference' => 'email']);
+        $admin = User::factory()->create(['role' => 'admin', 'notification_preference' => 'email']);
+
+        $time = Carbon::create(2025, 6, 5, 10, 0);
+
+        $appointment = Appointment::create([
+            'user_id' => $user->id,
+            'service_id' => $service->id,
+            'service_variant_id' => $variant->id,
+            'price_pln' => 100,
+            'appointment_at' => $time,
+            'status' => 'zaplanowana',
+        ]);
+
+        $newTime = $time->copy()->addHour();
+
+        $this->actingAs($admin)->post(route('admin.appointments.updateTime', [$appointment], false), [
+            'appointment_at' => $newTime->toDateTimeString(),
+        ])->assertJson(['success' => true]);
+
+        $appointment->refresh();
+        $this->assertSame('proponowana', $appointment->status);
+        $this->assertTrue($appointment->appointment_at->equalTo($newTime));
+
+        Notification::assertSentTo($user, StatusChangeNotification::class);
+    }
+}


### PR DESCRIPTION
## Summary
- set status to `proponowana` when appointment time is changed
- ensure WhatsApp log uses correct table
- test appointment rescheduling sends notification and updates status

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862a9b4506483298466d084d5c872f5