### PR TITLE
Remove unused contact policy route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -41,7 +41,6 @@ Route::post('/kontakt', [KontaktController::class, 'store'])->name('kontakt.stor
 Route::view('/polityka-prywatnosci', 'policy.privacy')->name('privacy');
 Route::view('/polityka-cookies', 'policy.cookies')->name('cookies');
 Route::view('/regulamin', 'policy.terms')->name('terms');
-Route::view('/dane-kontaktowe', 'policy.contact')->name('policy.contact');
 Route::view('/reklamacje', 'policy.complaints')->name('complaints');
 Route::view('/moje-zgody', 'policy.consents')->name('consents');
 Route::get('/api/working-hours', [AdminAppointmentController::class, 'workingHours'])->name('public.working-hours');

--- a/tests/Feature/PolicyPagesTest.php
+++ b/tests/Feature/PolicyPagesTest.php
@@ -27,7 +27,6 @@ class PolicyPagesTest extends TestCase
             ['/polityka-prywatnosci'],
             ['/polityka-cookies'],
             ['/regulamin'],
-            ['/dane-kontaktowe'],
             ['/reklamacje'],
             ['/moje-zgody'],
         ];


### PR DESCRIPTION
## Summary
- delete the `/dane-kontaktowe` route
- adjust tests accordingly

## Testing
- `./vendor/bin/phpunit` *(fails: AppointmentPendingTest::test_user_can_create_pending_when_confirmed)*

------
https://chatgpt.com/codex/tasks/task_e_68669d320130832989e4be7cf445c208