### PR TITLE
Add basic policy pages

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -28,8 +28,15 @@
     </main>
 
     <footer class="bg-gray-100 border-t mt-12">
-        <div class="max-w-7xl mx-auto px-4 py-6 text-center text-sm text-gray-600">
-            &copy; {{ date('Y') }} Akademia Zdrowych Włosów Black&White
+        <div class="max-w-7xl mx-auto px-4 py-6 text-center text-sm text-gray-600 space-y-2">
+            <div>&copy; {{ date('Y') }} Akademia Zdrowych Włosów Black&White</div>
+            <div class="space-x-4">
+                <a href="{{ route('privacy') }}" class="hover:underline">Polityka prywatności</a>
+                <a href="{{ route('cookies') }}" class="hover:underline">Polityka cookies</a>
+                <a href="{{ route('terms') }}" class="hover:underline">Regulamin</a>
+                <a href="{{ route('policy.contact') }}" class="hover:underline">Kontakt</a>
+                <a href="{{ route('complaints') }}" class="hover:underline">Reklamacje</a>
+            </div>
         </div>
     </footer>
     @stack('scripts')

--- a/resources/views/policy/complaints.blade.php
+++ b/resources/views/policy/complaints.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto py-20 prose">
+        <h1>Reklamacje</h1>
+        <p>Zasady składania reklamacji będą tutaj dostępne wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/resources/views/policy/contact.blade.php
+++ b/resources/views/policy/contact.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto py-20 prose">
+        <h1>Kontakt</h1>
+        <p>Dane kontaktowe oraz dodatkowe informacje będą tutaj dostępne wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/resources/views/policy/cookies.blade.php
+++ b/resources/views/policy/cookies.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto py-20 prose">
+        <h1>Polityka cookies</h1>
+        <p>Informacje o plikach cookies będą tutaj dostępne wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/resources/views/policy/privacy.blade.php
+++ b/resources/views/policy/privacy.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto py-20 prose">
+        <h1>Polityka prywatności</h1>
+        <p>Treść polityki prywatności będzie tutaj dostępna wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/resources/views/policy/terms.blade.php
+++ b/resources/views/policy/terms.blade.php
@@ -1,0 +1,6 @@
+<x-guest-layout>
+    <div class="max-w-3xl mx-auto py-20 prose">
+        <h1>Regulamin</h1>
+        <p>Treść regulaminu będzie tutaj dostępna wkrótce.</p>
+    </div>
+</x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,11 @@ Route::view('/faq', 'pages.faq')->name('faq');
 Route::get('/kontakt', [ContactController::class, 'show'])->name('kontakt');
 
 Route::post('/kontakt', [KontaktController::class, 'store'])->name('kontakt.store');
+Route::view('/polityka-prywatnosci', 'policy.privacy')->name('privacy');
+Route::view('/polityka-cookies', 'policy.cookies')->name('cookies');
+Route::view('/regulamin', 'policy.terms')->name('terms');
+Route::view('/dane-kontaktowe', 'policy.contact')->name('policy.contact');
+Route::view('/reklamacje', 'policy.complaints')->name('complaints');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add placeholder templates for privacy policy, cookies, terms, contact info and complaints
- register view routes for each policy page
- link policy pages from the public footer

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866493a5fc08329b643ad4b09a5f6a5