### PR TITLE
Allow clients confirm or decline appointments

### DIFF
--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -21,6 +21,20 @@
                                     <div class="text-sm text-gray-600">
                                             Status: {{ ucfirst($appointment->status) }}
                                     </div>
+                                    @if(in_array($appointment->status, ['oczekuje', 'proponowana']))
+                                        <div class="mt-2 space-x-2">
+                                            <form method="POST" action="{{ route('appointments.confirm', $appointment) }}" class="inline">
+                                                @csrf
+                                                @method('PATCH')
+                                                <button type="submit" class="px-2 py-1 bg-green-600 text-white rounded hover:bg-green-700 text-sm">Potwierdź</button>
+                                            </form>
+                                            <form method="POST" action="{{ route('appointments.decline', $appointment) }}" class="inline">
+                                                @csrf
+                                                @method('PATCH')
+                                                <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-sm">Odmów</button>
+                                            </form>
+                                        </div>
+                                    @endif
                             </div>
                     @empty
                             <p class="text-center text-gray-500">Nie masz jeszcze żadnych rezerwacji.</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/rezerwacje/dodaj', [AppointmentController::class, 'create'])->name('appointments.create');
     Route::post('/rezerwacje', [AppointmentController::class, 'store'])->name('appointments.store');
     Route::get('/rezerwacje/busy', [AppointmentController::class, 'busyTimes'])->name('appointments.busy');
+    Route::patch('/appointments/{appointment}/confirm', [AppointmentController::class, 'confirm'])->name('appointments.confirm');
+    Route::patch('/appointments/{appointment}/decline', [AppointmentController::class, 'decline'])->name('appointments.decline');
     Route::get('/moje-wiadomosci', [KontaktController::class, 'myMessages'])->name('messages.index');
     Route::get('/moje-wiadomosci/nowa', [KontaktController::class, 'create'])->name('messages.create');
     Route::post('/moje-wiadomosci', [KontaktController::class, 'store'])->name('messages.store');

--- a/tests/Feature/AppointmentDecisionTest.php
+++ b/tests/Feature/AppointmentDecisionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\User;
+use App\Notifications\StatusChangeNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class AppointmentDecisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createService(): array
+    {
+        $service = Service::create(['name' => 'Test Service']);
+        $variant = $service->variants()->create([
+            'variant_name' => 'Basic',
+            'duration_minutes' => 60,
+            'price_pln' => 100,
+        ]);
+        return [$service, $variant];
+    }
+
+    public function test_user_can_confirm_pending_appointment(): void
+    {
+        Notification::fake();
+
+        [$service, $variant] = $this->createService();
+        $user = User::factory()->create(['notification_preference' => 'email']);
+        $admin = User::factory()->create(['role' => 'admin', 'notification_preference' => 'email']);
+
+        $appointment = Appointment::create([
+            'user_id' => $user->id,
+            'service_id' => $service->id,
+            'service_variant_id' => $variant->id,
+            'price_pln' => 100,
+            'appointment_at' => now(),
+            'status' => 'proponowana',
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('appointments.confirm', $appointment, absolute: false))
+            ->assertRedirect(route('appointments.index', absolute: false));
+
+        $this->assertSame('zaplanowana', $appointment->fresh()->status);
+        Notification::assertSentTo($admin, StatusChangeNotification::class);
+    }
+
+    public function test_user_can_decline_pending_appointment(): void
+    {
+        Notification::fake();
+
+        [$service, $variant] = $this->createService();
+        $user = User::factory()->create(['notification_preference' => 'email']);
+        $admin = User::factory()->create(['role' => 'admin', 'notification_preference' => 'email']);
+
+        $appointment = Appointment::create([
+            'user_id' => $user->id,
+            'service_id' => $service->id,
+            'service_variant_id' => $variant->id,
+            'price_pln' => 100,
+            'appointment_at' => now(),
+            'status' => 'oczekuje',
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('appointments.decline', $appointment, absolute: false))
+            ->assertRedirect(route('appointments.index', absolute: false));
+
+        $this->assertSame('odwołana', $appointment->fresh()->status);
+        Notification::assertSentTo($admin, StatusChangeNotification::class);
+    }
+
+    public function test_user_cannot_modify_someone_elses_appointment(): void
+    {
+        [$service, $variant] = $this->createService();
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $appointment = Appointment::create([
+            'user_id' => $other->id,
+            'service_id' => $service->id,
+            'service_variant_id' => $variant->id,
+            'price_pln' => 100,
+            'appointment_at' => now(),
+            'status' => 'proponowana',
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('appointments.confirm', $appointment, absolute: false))
+            ->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- add confirm/decline routes for appointments
- implement confirm and decline actions for users
- show decision buttons on appointment list
- notify admin when client confirms or declines
- cover with feature tests

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862abb502ac8329970d3a2bea8fbf19