### PR TITLE
Update registration to return JWT

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,18 +2,19 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterClientDto } from './dto/register-client.dto';
+import { TokenDto } from './dto/token.dto';
 
 @Controller('auth')
 export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('login')
-    login(@Body() loginDto: LoginDto) {
+    login(@Body() loginDto: LoginDto): Promise<TokenDto> {
         return this.authService.login(loginDto.email, loginDto.password);
     }
 
     @Post('register')
-    register(@Body() registerDto: RegisterClientDto) {
+    register(@Body() registerDto: RegisterClientDto): Promise<TokenDto> {
         return this.authService.registerClient(registerDto);
     }
 }

--- a/backend/src/auth/dto/token.dto.ts
+++ b/backend/src/auth/dto/token.dto.ts
@@ -1,0 +1,3 @@
+export interface TokenDto {
+    access_token: string;
+}


### PR DESCRIPTION
## Summary
- sign a token when registering a new user
- return `{ access_token }` from the registration service
- update controller method signatures
- add a minimal DTO for token responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68729e6ace3883298dd16c2fa10e0400