### PR TITLE
Improve dashboard performance

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use App\Models\Appointment;
 
 class User extends Authenticatable
 {
@@ -44,4 +45,14 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function appointments()
+    {
+        return $this->hasMany(Appointment::class);
+    }
+
+    public function missedAppointments()
+    {
+        return $this->appointments()->where('status', 'nieodbyta');
+    }
 }


### PR DESCRIPTION
## Summary
- optimize Admin dashboard appointment check
- centralize `now()` usage to avoid repeated calls
- add appointment relations to User model

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686567264fec83299336afa47d776478