### PR TITLE
Add formulas controller and service

### DIFF
--- a/backend/src/appointments/appointments.module.ts
+++ b/backend/src/appointments/appointments.module.ts
@@ -5,9 +5,10 @@ import { AppointmentsService } from './appointments.service';
 import { ClientAppointmentsController } from './client-appointments.controller';
 import { EmployeeAppointmentsController } from './employee-appointments.controller';
 import { AdminAppointmentsController } from './admin-appointments.controller';
+import { FormulasModule } from '../formulas/formulas.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Appointment])],
+    imports: [TypeOrmModule.forFeature([Appointment]), FormulasModule],
     controllers: [
         ClientAppointmentsController,
         EmployeeAppointmentsController,

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -3,12 +3,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Appointment, AppointmentStatus } from './appointment.entity';
 import { Service } from '../catalog/service.entity';
+import { FormulasService } from '../formulas/formulas.service';
 
 @Injectable()
 export class AppointmentsService {
     constructor(
         @InjectRepository(Appointment)
         private readonly repo: Repository<Appointment>,
+        private readonly formulas: FormulasService,
     ) {}
 
     create(
@@ -62,7 +64,15 @@ export class AppointmentsService {
         if (dto.status) {
             appt.status = dto.status;
         }
-        return this.repo.save(appt);
+        const saved = await this.repo.save(appt);
+        if (dto.formulaDescription) {
+            await this.formulas.create(
+                appt.client.id,
+                dto.formulaDescription,
+                appt.id,
+            );
+        }
+        return saved;
     }
 
     remove(id: number) {

--- a/backend/src/appointments/dto/update-appointment.dto.ts
+++ b/backend/src/appointments/dto/update-appointment.dto.ts
@@ -24,4 +24,7 @@ export class UpdateAppointmentDto {
     @IsOptional()
     @IsEnum(AppointmentStatus)
     status?: AppointmentStatus;
+
+    @IsOptional()
+    formulaDescription?: string;
 }

--- a/backend/src/formulas/dto/create-formula.dto.ts
+++ b/backend/src/formulas/dto/create-formula.dto.ts
@@ -1,0 +1,13 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class CreateFormulaDto {
+    @IsInt()
+    clientId: number;
+
+    @IsString()
+    description: string;
+
+    @IsOptional()
+    @IsInt()
+    appointmentId?: number;
+}

--- a/backend/src/formulas/formulas.controller.ts
+++ b/backend/src/formulas/formulas.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { FormulasService } from './formulas.service';
+import { CreateFormulaDto } from './dto/create-formula.dto';
+
+@Controller('formulas')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FormulasController {
+    constructor(private readonly service: FormulasService) {}
+
+    @Get()
+    @Roles(Role.Client, Role.Employee)
+    listOwn(@Request() req) {
+        return this.service.findForUser(req.user.id);
+    }
+
+    @Get(':clientId')
+    @Roles(Role.Employee)
+    listForClient(@Param('clientId') clientId: number) {
+        return this.service.findForUser(Number(clientId));
+    }
+
+    @Post()
+    @Roles(Role.Employee)
+    create(@Body() dto: CreateFormulaDto) {
+        return this.service.create(dto.clientId, dto.description, dto.appointmentId);
+    }
+}

--- a/backend/src/formulas/formulas.module.ts
+++ b/backend/src/formulas/formulas.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Formula } from './formula.entity';
+import { FormulasService } from './formulas.service';
+import { FormulasController } from './formulas.controller';
 
 @Module({
     imports: [TypeOrmModule.forFeature([Formula])],
-    exports: [TypeOrmModule],
+    controllers: [FormulasController],
+    providers: [FormulasService],
+    exports: [TypeOrmModule, FormulasService],
 })
 export class FormulasModule {}

--- a/backend/src/formulas/formulas.service.ts
+++ b/backend/src/formulas/formulas.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Formula } from './formula.entity';
+
+@Injectable()
+export class FormulasService {
+    constructor(
+        @InjectRepository(Formula)
+        private readonly repo: Repository<Formula>,
+    ) {}
+
+    create(clientId: number, description: string, appointmentId?: number) {
+        const formula = this.repo.create({
+            client: { id: clientId } as any,
+            description,
+            appointment: appointmentId ? ({ id: appointmentId } as any) : null,
+        });
+        return this.repo.save(formula);
+    }
+
+    findForUser(clientId: number) {
+        return this.repo.find({
+            where: { client: { id: clientId } },
+            order: { id: 'ASC' },
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic formula management for appointments
- allow employees to record client formulas
- expose listing endpoints for employees and clients
- optionally create formulas when completing appointments

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873e5f1e3b883299ddf5586e03af1cf