### PR TITLE
Fix Prisma schema location

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build backend
         run: |
-          npx --prefix backend prisma generate
+          npx --prefix backend prisma generate --schema backend/prisma/schema.prisma
           npm --prefix backend run build
 
       - name: Deploy via SSH


### PR DESCRIPTION
## Summary
- fix path to Prisma schema in deploy workflow

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d6beb78408329b4feba936201f2c2