### PR TITLE
Add health check and Swagger docs

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { HealthController } from './health.controller';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true })],
-  controllers: [AppController],
-  providers: [AppService],
+    imports: [ConfigModule.forRoot({ isGlobal: true })],
+    controllers: [AppController, HealthController],
+    providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/health.controller.spec.ts
+++ b/backend/src/health.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+    let controller: HealthController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [HealthController],
+        }).compile();
+
+        controller = module.get<HealthController>(HealthController);
+    });
+
+    it('should return status ok', () => {
+        expect(controller.getHealth()).toEqual({ status: 'ok' });
+    });
+});

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+    @Get()
+    getHealth() {
+        return { status: 'ok' };
+    }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,15 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+    const app = await NestFactory.create(AppModule);
+    const config = new DocumentBuilder()
+        .setTitle('API')
+        .setVersion('1.0')
+        .build();
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api', app, document);
+    await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -5,21 +5,28 @@ import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+    let app: INestApplication<App>;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
-  });
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
-  });
+    it('/ (GET)', () => {
+        return request(app.getHttpServer())
+            .get('/')
+            .expect(200)
+            .expect('Hello World!');
+    });
+
+    it('/health (GET)', () => {
+        return request(app.getHttpServer())
+            .get('/health')
+            .expect(200)
+            .expect({ status: 'ok' });
+    });
 });


### PR DESCRIPTION
## Summary
- add `HealthController` with `/health` endpoint
- expose `HealthController` in the main module
- enable Swagger documentation in `main.ts`
- test `/health` in unit and e2e tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a2eedbfc8329bb125e6123bb0aca