### PR TITLE
Ensure apps close after each e2e test

### DIFF
--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -16,6 +16,10 @@ describe('AppController (e2e)', () => {
         await app.init();
     });
 
+    afterEach(async () => {
+        await app.close();
+    });
+
     it('/ (GET)', () => {
         return request(app.getHttpServer())
             .get('/')

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -16,6 +16,10 @@ describe('HealthController (e2e)', () => {
         await app.init();
     });
 
+    afterEach(async () => {
+        await app.close();
+    });
+
     it('/health (GET)', () => {
         return request(app.getHttpServer())
             .get('/health')


### PR DESCRIPTION
## Summary
- close the Nest app after each e2e test

## Testing
- `npm --prefix backend run test:e2e` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871055319448329b10f3883d10c557a