### PR TITLE
Add APP_KEY generation step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_NAME=Laravel
 APP_ENV=local
-APP_KEY=your-app-key
+APP_KEY=your-app-key # replace with a key generated via `php artisan key:generate --ansi`
 APP_DEBUG=true
 APP_URL=http://localhost
 # Default timezone is Europe/Warsaw

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Install the dependencies and compile the assets before running the project local
 ```bash
 # copy the example environment and fill in the required variables
 cp .env.example .env
-# edit `.env` and set APP_KEY, HCAPTCHA_SECRET, WHATSAPP_TOKEN, WHATSAPP_PHONE_ID and INSTAGRAM_ACCESS_TOKEN
+php artisan key:generate --ansi # writes a valid application key to `.env`
+# edit `.env` and set HCAPTCHA_SECRET, WHATSAPP_TOKEN, WHATSAPP_PHONE_ID and INSTAGRAM_ACCESS_TOKEN
 # optionally set WHATSAPP_TEMPLATE_LANG (defaults to "pl")
 
 composer install
@@ -38,6 +39,7 @@ npm run build
 touch database/database.sqlite
 php artisan migrate
 ```
+The previous command writes a valid APP_KEY to your `.env` file.
 
 Run the test suite to ensure everything works correctly:
 


### PR DESCRIPTION
## Summary
- show how to generate APP_KEY right after copying .env
- clarify in .env.example that the placeholder key must be replaced

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d72ee20d4832997eaeba109da005b