### PR TITLE
Add user and admin dashboard

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Appointment;
+use App\Models\KontaktMessage;
+use App\Models\User;
+
+class AdminDashboardController extends Controller
+{
+    public function index()
+    {
+        $nextAppointment = Appointment::with(['user', 'serviceVariant.service'])
+            ->where('appointment_at', '>=', now())
+            ->orderBy('appointment_at')
+            ->first();
+
+        $upcomingCount = Appointment::where('appointment_at', '>=', now())->count();
+
+        $pendingCount = Appointment::whereIn('status', ['oczekuje', 'proponowana'])->count();
+
+        $unreadMessages = KontaktMessage::where('is_from_admin', false)
+            ->where('is_read', false)
+            ->count();
+
+        $userCount = User::count();
+
+        return view('admin.dashboard', [
+            'nextAppointment' => $nextAppointment,
+            'upcomingCount' => $upcomingCount,
+            'pendingCount' => $pendingCount,
+            'unreadMessages' => $unreadMessages,
+            'userCount' => $userCount,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -35,8 +35,12 @@ class AuthenticatedSessionController extends Controller
             }
         }
 
-        // Domyślne zachowanie
-        return redirect()->intended(RouteServiceProvider::HOME);
+        // Domyślne zachowanie z rozróżnieniem roli
+        $home = auth()->user()->role === 'admin'
+            ? route('admin.dashboard')
+            : RouteServiceProvider::HOME;
+
+        return redirect()->intended($home);
     }
 
     /**

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,43 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-5">
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Najbliższa wizyta</p>
+                    @if($nextAppointment)
+                        <p class="mt-2 font-semibold">
+                            {{ $nextAppointment->appointment_at->format('d.m.Y H:i') }}
+                        </p>
+                        <p class="text-xs text-gray-600">
+                            {{ $nextAppointment->user->name }} - {{ $nextAppointment->serviceVariant->service->name }}
+                        </p>
+                    @else
+                        <p class="mt-2 text-gray-400 italic">Brak zaplanowanych wizyt</p>
+                    @endif
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Nadchodzące wizyty</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $upcomingCount }}</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Oczekuje potwierdzenia</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $pendingCount }}</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Nieprzeczytane wiadomości</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $unreadMessages }}</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Użytkownicy</p>
+                    <p class="mt-2 text-2xl font-bold">{{ $userCount }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -66,6 +66,7 @@
             <a href="{{ route('reservation.entry') }}" class="block text-indigo-600 font-semibold">Rezerwuj</a>
             @auth
                 @if(Auth::user()->role === 'admin')
+                    <a href="{{ route('dashboard') }}" class="block text-gray-700">Dashboard</a>
                     <a href="{{ route('admin.services.index') }}" class="block text-gray-700">Usługi (admin)</a>
                     <a href="{{ route('admin.calendar') }}" class="block text-gray-700">Kalendarz</a>
                     <a href="{{ route('admin.kontakt.edit') }}" class="block text-gray-700">Kontakt</a>
@@ -76,6 +77,7 @@
                     </a>
                     <a href="{{ route('admin.users.index') }}" class="block text-gray-700">Użytkownicy</a>
                 @else
+                    <a href="{{ route('dashboard') }}" class="block text-gray-700">Dashboard</a>
                     <a href="{{ route('appointments.index') }}" class="block text-gray-700">Moje rezerwacje</a>
                     <a href="{{ route('messages.index') }}" class="block text-gray-700">Wiadomości
                         @if($unreadMessages > 0)
@@ -95,6 +97,10 @@
         @auth
         <div class="hidden md:flex mt-4 pt-2 border-t flex-wrap gap-6 text-sm">
             @if(Auth::user()->role === 'admin')
+                <a href="{{ route('dashboard') }}" class="flex items-center text-gray-700 hover:underline">
+                    <x-heroicon-o-home-modern class="w-4 h-4 mr-1 text-gray-500" />
+                    Dashboard
+                </a>
                 <a href="{{ route('admin.services.index') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-cog class="w-4 h-4 mr-1 text-gray-500" />
                     Usługi (admin)
@@ -119,6 +125,10 @@
                     Użytkownicy
                 </a>
             @else
+                <a href="{{ route('dashboard') }}" class="flex items-center text-gray-700 hover:underline">
+                    <x-heroicon-o-home-modern class="w-4 h-4 mr-1 text-gray-500" />
+                    Dashboard
+                </a>
                 <a href="{{ route('appointments.index') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-calendar-days class="w-4 h-4 mr-1 text-gray-500" />
                     Moje rezerwacje

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AdminKontaktController;
 use App\Http\Controllers\AdminServiceController;
 use App\Http\Controllers\AdminUserController;
 use App\Http\Controllers\AdminCouponController;
+use App\Http\Controllers\AdminDashboardController;
 use App\Http\Controllers\AppointmentController;
 use App\Http\Controllers\KontaktController;
 use App\Http\Controllers\ContactController;
@@ -75,6 +76,7 @@ Route::middleware(['auth'])->group(function () {
 |--------------------------------------------------------------------------
 */
 Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/dashboard', [AdminDashboardController::class, 'index'])->name('dashboard');
     // Usługi
     Route::get('/uslugi', [AdminServiceController::class, 'index'])->name('services.index');
     Route::get('/uslugi/nowa', [AdminServiceController::class, 'create'])->name('services.create');


### PR DESCRIPTION
## Summary
- add dashboard links to navigation menu for admins and users
- redirect admin logins to a new advanced dashboard
- implement AdminDashboardController and view with stats
- route admin dashboard under `/admin/dashboard`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_686394d1a9788329b5134af2541f12be