### PR TITLE
Implement global authentication guards

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { Public } from './auth/public.decorator';
 import { AppService } from './app.service';
 
 @Controller()
@@ -6,6 +7,7 @@ export class AppController {
     constructor(private readonly appService: AppService) {}
 
     @Get()
+    @Public()
     getHello(): string {
         return this.appService.getHello();
     }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -4,23 +4,27 @@ import { RegisterClientDto } from './dto/register-client.dto';
 import { AuthTokensDto } from './dto/auth-tokens.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { LocalAuthGuard } from './local-auth.guard';
+import { Public } from './public.decorator';
 
 @Controller('auth')
 export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('login')
+    @Public()
     @UseGuards(LocalAuthGuard)
     login(@Request() req): Promise<AuthTokensDto> {
         return this.authService.generateTokens(req.user.id, req.user.role);
     }
 
     @Post('register')
+    @Public()
     register(@Body() registerDto: RegisterClientDto): Promise<AuthTokensDto> {
         return this.authService.registerClient(registerDto);
     }
 
     @Post('refresh')
+    @Public()
     refresh(@Body() dto: RefreshTokenDto): Promise<AuthTokensDto> {
         return this.authService.refresh(dto.refresh_token);
     }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { APP_GUARD } from '@nestjs/core';
 import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { LocalStrategy } from './local.strategy';
+import { JwtAuthGuard } from './jwt-auth.guard';
 import { RolesGuard } from './roles.guard';
 
 @Module({
@@ -15,8 +17,19 @@ import { RolesGuard } from './roles.guard';
             signOptions: { expiresIn: '1h' },
         }),
     ],
-    providers: [AuthService, JwtStrategy, LocalStrategy, RolesGuard],
+    providers: [
+        AuthService,
+        JwtStrategy,
+        LocalStrategy,
+        {
+            provide: APP_GUARD,
+            useClass: JwtAuthGuard,
+        },
+        {
+            provide: APP_GUARD,
+            useClass: RolesGuard,
+        },
+    ],
     controllers: [AuthController],
-    exports: [RolesGuard],
 })
 export class AuthModule {}

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -1,5 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from './public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+    constructor(private reflector: Reflector) {
+        super();
+    }
+
+    canActivate(context: ExecutionContext) {
+        const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+        if (isPublic) {
+            return true;
+        }
+        return super.canActivate(context);
+    }
+}

--- a/backend/src/auth/public.decorator.ts
+++ b/backend/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
+import { Public } from './auth/public.decorator';
 
 @Controller('health')
 export class HealthController {
     @Get()
+    @Public()
     getHealth() {
         return { status: 'ok' };
     }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -4,12 +4,9 @@ import {
     Get,
     Post,
     Request,
-    UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from './role.enum';
 
@@ -18,7 +15,6 @@ export class UsersController {
     constructor(private readonly usersService: UsersService) {}
 
     @Post()
-    @UseGuards(JwtAuthGuard, RolesGuard)
     @Roles(Role.Admin)
     create(@Body() createUserDto: CreateUserDto) {
         const { email, password, name, role } = createUserDto;
@@ -26,7 +22,6 @@ export class UsersController {
     }
 
     @Get('profile')
-    @UseGuards(JwtAuthGuard)
     async getProfile(@Request() req) {
         const user = await this.usersService.findOne(req.user.id);
         if (!user) {


### PR DESCRIPTION
## Summary
- register global `JwtAuthGuard` and `RolesGuard` in `AuthModule`
- allow skipping auth with new `Public` decorator
- adjust controllers to use `Public` where needed
- remove redundant guard usage in `UsersController`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: AggregateError - database connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_6873a538d43883299bb920f742c91e74