### PR TITLE
Refactor PrismaService generics

### DIFF
--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -1,8 +1,11 @@
 import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService extends PrismaClient implements OnModuleInit {
+export class PrismaService
+  extends PrismaClient<Prisma.PrismaClientOptions, 'beforeExit'>
+  implements OnModuleInit
+{
   async onModuleInit() {
     await this.$connect();
   }


### PR DESCRIPTION
## Summary
- ensure PrismaService subscribes to `beforeExit` event

## Testing
- `npm --prefix backend run build` *(fails: Cannot find module '...glob/node_modules/minimatch/dist/commonjs/index.js')*
- `npm --prefix backend test` *(fails: Cannot find module '...resolve.exports/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_686f7d12aefc83299f30c7a41bf6f9be