### PR TITLE
Add pagination to admin messages

### DIFF
--- a/app/Http/Controllers/AdminKontaktController.php
+++ b/app/Http/Controllers/AdminKontaktController.php
@@ -16,7 +16,7 @@ class AdminKontaktController extends Controller
             ->whereNull('reply_to_id')
             ->latest()
             ->with(['user', 'replies'])
-            ->get();
+            ->paginate(20);
 
         return view('admin.messages.index', compact('messages'));
     }

--- a/resources/views/admin/messages/index.blade.php
+++ b/resources/views/admin/messages/index.blade.php
@@ -22,5 +22,8 @@
                 @endif
             </a>
         @endforeach
+        <div class="mt-6">
+            {{ $messages->links() }}
+        </div>
     </div>
 </x-app-layout>

--- a/tests/Feature/AdminMessagesPaginationTest.php
+++ b/tests/Feature/AdminMessagesPaginationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\KontaktMessage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminMessagesPaginationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_paginates_messages(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create();
+
+        for ($i = 0; $i < 25; $i++) {
+            KontaktMessage::create([
+                'user_id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'message' => 'Test ' . $i,
+                'is_from_admin' => false,
+                'is_read' => false,
+            ]);
+        }
+
+        $response = $this->actingAs($admin)
+            ->get(route('admin.messages.index', absolute: false));
+
+        $response->assertOk();
+        $messages = $response->viewData('messages');
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $messages);
+        $this->assertCount(20, $messages);
+
+        $responsePage2 = $this->actingAs($admin)
+            ->get(route('admin.messages.index', ['page' => 2], absolute: false));
+
+        $responsePage2->assertOk();
+        $messagesPage2 = $responsePage2->viewData('messages');
+        $this->assertCount(5, $messagesPage2);
+    }
+}


### PR DESCRIPTION
## Summary
- paginate messages in `AdminKontaktController`
- show pagination links on admin message index page
- test that admin message index paginates results

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68664b9f4348832981e2a18be6ccb8d6