### PR TITLE
Add registration tests

### DIFF
--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { Role } from '../users/role.enum';
+import { RegisterClientDto } from './dto/register-client.dto';
+
+describe('AuthService.registerClient', () => {
+    let service: AuthService;
+    let users: { findByEmail: jest.Mock; createUser: jest.Mock };
+    let jwt: { signAsync: jest.Mock };
+
+    beforeEach(async () => {
+        users = { findByEmail: jest.fn(), createUser: jest.fn() };
+        jwt = { signAsync: jest.fn() };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                AuthService,
+                { provide: UsersService, useValue: users },
+                { provide: JwtService, useValue: jwt },
+            ],
+        }).compile();
+
+        service = module.get<AuthService>(AuthService);
+    });
+
+    it('returns token and creates user with hashed password', async () => {
+        const dto: RegisterClientDto = {
+            email: 'a@test.com',
+            password: 'secret',
+            name: 'Alice',
+        };
+        users.findByEmail.mockResolvedValue(null);
+        users.createUser.mockResolvedValue({ id: 1, email: dto.email, role: Role.Client });
+        jwt.signAsync.mockResolvedValue('jwt');
+
+        const result = await service.registerClient(dto);
+        expect(result).toEqual({ access_token: 'jwt' });
+        expect(jwt.signAsync).toHaveBeenCalledWith({ sub: 1, role: Role.Client });
+
+        const passed = users.createUser.mock.calls[0][1];
+        expect(await bcrypt.compare(dto.password, passed)).toBe(true);
+    });
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -40,9 +40,10 @@ export class AuthService {
         if (existing) {
             throw new BadRequestException('Email already registered');
         }
+        const hashed = await bcrypt.hash(dto.password, 10);
         const user = await this.usersService.createUser(
             dto.email,
-            dto.password,
+            hashed,
             dto.name,
             Role.Client,
         );

--- a/backend/test/register.e2e-spec.ts
+++ b/backend/test/register.e2e-spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('AuthController (e2e)', () => {
+    let app: INestApplication<App>;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+
+    it('/auth/register (POST)', () => {
+        return request(app.getHttpServer())
+            .post('/auth/register')
+            .send({ email: 'test@test.com', password: 'secret', name: 'Test' })
+            .expect(201)
+            .expect(res => {
+                expect(res.body).toHaveProperty('access_token');
+            });
+    });
+});


### PR DESCRIPTION
## Summary
- create unit tests for register flow
- hash password before creating user
- cover registration endpoint in e2e tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Unable to connect to DB)*

------
https://chatgpt.com/codex/tasks/task_e_68729fc7ea748329a7fa12db7dadbbce