### PR TITLE
Add auth required test for appointment creation

### DIFF
--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -141,5 +141,26 @@ describe('AppointmentsModule (e2e)', () => {
         expect(saved?.service.id).toBe(1);
     });
 
+    it('rejects unauthenticated appointment creation', async () => {
+        await servicesRepo.save(
+            servicesRepo.create({ name: 'style', duration: 30, price: 20 }),
+        );
+        const employee = await usersService.createUser(
+            'emp4@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const startTime = '2025-07-02T11:00:00.000Z';
+        await request(app.getHttpServer())
+            .post('/appointments/client')
+            .send({
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime,
+            })
+            .expect(401);
+    });
+
     });
 });


### PR DESCRIPTION
## Summary
- ensure an unauthenticated client request to POST /appointments/client returns 401

## Testing
- `npm run test:e2e` *(fails: sqlite3 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68756927867c8329b0d97603269e130d