### PR TITLE
Add linux engine target to Prisma

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,6 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- target linux debian openssl 3.0 engines in Prisma schema

## Testing
- `npx prisma generate` *(fails: Cannot find module '@prisma/engines')*
- `npm test --silent` *(fails: Cannot find module 'resolve.exports/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_686f766af42883299662334cfcb90e1b