### PR TITLE
Fix e2e script to use single jest worker

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",


### PR DESCRIPTION
## Summary
- run jest e2e tests in a single worker to avoid DB collisions

## Testing
- `npm run test:e2e` *(fails: Cannot read properties of undefined (reading 'close'))*

------
https://chatgpt.com/codex/tasks/task_e_6872ced782c883298279942f32d2b566