### PR TITLE
Validate user not admin for appointments

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -8,6 +8,7 @@ use App\Models\Blocker;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Rule;
 
 class AdminAppointmentController extends Controller
 {
@@ -177,6 +178,13 @@ class AdminAppointmentController extends Controller
             'service_description' => 'nullable|string',
             'products_used' => 'nullable|string',
         ]);
+
+        $user = User::find($request->user_id);
+        if ($user && $user->role === 'admin') {
+            throw ValidationException::withMessages([
+                'user_id' => ['Administratorzy powinni utworzyć blokadę czasu (blocker) zamiast wizyty.'],
+            ]);
+        }
         
         // Sprawdzenie czy termin jest w godzinach pracy
         $newDateTime = Carbon::parse($request->appointment_at);
@@ -235,6 +243,13 @@ class AdminAppointmentController extends Controller
             'service_description' => 'nullable|string',
             'products_used' => 'nullable|string',
         ]);
+
+        $user = User::find($request->user_id);
+        if ($user && $user->role === 'admin') {
+            throw ValidationException::withMessages([
+                'user_id' => ['Administratorzy powinni utworzyć blokadę czasu (blocker) zamiast wizyty.'],
+            ]);
+        }
 
         $newDateTime = Carbon::parse($request->appointment_at);
         $dayOfWeek = $newDateTime->dayOfWeek;

--- a/tests/Feature/AdminAppointmentAdminUserTest.php
+++ b/tests/Feature/AdminAppointmentAdminUserTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\ServiceVariant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class AdminAppointmentAdminUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createService(): array
+    {
+        $service = Service::create(['name' => 'Test Service']);
+        $variant = $service->variants()->create([
+            'variant_name' => 'Basic',
+            'duration_minutes' => 60,
+            'price_pln' => 100,
+        ]);
+        return [$service, $variant];
+    }
+
+    public function test_store_rejects_admin_user(): void
+    {
+        [$service, $variant] = $this->createService();
+        $admin = User::factory()->create(['role' => 'admin']);
+        $otherAdmin = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($admin)->post(
+            route('admin.appointments.store', absolute: false),
+            [
+                'user_id' => $otherAdmin->id,
+                'service_variant_id' => $variant->id,
+                'appointment_at' => Carbon::now()->addDay()->toDateTimeString(),
+                'price_pln' => 100,
+                'discount_percent' => 0,
+                'note_user' => '',
+                'service_description' => '',
+                'products_used' => '',
+            ]
+        );
+
+        $response->assertSessionHasErrors('user_id');
+    }
+
+    public function test_update_rejects_admin_user(): void
+    {
+        [$service, $variant] = $this->createService();
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create();
+        $otherAdmin = User::factory()->create(['role' => 'admin']);
+
+        $appointment = Appointment::create([
+            'user_id' => $user->id,
+            'service_id' => $service->id,
+            'service_variant_id' => $variant->id,
+            'price_pln' => 100,
+            'appointment_at' => Carbon::now()->addDay(),
+            'status' => 'zaplanowana',
+        ]);
+
+        $response = $this->actingAs($admin)->patch(
+            route('admin.appointments.update', $appointment, absolute: false),
+            [
+                'user_id' => $otherAdmin->id,
+                'service_variant_id' => $variant->id,
+                'appointment_at' => Carbon::now()->addDays(2)->toDateTimeString(),
+                'status' => 'zaplanowana',
+                'price_pln' => 100,
+                'discount_percent' => 0,
+                'note_user' => '',
+                'service_description' => '',
+                'products_used' => '',
+            ]
+        );
+
+        $response->assertSessionHasErrors('user_id');
+    }
+}


### PR DESCRIPTION
## Summary
- prevent creating or updating appointments for admin accounts
- add regression tests for admin appointments with admin user id

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863ec8e7f908329aa5f889608c7866c