### PR TITLE
Add Prisma schema models

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,3 +12,182 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model User {
+  id                      Int                    @id @default(autoincrement())
+  name                    String
+  email                   String                 @unique
+  emailVerifiedAt         DateTime?              @map("email_verified_at")
+  role                    String                 @default("user")
+  phone                   String?
+  notificationPreference  String                 @default("email") @map("notification_preference")
+  password                String
+  rememberToken           String?                @map("remember_token")
+  appointments            Appointment[]
+  kontaktMessages         KontaktMessage[]
+  adminMessages           KontaktMessage[]       @relation("AdminMessages")
+  blockers                Blocker[]              @relation("AdminBlockers")
+  sessions                Session[]
+  createdAt               DateTime               @default(now()) @map("created_at")
+  updatedAt               DateTime               @updatedAt @map("updated_at")
+
+  @@map("users")
+}
+
+model PasswordResetToken {
+  email     String  @id
+  token     String
+  createdAt DateTime? @map("created_at")
+
+  @@map("password_reset_tokens")
+}
+
+model Session {
+  id           String  @id @db.VarChar(191)
+  user         User?   @relation(fields: [userId], references: [id])
+  userId       Int?    @map("user_id")
+  ipAddress    String? @map("ip_address") @db.VarChar(45)
+  userAgent    String? @map("user_agent")
+  payload      String?
+  lastActivity Int     @map("last_activity")
+
+  @@map("sessions")
+}
+
+model Service {
+  id          Int             @id @default(autoincrement())
+  name        String
+  description String?
+  variants    ServiceVariant[]
+  createdAt   DateTime        @default(now()) @map("created_at")
+  updatedAt   DateTime        @updatedAt @map("updated_at")
+
+  @@map("services")
+}
+
+model ServiceVariant {
+  id             Int          @id @default(autoincrement())
+  service        Service      @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId      Int          @map("service_id")
+  variantName    String       @map("variant_name")
+  durationMinutes Int         @map("duration_minutes")
+  pricePln       Int          @map("price_pln")
+  appointments   Appointment[]
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+
+  @@map("service_variants")
+}
+
+model Appointment {
+  id               Int             @id @default(autoincrement())
+  user             User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId           Int             @map("user_id")
+  service          Service         @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId        Int             @map("service_id")
+  serviceVariant   ServiceVariant  @relation(fields: [serviceVariantId], references: [id], onDelete: Cascade)
+  serviceVariantId Int             @map("service_variant_id")
+  coupon           Coupon?         @relation(fields: [couponId], references: [id], onDelete: SetNull)
+  couponId         Int?            @map("coupon_id")
+  appointmentAt    DateTime        @map("appointment_at")
+  status           String          @default("zaplanowana")
+  noteClient       String?         @map("note_client")
+  noteInternal     String?         @map("note_internal")
+  pricePln         Int             @default(0) @map("price_pln")
+  discountPercent  Int             @default(0) @map("discount_percent")
+  noteUser         String?         @map("note_user")
+  serviceDescription String?       @map("service_description")
+  productsUsed     String?         @map("products_used")
+  amountPaidPln    Int?            @map("amount_paid_pln")
+  paymentMethod    String?         @map("payment_method")
+  createdAt        DateTime        @default(now()) @map("created_at")
+  updatedAt        DateTime        @updatedAt @map("updated_at")
+
+  @@map("appointments")
+}
+
+model Coupon {
+  id             Int            @id @default(autoincrement())
+  code           String         @unique
+  discountPercent Int           @map("discount_percent")
+  expiresAt      DateTime?      @map("expires_at")
+  usageLimit     Int?           @map("usage_limit")
+  usedCount      Int            @default(0) @map("used_count")
+  appointments   Appointment[]
+  createdAt      DateTime       @default(now()) @map("created_at")
+  updatedAt      DateTime       @updatedAt @map("updated_at")
+
+  @@map("coupons")
+}
+
+model Blocker {
+  id        Int      @id @default(autoincrement())
+  admin     User     @relation("AdminBlockers", fields: [adminId], references: [id], onDelete: Cascade)
+  adminId   Int      @map("admin_id")
+  startsAt  DateTime @map("starts_at")
+  endsAt    DateTime? @map("ends_at")
+  note      String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("blockers")
+}
+
+model KontaktMessage {
+  id          Int              @id @default(autoincrement())
+  name        String
+  email       String?
+  phone       String?          @db.VarChar(30)
+  message     String           @db.Text
+  category    String?
+  status      String           @default("nowa")
+  user        User?            @relation(fields: [userId], references: [id])
+  userId      Int?             @map("user_id")
+  admin       User?            @relation("AdminMessages", fields: [adminId], references: [id])
+  adminId     Int?             @map("admin_id")
+  replyTo     KontaktMessage?  @relation("MessageReplies", fields: [replyToId], references: [id])
+  replies     KontaktMessage[] @relation("MessageReplies")
+  replyToId   Int?             @map("reply_to_id")
+  isFromAdmin Boolean          @default(false) @map("is_from_admin")
+  isRead      Boolean          @default(false) @map("is_read")
+  createdAt   DateTime         @default(now()) @map("created_at")
+  updatedAt   DateTime         @updatedAt @map("updated_at")
+
+  @@map("kontakt_messages")
+}
+
+model ContactInfo {
+  id            Int      @id @default(autoincrement())
+  salonName     String?  @map("salon_name")
+  addressLine1  String   @map("address_line1")
+  addressLine2  String?  @map("address_line2")
+  city          String
+  postalCode    String   @map("postal_code")
+  phone         String
+  email         String
+  description   String?
+  workingHours  Json?    @map("working_hours")
+  facebookUrl   String?  @map("facebook_url")
+  instagramUrl  String?  @map("instagram_url")
+  googleMapsUrl String?  @map("google_maps_url")
+  latitude      Decimal? @db.Decimal(10, 7)
+  longitude     Decimal? @db.Decimal(10, 7)
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  @@map("contact_info")
+}
+
+model WhatsAppMessageLog {
+  id         Int     @id @default(autoincrement())
+  recipient  String
+  template   String?
+  parameters Json?
+  status     String?
+  responseId String? @map("response_id")
+  errorCode  Int?    @map("error_code")
+  errorBody  String? @map("error_body")
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@map("whatsapp_message_logs")
+}


### PR DESCRIPTION
## Summary
- define Prisma models for backend services like users and appointments

## Testing
- `npx prisma generate` *(fails: Cannot find module '@prisma/engines/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_686e7e268ba4832991a9e199769ab7ea