### PR TITLE
Add admin dashboard stats test

### DIFF
--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Appointment extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'user_id',
         'service_id',

--- a/database/factories/AppointmentFactory.php
+++ b/database/factories/AppointmentFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\ServiceVariant;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AppointmentFactory extends Factory
+{
+    protected $model = Appointment::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'service_id' => Service::factory(),
+            'service_variant_id' => ServiceVariant::factory(),
+            'price_pln' => 100,
+            'discount_percent' => 0,
+            'appointment_at' => $this->faker->dateTimeBetween('-1 month', '+1 month'),
+            'status' => 'zaplanowana',
+        ];
+    }
+}

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceFactory extends Factory
+{
+    protected $model = Service::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/database/factories/ServiceVariantFactory.php
+++ b/database/factories/ServiceVariantFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ServiceVariant;
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceVariantFactory extends Factory
+{
+    protected $model = ServiceVariant::class;
+
+    public function definition(): array
+    {
+        return [
+            'service_id' => Service::factory(),
+            'variant_name' => $this->faker->word(),
+            'duration_minutes' => 60,
+            'price_pln' => 100,
+        ];
+    }
+}

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\ServiceVariant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class AdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_shows_nearest_three_appointments_and_monthly_stats(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create();
+        $service = Service::factory()->create();
+        $variant = ServiceVariant::factory()->for($service)->create();
+
+        // Upcoming appointments
+        $a1 = Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDay()]);
+        $a2 = Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDays(2)]);
+        $a3 = Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDays(3)]);
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDays(4)]);
+
+        // Stats for current month
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create([
+                'appointment_at' => Carbon::now()->startOfMonth()->addHours(5),
+                'status' => 'odbyta',
+            ]);
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create([
+                'appointment_at' => Carbon::now()->startOfMonth()->addHours(6),
+                'status' => 'odbyta',
+            ]);
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create([
+                'appointment_at' => Carbon::now()->startOfMonth()->addHours(7),
+                'status' => 'nieodbyta',
+            ]);
+
+        $response = $this->actingAs($admin)->get(route('admin.dashboard', absolute: false));
+        $response->assertOk();
+
+        $appointments = $response->viewData('upcomingAppointments');
+        $this->assertEqualsCanonicalizing([
+            $a1->id,
+            $a2->id,
+            $a3->id,
+        ], $appointments->pluck('id')->all());
+
+        $response->assertViewHas('completedThisMonth', 2);
+        $response->assertViewHas('missedThisMonth', 1);
+    }
+}


### PR DESCRIPTION
## Summary
- create factories for `Appointment`, `Service`, and `ServiceVariant`
- enable factory usage in `Appointment` model
- add feature test for admin dashboard statistics

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68655b6daf2c8329af7ac4aca955b241