### PR TITLE
Add migrations for salon entities

### DIFF
--- a/backend/src/migrations/20250711192004-CreateCategoriesTable.ts
+++ b/backend/src/migrations/20250711192004-CreateCategoriesTable.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateCategoriesTable20250711192004 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'category',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'name',
+                        type: 'varchar',
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('category');
+    }
+}

--- a/backend/src/migrations/20250711192005-CreateServicesTable.ts
+++ b/backend/src/migrations/20250711192005-CreateServicesTable.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateServicesTable20250711192005 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'service',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'name', type: 'varchar' },
+                    { name: 'description', type: 'varchar', isNullable: true },
+                    { name: 'duration', type: 'int' },
+                    { name: 'price', type: 'decimal', precision: 10, scale: 2 },
+                    {
+                        name: 'defaultCommissionPercent',
+                        type: 'float',
+                        isNullable: true,
+                    },
+                    { name: 'categoryId', type: 'int', isNullable: true },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'service',
+            new TableForeignKey({
+                columnNames: ['categoryId'],
+                referencedTableName: 'category',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('service');
+    }
+}

--- a/backend/src/migrations/20250711192006-CreateProductsTable.ts
+++ b/backend/src/migrations/20250711192006-CreateProductsTable.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateProductsTable20250711192006 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'product',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'name', type: 'varchar' },
+                    { name: 'brand', type: 'varchar', isNullable: true },
+                    { name: 'unitPrice', type: 'decimal', precision: 10, scale: 2 },
+                    { name: 'stock', type: 'int' },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('product');
+    }
+}

--- a/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
+++ b/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateAppointmentsTable20250711192007 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'appointment',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'clientId', type: 'int' },
+                    { name: 'employeeId', type: 'int' },
+                    { name: 'startTime', type: 'datetime' },
+                    { name: 'endTime', type: 'datetime', isNullable: true },
+                    { name: 'notes', type: 'varchar', isNullable: true },
+                    { name: 'serviceId', type: 'int' },
+                    {
+                        name: 'status',
+                        type: 'enum',
+                        enum: ['scheduled', 'completed', 'cancelled'],
+                        default: `'scheduled'`,
+                    },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('appointment', [
+            new TableForeignKey({
+                columnNames: ['clientId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+            }),
+            new TableForeignKey({
+                columnNames: ['employeeId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+            }),
+            new TableForeignKey({
+                columnNames: ['serviceId'],
+                referencedTableName: 'service',
+                referencedColumnNames: ['id'],
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('appointment');
+    }
+}

--- a/backend/src/migrations/20250711192008-CreateFormulasTable.ts
+++ b/backend/src/migrations/20250711192008-CreateFormulasTable.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateFormulasTable20250711192008 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'formula',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'description', type: 'text' },
+                    {
+                        name: 'date',
+                        type: 'datetime',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                    { name: 'clientId', type: 'int' },
+                    { name: 'appointmentId', type: 'int', isNullable: true },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('formula', [
+            new TableForeignKey({
+                columnNames: ['clientId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+            }),
+            new TableForeignKey({
+                columnNames: ['appointmentId'],
+                referencedTableName: 'appointment',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('formula');
+    }
+}

--- a/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
+++ b/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateCommissionRecordsTable20250711192009 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'commission_record',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'employeeId', type: 'int' },
+                    { name: 'appointmentId', type: 'int', isNullable: true },
+                    { name: 'productId', type: 'int', isNullable: true },
+                    { name: 'amount', type: 'decimal', precision: 10, scale: 2 },
+                    { name: 'percent', type: 'float' },
+                    {
+                        name: 'createdAt',
+                        type: 'datetime',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('commission_record', [
+            new TableForeignKey({
+                columnNames: ['employeeId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+            }),
+            new TableForeignKey({
+                columnNames: ['appointmentId'],
+                referencedTableName: 'appointment',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+            new TableForeignKey({
+                columnNames: ['productId'],
+                referencedTableName: 'product',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('commission_record');
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations for Category, Service, Product, Appointment, Formula and CommissionRecord tables
- run migrations automatically via existing `migrationsRun` setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e5fbf9e48329a4f00ebf896b4031