### PR TITLE
Add unique employee appointment index

### DIFF
--- a/backend/src/appointments/appointment.entity.ts
+++ b/backend/src/appointments/appointment.entity.ts
@@ -4,6 +4,7 @@ import {
     ManyToOne,
     Column,
     OneToMany,
+    Index,
 } from 'typeorm';
 import { User } from '../users/user.entity';
 import { Service } from '../catalog/service.entity';
@@ -14,7 +15,7 @@ export enum AppointmentStatus {
     Completed = 'completed',
     Cancelled = 'cancelled',
 }
-
+@Index(['employee', 'startTime'], { unique: true })
 @Entity()
 export class Appointment {
     @PrimaryGeneratedColumn()


### PR DESCRIPTION
## Summary
- enforce uniqueness on appointment `employee` and `startTime`

## Testing
- `npm test --silent` *(fails: Variable 'formulas' is used before being assigned)*

------
https://chatgpt.com/codex/tasks/task_e_6875288e693c832991fde91f4ed7166b