### PR TITLE
Fix timestamp in AdminAppointmentUpdateTest

### DIFF
--- a/tests/Feature/AdminAppointmentUpdateTest.php
+++ b/tests/Feature/AdminAppointmentUpdateTest.php
@@ -31,7 +31,7 @@ class AdminAppointmentUpdateTest extends TestCase
         $admin = User::factory()->create(['role' => 'admin']);
         $user = User::factory()->create();
 
-        $oldTime = Carbon::now()->addDay()->setTime(10, 0);
+        $oldTime = Carbon::create(2025, 6, 10, 10, 0); // Tuesday
         $appointment = Appointment::create([
             'user_id' => $user->id,
             'service_id' => $service->id,


### PR DESCRIPTION
## Summary
- use a fixed timestamp for `AdminAppointmentUpdateTest`
- run `php artisan test`

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68722e1646c08329befc38ad1f0fb4f0