### PR TITLE
Add Lato and Open Sans fonts

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,10 @@
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>{{ config('app.name', 'Salon Black&White') }}</title>
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+
   @vite(['resources/css/app.css', 'resources/js/app.js'])
   <link
     rel="stylesheet"

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config('app.name', 'Salon Black&White') }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <link
         rel="stylesheet"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,7 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+                sans: ['Lato', 'Open Sans', 'Figtree', ...defaultTheme.fontFamily.sans],
             },
         },
     },


### PR DESCRIPTION
## Summary
- load Lato and Open Sans from Google Fonts in layouts
- configure Tailwind to use the new fonts

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_686783817acc83299e016e0c60265438