### PR TITLE
Add Prepare environment step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,11 @@ jobs:
           npm ci
           npm --prefix backend ci
 
+      - name: Prepare environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate --force
+
       - name: Run tests
         run: php artisan test
 


### PR DESCRIPTION
## Summary
- add a `Prepare environment` step before running tests in the deploy workflow

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cd0842083299904ed152bed1362