### PR TITLE
Fix description column type

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -9,7 +9,7 @@ export class Service {
     @Column()
     name: string;
 
-    @Column({ nullable: true })
+    @Column({ type: 'text', nullable: true })
     description: string | null;
 
     @Column('int')


### PR DESCRIPTION
## Summary
- specify text type for Service.description column
- run backend unit and e2e tests using PostgreSQL

## Testing
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/salon_test npm test`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/salon_test npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6874d32383748329b8ad41b1e33565e8