### PR TITLE
Add Services CRUD module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { MessagesModule } from './messages/messages.module';
 import { CatalogModule } from './catalog/catalog.module';
 import { FormulasModule } from './formulas/formulas.module';
 import { CommissionsModule } from './commissions/commissions.module';
+import { ServicesModule } from './services/services.module';
 
 @Module({
     imports: [
@@ -38,6 +39,7 @@ import { CommissionsModule } from './commissions/commissions.module';
         CatalogModule,
         FormulasModule,
         CommissionsModule,
+        ServicesModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/services/dto/create-service.dto.ts
+++ b/backend/src/services/dto/create-service.dto.ts
@@ -1,0 +1,24 @@
+import { IsInt, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateServiceDto {
+    @IsString()
+    name: string;
+
+    @IsOptional()
+    @IsString()
+    description?: string;
+
+    @IsInt()
+    duration: number;
+
+    @IsNumber()
+    price: number;
+
+    @IsOptional()
+    @IsNumber()
+    defaultCommissionPercent?: number | null;
+
+    @IsOptional()
+    @IsInt()
+    categoryId?: number | null;
+}

--- a/backend/src/services/dto/update-service.dto.ts
+++ b/backend/src/services/dto/update-service.dto.ts
@@ -1,0 +1,27 @@
+import { IsInt, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class UpdateServiceDto {
+    @IsOptional()
+    @IsString()
+    name?: string;
+
+    @IsOptional()
+    @IsString()
+    description?: string | null;
+
+    @IsOptional()
+    @IsInt()
+    duration?: number;
+
+    @IsOptional()
+    @IsNumber()
+    price?: number;
+
+    @IsOptional()
+    @IsNumber()
+    defaultCommissionPercent?: number | null;
+
+    @IsOptional()
+    @IsInt()
+    categoryId?: number | null;
+}

--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -1,0 +1,47 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { ServicesService } from './services.service';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
+
+@Controller('services')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ServicesController {
+    constructor(private readonly service: ServicesService) {}
+
+    @Get()
+    @Roles(Role.Admin, Role.Client)
+    list() {
+        return this.service.findAll();
+    }
+
+    @Post()
+    @Roles(Role.Admin)
+    create(@Body() dto: CreateServiceDto) {
+        return this.service.create(dto);
+    }
+
+    @Patch(':id')
+    @Roles(Role.Admin)
+    update(@Param('id') id: number, @Body() dto: UpdateServiceDto) {
+        return this.service.update(Number(id), dto);
+    }
+
+    @Delete(':id')
+    @Roles(Role.Admin)
+    remove(@Param('id') id: number) {
+        return this.service.remove(Number(id));
+    }
+}

--- a/backend/src/services/services.module.ts
+++ b/backend/src/services/services.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Service as ServiceEntity } from '../catalog/service.entity';
+import { ServicesService } from './services.service';
+import { ServicesController } from './services.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([ServiceEntity])],
+    controllers: [ServicesController],
+    providers: [ServicesService],
+})
+export class ServicesModule {}

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Service as ServiceEntity } from '../catalog/service.entity';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
+
+@Injectable()
+export class ServicesService {
+    constructor(
+        @InjectRepository(ServiceEntity)
+        private readonly repo: Repository<ServiceEntity>,
+    ) {}
+
+    create(dto: CreateServiceDto) {
+        const entity = this.repo.create({
+            ...dto,
+            category: dto.categoryId ? ({ id: dto.categoryId } as any) : null,
+        });
+        return this.repo.save(entity);
+    }
+
+    findAll() {
+        return this.repo.find();
+    }
+
+    findOne(id: number) {
+        return this.repo.findOne({ where: { id } });
+    }
+
+    async update(id: number, dto: UpdateServiceDto) {
+        const entity = await this.repo.findOne({ where: { id } });
+        if (!entity) {
+            return undefined;
+        }
+        if (dto.categoryId !== undefined) {
+            entity.category = dto.categoryId ? ({ id: dto.categoryId } as any) : null;
+        }
+        if (dto.name !== undefined) {
+            entity.name = dto.name;
+        }
+        if (dto.description !== undefined) {
+            entity.description = dto.description;
+        }
+        if (dto.duration !== undefined) {
+            entity.duration = dto.duration;
+        }
+        if (dto.price !== undefined) {
+            entity.price = dto.price;
+        }
+        if (dto.defaultCommissionPercent !== undefined) {
+            entity.defaultCommissionPercent = dto.defaultCommissionPercent;
+        }
+        return this.repo.save(entity);
+    }
+
+    remove(id: number) {
+        return this.repo.delete(id);
+    }
+}


### PR DESCRIPTION
## Summary
- generate services module, controller and service
- implement CRUD logic using TypeORM
- restrict modification to admins while allowing clients to list
- register ServicesModule in AppModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e5e479fc83299319cb0840e65cef