### PR TITLE
Fix e2e test datasource

### DIFF
--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
       : {
           type: 'postgres',
           url,
+          entities: [join(__dirname, '../src/**/*.entity.ts')],
           migrations: [join(__dirname, '../src/migrations/*.ts')],
         }
   );


### PR DESCRIPTION
## Summary
- point Postgres datasource to all entity files for tests

## Testing
- `npm run test:e2e` *(fails: expected 400 "Bad Request", got 201 "Created")*

------
https://chatgpt.com/codex/tasks/task_e_68757d5cbf688329a2d96ce760b543b0