### PR TITLE
Add health endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { HealthController } from './health.controller';
 
 @Module({
     imports: [
@@ -13,7 +14,7 @@ import { AppService } from './app.service';
             autoLoadEntities: true,
         }),
     ],
-    controllers: [AppController],
+    controllers: [AppController, HealthController],
     providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+    @Get()
+    getHealth() {
+        return { status: 'ok' };
+    }
+}

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('HealthController (e2e)', () => {
+    let app: INestApplication<App>;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
+
+    it('/health (GET)', () => {
+        return request(app.getHttpServer())
+            .get('/health')
+            .expect(200)
+            .expect({ status: 'ok' });
+    });
+});


### PR DESCRIPTION
## Summary
- add basic HealthController with `/health` route
- register HealthController in AppModule
- test new endpoint via e2e test

## Testing
- `npm run test:e2e` *(fails: Unable to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_6870e9673bc48329a1ca5ccbe57460da