### PR TITLE
Fix appointment status logic

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -226,6 +226,11 @@ class AdminAppointmentController extends Controller
         $price    = $request->price_pln ?? $variant->price_pln;
         $price    = round($price * (100 - $discount) / 100);
 
+        $status = $request->status;
+        if ($appointment->appointment_at->ne($newDateTime) && $status === 'zaplanowana') {
+            $status = 'proponowana';
+        }
+
         $appointment->update([
             'user_id' => $request->user_id,
             'service_id' => $variant->service_id,
@@ -233,7 +238,7 @@ class AdminAppointmentController extends Controller
             'price_pln' => $price,
             'discount_percent' => $discount,
             'appointment_at' => $request->appointment_at,
-            'status' => $request->status,
+            'status' => $status,
             'note_user' => $request->note_user,
             'service_description' => $request->service_description,
             'products_used' => $request->products_used,

--- a/tests/Feature/AdminAppointmentUpdateTest.php
+++ b/tests/Feature/AdminAppointmentUpdateTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\ServiceVariant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class AdminAppointmentUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createService(): array
+    {
+        $service = Service::create(['name' => 'Test Service']);
+        $variant = $service->variants()->create([
+            'variant_name' => 'Basic',
+            'duration_minutes' => 60,
+            'price_pln' => 100,
+        ]);
+        return [$service, $variant];
+    }
+
+    public function test_date_change_sets_status_to_proposed(): void
+    {
+        [$service, $variant] = $this->createService();
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create();
+
+        $oldTime = Carbon::now()->addDay()->setTime(10, 0);
+        $appointment = Appointment::create([
+            'user_id' => $user->id,
+            'service_id' => $service->id,
+            'service_variant_id' => $variant->id,
+            'price_pln' => 100,
+            'appointment_at' => $oldTime,
+            'status' => 'zaplanowana',
+        ]);
+
+        $newTime = $oldTime->copy()->addHour();
+
+        $response = $this->actingAs($admin)->patch(
+            route('admin.appointments.update', $appointment, absolute: false),
+            [
+                'user_id' => $user->id,
+                'service_variant_id' => $variant->id,
+                'appointment_at' => $newTime->toDateTimeString(),
+                'status' => 'zaplanowana',
+                'price_pln' => 100,
+                'discount_percent' => 0,
+                'note_user' => '',
+                'service_description' => '',
+                'products_used' => '',
+            ]
+        );
+
+        $response->assertOk();
+        $appointment->refresh();
+
+        $this->assertSame('proponowana', $appointment->status);
+        $this->assertTrue($appointment->appointment_at->eq($newTime));
+    }
+}


### PR DESCRIPTION
## Summary
- adjust status auto-update in AdminAppointmentController
- add test covering status change when appointment time changes

## Testing
- `composer --version` *(fails: command not found)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862aa16c03c83298361af862e8b5ddf