### PR TITLE
Add client restriction e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ tailwindcss
 output_tree*.txt
 .env.bak
 
+backend/test.sqlite

--- a/backend/test/services.e2e-spec.ts
+++ b/backend/test/services.e2e-spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('ServicesModule (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('rejects client creating a service', async () => {
+    const register = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'client@services.com', password: 'secret', name: 'Client' })
+      .expect(201);
+    const token = register.body.access_token;
+
+    await request(app.getHttpServer())
+      .post('/services')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'cut', duration: 30, price: 10 })
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add a services e2e test verifying clients cannot create services
- ignore test sqlite db

## Testing
- `npm test --silent`
- `npm run test:e2e --silent` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68756b5446048329ab27043b6389054c