### PR TITLE
Update docs for FreeBSD workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,9 @@ relies on the dependencies installed in **Backend Setup**:
 ```bash
 npm run test:e2e
 ```
+
+### Running the backend on FreeBSD
+
+The API server can be built on macOS or Linux and copied to a FreeBSD
+machine. Follow the "Run on FreeBSD" section in `backend/README.md` for
+detailed steps.

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,6 +61,18 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
+## Run on FreeBSD
+
+To avoid Prisma engine checksum errors on FreeBSD, build the project on
+macOS or Linux and copy the compiled output:
+
+1. Run `npm install` and `npx prisma generate` on a Unix-like system.
+2. Remove or empty the `postinstall` script in `package.json`.
+3. Archive the entire `backend/` directory (including `node_modules`) and
+   extract it on the FreeBSD server.
+4. Start the server with `npm start` or `node dist/main.js` without running
+   `npm install` again.
+
 ## Run tests
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to bundle the backend for FreeBSD
- reference the new procedure in the main README

## Testing
- `composer test` *(fails: command not found)*
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d51f982888329acc2a117adbad7d4