### PR TITLE
Add basic commissions endpoints

### DIFF
--- a/backend/src/commissions/commissions.controller.ts
+++ b/backend/src/commissions/commissions.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Request } from '@nestjs/common';
+import { CommissionsService } from './commissions.service';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+
+@Controller('commissions')
+export class CommissionsController {
+    constructor(private readonly service: CommissionsService) {}
+
+    @Get('admin')
+    @Roles(Role.Admin)
+    listAll() {
+        return this.service.listAll();
+    }
+
+    @Get('employee')
+    @Roles(Role.Employee)
+    listOwn(@Request() req) {
+        return this.service.listForEmployee(req.user.id);
+    }
+}

--- a/backend/src/commissions/commissions.module.ts
+++ b/backend/src/commissions/commissions.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommissionRecord } from './commission-record.entity';
+import { CommissionsService } from './commissions.service';
+import { CommissionsController } from './commissions.controller';
 
 @Module({
     imports: [TypeOrmModule.forFeature([CommissionRecord])],
+    controllers: [CommissionsController],
+    providers: [CommissionsService],
     exports: [TypeOrmModule],
 })
 export class CommissionsModule {}

--- a/backend/src/commissions/commissions.service.ts
+++ b/backend/src/commissions/commissions.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CommissionRecord } from './commission-record.entity';
+
+@Injectable()
+export class CommissionsService {
+    constructor(
+        @InjectRepository(CommissionRecord)
+        private readonly repo: Repository<CommissionRecord>,
+    ) {}
+
+    listAll() {
+        return this.repo.find();
+    }
+
+    listForEmployee(employeeId: number) {
+        return this.repo.find({ where: { employee: { id: employeeId } } });
+    }
+}

--- a/backend/test/commissions.e2e-spec.ts
+++ b/backend/test/commissions.e2e-spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+
+describe('CommissionsModule (e2e)', () => {
+    let app: INestApplication<App>;
+    let usersService: UsersService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        usersService = moduleFixture.get(UsersService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('employee can list own commissions', async () => {
+        await usersService.createUser('emp@comm.com', 'secret', 'Emp', Role.Employee);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'emp@comm.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+        await request(app.getHttpServer())
+            .get('/commissions/employee')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+    });
+
+    it('employee cannot access admin commissions', async () => {
+        await usersService.createUser('emp2@comm.com', 'secret', 'Emp2', Role.Employee);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'emp2@comm.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+        await request(app.getHttpServer())
+            .get('/commissions/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403);
+    });
+});


### PR DESCRIPTION
## Summary
- add service & controller for commissions
- expose routes for admins and employees
- cover new logic with e2e test

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Data type "enum" not supported / sqlite driver not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6873e5f79cf483299fdf4f40ad158035