### PR TITLE
Add tests to CI pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+          extensions: mbstring, intl, pdo_sqlite
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -28,10 +29,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rsync openssh-client
 
       - name: Install Composer dependencies
-        run: composer install --no-interaction --no-progress --no-dev
+        run: composer install --no-interaction --no-progress
 
       - name: Install NPM dependencies
         run: npm ci
+
+      - name: Run tests
+        run: php artisan test
 
       - name: Build assets
         run: npm run build

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -14,12 +14,13 @@ pipelines:
             - composer
             - npm
           script:
-            - apt-get update && apt-get install -y unzip git nodejs npm
+            - apt-get update && apt-get install -y unzip git nodejs npm libsqlite3-dev
+            - docker-php-ext-install pdo_sqlite
             - curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-            - composer install --no-interaction --no-progress --no-dev
+            - composer install --no-interaction --no-progress
             - npm ci
+            - php artisan test
             - npm run build
-            # (Opcjonalnie) composer test
           artifacts:
             - vendor/**
             - public/build/**


### PR DESCRIPTION
## Summary
- install PHP extensions and dev dependencies in CI
- run `php artisan test` in GitHub and Bitbucket pipelines

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68655f8e0d148329863a937cf1641aad