### PR TITLE
Improve message highlighting logic

### DIFF
--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -12,13 +12,17 @@
 
         @forelse($messages as $msg)
             @php
+                $unreadAdminReplies = $msg->replies
+                    ->where('is_from_admin', true)
+                    ->where('is_read', false)
+                    ->count();
+
                 $textColor = '';
-                if (! $msg->is_read && $msg->is_from_admin) {
+
+                if ($unreadAdminReplies > 0) {
                     $textColor = 'text-red-600';
-                } elseif ($msg->replies->where('is_from_admin', true)->isEmpty()) {
+                } elseif ($msg->replies->where('is_from_admin', true)->count() === 0) {
                     $textColor = 'text-orange-600';
-                } elseif ($msg->replies->where('is_from_admin', true)->isNotEmpty() && $msg->is_read) {
-                    $textColor = 'text-green-600';
                 }
             @endphp
             <a href="{{ route('messages.show', $msg->id) }}" class="block bg-white p-4 rounded-lg shadow mb-4 hover:bg-gray-50 {{ $textColor }}">

--- a/tests/Feature/AppointmentBusyTimesTest.php
+++ b/tests/Feature/AppointmentBusyTimesTest.php
@@ -49,7 +49,7 @@ class AppointmentBusyTimesTest extends TestCase
         $data = $response->json();
 
         $this->assertCount(2, $data);
-        $starts = array_column($data, 'start');
+        $starts = array_map(fn ($s) => Carbon::parse($s)->setTimezone('Europe/Warsaw')->format('Y-m-d H:i:s'), array_column($data, 'start'));
         $this->assertContains($appointmentTime->format('Y-m-d H:i:s'), $starts);
         $this->assertContains($blockerStart->format('Y-m-d H:i:s'), $starts);
     }

--- a/tests/Feature/MessageHighlightTest.php
+++ b/tests/Feature/MessageHighlightTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\KontaktMessage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MessageHighlightTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createThreadWithAdminReply(bool $replyRead = false): KontaktMessage
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create(["role" => "admin"]);
+
+        $message = KontaktMessage::create([
+            "user_id"       => $user->id,
+            "name"          => $user->name,
+            "email"         => $user->email,
+            "message"       => "Initial from user",
+            "reply_to_id"   => null,
+            "is_from_admin" => false,
+            "is_read"       => true,
+        ]);
+
+        KontaktMessage::create([
+            "user_id"       => $user->id,
+            "admin_id"      => $admin->id,
+            "name"          => $admin->name,
+            "email"         => $admin->email,
+            "message"       => "Reply from admin",
+            "reply_to_id"   => $message->id,
+            "is_from_admin" => true,
+            "is_read"       => $replyRead,
+        ]);
+
+        return $message;
+    }
+
+    public function test_unread_admin_reply_highlights_red(): void
+    {
+        $message = $this->createThreadWithAdminReply(false);
+        $user = $message->user;
+
+        $response = $this->actingAs($user)->get(route("messages.index", absolute: false));
+        $response->assertOk();
+        $response->assertSee("hover:bg-gray-50 text-red-600");
+    }
+
+    public function test_highlight_removed_after_reading(): void
+    {
+        $message = $this->createThreadWithAdminReply(false);
+        $user = $message->user;
+
+        $this->actingAs($user)->get(route("messages.show", $message->id, absolute: false));
+
+        $response = $this->actingAs($user)->get(route("messages.index", absolute: false));
+        $response->assertOk();
+        $response->assertDontSee("hover:bg-gray-50 text-red-600");
+    }
+
+    public function test_no_admin_reply_highlights_orange(): void
+    {
+        $user = User::factory()->create();
+
+        KontaktMessage::create([
+            "user_id"       => $user->id,
+            "name"          => $user->name,
+            "email"         => $user->email,
+            "message"       => "Waiting for reply",
+            "reply_to_id"   => null,
+            "is_from_admin" => false,
+        ]);
+
+        $response = $this->actingAs($user)->get(route("messages.index", absolute: false));
+        $response->assertOk();
+        $response->assertSee("text-orange-600");
+    }
+}


### PR DESCRIPTION
## Summary
- refine text color calculation in messages index
- add feature test for message highlighting
- fix busy times test for timezone-safe comparison

## Testing
- `php ./vendor/bin/phpunit --filter MessageHighlightTest`
- `php ./vendor/bin/phpunit --filter AppointmentBusyTimesTest`
- `php ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68640263c9fc83299d18fd8044c14f7f