### PR TITLE
Fix beforeEach setup in appointments tests

### DIFF
--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import {
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { AppointmentsService } from './appointments.service';
 import { Appointment, AppointmentStatus } from './appointment.entity';
 import { CommissionRecord } from '../commissions/commission-record.entity';
@@ -21,12 +25,14 @@ describe('AppointmentsService', () => {
 
   beforeEach(async () => {
     repo = { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOne: jest.fn(), delete: jest.fn() };
-
+    commissionRepo = { create: jest.fn(), save: jest.fn() };
+    formulas = { create: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AppointmentsService,
         { provide: getRepositoryToken(Appointment), useValue: repo },
+        { provide: getRepositoryToken(CommissionRecord), useValue: commissionRepo },
 
         { provide: FormulasService, useValue: formulas },
       ],


### PR DESCRIPTION
## Summary
- initialize `commissionRepo` and `formulas` mocks in `appointments.service.spec.ts`
- provide the `CommissionRecord` repository in the test module
- import missing Nest exceptions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68752ef9005883299831d5beac55d181