### PR TITLE
Implement login validation and JWT token

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { Role } from '../users/role.enum';
+
+describe('AuthService', () => {
+    let service: AuthService;
+    let users: { findByEmail: jest.Mock };
+    let jwt: { signAsync: jest.Mock };
+
+    beforeEach(async () => {
+        users = { findByEmail: jest.fn() };
+        jwt = { signAsync: jest.fn() };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                AuthService,
+                { provide: UsersService, useValue: users },
+                { provide: JwtService, useValue: jwt },
+            ],
+        }).compile();
+
+        service = module.get<AuthService>(AuthService);
+    });
+
+    describe('validateUser', () => {
+        it('returns user without password when credentials valid', async () => {
+            const pass = await bcrypt.hash('secret', 10);
+            users.findByEmail.mockResolvedValue({ id: 1, email: 'a@test.com', password: pass, role: Role.Client });
+
+            await expect(service.validateUser('a@test.com', 'secret')).resolves.toEqual(
+                expect.objectContaining({ id: 1, email: 'a@test.com', role: Role.Client }),
+            );
+        });
+
+        it('throws Unauthorized when user not found', async () => {
+            users.findByEmail.mockResolvedValue(null);
+            await expect(service.validateUser('a@test.com', 'secret')).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('throws Unauthorized when password mismatch', async () => {
+            const pass = await bcrypt.hash('secret', 10);
+            users.findByEmail.mockResolvedValue({ id: 1, email: 'a@test.com', password: pass, role: Role.Client });
+
+            await expect(service.validateUser('a@test.com', 'wrong')).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+    });
+
+    it('login returns signed token', async () => {
+        const pass = await bcrypt.hash('secret', 10);
+        users.findByEmail.mockResolvedValue({ id: 2, email: 'b@test.com', password: pass, role: Role.Client });
+        jwt.signAsync.mockResolvedValue('token');
+
+        const result = await service.login('b@test.com', 'secret');
+        expect(result).toEqual({ access_token: 'token' });
+        expect(jwt.signAsync).toHaveBeenCalledWith({ sub: 2, role: Role.Client });
+    });
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -12,21 +12,26 @@ export class AuthService {
         private readonly jwtService: JwtService,
     ) {}
 
-    async login(email: string, password: string) {
+    async validateUser(email: string, password: string) {
         const user = await this.usersService.findByEmail(email);
         if (!user) {
             throw new UnauthorizedException('Invalid credentials');
         }
-        const valid = await bcrypt.compare(password, user.password);
-        if (!valid) {
+        const isValid = await bcrypt.compare(password, user.password);
+        if (!isValid) {
             throw new UnauthorizedException('Invalid credentials');
         }
+        const { password: _pw, ...result } = user;
+        return result;
+    }
+
+    async login(email: string, password: string) {
+        const user = await this.validateUser(email, password);
         const token = await this.jwtService.signAsync({
             sub: user.id,
             role: user.role,
         });
-        const { password: _pw, ...result } = user;
-        return { user: result, access_token: token };
+        return { access_token: token };
     }
 
     async registerClient(dto: RegisterClientDto) {


### PR DESCRIPTION
## Summary
- add `validateUser` method in auth service
- refactor `login` to use `validateUser`
- expose JWT only via `{ access_token }`
- create unit tests for new auth behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687237d7bc74832995966e74a279ca94