### PR TITLE
Add admin dashboard display test

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -28,7 +28,6 @@ class AdminDashboardController extends Controller
         $now = Carbon::now();
 
         $upcomingAppointments = Appointment::with('user')
-            ->withExists('user.missedAppointments')
             ->where('appointment_at', '>=', $now)
             ->where('status', '!=', 'odwołana')
             ->orderBy('appointment_at')
@@ -36,7 +35,7 @@ class AdminDashboardController extends Controller
             ->get();
 
         $upcomingAppointments->each(function ($appointment) {
-            $appointment->has_missed = $appointment->user_missed_appointments_exists;
+            $appointment->has_missed = $appointment->user->missedAppointments()->exists();
         });
 
         $currentStart   = $now->copy()->startOfMonth();

--- a/tests/Feature/AdminDashboardDisplayTest.php
+++ b/tests/Feature/AdminDashboardDisplayTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\ServiceVariant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class AdminDashboardDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_displays_next_three_appointments_and_stats(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create(['name' => 'Alice']);
+        $user2 = User::factory()->create(['name' => 'Bob']);
+        $service = Service::factory()->create();
+        $variant = ServiceVariant::factory()->for($service)->create();
+
+        // Upcoming appointments
+        $a1 = Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDay()]);
+        $a2 = Appointment::factory()->for($user2)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDays(2)]);
+        $a3 = Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDays(3)]);
+        $a4 = Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create(['appointment_at' => Carbon::now()->addDays(4)]);
+
+        // Stats for current month
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create([
+                'appointment_at' => Carbon::now()->startOfMonth()->addHours(5),
+                'status' => 'odbyta',
+            ]);
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create([
+                'appointment_at' => Carbon::now()->startOfMonth()->addHours(6),
+                'status' => 'odbyta',
+            ]);
+        Appointment::factory()->for($user)->for($service)->for($variant)
+            ->create([
+                'appointment_at' => Carbon::now()->startOfMonth()->addHours(7),
+                'status' => 'nieodbyta',
+            ]);
+
+        $response = $this->actingAs($admin)
+            ->get(route('admin.dashboard', absolute: false));
+
+        $response->assertOk();
+        $response->assertSee($a1->appointment_at->format('d.m.Y H:i'));
+        $response->assertSee($a2->appointment_at->format('d.m.Y H:i'));
+        $response->assertSee($a3->appointment_at->format('d.m.Y H:i'));
+        $response->assertDontSee($a4->appointment_at->format('d.m.Y H:i'));
+        $response->assertSee('Odbyte: 2');
+        $response->assertSee('Nieodbyte: 1');
+    }
+}


### PR DESCRIPTION
## Summary
- use runtime check for missed appointments instead of withExists
- add feature test covering rendered admin dashboard output

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68656e61a5248329beb7502ccf445ffc