### PR TITLE
Fix refresh token test expectation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -69,6 +69,8 @@ $ npm run test:cov
 
 End-to-end tests require all dependencies installed and a reachable database.
 Ensure your `DATABASE_URL` points to a running instance before executing them.
+One test posts to `/auth/refresh` without seeding a user first to confirm
+that unknown tokens result in a `401 Unauthorized` response.
 
 ## Deployment
 

--- a/backend/test/refresh.e2e-spec.ts
+++ b/backend/test/refresh.e2e-spec.ts
@@ -20,10 +20,12 @@ describe('AuthController.refresh (e2e)', () => {
         await app.close();
     });
 
+    // No user is seeded here so any refresh token should be invalid
+    // and the endpoint must return Unauthorized (401).
     it('/auth/refresh (POST)', () => {
         return request(app.getHttpServer())
             .post('/auth/refresh')
             .send({ refresh_token: 'token' })
-            .expect(201);
+            .expect(401);
     });
 });


### PR DESCRIPTION
## Summary
- expect 401 from `/auth/refresh` when no user exists
- document the purpose of the failing refresh token test

## Testing
- `npm run test:e2e` *(fails: Unable to connect to the database)*
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872c493d3f883298b12a4726e6bfb9a