### PR TITLE
Add client appointment creation e2e test

### DIFF
--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -5,11 +5,17 @@ import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 import { Role } from './../src/users/role.enum';
 import { UsersService } from './../src/users/users.service';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Service as CatalogService } from './../src/catalog/service.entity';
+import { Appointment } from './../src/appointments/appointment.entity';
 
 
 describe('AppointmentsModule (e2e)', () => {
     let app: INestApplication<App>;
     let usersService: UsersService;
+    let servicesRepo: Repository<CatalogService>;
+    let appointmentsRepo: Repository<Appointment>;
 
 
     beforeEach(async () => {
@@ -21,6 +27,8 @@ describe('AppointmentsModule (e2e)', () => {
         app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
         await app.init();
         usersService = moduleFixture.get(UsersService);
+        servicesRepo = moduleFixture.get(getRepositoryToken(CatalogService));
+        appointmentsRepo = moduleFixture.get(getRepositoryToken(Appointment));
 
     });
 
@@ -88,6 +96,49 @@ describe('AppointmentsModule (e2e)', () => {
             .delete(`/appointments/admin/${id}`)
             .set('Authorization', `Bearer ${token}`)
             .expect(200);
+    });
+
+    it('client can create an appointment', async () => {
+        await servicesRepo.save(
+            servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
+        );
+        const client = await usersService.createUser(
+            'client3@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await usersService.createUser(
+            'emp3@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'client3@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+        const startTime = '2025-07-01T11:00:00.000Z';
+
+        const res = await request(app.getHttpServer())
+            .post('/appointments/client')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime,
+            })
+            .expect(201);
+
+        const saved = await appointmentsRepo.findOne({
+            where: { id: res.body.id },
+        });
+        expect(saved).toBeDefined();
+        expect(saved?.client.id).toBe(client.id);
+        expect(saved?.employee.id).toBe(employee.id);
+        expect(saved?.service.id).toBe(1);
     });
 
     });


### PR DESCRIPTION
## Summary
- add service and appointment repositories to the appointment e2e test
- verify client can create an appointment via `/appointments/client`

## Testing
- `npm run test:e2e` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68756465c7888329b511bc440d53a2f4