### PR TITLE
Add env example placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Example environment values.
+# Copy this file to .env and set real credentials.
+
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=your-app-key # replace with a key generated via `php artisan key:generate --ansi`
@@ -75,4 +78,4 @@ SESSION_SAME_SITE=lax
 SESSION_SECURE_COOKIE=true
 HCAPTCHA_SECRET=
 
-DATABASE_URL=postgres://user:pass@localhost:5432/database
+DATABASE_URL=postgres://user:pass@localhost:5432/database # example connection string

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,14 @@
+# Example environment variables for the NestJS backend
+# Copy this file to `.env` and replace the values with your own credentials.
+
+# Port the application listens on
 PORT=3001
+
+# Allowed frontend URL for CORS
 FRONTEND_URL=http://localhost:3000
+
+# Database connection string
 DATABASE_URL=postgres://user:pass@localhost:5432/salonbw_dev
+
+# Secret used to sign JWT tokens
 JWT_SECRET=your-jwt-secret


### PR DESCRIPTION
## Summary
- document `.env` placeholder values in root `.env.example`
- clarify backend `.env.example` values and add comments

## Testing
- `composer test` *(fails: No application encryption key specified)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f4b502648329b6340a0dee566300