### PR TITLE
Use SQLite during tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -69,14 +69,14 @@ $ npm run test:cov
 ```
 
 End-to-end tests require all dependencies installed. Set
-`DATABASE_URL=sqlite::memory:` (or simply leave the variable unset) to use an
-in-memory SQLite database so the tests run without a local Postgres instance.
+`DATABASE_URL=sqlite::memory:` (or point to a disposable file like
+`sqlite:./test.sqlite`) so the tests run without a local Postgres instance.
 One test posts to `/auth/refresh` without seeding a user first to confirm that
 unknown tokens result in a `401 Unauthorized` response.
 
 The test runner expects this database to be clean. Jest hooks automatically
-truncate the tables between test files, so use a dedicated test database or one
-whose contents can be safely wiped.
+drop and recreate all tables between test files, so use a dedicated test database
+or one whose contents can be safely wiped.
 
 Example sequence using the in-memory database:
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { MessagesModule } from './messages/messages.module';
 import { CatalogModule } from './catalog/catalog.module';
 import { FormulasModule } from './formulas/formulas.module';
 import { CommissionsModule } from './commissions/commissions.module';
+import { ServicesModule } from './services/services.module';
 
 @Module({
     imports: [
@@ -38,6 +39,7 @@ import { CommissionsModule } from './commissions/commissions.module';
         CatalogModule,
         FormulasModule,
         CommissionsModule,
+        ServicesModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -1,6 +1,8 @@
 import { DataSource } from 'typeorm';
 import { config } from 'dotenv';
 import { beforeAll, afterAll, afterEach } from '@jest/globals';
+import { join } from 'path';
+import { Service as CatalogService } from '../src/catalog/service.entity';
 
 config({ path: '.env' });
 if (!process.env.DATABASE_URL) {
@@ -14,27 +16,38 @@ beforeAll(async () => {
   const isSqlite = url.startsWith('sqlite:');
   dataSource = new DataSource(
     isSqlite
-      ? { type: 'sqlite', database: url.replace('sqlite:', '') }
-      : { type: 'postgres', url }
+      ? {
+          type: 'sqlite',
+          database: url.replace('sqlite:', ''),
+          entities: [join(__dirname, '../src/**/*.entity.ts')],
+        }
+      : {
+          type: 'postgres',
+          url,
+          migrations: [join(__dirname, '../src/migrations/*.ts')],
+        }
   );
   await dataSource.initialize();
+  if (isSqlite) {
+    await dataSource.synchronize();
+  } else {
+    await dataSource.runMigrations();
+  }
+  const repo = dataSource.getRepository(CatalogService);
+  await repo.save(repo.create({ name: 'cut', duration: 30, price: 10 }));
   (dataSource as any).isSqlite = isSqlite;
 });
 
 afterEach(async () => {
   if (dataSource?.isInitialized) {
-    try {
-      if ((dataSource as any).isSqlite) {
-        await dataSource.query('DELETE FROM user');
-        await dataSource
-          .query("DELETE FROM sqlite_sequence WHERE name='user'")
-          .catch(() => {});
-      } else {
-        await dataSource.query('TRUNCATE TABLE "user" RESTART IDENTITY CASCADE');
-      }
-    } catch {
-      // ignore if table does not exist
+    if ((dataSource as any).isSqlite) {
+      await dataSource.synchronize(true);
+    } else {
+      await dataSource.dropDatabase();
+      await dataSource.runMigrations();
     }
+    const repo = dataSource.getRepository(CatalogService);
+    await repo.save(repo.create({ name: 'cut', duration: 30, price: 10 }));
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure test environment defaults to a SQLite DB
- seed a basic service in tests and reset the DB between suites
- include ServicesModule so service routes exist
- note DB requirement in backend README

## Testing
- `DATABASE_URL=sqlite:./test.sqlite npm run test:e2e` *(fails: AppointmentsModule rejects past start time)*

------
https://chatgpt.com/codex/tasks/task_e_6875729339f88329b3d52416df8d4ef3