### PR TITLE
Update FreeBSD instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ npm run build
 
 For running the service on FreeBSD without reinstalling packages, see the
 [cross-platform workflow](backend/README.md#cross-platform-workflow-macoslinux--freebsd).
+When preparing the backend on macOS or Linux, add `freebsd14` to
+`binaryTargets` in `backend/prisma/schema.prisma` before running
+`npx prisma generate`.
 
 Start the service in watch mode while developing:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -53,11 +53,13 @@ engines from source before running `npx prisma init` or any migration commands.
 If you need to run the service on FreeBSD but cannot install Prisma there,
 prepare the project on a macOS or Linux machine first.
 
-1. Install the dependencies and generate the Prisma client:
+1. Install the dependencies, add `freebsd14` to the Prisma
+   `binaryTargets` and generate the client:
 
     ```bash
     cd backend
     npm install
+    # edit prisma/schema.prisma and append "freebsd14" to binaryTargets
     npx prisma generate
     ```
 
@@ -80,6 +82,9 @@ prepare the project on a macOS or Linux machine first.
 
 This workflow avoids running `npm install` on FreeBSD while keeping the Prisma
 client generated on a supported platform.
+
+After editing `prisma/schema.prisma`, run `npx prisma generate` again before
+archiving the `backend/` directory.
 
 ## Compile and run the project
 


### PR DESCRIPTION
## Summary
- document adding `freebsd14` to Prisma `binaryTargets`
- clarify regenerating the Prisma client after editing the schema
- reference the FreeBSD step from the root README

## Testing
- `composer test` *(fails: command not found)*
- `npm run test:e2e` *(fails to find module)*

------
https://chatgpt.com/codex/tasks/task_e_686f90736c9c8329b50689873dcbe1ff