### PR TITLE
Add appointments relation to Service model

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Service {
   name        String
   description String?
   variants    ServiceVariant[]
+  appointments Appointment[]
   createdAt   DateTime        @default(now()) @map("created_at")
   updatedAt   DateTime        @updatedAt @map("updated_at")
 


### PR DESCRIPTION
## Summary
- add `appointments` relation to the Service model in Prisma schema

## Testing
- `npx prisma format --schema=prisma/schema.prisma` *(fails: cannot find module '@prisma/engines')*
- `npx prisma generate --schema=backend/prisma/schema.prisma` *(fails: cannot find module '@prisma/engines')*

------
https://chatgpt.com/codex/tasks/task_e_686f78ec9944832985409787370ab54d