### PR TITLE
Fix appointment status assertion

### DIFF
--- a/tests/Feature/AppointmentPendingTest.php
+++ b/tests/Feature/AppointmentPendingTest.php
@@ -66,6 +66,6 @@ class AppointmentPendingTest extends TestCase
 
         $response->assertRedirect('/dashboard');
         $this->assertSame(2, Appointment::count());
-        $this->assertEquals('zaplanowana', Appointment::latest()->first()->status);
+        $this->assertEquals('oczekuje', Appointment::latest()->first()->status);
     }
 }


### PR DESCRIPTION
## Summary
- fix test assertion for pending appointments

## Testing
- `php artisan test` *(fails: AppointmentPendingTest)*

------
https://chatgpt.com/codex/tasks/task_e_686699913e108329a926a70a8abc3d56