### PR TITLE
Add tests

### DIFF
--- a/backend/src/app.service.spec.ts
+++ b/backend/src/app.service.spec.ts
@@ -1,0 +1,8 @@
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  it('getHello returns greeting', () => {
+    const service = new AppService();
+    expect(service.getHello()).toBe('Hello World!');
+  });
+});

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AppointmentsService } from './appointments.service';
+import { Appointment, AppointmentStatus } from './appointment.entity';
+
+describe('AppointmentsService', () => {
+  let service: AppointmentsService;
+  let repo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+    findOne: jest.Mock;
+    delete: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    repo = { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOne: jest.fn(), delete: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppointmentsService,
+        { provide: getRepositoryToken(Appointment), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get<AppointmentsService>(AppointmentsService);
+  });
+
+  it('create builds and saves a new appointment', async () => {
+    const created = { id: 1 } as Appointment;
+    repo.create.mockReturnValue(created);
+    repo.save.mockResolvedValue(created);
+
+    const result = await service.create(1, 2, 3, '2025-07-01T10:00:00.000Z');
+
+    expect(repo.create).toHaveBeenCalledWith({
+      client: { id: 1 },
+      employee: { id: 2 },
+      service: { id: 3 },
+      startTime: new Date('2025-07-01T10:00:00.000Z'),
+      status: AppointmentStatus.Scheduled,
+    });
+    expect(repo.save).toHaveBeenCalledWith(created);
+    expect(result).toBe(created);
+  });
+
+  it('findClientAppointments queries by client id', async () => {
+    repo.find.mockResolvedValue([]);
+    await service.findClientAppointments(4);
+    expect(repo.find).toHaveBeenCalledWith({ where: { client: { id: 4 } } });
+  });
+
+  it('update modifies existing appointment', async () => {
+    const existing: any = { id: 2, status: AppointmentStatus.Scheduled };
+    repo.findOne.mockResolvedValue(existing);
+    repo.save.mockResolvedValue(existing);
+
+    await service.update(2, { status: AppointmentStatus.Completed, notes: 'done' });
+
+    expect(existing.status).toBe(AppointmentStatus.Completed);
+    expect(existing.notes).toBe('done');
+    expect(repo.save).toHaveBeenCalledWith(existing);
+  });
+
+  it('remove calls repository delete', async () => {
+    repo.delete.mockResolvedValue({});
+    await service.remove(5);
+    expect(repo.delete).toHaveBeenCalledWith(5);
+  });
+});

--- a/backend/src/messages/messages.service.spec.ts
+++ b/backend/src/messages/messages.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MessagesService } from './messages.service';
+import { Message } from './message.entity';
+
+describe('MessagesService', () => {
+  let service: MessagesService;
+  let repo: { create: jest.Mock; save: jest.Mock; find: jest.Mock };
+
+  beforeEach(async () => {
+    repo = { create: jest.fn(), save: jest.fn(), find: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MessagesService, { provide: getRepositoryToken(Message), useValue: repo }],
+    }).compile();
+
+    service = module.get<MessagesService>(MessagesService);
+  });
+
+  it('create saves a new message', async () => {
+    const msg = { id: 1 } as Message;
+    repo.create.mockReturnValue(msg);
+    repo.save.mockResolvedValue(msg);
+
+    const result = await service.create(1, 2, 'hello');
+
+    expect(repo.create).toHaveBeenCalledWith({
+      sender: { id: 1 },
+      recipient: { id: 2 },
+      content: 'hello',
+    });
+    expect(repo.save).toHaveBeenCalledWith(msg);
+    expect(result).toBe(msg);
+  });
+
+  it('findForUser queries for both sender and recipient', async () => {
+    repo.find.mockResolvedValue([]);
+    await service.findForUser(3);
+    expect(repo.find).toHaveBeenCalledWith({
+      where: [
+        { sender: { id: 3 } },
+        { recipient: { id: 3 } },
+      ],
+      order: { id: 'ASC' },
+    });
+  });
+});

--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -3,9 +3,11 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { Role } from './../src/users/role.enum';
 
 describe('AppointmentsModule (e2e)', () => {
     let app: INestApplication<App>;
+    let usersService: import('../src/users/users.service').UsersService;
 
     beforeEach(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,6 +17,7 @@ describe('AppointmentsModule (e2e)', () => {
         app = moduleFixture.createNestApplication();
         app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
         await app.init();
+        usersService = moduleFixture.get('UsersService');
     });
 
     afterEach(async () => {
@@ -45,5 +48,41 @@ describe('AppointmentsModule (e2e)', () => {
             .get('/appointments/admin')
             .set('Authorization', `Bearer ${token}`)
             .expect(403);
+    });
+
+    it('admin can CRUD appointments', async () => {
+        const client = await usersService.createUser('c@test.com', 'secret', 'C', Role.Client);
+        const employee = await usersService.createUser('e@test.com', 'secret', 'E', Role.Employee);
+        await usersService.createUser('a@test.com', 'secret', 'A', Role.Admin);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'a@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        const create = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: '2025-07-01T10:00:00.000Z',
+            })
+            .expect(201);
+
+        const id = create.body.id;
+
+        await request(app.getHttpServer())
+            .patch(`/appointments/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ notes: 'done' })
+            .expect(200);
+
+        await request(app.getHttpServer())
+            .delete(`/appointments/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
     });
 });

--- a/backend/test/messages.e2e-spec.ts
+++ b/backend/test/messages.e2e-spec.ts
@@ -49,4 +49,20 @@ describe('MessagesModule (e2e)', () => {
             .set('Authorization', `Bearer ${token}`)
             .expect(200);
     });
+
+    it('forbids admin from accessing messages endpoints', async () => {
+        await usersService.createUser('admin@msg.com', 'secret', 'Admin', Role.Admin);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@msg.com', password: 'secret' })
+            .expect(201);
+
+        const token = login.body.access_token;
+
+        await request(app.getHttpServer())
+            .get('/messages')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403);
+    });
 });


### PR DESCRIPTION
## Summary
- add unit tests for appointments, messages and app service
- extend CRUD checks in appointments and messages e2e tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: DataTypeNotSupportedError)*

------
https://chatgpt.com/codex/tasks/task_e_6873e60349dc8329b4f992f37abf29dd