### PR TITLE
Add repo.findOne argument assertion

### DIFF
--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -58,6 +58,12 @@ describe('AppointmentsService', () => {
     await expect(
       service.create(1, 2, 3, '2025-07-01T10:00:00.000Z'),
     ).rejects.toThrow(ConflictException);
+    expect(repo.findOne).toHaveBeenCalledWith({
+      where: {
+        employee: { id: 2 },
+        startTime: new Date('2025-07-01T10:00:00.000Z'),
+      },
+    });
     expect(repo.create).not.toHaveBeenCalled();
     expect(repo.save).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- extend appointments service test to assert repo.findOne arguments

## Testing
- `npm test` *(fails: variable 'formulas' used before assignment and missing imports in appointments.service.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687526e118748329aa87988611cdb75b