### PR TITLE
Fix duplicates in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /.phpunit.cache
-/node_modules
 /public/build
 /public/hot
 /public/storage
@@ -46,7 +45,6 @@ tailwindcss
 
 # Maven
 target/
-dist/
 
 # JetBrains IDE
 .idea/


### PR DESCRIPTION
## Summary
- dedupe `node_modules/` and `dist/` entries in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d632a109083299542d0c9cb2da514