### PR TITLE
Update backend README with DB instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,6 +27,16 @@
 
 ## Project setup
 
+First copy the example environment file and provide a connection string:
+
+```bash
+cp .env.example .env
+# edit DATABASE_URL to point at your Postgres database
+```
+
+You can also adjust `src/app.module.ts` to use a different database engine,
+for example SQLite, when running tests locally.
+
 ```bash
 $ npm install
 ```
@@ -56,6 +66,9 @@ $ npm run test:e2e
 # test coverage
 $ npm run test:cov
 ```
+
+End-to-end tests require all dependencies installed and a reachable database.
+Ensure your `DATABASE_URL` points to a running instance before executing them.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- add setup notes about `.env` and DATABASE_URL
- clarify dependency and DB requirements for e2e tests

## Testing
- `npm test` *(fails: cannot find bcrypt module)*
- `composer test` *(fails: missing app key)*

------
https://chatgpt.com/codex/tasks/task_e_6872c160bdc08329b8da27977b3b1560