### PR TITLE
Update dashboard counters

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -17,11 +17,15 @@ class DashboardController extends Controller
             ->orderBy('appointment_at')
             ->first();
 
+        $currentYear = now()->year;
+
         $pastCount = Appointment::where('user_id', $userId)
+            ->whereYear('appointment_at', $currentYear)
             ->where('status', 'odbyta')
             ->count();
 
         $missedCount = Appointment::where('user_id', $userId)
+            ->whereYear('appointment_at', $currentYear)
             ->where('status', 'nieodbyta')
             ->count();
 
@@ -36,10 +40,12 @@ class DashboardController extends Controller
 
         return view('dashboard', [
             'nextAppointment' => $nextAppointment,
-            'pastCount' => $pastCount,
-            'missedCount' => $missedCount,
-            'pendingCount' => $pendingCount,
-            'unreadMessages' => $unreadMessages,
+            'pastCount'       => $pastCount,
+            'missedCount'     => $missedCount,
+            'pendingCount'    => $pendingCount,
+            'unreadMessages'  => $unreadMessages,
+            'messagesUrl'     => route('messages.index'),
+            'pendingUrl'      => route('appointments.index'),
         ]);
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,10 +11,12 @@
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Najbliższa wizyta</p>
                     @if($nextAppointment)
-                        <p class="mt-2 font-semibold">
-                            {{ $nextAppointment->appointment_at->format('d.m.Y H:i') }}
-                        </p>
-                        <p class="text-xs text-gray-600 capitalize">{{ $nextAppointment->status }}</p>
+                        <a href="{{ route('admin.calendar', ['jump' => $nextAppointment->id]) }}" class="block hover:underline">
+                            <p class="mt-2 font-semibold">
+                                {{ $nextAppointment->appointment_at->format('d.m.Y H:i') }}
+                            </p>
+                            <p class="text-xs text-gray-600 capitalize">{{ $nextAppointment->status }}</p>
+                        </a>
                     @else
                         <p class="mt-2 text-gray-400 italic">Brak zaplanowanych wizyt</p>
                     @endif
@@ -26,11 +28,15 @@
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Oczekuje potwierdzenia</p>
-                    <p class="mt-2 text-2xl font-bold">{{ $pendingCount }}</p>
+                    <p class="mt-2 text-2xl font-bold">
+                        <a href="{{ $pendingUrl }}" class="hover:underline">{{ $pendingCount }}</a>
+                    </p>
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Nieprzeczytane wiadomości</p>
-                    <p class="mt-2 text-2xl font-bold">{{ $unreadMessages }}</p>
+                    <p class="mt-2 text-2xl font-bold">
+                        <a href="{{ $messagesUrl }}" class="hover:underline">{{ $unreadMessages }}</a>
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- filter appointment statistics by current year
- provide URLs to messages and appointments in the dashboard
- link next appointment panel to calendar
- make counters clickable

## Testing
- `composer test` *(fails: AppointmentBusyTimesTest)*

------
https://chatgpt.com/codex/tasks/task_e_6863f8fed3e08329a9e13127f7ff3d90