### PR TITLE
Switch datetime columns to timestamp

### DIFF
--- a/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
+++ b/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
@@ -15,8 +15,8 @@ export class CreateAppointmentsTable20250711192007 implements MigrationInterface
                     },
                     { name: 'clientId', type: 'int' },
                     { name: 'employeeId', type: 'int' },
-                    { name: 'startTime', type: 'datetime' },
-                    { name: 'endTime', type: 'datetime', isNullable: true },
+                    { name: 'startTime', type: 'timestamp' },
+                    { name: 'endTime', type: 'timestamp', isNullable: true },
                     { name: 'notes', type: 'varchar', isNullable: true },
                     { name: 'serviceId', type: 'int' },
                     {

--- a/backend/src/migrations/20250711192008-CreateFormulasTable.ts
+++ b/backend/src/migrations/20250711192008-CreateFormulasTable.ts
@@ -16,7 +16,7 @@ export class CreateFormulasTable20250711192008 implements MigrationInterface {
                     { name: 'description', type: 'text' },
                     {
                         name: 'date',
-                        type: 'datetime',
+                        type: 'timestamp',
                         default: 'CURRENT_TIMESTAMP',
                     },
                     { name: 'clientId', type: 'int' },

--- a/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
+++ b/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
@@ -20,7 +20,7 @@ export class CreateCommissionRecordsTable20250711192009 implements MigrationInte
                     { name: 'percent', type: 'float' },
                     {
                         name: 'createdAt',
-                        type: 'datetime',
+                        type: 'timestamp',
                         default: 'CURRENT_TIMESTAMP',
                     },
                 ],


### PR DESCRIPTION
## Summary
- use `timestamp` columns for appointments, formulas, and commission records

## Testing
- `npm install`
- `npm run test:e2e` *(fails: AppointmentsModule rejects appointment with past start time)*

------
https://chatgpt.com/codex/tasks/task_e_687578f1d1d4832996af5c611fe5ee85