### PR TITLE
Add PrismaService to NestJS backend

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaService } from './prisma.service';
 import { HealthController } from './health.controller';
 
 @Module({
     imports: [ConfigModule.forRoot({ isGlobal: true })],
     controllers: [AppController, HealthController],
-    providers: [AppService],
+    providers: [AppService, PrismaService],
+    exports: [PrismaService],
 })
 export class AppModule {}

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add PrismaService that wraps PrismaClient
- register PrismaService in AppModule to make it injectable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a4afc2588329adeb3bbe49a18f59