### PR TITLE
Update pipeline to use Node 20

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -14,7 +14,9 @@ pipelines:
             - composer
             - npm
           script:
-            - apt-get update && apt-get install -y unzip git nodejs npm libsqlite3-dev
+            - apt-get update && apt-get install -y curl unzip git libsqlite3-dev
+            - curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+            - apt-get install -y nodejs
             - docker-php-ext-install pdo_sqlite
             - curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
             - composer install --no-interaction --no-progress


### PR DESCRIPTION
## Summary
- install Node 20 in Bitbucket pipeline using NodeSource

## Testing
- `npm ci`
- `npm --prefix backend ci`
- `npx --prefix backend prisma generate --schema backend/prisma/schema.prisma`
- `npm --prefix backend run build` *(fails: Argument of type '"beforeExit"' is not assignable to parameter of type 'never')*
- `npm run build`
- `npm run test:e2e` *(fails: Argument of type '"beforeExit"' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_686d633a86908329b99d9a3fc678d48c