### PR TITLE
Add missing status options in edit appointment

### DIFF
--- a/resources/views/admin/appointments/edit.blade.php
+++ b/resources/views/admin/appointments/edit.blade.php
@@ -32,8 +32,10 @@
                 <select name="status" id="status" class="w-full p-2 border rounded">
                     <option value="zaplanowana" @selected($appointment->status === 'zaplanowana')>Zaplanowana</option>
                     <option value="oczekuje" @selected($appointment->status === 'oczekuje')>Oczekuje</option>
+                    <option value="proponowana" @selected($appointment->status === 'proponowana')>Proponowana</option>
                     <option value="odbyta" @selected($appointment->status === 'odbyta')>Odbyta</option>
                     <option value="odwołana" @selected($appointment->status === 'odwołana')>Odwołana</option>
+                    <option value="nieodbyta" @selected($appointment->status === 'nieodbyta')>Nieodbyta</option>
                 </select>
             </div>
             <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Zapisz zmiany</button>


### PR DESCRIPTION
## Summary
- allow editing appointment status values like proposed and missed

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000]: General error: 1 no such table: whats_app_message_logs)*

------
https://chatgpt.com/codex/tasks/task_e_6862aa2103d4832996294f1aa0f483c6