### PR TITLE
Remove global RolesGuard and add admin role test

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,8 +6,6 @@ import { AppService } from './app.service';
 import { HealthController } from './health.controller';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
-import { APP_GUARD } from '@nestjs/core';
-import { RolesGuard } from './auth/roles.guard';
 
 @Module({
     imports: [
@@ -24,12 +22,6 @@ import { RolesGuard } from './auth/roles.guard';
         AuthModule,
     ],
     controllers: [AppController, HealthController],
-    providers: [
-        AppService,
-        {
-            provide: APP_GUARD,
-            useClass: RolesGuard,
-        },
-    ],
+    providers: [AppService],
 })
 export class AppModule {}

--- a/backend/test/roles.e2e-spec.ts
+++ b/backend/test/roles.e2e-spec.ts
@@ -3,9 +3,12 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
 
 describe('RolesGuard (e2e)', () => {
     let app: INestApplication<App>;
+    let usersService: UsersService;
 
     beforeEach(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,6 +18,7 @@ describe('RolesGuard (e2e)', () => {
         app = moduleFixture.createNestApplication();
         app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
         await app.init();
+        usersService = moduleFixture.get(UsersService);
     });
 
     afterEach(async () => {
@@ -26,7 +30,11 @@ describe('RolesGuard (e2e)', () => {
     it('rejects non-admin user creating a new user', async () => {
         const register = await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'client@test.com', password: 'secret', name: 'Client' })
+            .send({
+                email: 'client@test.com',
+                password: 'secret',
+                name: 'Client',
+            })
             .expect(201);
 
         const token = register.body.access_token;
@@ -36,5 +44,31 @@ describe('RolesGuard (e2e)', () => {
             .set('Authorization', `Bearer ${token}`)
             .send({ email: 'new@test.com', password: 'secret', name: 'New' })
             .expect(403);
+    });
+
+    it('allows admin user to create a new user', async () => {
+        await usersService.createUser(
+            'admin@test.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@test.com', password: 'secret' })
+            .expect(201);
+
+        const token = login.body.access_token;
+
+        await request(app.getHttpServer())
+            .post('/users')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                email: 'client2@test.com',
+                password: 'secret',
+                name: 'Client2',
+            })
+            .expect(201);
     });
 });


### PR DESCRIPTION
## Summary
- remove global RolesGuard from `AppModule`
- update e2e roles spec to create an admin user and verify admin access

## Testing
- `npm run test:e2e` *(fails: AggregateError)*

------
https://chatgpt.com/codex/tasks/task_e_6873a00d28948329acf0d613dc551e6f