### PR TITLE
Add users module with entity

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthController } from './health.controller';
+import { UsersModule } from './users/users.module';
 
 @Module({
     imports: [
@@ -13,6 +14,7 @@ import { HealthController } from './health.controller';
             url: process.env.DATABASE_URL,
             autoLoadEntities: true,
         }),
+        UsersModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,7 +6,7 @@ async function bootstrap() {
     const app = await NestFactory.create(AppModule);
 
     const configService = app.get(ConfigService);
-    app.enableCors({ origin: configService.get('FRONTEND_URL') });
+    app.enableCors({ origin: configService.get<string>('FRONTEND_URL') });
 
     await app.listen(process.env.PORT ?? 3000);
 }

--- a/backend/src/users/role.enum.ts
+++ b/backend/src/users/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+    Client = 'client',
+    Employee = 'employee',
+    Admin = 'admin',
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Role } from './role.enum';
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ unique: true })
+    email: string;
+
+    @Column()
+    password: string; // hashed
+
+    @Column()
+    name: string;
+
+    @Column({ type: 'enum', enum: Role })
+    role: Role;
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './user.entity';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([User])],
+    exports: [TypeOrmModule],
+})
+export class UsersModule {}


### PR DESCRIPTION
## Summary
- add `Role` enum defining user roles
- implement `User` entity with role field
- add `UsersModule` providing User entity
- import `UsersModule` into `AppModule`
- tighten Cors config type

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68710a0551cc83299ca7ab85178a3994