### PR TITLE
Fix TypeORM sync for postgres

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,7 +27,8 @@ import { CommissionsModule } from './commissions/commissions.module';
                     autoLoadEntities: true,
                     migrations: [__dirname + '/migrations/*.ts'],
                     migrationsRun: !isSqlite,
-                    synchronize: process.env.NODE_ENV !== 'production',
+                    synchronize:
+                        isSqlite && process.env.NODE_ENV !== 'production',
                 } as any;
             },
         }),
@@ -38,7 +39,6 @@ import { CommissionsModule } from './commissions/commissions.module';
         CatalogModule,
         FormulasModule,
         CommissionsModule,
-
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],


### PR DESCRIPTION
## Summary
- sync schema only when using SQLite (avoid duplicate table errors on Postgres)

## Testing
- `npm --prefix backend run test:e2e` *(fails: `SQLITE_ERROR: no such table: user` but no `relation already exists` errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874f4df84048329860202161f7ec0fd