### PR TITLE
Fix refresh e2e status code

### DIFF
--- a/backend/test/refresh.e2e-spec.ts
+++ b/backend/test/refresh.e2e-spec.ts
@@ -24,6 +24,6 @@ describe('AuthController.refresh (e2e)', () => {
         return request(app.getHttpServer())
             .post('/auth/refresh')
             .send({ refresh_token: 'token' })
-            .expect(201 || 200);
+            .expect(201);
     });
 });


### PR DESCRIPTION
## Summary
- fix status code in refresh e2e test

## Testing
- `npm install` in `backend`
- `npm run test:e2e` *(fails: Unable to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_6872c04bb95083299b574c0ceff105c3