### PR TITLE
Fix e2e cleanup and run sequentially

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -17,7 +17,9 @@ describe('AppController (e2e)', () => {
     });
 
     afterEach(async () => {
-        await app.close();
+        if (app) {
+            await app.close();
+        }
     });
 
     it('/ (GET)', () => {

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -17,7 +17,9 @@ describe('HealthController (e2e)', () => {
     });
 
     afterEach(async () => {
-        await app.close();
+        if (app) {
+            await app.close();
+        }
     });
 
     it('/health (GET)', () => {

--- a/backend/test/login.e2e-spec.ts
+++ b/backend/test/login.e2e-spec.ts
@@ -17,7 +17,9 @@ describe('AuthController.login (e2e)', () => {
     });
 
     afterEach(async () => {
-        await app.close();
+        if (app) {
+            await app.close();
+        }
     });
 
     it('/auth/login (POST) authenticates seeded user', async () => {

--- a/backend/test/profile.e2e-spec.ts
+++ b/backend/test/profile.e2e-spec.ts
@@ -17,7 +17,9 @@ describe('UsersController (e2e)', () => {
     });
 
     afterEach(async () => {
-        await app.close();
+        if (app) {
+            await app.close();
+        }
     });
 
     it('rejects unauthenticated requests', () => {

--- a/backend/test/refresh.e2e-spec.ts
+++ b/backend/test/refresh.e2e-spec.ts
@@ -17,7 +17,9 @@ describe('AuthController.refresh (e2e)', () => {
     });
 
     afterEach(async () => {
-        await app.close();
+        if (app) {
+            await app.close();
+        }
     });
 
     // No user is seeded here so any refresh token should be invalid

--- a/backend/test/register.e2e-spec.ts
+++ b/backend/test/register.e2e-spec.ts
@@ -17,7 +17,9 @@ describe('AuthController (e2e)', () => {
     });
 
     afterEach(async () => {
-        await app.close();
+        if (app) {
+            await app.close();
+        }
     });
 
     it('/auth/register (POST)', () => {


### PR DESCRIPTION
## Summary
- clean up NestJS E2E tests only if the app booted
- run E2E suite sequentially via `--runInBand`

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run test:e2e` *(fails: AggregateError / cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6872cedaf1a883298057464717a38d9c