### PR TITLE
Add backend environment example file

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,0 @@
-DATABASE_URL=postgresql://user:password@localhost:5432/dbname
-JWT_SECRET=your-secret-key

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+# Environment configuration for the NestJS backend
+# Copy this file to `.env` and fill in the values
+
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+JWT_SECRET=your-secret-key

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 # Keep environment variables out of version control
 .env
+!.env.example
 
 /generated/prisma


### PR DESCRIPTION
## Summary
- remove backend `.env` from version control
- keep real env files ignored and add `.env.example` placeholders

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_686cddc81eb88329b6ba731271e10178