### PR TITLE
Fix closing brace in appointments test

### DIFF
--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -199,6 +199,4 @@ describe('AppointmentsModule (e2e)', () => {
             })
             .expect(401);
     });
-
-    });
 });


### PR DESCRIPTION
## Summary
- fix extraneous closing brace at end of appointments e2e test

## Testing
- `npm run test:e2e` *(fails: QueryFailedError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687571590c1c832990401469ba0e1a51