### PR TITLE
Update backend setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Before running the NestJS server or any tests make sure to install the
 backend dependencies, generate the Prisma client, and compile the project:
 
 ```bash
+cp backend/.env.example backend/.env
+# fill in DATABASE_URL and JWT_SECRET
 cd backend
 npm install
 npx prisma generate

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,8 @@ Make sure the following tools are available before running the backend:
 $ npm install
 ```
 
+Copy `.env.example` to `.env` and set `DATABASE_URL` and `JWT_SECRET` before running the service.
+
 ## Prisma engine limitations
 
 Prisma does not publish precompiled query engine binaries for FreeBSD. If you


### PR DESCRIPTION
## Summary
- document how to create the backend environment file
- add small note in backend README about the `.env` file

## Testing
- `composer test` *(fails: vendor autoload missing)*
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d15b39bb48329acb4359d06fae18b