### PR TITLE
Update backend docs for FreeBSD workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ npx prisma generate
 npm run build
 ```
 
+For running the service on FreeBSD without reinstalling packages, see the
+[cross-platform workflow](backend/README.md#cross-platform-workflow-macoslinux--freebsd).
+
 Start the service in watch mode while developing:
 
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,39 @@ run the CLI on that platform you may encounter checksum errors. Set the
 `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` environment variable or build the
 engines from source before running `npx prisma init` or any migration commands.
 
+## Cross-platform workflow (macOS/Linux -> FreeBSD)
+
+If you need to run the service on FreeBSD but cannot install Prisma there,
+prepare the project on a macOS or Linux machine first.
+
+1. Install the dependencies and generate the Prisma client:
+
+    ```bash
+    cd backend
+    npm install
+    npx prisma generate
+    ```
+
+2. Archive the `backend/` directory with `node_modules` intact and copy it to
+   the FreeBSD server:
+
+    ```bash
+    tar czf backend.tgz backend
+    scp backend.tgz freebsd:/opt/app
+    ```
+
+3. Extract the archive on FreeBSD and start the service without reinstalling
+   packages:
+
+    ```bash
+    tar xzf backend.tgz
+    cd backend
+    npm run start
+    ```
+
+This workflow avoids running `npm install` on FreeBSD while keeping the Prisma
+client generated on a supported platform.
+
 ## Compile and run the project
 
 ```bash


### PR DESCRIPTION
## Summary
- document preparing the backend on macOS/Linux and running on FreeBSD
- link to the new workflow from the project root README

## Testing
- `composer test` *(fails: command not found)*
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d542a93cc8329864f911f6c7ddcea