### PR TITLE
Fix Prisma beforeExit typing

### DIFF
--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -1,8 +1,11 @@
 import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService extends PrismaClient implements OnModuleInit {
+export class PrismaService extends PrismaClient<
+  Prisma.PrismaClientOptions,
+  'query' | 'info' | 'warn' | 'error' | 'beforeExit'
+> implements OnModuleInit {
   async onModuleInit() {
     await this.$connect();
   }


### PR DESCRIPTION
## Summary
- update `PrismaService` to type the `beforeExit` hook
- regenerate Prisma client

## Testing
- `npm --prefix backend run build`
- `npm --prefix backend run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_686d67a056e08329b7edee8c6cc6d93e