### PR TITLE
Use NODE_ENV for TypeORM sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,4 @@ SESSION_SECURE_COOKIE=true
 HCAPTCHA_SECRET=
 
 DATABASE_URL=postgres://user:pass@localhost:5432/database # example connection string
+NODE_ENV=development # change to "production" when deploying

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { UsersModule } from './users/users.module';
             autoLoadEntities: true,
             migrations: [__dirname + '/migrations/*.ts'],
             migrationsRun: true,
+            synchronize: process.env.NODE_ENV !== 'production',
         }),
         UsersModule,
     ],


### PR DESCRIPTION
## Summary
- control TypeORM synchronization via `NODE_ENV`
- add `NODE_ENV` example var to `.env.example`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6871670ade688329be83b863bb622a04