### PR TITLE
Fix pending appointment test ordering

### DIFF
--- a/tests/Feature/AppointmentPendingTest.php
+++ b/tests/Feature/AppointmentPendingTest.php
@@ -66,6 +66,6 @@ class AppointmentPendingTest extends TestCase
 
         $response->assertRedirect('/dashboard');
         $this->assertSame(2, Appointment::count());
-        $this->assertEquals('oczekuje', Appointment::latest()->first()->status);
+        $this->assertEquals('oczekuje', Appointment::orderByDesc('id')->first()->status);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the test retrieves the newest appointment by ordering by ID

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6866a7146d708329b3f0de88c9032a28