### PR TITLE
Update test instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -68,12 +68,11 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
-End-to-end tests require all dependencies installed. They default to an
-in-memory SQLite database when `DATABASE_URL` is unset. Set
-`DATABASE_URL=sqlite::memory:` (or simply leave the variable unset) so the tests
-run without a local Postgres instance. One test posts to `/auth/refresh` without
-seeding a user first to confirm that unknown tokens result in a
-`401 Unauthorized` response.
+End-to-end tests require all dependencies installed. Set
+`DATABASE_URL=sqlite::memory:` (or simply leave the variable unset) to use an
+in-memory SQLite database so the tests run without a local Postgres instance.
+One test posts to `/auth/refresh` without seeding a user first to confirm that
+unknown tokens result in a `401 Unauthorized` response.
 
 The test runner expects this database to be clean. Jest hooks automatically
 truncate the tables between test files, so use a dedicated test database or one


### PR DESCRIPTION
## Summary
- clarify how to run e2e tests without Postgres by using an in-memory database

## Testing
- `npm run test` (fails: Nest can't resolve dependencies)
- `DATABASE_URL=sqlite::memory: npm run test:e2e` (fails: no such table: user)

------
https://chatgpt.com/codex/tasks/task_e_6875066b84188329835e1e106714e4fa