### PR TITLE
Add nullable decorator to service description

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -9,6 +9,7 @@ export class Service {
     @Column()
     name: string;
 
+    @Column({ nullable: true })
     description: string | null;
 
     @Column('int')


### PR DESCRIPTION
## Summary
- mark `Service.description` field nullable

## Testing
- `npm --prefix backend run build`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6875ff1ff7dc8329b895ac44c91dec70