### PR TITLE
Implement dynamic working hours

### DIFF
--- a/app/Http/Controllers/AdminAppointmentController.php
+++ b/app/Http/Controllers/AdminAppointmentController.php
@@ -5,6 +5,7 @@ use App\Models\ServiceVariant;
 use App\Models\Service;
 use App\Models\User;
 use App\Models\Blocker;
+use App\Models\ContactInfo;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -122,11 +123,10 @@ class AdminAppointmentController extends Controller
         $dayOfWeek = $newTime->dayOfWeek;
         $timeOfDay = $newTime->format('H:i');
         
-        // Pobierz godziny pracy dla danego dnia tygodnia
-        // Domyślne godziny pracy
-        $workingHoursStart = '09:00';
-        $workingHoursEnd = '18:00';
-        $isWorkingDay = in_array($dayOfWeek, [1, 2, 3, 4, 5, 6]); // Poniedziałek-Sobota
+        $hours = ContactInfo::getDefault()->formattedWorkingHours();
+        $workingHoursStart = $hours['start'];
+        $workingHoursEnd = $hours['end'];
+        $isWorkingDay = in_array($dayOfWeek, $hours['daysOfWeek']);
         
         // Sprawdź czy dzień jest dniem roboczym
         if (!$isWorkingDay) {
@@ -191,10 +191,10 @@ class AdminAppointmentController extends Controller
         $dayOfWeek = $newDateTime->dayOfWeek;
         $timeOfDay = $newDateTime->format('H:i');
         
-        // Domyślne godziny pracy
-        $workingHoursStart = '09:00';
-        $workingHoursEnd = '18:00';
-        $isWorkingDay = in_array($dayOfWeek, [1, 2, 3, 4, 5, 6]); // Poniedziałek-Sobota
+        $hours = ContactInfo::getDefault()->formattedWorkingHours();
+        $workingHoursStart = $hours['start'];
+        $workingHoursEnd = $hours['end'];
+        $isWorkingDay = in_array($dayOfWeek, $hours['daysOfWeek']);
         
         // Sprawdź czy dzień jest dniem roboczym
         if (!$isWorkingDay) {
@@ -254,9 +254,10 @@ class AdminAppointmentController extends Controller
         $newDateTime = Carbon::parse($request->appointment_at);
         $dayOfWeek = $newDateTime->dayOfWeek;
         $timeOfDay = $newDateTime->format('H:i');
-        $workingHoursStart = '09:00';
-        $workingHoursEnd = '18:00';
-        $isWorkingDay = in_array($dayOfWeek, [1, 2, 3, 4, 5, 6]);
+        $hours = ContactInfo::getDefault()->formattedWorkingHours();
+        $workingHoursStart = $hours['start'];
+        $workingHoursEnd = $hours['end'];
+        $isWorkingDay = in_array($dayOfWeek, $hours['daysOfWeek']);
         if (!$isWorkingDay || $timeOfDay < $workingHoursStart || $timeOfDay > $workingHoursEnd) {
             throw ValidationException::withMessages([
                 'appointment_at' => ['Nie można zaplanować rezerwacji poza godzinami pracy.'],
@@ -329,14 +330,9 @@ class AdminAppointmentController extends Controller
     // Pobieranie godzin pracy
     public function workingHours()
     {
-        // Domyślne godziny pracy
-        $workingHours = [
-            'start' => '09:00',
-            'end' => '18:00',
-            'daysOfWeek' => [1, 2, 3, 4, 5, 6], // Poniedziałek-Sobota
-        ];
+        $hours = ContactInfo::getDefault()->formattedWorkingHours();
 
-        return response()->json($workingHours);
+        return response()->json($hours);
     }
 
     // Historia wizyt klienta dla danej wizyty

--- a/app/Models/ContactInfo.php
+++ b/app/Models/ContactInfo.php
@@ -87,4 +87,45 @@ class ContactInfo extends Model
         
         return $contactInfo;
     }
+
+    /**
+     * Return working hours formatted for calendar JS.
+     */
+    public function formattedWorkingHours(): array
+    {
+        $hours = $this->working_hours ?? [];
+
+        $map = [
+            'sunday' => 0,
+            'monday' => 1,
+            'tuesday' => 2,
+            'wednesday' => 3,
+            'thursday' => 4,
+            'friday' => 5,
+            'saturday' => 6,
+        ];
+
+        $days = [];
+        $starts = [];
+        $ends = [];
+
+        foreach ($map as $key => $index) {
+            if (isset($hours[$key]) && is_array($hours[$key]) && count($hours[$key]) === 2) {
+                $days[] = $index;
+                $starts[] = $hours[$key][0];
+                $ends[] = $hours[$key][1];
+            }
+        }
+
+        sort($days);
+
+        $start = !empty($starts) ? min($starts) : '09:00';
+        $end = !empty($ends) ? max($ends) : '18:00';
+
+        return [
+            'start' => $start,
+            'end' => $end,
+            'daysOfWeek' => $days,
+        ];
+    }
 }

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -8,7 +8,7 @@ import listPlugin from '@fullcalendar/list';
 // console.log('Calendar.js loaded - wersja z wymuszonym inicjowaniem');
 
 // Funkcja inicjalizująca kalendarz
-function initializeCalendar() {
+async function initializeCalendar() {
   // console.log('Inicjalizacja kalendarza rozpoczęta');
 
   const el = document.getElementById('calendar');
@@ -25,6 +25,7 @@ function initializeCalendar() {
   }
   
   const url = el.dataset.eventsUrl;
+  const workingHoursUrl = el.dataset.workingHoursUrl;
   // console.log('URL wydarzeń:', url);
   
   if (!url) {
@@ -36,11 +37,22 @@ function initializeCalendar() {
   window.modalIsOpen = false;
   
   // Godziny pracy salonu
-  const workingHours = {
-    start: '09:00', // Godzina otwarcia
-    end: '18:00',   // Godzina zamknięcia
-    daysOfWeek: [1, 2, 3, 4, 5, 6], // Poniedziałek-Sobota (0=Niedziela, 1=Poniedziałek, itd.)
+  let workingHours = {
+    start: '09:00',
+    end: '18:00',
+    daysOfWeek: [1, 2, 3, 4, 5, 6],
   };
+
+  if (workingHoursUrl) {
+    try {
+      const resp = await fetch(workingHoursUrl);
+      if (resp.ok) {
+        workingHours = await resp.json();
+      }
+    } catch (e) {
+      console.error('Failed to fetch working hours', e);
+    }
+  }
   
   // console.log('Inicjalizacja FullCalendar z pluginami');
   
@@ -325,9 +337,9 @@ function initializeCalendar() {
 }
 
 // Standardowa inicjalizacja przy załadowaniu DOM
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
   // console.log('DOMContentLoaded event fired');
-  const calendar = initializeCalendar();
+  const calendar = await initializeCalendar();
 
   const params = new URLSearchParams(window.location.search);
   const jumpId = params.get('jump');

--- a/resources/views/admin/appointments/calendar.blade.php
+++ b/resources/views/admin/appointments/calendar.blade.php
@@ -74,6 +74,7 @@
     <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
         <div id="calendar"
              data-events-url="{{ route('admin.appointments.api') }}"
+             data-working-hours-url="{{ route('admin.appointments.workingHours') }}"
              class="bg-white shadow rounded-lg p-4">
         </div>
     </div>

--- a/tests/Feature/ContactInfoTest.php
+++ b/tests/Feature/ContactInfoTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\ContactInfo;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -27,5 +28,46 @@ class ContactInfoTest extends TestCase
 
         $this->assertNotNull($contactInfo->latitude);
         $this->assertNotNull($contactInfo->longitude);
+    }
+
+    public function test_formatted_working_hours_returns_correct_data(): void
+    {
+        $info = ContactInfo::create([
+            'salon_name' => 'Salon',
+            'address_line1' => 'A1',
+            'city' => 'City',
+            'postal_code' => '00-000',
+            'phone' => '123',
+            'email' => 'a@b.com',
+            'working_hours' => [
+                'monday' => ['08:00', '16:00'],
+                'wednesday' => ['10:00', '18:00'],
+            ],
+        ]);
+
+        $result = $info->formattedWorkingHours();
+
+        $this->assertSame('08:00', $result['start']);
+        $this->assertSame('18:00', $result['end']);
+        $this->assertEquals([1,3], $result['daysOfWeek']);
+    }
+
+    public function test_working_hours_endpoint_returns_hours(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $info = ContactInfo::getDefault();
+        $info->update([
+            'working_hours' => [
+                'monday' => ['07:00', '15:00'],
+            ],
+        ]);
+
+        $response = $this->actingAs($admin)->getJson(route('admin.appointments.workingHours', absolute: false));
+        $response->assertOk();
+        $response->assertJson([
+            'start' => '07:00',
+            'end' => '15:00',
+            'daysOfWeek' => [1],
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- expose formatted working hours via `ContactInfo`
- use contact info for working hours in `AdminAppointmentController`
- fetch hours dynamically in calendar view and JS
- test formatted hours and API

## Testing
- `php artisan test --testsuite Feature --filter ContactInfoTest`
- `php artisan test --testsuite Feature`

------
https://chatgpt.com/codex/tasks/task_e_6866521f40708329be5068071b246a5a