### PR TITLE
Add user migration & enable migrations

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,8 @@ import { UsersModule } from './users/users.module';
             type: 'postgres',
             url: process.env.DATABASE_URL,
             autoLoadEntities: true,
+            migrations: [__dirname + '/migrations/*.ts'],
+            migrationsRun: true,
         }),
         UsersModule,
     ],

--- a/backend/src/migrations/20250711192002-CreateUsersTable.ts
+++ b/backend/src/migrations/20250711192002-CreateUsersTable.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateUsersTable20250711192002 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'user',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'email',
+                        type: 'varchar',
+                        isUnique: true,
+                    },
+                    {
+                        name: 'password',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'name',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'role',
+                        type: 'enum',
+                        enum: ['client', 'employee', 'admin'],
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('user');
+    }
+}


### PR DESCRIPTION
## Summary
- add CreateUsersTable migration to match `User` entity
- load migrations in TypeORM configuration and run them automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871633eaaf08329b477bb0183af869f