### PR TITLE
Admin dashboard shows upcoming visits and stats

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -24,9 +24,60 @@ class AdminDashboardController extends Controller
 
         $userCount = User::count();
 
+        $upcomingAppointments = Appointment::with('user')
+            ->where('appointment_at', '>=', now())
+            ->where('status', '!=', 'odwołana')
+            ->orderBy('appointment_at')
+            ->take(3)
+            ->get()
+            ->map(function ($appointment) {
+                $appointment->has_missed = Appointment::where('user_id', $appointment->user_id)
+                    ->where('status', 'nieodbyta')
+                    ->exists();
+                return $appointment;
+            });
+
+        $currentStart = now()->startOfMonth();
+        $currentEnd   = now()->endOfMonth();
+        $lastMonthStart = now()->subMonth()->startOfMonth();
+        $lastMonthEnd   = now()->subMonth()->endOfMonth();
+        $lastYearStart  = now()->subYear()->startOfMonth();
+        $lastYearEnd    = now()->subYear()->endOfMonth();
+
+        $completedThisMonth = Appointment::whereBetween('appointment_at', [$currentStart, $currentEnd])
+            ->where('status', 'odbyta')
+            ->count();
+
+        $missedThisMonth = Appointment::whereBetween('appointment_at', [$currentStart, $currentEnd])
+            ->where('status', 'nieodbyta')
+            ->count();
+
+        $completedLastMonth = Appointment::whereBetween('appointment_at', [$lastMonthStart, $lastMonthEnd])
+            ->where('status', 'odbyta')
+            ->count();
+
+        $missedLastMonth = Appointment::whereBetween('appointment_at', [$lastMonthStart, $lastMonthEnd])
+            ->where('status', 'nieodbyta')
+            ->count();
+
+        $completedLastYear = Appointment::whereBetween('appointment_at', [$lastYearStart, $lastYearEnd])
+            ->where('status', 'odbyta')
+            ->count();
+
+        $missedLastYear = Appointment::whereBetween('appointment_at', [$lastYearStart, $lastYearEnd])
+            ->where('status', 'nieodbyta')
+            ->count();
+
         return view('admin.dashboard', [
-            'unreadMessages' => $unreadMessages,
-            'userCount' => $userCount,
+            'unreadMessages'      => $unreadMessages,
+            'userCount'          => $userCount,
+            'upcomingAppointments' => $upcomingAppointments,
+            'completedThisMonth' => $completedThisMonth,
+            'missedThisMonth'    => $missedThisMonth,
+            'completedLastMonth' => $completedLastMonth,
+            'missedLastMonth'    => $missedLastMonth,
+            'completedLastYear'  => $completedLastYear,
+            'missedLastYear'     => $missedLastYear,
         ]);
     }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -7,7 +7,7 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-2">
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Nieprzeczytane wiadomości</p>
                     <p class="mt-2 text-2xl font-bold">{{ $unreadMessages }}</p>
@@ -15,6 +15,29 @@
                 <div class="bg-white p-6 rounded-lg shadow">
                     <p class="text-sm text-gray-500">Użytkownicy</p>
                     <p class="mt-2 text-2xl font-bold">{{ $userCount }}</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Najbliższe wizyty</p>
+                    @forelse($upcomingAppointments as $appointment)
+                        <div class="mt-2">
+                            <p class="font-semibold">
+                                {{ $appointment->appointment_at->format('d.m.Y H:i') }}
+                                – {{ $appointment->user->name }}
+                            </p>
+                            @if($appointment->has_missed)
+                                <p class="text-xs text-red-600">Klient ma nieodbyte wizyty</p>
+                            @endif
+                        </div>
+                    @empty
+                        <p class="mt-2 text-gray-400 italic">Brak zaplanowanych wizyt</p>
+                    @endforelse
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">Statystyka miesiąca</p>
+                    <p class="mt-2 text-sm">Odbyte: {{ $completedThisMonth }}</p>
+                    <p class="text-xs text-gray-600">Poprzedni miesiąc: {{ $completedLastMonth }}, rok temu: {{ $completedLastYear }}</p>
+                    <p class="mt-2 text-sm">Nieodbyte: {{ $missedThisMonth }}</p>
+                    <p class="text-xs text-gray-600">Poprzedni miesiąc: {{ $missedLastMonth }}, rok temu: {{ $missedLastYear }}</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add query logic for upcoming appointments and monthly stats in `AdminDashboardController`
- display three nearest visits and monthly statistics on the admin dashboard

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686552f7b1788329b88ecc7a711331c3