### PR TITLE
Add appointment ownership checks

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Appointment, AppointmentStatus } from './appointment.entity';
 import { Service } from '../catalog/service.entity';
 import { FormulasService } from '../formulas/formulas.service';
+import { Role } from '../users/role.enum';
 
 @Injectable()
 export class AppointmentsService {
@@ -41,11 +42,7 @@ export class AppointmentsService {
         return this.repo.find();
     }
 
-    async update(id: number, dto: any) {
-        const appt = await this.repo.findOne({ where: { id } });
-        if (!appt) {
-            return undefined;
-        }
+    private async applyUpdates(appt: Appointment, dto: any) {
         if (dto.startTime) {
             appt.startTime = new Date(dto.startTime);
         }
@@ -75,7 +72,43 @@ export class AppointmentsService {
         return saved;
     }
 
+    async update(id: number, dto: any) {
+        const appt = await this.repo.findOne({ where: { id } });
+        if (!appt) {
+            return undefined;
+        }
+        return this.applyUpdates(appt, dto);
+    }
+
     remove(id: number) {
+        return this.repo.delete(id);
+    }
+
+    async updateForUser(id: number, userId: number, role: Role, dto: any) {
+        const appt = await this.repo.findOne({ where: { id } });
+        if (!appt) {
+            return undefined;
+        }
+        if (
+            (role === Role.Client && appt.client.id !== userId) ||
+            (role === Role.Employee && appt.employee.id !== userId)
+        ) {
+            throw new ForbiddenException();
+        }
+        return this.applyUpdates(appt, dto);
+    }
+
+    async removeForUser(id: number, userId: number, role: Role) {
+        const appt = await this.repo.findOne({ where: { id } });
+        if (!appt) {
+            return undefined;
+        }
+        if (
+            (role === Role.Client && appt.client.id !== userId) ||
+            (role === Role.Employee && appt.employee.id !== userId)
+        ) {
+            throw new ForbiddenException();
+        }
         return this.repo.delete(id);
     }
 }

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -32,12 +32,18 @@ export class ClientAppointmentsController {
     update(
         @Param('id') id: number,
         @Body() dto: UpdateAppointmentDto,
+        @Request() req,
     ) {
-        return this.service.update(Number(id), dto);
+        return this.service.updateForUser(
+            Number(id),
+            req.user.id,
+            Role.Client,
+            dto,
+        );
     }
 
     @Delete(':id')
-    remove(@Param('id') id: number) {
-        return this.service.remove(Number(id));
+    remove(@Param('id') id: number, @Request() req) {
+        return this.service.removeForUser(Number(id), req.user.id, Role.Client);
     }
 }

--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -18,7 +18,16 @@ export class EmployeeAppointmentsController {
     }
 
     @Patch(':id')
-    update(@Param('id') id: number, @Body() dto: UpdateAppointmentDto) {
-        return this.service.update(Number(id), dto);
+    update(
+        @Param('id') id: number,
+        @Body() dto: UpdateAppointmentDto,
+        @Request() req,
+    ) {
+        return this.service.updateForUser(
+            Number(id),
+            req.user.id,
+            Role.Employee,
+            dto,
+        );
     }
 }

--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -4,10 +4,15 @@ import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 import { Role } from './../src/users/role.enum';
+import { UsersService } from './../src/users/users.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Service as CatalogService } from './../src/catalog/service.entity';
 
 describe('AppointmentsModule (e2e)', () => {
     let app: INestApplication<App>;
-    let usersService: import('../src/users/users.service').UsersService;
+    let usersService: UsersService;
+    let serviceRepo: Repository<CatalogService>;
 
     beforeEach(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -17,7 +22,13 @@ describe('AppointmentsModule (e2e)', () => {
         app = moduleFixture.createNestApplication();
         app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
         await app.init();
-        usersService = moduleFixture.get('UsersService');
+        usersService = moduleFixture.get(UsersService);
+        serviceRepo = moduleFixture.get(getRepositoryToken(CatalogService));
+        await serviceRepo.save({
+            name: 'Cut',
+            duration: 30,
+            price: 10,
+        });
     });
 
     afterEach(async () => {
@@ -84,5 +95,79 @@ describe('AppointmentsModule (e2e)', () => {
             .delete(`/appointments/admin/${id}`)
             .set('Authorization', `Bearer ${token}`)
             .expect(200);
+    });
+
+    it('client cannot modify another client appointment', async () => {
+        const client1 = await usersService.createUser('c1@test.com', 'secret', 'C1', Role.Client);
+        const client2 = await usersService.createUser('c2@test.com', 'secret', 'C2', Role.Client);
+        const employee = await usersService.createUser('e2@test.com', 'secret', 'E2', Role.Employee);
+        await usersService.createUser('admin2@test.com', 'secret', 'A', Role.Admin);
+
+        const adminLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin2@test.com', password: 'secret' })
+            .expect(201);
+        const adminToken = adminLogin.body.access_token;
+
+        const create = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({
+                clientId: client1.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: '2025-07-01T10:00:00.000Z',
+            })
+            .expect(201);
+        const id = create.body.id;
+
+        const loginClient2 = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'c2@test.com', password: 'secret' })
+            .expect(201);
+        const token = loginClient2.body.access_token;
+
+        await request(app.getHttpServer())
+            .patch(`/appointments/client/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ notes: 'fail' })
+            .expect(403);
+    });
+
+    it('employee cannot modify appointment of another employee', async () => {
+        const client = await usersService.createUser('c3@test.com', 'secret', 'C3', Role.Client);
+        const emp1 = await usersService.createUser('e3@test.com', 'secret', 'E3', Role.Employee);
+        const emp2 = await usersService.createUser('e4@test.com', 'secret', 'E4', Role.Employee);
+        await usersService.createUser('admin3@test.com', 'secret', 'A', Role.Admin);
+
+        const adminLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin3@test.com', password: 'secret' })
+            .expect(201);
+        const adminToken = adminLogin.body.access_token;
+
+        const create = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({
+                clientId: client.id,
+                employeeId: emp1.id,
+                serviceId: 1,
+                startTime: '2025-07-01T10:00:00.000Z',
+            })
+            .expect(201);
+        const id = create.body.id;
+
+        const loginEmp2 = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'e4@test.com', password: 'secret' })
+            .expect(201);
+        const empToken = loginEmp2.body.access_token;
+
+        await request(app.getHttpServer())
+            .patch(`/appointments/employee/${id}`)
+            .set('Authorization', `Bearer ${empToken}`)
+            .send({ notes: 'nope' })
+            .expect(403);
     });
 });

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -4,7 +4,7 @@ import { beforeAll, afterAll, afterEach } from '@jest/globals';
 
 config({ path: '.env' });
 if (!process.env.DATABASE_URL) {
-  process.env.DATABASE_URL = 'sqlite::memory:';
+  process.env.DATABASE_URL = 'sqlite:./test.sqlite';
 }
 
 let dataSource: DataSource;
@@ -23,13 +23,17 @@ beforeAll(async () => {
 
 afterEach(async () => {
   if (dataSource?.isInitialized) {
-    if ((dataSource as any).isSqlite) {
-      await dataSource.query('DELETE FROM user');
-      await dataSource
-        .query('DELETE FROM sqlite_sequence WHERE name=\'user\'')
-        .catch(() => {});
-    } else {
-      await dataSource.query('TRUNCATE TABLE "user" RESTART IDENTITY CASCADE');
+    try {
+      if ((dataSource as any).isSqlite) {
+        await dataSource.query('DELETE FROM user');
+        await dataSource
+          .query("DELETE FROM sqlite_sequence WHERE name='user'")
+          .catch(() => {});
+      } else {
+        await dataSource.query('TRUNCATE TABLE "user" RESTART IDENTITY CASCADE');
+      }
+    } catch {
+      // ignore if table does not exist
     }
   }
 });


### PR DESCRIPTION
## Summary
- restrict appointment updates and deletes to owning user
- wire ownership checks into client/employee controllers
- test forbidden access for wrong owner
- keep e2e DB consistent during tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: SQLITE_CONSTRAINT: FOREIGN KEY constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_68750dfe697c83298db735210233dd69