### PR TITLE
Add role based access control guard

### DIFF
--- a/backend/src/auth/roles.decorator.ts
+++ b/backend/src/auth/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../users/role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/auth/roles.guard.ts
+++ b/backend/src/auth/roles.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { Role } from '../users/role.enum';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+    constructor(private readonly reflector: Reflector) {}
+
+    canActivate(context: ExecutionContext): boolean {
+        const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+        if (!requiredRoles || requiredRoles.length === 0) {
+            return true;
+        }
+        const request = context.switchToHttp().getRequest();
+        const user = request.user;
+        if (!user || !requiredRoles.includes(user.role)) {
+            throw new ForbiddenException();
+        }
+        return true;
+    }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -9,12 +9,17 @@ import {
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from './role.enum';
 
 @Controller('users')
 export class UsersController {
     constructor(private readonly usersService: UsersService) {}
 
     @Post()
+    @UseGuards(JwtAuthGuard, RolesGuard)
+    @Roles(Role.Admin)
     create(@Body() createUserDto: CreateUserDto) {
         const { email, password, name, role } = createUserDto;
         return this.usersService.createUser(email, password, name, role);

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,10 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { RolesGuard } from '../auth/roles.guard';
 
 @Module({
     imports: [TypeOrmModule.forFeature([User])],
-    providers: [UsersService],
+    providers: [UsersService, RolesGuard],
     controllers: [UsersController],
     exports: [TypeOrmModule, UsersService],
 })

--- a/backend/test/roles.e2e-spec.ts
+++ b/backend/test/roles.e2e-spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('RolesGuard (e2e)', () => {
+    let app: INestApplication<App>;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('rejects non-admin user creating a new user', async () => {
+        const register = await request(app.getHttpServer())
+            .post('/auth/register')
+            .send({ email: 'client@test.com', password: 'secret', name: 'Client' })
+            .expect(201);
+
+        const token = register.body.access_token;
+
+        return request(app.getHttpServer())
+            .post('/users')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ email: 'new@test.com', password: 'secret', name: 'New' })
+            .expect(403);
+    });
+});


### PR DESCRIPTION
## Summary
- add Roles decorator and guard for role-based authorization
- register the guard in UsersModule
- protect the UsersController.create endpoint with role check
- add e2e test verifying non-admin access is forbidden

## Testing
- `npm test`
- `npm run test:e2e` *(fails: AggregateError - likely due to missing Postgres connection)*

------
https://chatgpt.com/codex/tasks/task_e_6873790c211c8329821288e3c0fbd242