### PR TITLE
Fix unread replies marking on admin message view

### DIFF
--- a/app/Http/Controllers/AdminKontaktController.php
+++ b/app/Http/Controllers/AdminKontaktController.php
@@ -25,9 +25,13 @@ class AdminKontaktController extends Controller
     {
         $message = KontaktMessage::with(['user', 'replies.user', 'replies.admin'])->findOrFail($id);
 
+        $message->replies()
+            ->where('is_from_admin', false)
+            ->where('is_read', false)
+            ->update(['is_read' => true]);
+
         if (! $message->is_read) {
             $message->update(['is_read' => true]);
-            $message->replies()->where('is_from_admin', false)->update(['is_read' => true]);
         }
 
         return view('admin.messages.show', compact('message'));


### PR DESCRIPTION
## Summary
- mark unread user replies as read whenever an admin opens the conversation
- only set the parent message's read status if needed

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68640769e9e48329a58e643331bc634c