### PR TITLE
Fix create method return type

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -22,7 +22,7 @@ export class AppointmentsService {
         employeeId: number,
         serviceId: number,
         startTime: string,
-    ) {
+    ): Promise<Appointment> {
         const existing = await this.repo.findOne({
             where: {
                 employee: { id: employeeId },


### PR DESCRIPTION
## Summary
- specify `Promise<Appointment>` return type for `create`

## Testing
- `npm test` *(fails: appointments.service.spec.ts compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687524eff6c88329b4c9ec20e0151395