### PR TITLE
Add status transitions for messages

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -11,7 +11,11 @@ class AdminDashboardController extends Controller
     public function index()
     {
         $unreadMessages = KontaktMessage::where('is_from_admin', false)
-            ->where('is_read', false)
+            ->whereNull('reply_to_id')
+            ->whereIn('status', [
+                KontaktMessage::STATUS_SENT,
+                KontaktMessage::STATUS_NEW_REPLY,
+            ])
             ->count();
 
         $userCount = User::count();

--- a/app/Http/Controllers/AdminKontaktController.php
+++ b/app/Http/Controllers/AdminKontaktController.php
@@ -30,9 +30,10 @@ class AdminKontaktController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        if (! $message->is_read) {
-            $message->update(['is_read' => true]);
-        }
+        $message->update([
+            'is_read' => true,
+            'status'  => KontaktMessage::STATUS_READ,
+        ]);
 
         return view('admin.messages.show', compact('message'));
     }
@@ -52,7 +53,10 @@ class AdminKontaktController extends Controller
             'reply_to_id'  => $parent->id,
             'is_from_admin'=> true,
             'is_read'      => false,
+            'status'       => KontaktMessage::STATUS_SENT,
         ]);
+
+        $parent->update(['status' => KontaktMessage::STATUS_NEW_REPLY]);
         // Powiadomienia są wysyłane przez KontaktMessageObserver
         return back()->with('success', 'Odpowiedź wysłana do klienta.');
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -34,8 +34,8 @@ class DashboardController extends Controller
             ->count();
 
         $unreadMessages = KontaktMessage::where('user_id', $userId)
-            ->where('is_from_admin', true)
-            ->where('is_read', false)
+            ->whereNull('reply_to_id')
+            ->where('status', KontaktMessage::STATUS_NEW_REPLY)
             ->count();
 
         return view('dashboard', [

--- a/app/Http/Controllers/KontaktController.php
+++ b/app/Http/Controllers/KontaktController.php
@@ -28,9 +28,10 @@ class KontaktController extends Controller
             ->where('is_read', false)
             ->update(['is_read' => true]);
 
-        if (! $message->is_read) {
-            $message->update(['is_read' => true]);
-        }
+        $message->update([
+            'is_read' => true,
+            'status'  => KontaktMessage::STATUS_READ,
+        ]);
 
         return view('messages.show', compact('message'));
     }
@@ -70,7 +71,7 @@ class KontaktController extends Controller
                 'reply_to_id'   => null, // ensure new thread
                 'is_from_admin' => false,
                 'is_read'       => false,
-                'status'        => 'nowa',
+                'status'        => KontaktMessage::STATUS_SENT,
             ]);
         } else {
             $request->validate([
@@ -90,7 +91,7 @@ class KontaktController extends Controller
                 'reply_to_id'    => null, // ensure new thread for guests
                 'is_from_admin'  => false,
                 'is_read'        => false,
-                'status'         => 'nowa',
+                'status'         => KontaktMessage::STATUS_SENT,
             ]);
         }
 
@@ -116,8 +117,10 @@ class KontaktController extends Controller
             'user_id'       => auth()->id(),
             'is_from_admin' => false,
             'is_read'       => false,
-            'status'        => 'nowa',
+            'status'        => KontaktMessage::STATUS_SENT,
         ]);
+
+        $parent->update(['status' => KontaktMessage::STATUS_NEW_REPLY]);
 
         return back()->with('success', 'Twoja wiadomość została wysłana.');
     }

--- a/app/Models/KontaktMessage.php
+++ b/app/Models/KontaktMessage.php
@@ -9,6 +9,10 @@ class KontaktMessage extends Model
 {
     use HasFactory;
 
+    public const STATUS_SENT = 'wyslane';
+    public const STATUS_READ = 'odczytana';
+    public const STATUS_NEW_REPLY = 'nowa';
+
     protected $table = 'kontakt_messages';
 
     protected $fillable = [
@@ -27,7 +31,7 @@ class KontaktMessage extends Model
     protected $attributes = [
         'is_from_admin' => false,
         'is_read' => false,
-        'status' => 'nowa',
+        'status' => self::STATUS_SENT,
     ];
 
     protected $casts = [

--- a/database/migrations/2025_07_02_000000_extend_status_enum_in_kontakt_messages.php
+++ b/database/migrations/2025_07_02_000000_extend_status_enum_in_kontakt_messages.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE kontakt_messages MODIFY status ENUM('nowa','odczytana','zamknieta','wyslane') DEFAULT 'nowa'");
+        }
+    }
+
+    public function down(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE kontakt_messages MODIFY status ENUM('nowa','odczytana','zamknieta') DEFAULT 'nowa'");
+        }
+    }
+};

--- a/tests/Feature/KontaktMessageStatusTest.php
+++ b/tests/Feature/KontaktMessageStatusTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\KontaktMessage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class KontaktMessageStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_status_transitions_on_send_read_and_reply(): void
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $this->actingAs($user)->post(route('messages.store', absolute: false), [
+            'message' => 'Hello',
+            'category' => '',
+            'phone' => '',
+        ]);
+
+        $message = KontaktMessage::first();
+        $this->assertSame(KontaktMessage::STATUS_SENT, $message->status);
+
+        $this->actingAs($admin)->get(route('admin.messages.show', $message->id, absolute: false));
+        $this->assertSame(KontaktMessage::STATUS_READ, $message->fresh()->status);
+
+        $this->actingAs($admin)->post(route('admin.messages.reply', $message->id, absolute: false), [
+            'message' => 'Reply',
+        ]);
+        $this->assertSame(KontaktMessage::STATUS_NEW_REPLY, $message->fresh()->status);
+
+        $this->actingAs($user)->get(route('messages.show', $message->id, absolute: false));
+        $this->assertSame(KontaktMessage::STATUS_READ, $message->fresh()->status);
+
+        $this->actingAs($user)->post(route('messages.reply', $message->id, absolute: false), [
+            'message' => 'Back at you',
+        ]);
+        $this->assertSame(KontaktMessage::STATUS_NEW_REPLY, $message->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Summary
- add constants for message statuses
- count dashboard alerts by status
- update messages controllers to track sent/read/new reply states
- add migration for the new `wyslane` status value
- test KontaktMessage status transitions

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68640d14907c8329aefaa4e5500be5c2