### PR TITLE
Refresh calendar on drag

### DIFF
--- a/app/Models/WhatsAppMessageLog.php
+++ b/app/Models/WhatsAppMessageLog.php
@@ -9,6 +9,8 @@ class WhatsAppMessageLog extends Model
 {
     use HasFactory;
 
+    protected $table = 'whatsapp_message_logs';
+
     protected $fillable = [
         'recipient',
         'template',

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -132,6 +132,19 @@ function initializeCalendar() {
             // Uaktualnij dane wydarzenia, aby klikanie pokazywało nowy termin
             const local = newDate.substring(0,16).replace('T', ' ');
             info.event.setExtendedProp('datetime', local);
+            // Odswiezenie danych z API, aby kalendarz od razu pokazal zmiany
+            if (info.view && info.view.calendar) {
+              info.view.calendar.refetchEvents();
+            }
+            if (data.color) {
+              info.event.setProp('backgroundColor', data.color);
+              info.event.setProp('borderColor', data.color);
+            }
+            if (data.extendedProps) {
+              Object.entries(data.extendedProps).forEach(([key, val]) => {
+                info.event.setExtendedProp(key, val);
+              });
+            }
             showNotification('Termin rezerwacji został zaktualizowany.');
           } else {
             info.revert();


### PR DESCRIPTION
## Summary
- refresh calendar events after drag/update
- fix WhatsAppMessageLog table name for tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6862aa1c496c83299ae9658de6de45e5