### PR TITLE
Add commission base migration

### DIFF
--- a/backend/src/migrations/20250711192010-AddCommissionBaseToUser.ts
+++ b/backend/src/migrations/20250711192010-AddCommissionBaseToUser.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddCommissionBaseToUser20250711192010 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'user',
+            new TableColumn({
+                name: 'commissionBase',
+                type: 'float',
+                isNullable: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('user', 'commissionBase');
+    }
+}


### PR DESCRIPTION
## Summary
- add commissionBase float column for user
- run migrations in tests

## Testing
- `npm run test:e2e` *(fails: AppointmentsModule (e2e) rejects appointment with past start time)*

------
https://chatgpt.com/codex/tasks/task_e_6875fdda6eec83298bf490eafd9fdd4d