### PR TITLE
Remove redundant password hashing

### DIFF
--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -34,7 +34,7 @@ describe('AuthService.registerClient', () => {
         service = module.get<AuthService>(AuthService);
     });
 
-    it('returns tokens and creates user with hashed password', async () => {
+    it('returns tokens and creates user with provided password', async () => {
         const dto: RegisterClientDto = {
             email: 'a@test.com',
             password: 'secret',
@@ -58,6 +58,6 @@ describe('AuthService.registerClient', () => {
         });
 
         const passed = users.createUser.mock.calls[0][1];
-        expect(await bcrypt.compare(dto.password, passed)).toBe(true);
+        expect(passed).toBe(dto.password);
     });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -47,10 +47,9 @@ export class AuthService {
         if (existing) {
             throw new BadRequestException('Email already registered');
         }
-        const hashed = await bcrypt.hash(dto.password, 10);
         const user = await this.usersService.createUser(
             dto.email,
-            hashed,
+            dto.password,
             dto.name,
             Role.Client,
         );


### PR DESCRIPTION
## Summary
- stop hashing password inside `AuthService.registerClient`
- update register client unit test accordingly
- install dependencies and run full Node and Laravel test suites

## Testing
- `npm test` in `backend`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6872c4727a38832993458d372f51bfef