### PR TITLE
Add global roles guard

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,8 @@ import { AppService } from './app.service';
 import { HealthController } from './health.controller';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { APP_GUARD } from '@nestjs/core';
+import { RolesGuard } from './auth/roles.guard';
 
 @Module({
     imports: [
@@ -22,6 +24,12 @@ import { AuthModule } from './auth/auth.module';
         AuthModule,
     ],
     controllers: [AppController, HealthController],
-    providers: [AppService],
+    providers: [
+        AppService,
+        {
+            provide: APP_GUARD,
+            useClass: RolesGuard,
+        },
+    ],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { LocalStrategy } from './local.strategy';
+import { RolesGuard } from './roles.guard';
 
 @Module({
     imports: [
@@ -14,7 +15,8 @@ import { LocalStrategy } from './local.strategy';
             signOptions: { expiresIn: '1h' },
         }),
     ],
-    providers: [AuthService, JwtStrategy, LocalStrategy],
+    providers: [AuthService, JwtStrategy, LocalStrategy, RolesGuard],
     controllers: [AuthController],
+    exports: [RolesGuard],
 })
 export class AuthModule {}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,11 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
-import { RolesGuard } from '../auth/roles.guard';
 
 @Module({
     imports: [TypeOrmModule.forFeature([User])],
-    providers: [UsersService, RolesGuard],
+    providers: [UsersService],
     controllers: [UsersController],
     exports: [TypeOrmModule, UsersService],
 })


### PR DESCRIPTION
## Summary
- export `RolesGuard` from the auth module
- register `RolesGuard` as an `APP_GUARD` so role checks work across modules
- simplify `UsersModule` provider list

## Testing
- `npm run test`
- `npm run test:e2e` *(fails: AggregateError)*
- `composer test` *(fails: missing vendor packages)*

------
https://chatgpt.com/codex/tasks/task_e_687399d208bc83299330976c3ce348f1