### PR TITLE
Add user appointments calendar view

### DIFF
--- a/resources/js/userAppointmentsCalendar.js
+++ b/resources/js/userAppointmentsCalendar.js
@@ -1,0 +1,22 @@
+import { Calendar } from '@fullcalendar/core';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import listPlugin from '@fullcalendar/list';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const el = document.getElementById('calendar');
+    if (!el) return;
+    const url = el.dataset.eventsUrl;
+    const calendar = new Calendar(el, {
+        plugins: [dayGridPlugin, timeGridPlugin, listPlugin],
+        initialView: 'timeGridWeek',
+        headerToolbar: {
+            left: 'prev,next today',
+            center: 'title',
+            right: 'dayGridMonth,timeGridWeek,listWeek'
+        },
+        locale: 'pl',
+        events: url,
+    });
+    calendar.render();
+});

--- a/resources/views/appointments/calendar.blade.php
+++ b/resources/views/appointments/calendar.blade.php
@@ -1,0 +1,15 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl leading-tight">
+            Mój kalendarz wizyt
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div id="calendar" data-events-url="{{ route('appointments.calendar.api') }}" class="bg-white shadow rounded-lg p-4"></div>
+    </div>
+
+    @push('scripts')
+        @vite('resources/js/userAppointmentsCalendar.js')
+    @endpush
+</x-app-layout>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,7 +11,7 @@
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Najbliższa wizyta</p>
                     @if($nextAppointment)
-                        <a href="{{ route('admin.calendar', ['jump' => $nextAppointment->id]) }}" class="block hover:underline">
+                        <a href="{{ route('appointments.calendar', ['jump' => $nextAppointment->id]) }}" class="block hover:underline">
                             <p class="mt-2 font-semibold">
                                 {{ $nextAppointment->appointment_at->format('d.m.Y H:i') }}
                             </p>
@@ -37,6 +37,10 @@
                     <p class="mt-2 text-2xl font-bold">
                         <a href="{{ $messagesUrl }}" class="hover:underline">{{ $unreadMessages }}</a>
                     </p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Kalendarz wizyt</p>
+                    <a href="{{ route('appointments.calendar') }}" class="mt-2 inline-block text-indigo-600 hover:underline">Przeglądaj</a>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -80,6 +80,7 @@
                 @else
                     <a href="{{ route('dashboard') }}" class="block text-gray-700">Dashboard</a>
                     <a href="{{ route('appointments.index') }}" class="block text-gray-700">Moje rezerwacje</a>
+                    <a href="{{ route('appointments.calendar') }}" class="block text-gray-700">Kalendarz wizyt</a>
                     <a href="{{ route('messages.index') }}" class="block text-gray-700">Wiadomości
                         @if($unreadMessages > 0)
                             <span class="ml-1 bg-red-500 text-white rounded-full px-2 text-xs">{{ $unreadMessages }}</span>
@@ -137,6 +138,10 @@
                 <a href="{{ route('appointments.index') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-calendar-days class="w-4 h-4 mr-1 text-gray-500" />
                     Moje rezerwacje
+                </a>
+                <a href="{{ route('appointments.calendar') }}" class="flex items-center text-gray-700 hover:underline">
+                    <x-heroicon-o-calendar class="w-4 h-4 mr-1 text-gray-500" />
+                    Kalendarz
                 </a>
                 <a href="{{ route('messages.index') }}" class="flex items-center text-gray-700 hover:underline">
                     <x-heroicon-o-chat-bubble-left class="w-4 h-4 mr-1 text-gray-500" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,8 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth'])->group(function () {
     Route::get('/moje-wizyty', [AppointmentController::class, 'index'])->name('appointments.index');
     Route::get('/moje-wizyty/{id}', [AppointmentController::class, 'show'])->name('appointments.show');
+    Route::get('/kalendarz/moje-wizyty', [AppointmentController::class, 'calendar'])->name('appointments.calendar');
+    Route::get('/kalendarz/moje-wizyty/api', [AppointmentController::class, 'calendarApi'])->name('appointments.calendar.api');
     Route::get('/rezerwacje/dodaj', [AppointmentController::class, 'create'])->name('appointments.create');
     Route::post('/rezerwacje', [AppointmentController::class, 'store'])->name('appointments.store');
     Route::get('/rezerwacje/busy', [AppointmentController::class, 'busyTimes'])->name('appointments.busy');

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
         'resources/js/app.js',
         'resources/js/calendar.js',
         'resources/js/userCalendar.js',
+        'resources/js/userAppointmentsCalendar.js',
       ],
       refresh: true,
     }),


### PR DESCRIPTION
## Summary
- show user's appointments in a calendar
- expose `/kalendarz/moje-wizyty` and API endpoint
- link new calendar from navigation and dashboard
- include new JS build asset for the simple calendar

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa6344e08329aa0612eb9d3e4234