### PR TITLE
Fix Prisma output path

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- use default Prisma client output

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_686cdca416dc8329ad9311418fdf49cf