### PR TITLE
Add profile endpoint skeleton

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Request } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 
@@ -10,5 +10,11 @@ export class UsersController {
     create(@Body() createUserDto: CreateUserDto) {
         const { email, password, name, role } = createUserDto;
         return this.usersService.createUser(email, password, name, role);
+    }
+
+    @Get('profile')
+    getProfile(@Request() req) {
+        // TODO: replace with JWT-authenticated user
+        return req.user ?? {};
     }
 }

--- a/backend/test/profile.e2e-spec.ts
+++ b/backend/test/profile.e2e-spec.ts
@@ -1,0 +1,29 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('UsersController (e2e)', () => {
+    let app: INestApplication<App>;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+
+    it('/profile (GET)', () => {
+        return request(app.getHttpServer())
+            .get('/profile')
+            .expect(200)
+            .expect({});
+    });
+});


### PR DESCRIPTION
## Summary
- add a `/profile` endpoint skeleton in `UsersController`
- test coverage for `/profile`

## Testing
- `npm run test:e2e` *(fails: unable to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_687126b2b8ec8329b07964854b62e888