### PR TITLE
Add user dashboard metrics

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Appointment;
+use App\Models\KontaktMessage;
+use Illuminate\Support\Facades\Auth;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $userId = Auth::id();
+
+        $nextAppointment = Appointment::where('user_id', $userId)
+            ->where('appointment_at', '>=', now())
+            ->orderBy('appointment_at')
+            ->first();
+
+        $pastCount = Appointment::where('user_id', $userId)
+            ->where('status', 'odbyta')
+            ->count();
+
+        $missedCount = Appointment::where('user_id', $userId)
+            ->where('status', 'nieodbyta')
+            ->count();
+
+        $pendingCount = Appointment::where('user_id', $userId)
+            ->whereIn('status', ['oczekuje', 'proponowana'])
+            ->count();
+
+        $unreadMessages = KontaktMessage::where('user_id', $userId)
+            ->where('is_from_admin', true)
+            ->where('is_read', false)
+            ->count();
+
+        return view('dashboard', [
+            'nextAppointment' => $nextAppointment,
+            'pastCount' => $pastCount,
+            'missedCount' => $missedCount,
+            'pendingCount' => $pendingCount,
+            'unreadMessages' => $unreadMessages,
+        ]);
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,16 +7,31 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-            <div class="p-6 text-gray-900 space-y-2">
-                <p>Witaj, <strong>{{ Auth::user()->name }}</strong>!</p>
-                <p>To jest Twoje centrum zarządzania. Wkrótce pojawią się tutaj:</p>
-                <ul class="list-disc list-inside text-sm text-gray-700">
-                    <li>Twoje rezerwacje</li>
-                    <li>Lista dostępnych usług</li>
-                    <li>Profil użytkownika</li>
-                </ul>
-            </div>
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Najbliższa wizyta</p>
+                    @if($nextAppointment)
+                        <p class="mt-2 font-semibold">
+                            {{ $nextAppointment->appointment_at->format('d.m.Y H:i') }}
+                        </p>
+                        <p class="text-xs text-gray-600 capitalize">{{ $nextAppointment->status }}</p>
+                    @else
+                        <p class="mt-2 text-gray-400 italic">Brak zaplanowanych wizyt</p>
+                    @endif
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Odbyte wizyty</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $pastCount }}</p>
+                    <p class="text-sm text-gray-500 mt-1">Nieodbyte: {{ $missedCount }}</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Oczekuje potwierdzenia</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $pendingCount }}</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Nieprzeczytane wiadomości</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $unreadMessages }}</p>
+                </div>
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\KontaktController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReservationEntryController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\GalleryController;
 use Illuminate\Support\Facades\Route;
 
@@ -41,9 +42,7 @@ Route::post('/kontakt', [KontaktController::class, 'store'])->name('kontakt.stor
 |--------------------------------------------------------------------------
 */
 Route::middleware('auth')->group(function () {
-    Route::get('/dashboard', function () {
-        return view('dashboard');
-    })->name('dashboard');
+    Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');


### PR DESCRIPTION
## Summary
- add `DashboardController` with appointment and message metrics
- wire `/dashboard` route to new controller
- show upcoming visit, visit stats, pending confirmations, and unread message count on dashboard

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6862abae060883299cff12962d264978