### PR TITLE
Add FreeBSD Prisma note

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,13 @@
 $ npm install
 ```
 
+## Prisma engine limitations
+
+Prisma does not publish precompiled query engine binaries for FreeBSD. If you
+run the CLI on that platform you may encounter checksum errors. Set the
+`PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` environment variable or build the
+engines from source before running `npx prisma init` or any migration commands.
+
 ## Compile and run the project
 
 ```bash


### PR DESCRIPTION
## Summary
- document Prisma engine limitations for FreeBSD in `backend/README.md`

## Testing
- `npm --prefix backend install`
- `npm --prefix backend run test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6867bd0d9ef4832980f5a3f9a434a1ae