### PR TITLE
Enable CORS using environment variable

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,7 +6,7 @@ import { AppService } from './app.service';
 
 @Module({
     imports: [
-        ConfigModule.forRoot(),
+        ConfigModule.forRoot({ envFilePath: '.env' }),
         TypeOrmModule.forRoot({
             type: 'postgres',
             url: process.env.DATABASE_URL,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
+
+    const configService = app.get(ConfigService);
+    app.enableCors({ origin: configService.get('FRONTEND_URL') });
+
     await app.listen(process.env.PORT ?? 3000);
 }
 void bootstrap();


### PR DESCRIPTION
## Summary
- load env vars with `ConfigModule.forRoot({ envFilePath: '.env' })`
- enable CORS from `FRONTEND_URL`

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6870e603db188329809770c8da983a1c