### PR TITLE
Fix admin message counter logic

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -12,10 +12,14 @@ class AdminDashboardController extends Controller
     {
         $unreadMessages = KontaktMessage::where('is_from_admin', false)
             ->whereNull('reply_to_id')
-            ->whereIn('status', [
-                KontaktMessage::STATUS_SENT,
-                KontaktMessage::STATUS_NEW_REPLY,
-            ])
+            ->where(function ($query) {
+                $query->whereDoesntHave('replies', function ($q) {
+                    $q->where('is_from_admin', true);
+                })->orWhereHas('replies', function ($q) {
+                    $q->where('is_from_admin', false)
+                        ->where('is_read', false);
+                });
+            })
             ->count();
 
         $userCount = User::count();

--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -16,7 +16,9 @@
                 @if(!$last || !$last->is_from_admin)
                     <div class="text-red-600 text-xs mt-1">Wymaga odpowiedzi</div>
                 @else
-                    <div class="text-green-600 text-xs mt-1">Odpowiedź udzielona</div>
+                    <div class="text-xs mt-1 {{ $last->is_read ? 'text-green-600' : 'text-yellow-600' }}">
+                        {{ $last->is_read ? 'Odczytana przez użytkownika' : 'Nieodczytana przez użytkownika' }}
+                    </div>
                 @endif
             </a>
         @endforeach

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -8,10 +8,14 @@
             if (Auth::user()->role === 'admin') {
                 $unreadMessages = KontaktMessage::where('is_from_admin', false)
                     ->whereNull('reply_to_id')
-                    ->whereIn('status', [
-                        KontaktMessage::STATUS_SENT,
-                        KontaktMessage::STATUS_NEW_REPLY,
-                    ])
+                    ->where(function ($query) {
+                        $query->whereDoesntHave('replies', function ($q) {
+                            $q->where('is_from_admin', true);
+                        })->orWhereHas('replies', function ($q) {
+                            $q->where('is_from_admin', false)
+                                ->where('is_read', false);
+                        });
+                    })
                     ->count();
             } else {
                 $unreadMessages = KontaktMessage::where('user_id', Auth::id())

--- a/tests/Feature/AdminMessageCounterTest.php
+++ b/tests/Feature/AdminMessageCounterTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\KontaktMessage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminMessageCounterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function unreadCount(): int
+    {
+        return KontaktMessage::where('is_from_admin', false)
+            ->whereNull('reply_to_id')
+            ->where(function ($query) {
+                $query->whereDoesntHave('replies', function ($q) {
+                    $q->where('is_from_admin', true);
+                })->orWhereHas('replies', function ($q) {
+                    $q->where('is_from_admin', false)
+                        ->where('is_read', false);
+                });
+            })->count();
+    }
+
+    public function test_counter_ignores_threads_waiting_for_user(): void
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $message = KontaktMessage::create([
+            'user_id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'message' => 'Hello',
+            'is_from_admin' => false,
+            'is_read' => false,
+        ]);
+
+        $this->assertSame(1, $this->unreadCount());
+
+        KontaktMessage::create([
+            'user_id' => $user->id,
+            'admin_id' => $admin->id,
+            'name' => $admin->name,
+            'email' => $admin->email,
+            'message' => 'Reply',
+            'reply_to_id' => $message->id,
+            'is_from_admin' => true,
+            'is_read' => false,
+        ]);
+        $message->update(['status' => KontaktMessage::STATUS_NEW_REPLY]);
+
+        $this->assertSame(0, $this->unreadCount());
+
+        KontaktMessage::create([
+            'user_id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'message' => 'Thanks',
+            'reply_to_id' => $message->id,
+            'is_from_admin' => false,
+            'is_read' => false,
+        ]);
+        $message->update(['status' => KontaktMessage::STATUS_NEW_REPLY]);
+
+        $this->assertSame(1, $this->unreadCount());
+    }
+}


### PR DESCRIPTION
## Summary
- refine unread message query for admin dashboard and navigation
- show read status on admin messages list
- add test covering admin message counter behavior

## Testing
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68653d78bb148329b33357c9c3c4ab11