### PR TITLE
Fix refresh token secret usage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,7 @@ FRONTEND_URL=http://localhost:3000
 # Database connection string
 DATABASE_URL=postgres://user:pass@localhost:5432/salonbw_dev
 
-# Secret used to sign JWT tokens
+# Secret used to sign JWT access tokens
 JWT_SECRET=your-jwt-secret
+# Secret used to sign JWT refresh tokens
 JWT_REFRESH_SECRET=your-refresh-secret

--- a/backend/README.md
+++ b/backend/README.md
@@ -32,6 +32,7 @@ First copy the example environment file and provide a connection string:
 ```bash
 cp .env.example .env
 # edit DATABASE_URL to point at your Postgres database
+# set JWT_SECRET and JWT_REFRESH_SECRET for access and refresh tokens
 ```
 
 You can also adjust `src/app.module.ts` to use a different database engine,

--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -46,16 +46,22 @@ describe('AuthService.registerClient', () => {
             email: dto.email,
             role: Role.Client,
         });
-        jwt.signAsync.mockResolvedValue('jwt');
+        jwt.signAsync
+            .mockResolvedValueOnce('access')
+            .mockResolvedValueOnce('refresh');
 
         const result = await service.registerClient(dto);
-        expect(result).toHaveProperty('access_token', 'jwt');
-        expect(result).toHaveProperty('refresh_token');
-        expect(users.updateRefreshToken).toHaveBeenCalled();
-        expect(jwt.signAsync).toHaveBeenCalledWith({
+        expect(result).toEqual({ access_token: 'access', refresh_token: 'refresh' });
+        expect(users.updateRefreshToken).toHaveBeenCalledWith(1, 'refresh');
+        expect(jwt.signAsync).toHaveBeenNthCalledWith(1, {
             sub: 1,
             role: Role.Client,
         });
+        expect(jwt.signAsync).toHaveBeenNthCalledWith(
+            2,
+            { sub: 1 },
+            expect.objectContaining({ secret: expect.any(String) }),
+        );
 
         const passed = users.createUser.mock.calls[0][1];
         expect(passed).toBe(dto.password);


### PR DESCRIPTION
## Summary
- use `JWT_REFRESH_SECRET` when issuing/validating refresh tokens
- document JWT secrets in backend README
- clarify refresh secret comment in env example
- update auth service unit tests for new token behavior

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6873a53f2d0083298d8bac4875d40e9c