### PR TITLE
Add blocker calendar and clean admin dashboard

### DIFF
--- a/app/Http/Controllers/AdminBlockerController.php
+++ b/app/Http/Controllers/AdminBlockerController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Blocker;
+use Carbon\Carbon;
+
+class AdminBlockerController extends Controller
+{
+    public function calendar()
+    {
+        return view('admin.blockers.calendar');
+    }
+
+    public function api()
+    {
+        return Blocker::all()->map(function ($blocker) {
+            return [
+                'id' => $blocker->id,
+                'title' => 'Blokada',
+                'start' => $blocker->starts_at,
+                'end' => ($blocker->ends_at ?? Carbon::parse($blocker->starts_at)->addHour())->toDateTimeString(),
+                'color' => '#6b7280',
+                'extendedProps' => [
+                    'note' => $blocker->note,
+                ],
+            ];
+        });
+    }
+}

--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -10,15 +10,6 @@ class AdminDashboardController extends Controller
 {
     public function index()
     {
-        $nextAppointment = Appointment::with(['user', 'serviceVariant.service'])
-            ->where('appointment_at', '>=', now())
-            ->orderBy('appointment_at')
-            ->first();
-
-        $upcomingCount = Appointment::where('appointment_at', '>=', now())->count();
-
-        $pendingCount = Appointment::whereIn('status', ['oczekuje', 'proponowana'])->count();
-
         $unreadMessages = KontaktMessage::where('is_from_admin', false)
             ->where('is_read', false)
             ->count();
@@ -26,9 +17,6 @@ class AdminDashboardController extends Controller
         $userCount = User::count();
 
         return view('admin.dashboard', [
-            'nextAppointment' => $nextAppointment,
-            'upcomingCount' => $upcomingCount,
-            'pendingCount' => $pendingCount,
             'unreadMessages' => $unreadMessages,
             'userCount' => $userCount,
         ]);

--- a/resources/views/admin/blockers/calendar.blade.php
+++ b/resources/views/admin/blockers/calendar.blade.php
@@ -1,0 +1,15 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl leading-tight">
+            Zarządzanie blokadami czasu
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div id="calendar" data-events-url="{{ route('admin.blockers.api') }}" class="bg-white shadow rounded-lg p-4"></div>
+    </div>
+
+    @push('scripts')
+        @vite('resources/js/calendar.js')
+    @endpush
+</x-app-layout>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -7,28 +7,7 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-5">
-                <div class="bg-white p-6 rounded-lg shadow">
-                    <p class="text-sm text-gray-500">Najbliższa wizyta</p>
-                    @if($nextAppointment)
-                        <p class="mt-2 font-semibold">
-                            {{ $nextAppointment->appointment_at->format('d.m.Y H:i') }}
-                        </p>
-                        <p class="text-xs text-gray-600">
-                            {{ $nextAppointment->user->name }} - {{ $nextAppointment->serviceVariant->service->name }}
-                        </p>
-                    @else
-                        <p class="mt-2 text-gray-400 italic">Brak zaplanowanych wizyt</p>
-                    @endif
-                </div>
-                <div class="bg-white p-6 rounded-lg shadow">
-                    <p class="text-sm text-gray-500">Nadchodzące wizyty</p>
-                    <p class="mt-2 text-2xl font-bold">{{ $upcomingCount }}</p>
-                </div>
-                <div class="bg-white p-6 rounded-lg shadow">
-                    <p class="text-sm text-gray-500">Oczekuje potwierdzenia</p>
-                    <p class="mt-2 text-2xl font-bold">{{ $pendingCount }}</p>
-                </div>
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-2">
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Nieprzeczytane wiadomości</p>
                     <p class="mt-2 text-2xl font-bold">{{ $unreadMessages }}</p>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -69,6 +69,7 @@
                     <a href="{{ route('dashboard') }}" class="block text-gray-700">Dashboard</a>
                     <a href="{{ route('admin.services.index') }}" class="block text-gray-700">Usługi (admin)</a>
                     <a href="{{ route('admin.calendar') }}" class="block text-gray-700">Kalendarz</a>
+                    <a href="{{ route('admin.blockers.calendar') }}" class="block text-gray-700">Blokady</a>
                     <a href="{{ route('admin.kontakt.edit') }}" class="block text-gray-700">Kontakt</a>
                     <a href="{{ route('admin.messages.index') }}" class="block text-gray-700">Wiadomości
                         @if($unreadMessages > 0)
@@ -108,6 +109,10 @@
                 <a href="{{ route('admin.calendar') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-calendar class="w-4 h-4 mr-1 text-gray-500" />
                     Kalendarz
+                </a>
+                <a href="{{ route('admin.blockers.calendar') }}" class="flex items-center text-gray-700 hover:underline">
+                    <x-heroicon-o-lock-closed class="w-4 h-4 mr-1 text-gray-500" />
+                    Blokady
                 </a>
                 <a href="{{ route('admin.kontakt.edit') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-phone class="w-4 h-4 mr-1 text-gray-500" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\AdminServiceController;
 use App\Http\Controllers\AdminUserController;
 use App\Http\Controllers\AdminCouponController;
 use App\Http\Controllers\AdminDashboardController;
+use App\Http\Controllers\AdminBlockerController;
 use App\Http\Controllers\AppointmentController;
 use App\Http\Controllers\KontaktController;
 use App\Http\Controllers\ContactController;
@@ -105,6 +106,10 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
     Route::patch('/kalendarz/{appointment}/cancel', [AdminAppointmentController::class, 'cancel'])->name('appointments.cancel');
     Route::patch('/kalendarz/{appointment}/status', [AdminAppointmentController::class, 'updateStatus'])->name('appointments.updateStatus');
     Route::get('/kalendarz/{appointment}', [AdminAppointmentController::class, 'show'])->name('appointments.show');
+
+    // Blokady
+    Route::get('/blokady', [AdminBlockerController::class, 'calendar'])->name('blockers.calendar');
+    Route::get('/blokady/api', [AdminBlockerController::class, 'api'])->name('blockers.api');
     
     // API do dropdownów i godzin pracy
     Route::get('/api/users', [AdminAppointmentController::class, 'users'])->name('appointments.users');


### PR DESCRIPTION
## Summary
- trim appointment stats from the admin dashboard
- add a simple blocker management calendar
- link blocker calendar from navigation
- wire new controller and routes for blockers

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ef355bd08329821ed3093ca6d6c0