### PR TITLE
Fix unread message counter

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -7,7 +7,11 @@
         if (Auth::check()) {
             if (Auth::user()->role === 'admin') {
                 $unreadMessages = KontaktMessage::where('is_from_admin', false)
-                    ->where('is_read', false)
+                    ->whereNull('reply_to_id')
+                    ->whereIn('status', [
+                        KontaktMessage::STATUS_SENT,
+                        KontaktMessage::STATUS_NEW_REPLY,
+                    ])
                     ->count();
             } else {
                 $unreadMessages = KontaktMessage::where('user_id', Auth::id())


### PR DESCRIPTION
## Summary
- align navigation unread message count with AdminDashboard logic

## Testing
- `composer install` *(fails: composer not found)*
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865224a92d08329b591ad20337d6eb9