### PR TITLE
Add db isolation for e2e tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -70,6 +70,10 @@ $ npm run test:cov
 End-to-end tests require all dependencies installed and a reachable database.
 Ensure your `DATABASE_URL` points to a running instance before executing them.
 
+The test runner expects this database to be clean. Jest hooks automatically
+truncate the tables between test files, so use a dedicated test database or one
+whose contents can be safely wiped.
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "setupFilesAfterEnv": ["./setup.ts"]
 }

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -1,0 +1,27 @@
+import { DataSource } from 'typeorm';
+import { config } from 'dotenv';
+import { beforeAll, afterAll, afterEach } from '@jest/globals';
+
+config({ path: '.env' });
+
+let dataSource: DataSource;
+
+beforeAll(async () => {
+  dataSource = new DataSource({
+    type: 'postgres',
+    url: process.env.DATABASE_URL,
+  });
+  await dataSource.initialize();
+});
+
+afterEach(async () => {
+  if (dataSource?.isInitialized) {
+    await dataSource.query('TRUNCATE TABLE "user" RESTART IDENTITY CASCADE');
+  }
+});
+
+afterAll(async () => {
+  if (dataSource?.isInitialized) {
+    await dataSource.destroy();
+  }
+});


### PR DESCRIPTION
## Summary
- truncate DB tables between e2e tests via Jest setup hook
- use new setup file in `jest-e2e.json`
- document the clean DB requirement in backend README

## Testing
- `npm run test:e2e` *(fails: cannot connect to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_6872c48757d48329b7d8d95a8189c39b