### PR TITLE
Fix description column type in Service entity

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -9,7 +9,7 @@ export class Service {
     @Column()
     name: string;
 
-    @Column({ nullable: true })
+    @Column('text', { nullable: true })
     description: string | null;
 
     @Column('int')

--- a/backend/src/migrations/20250711192005-CreateServicesTable.ts
+++ b/backend/src/migrations/20250711192005-CreateServicesTable.ts
@@ -14,7 +14,7 @@ export class CreateServicesTable20250711192005 implements MigrationInterface {
                         generationStrategy: 'increment',
                     },
                     { name: 'name', type: 'varchar' },
-                    { name: 'description', type: 'varchar', isNullable: true },
+                    { name: 'description', type: 'text', isNullable: true },
                     { name: 'duration', type: 'int' },
                     { name: 'price', type: 'decimal', precision: 10, scale: 2 },
                     {


### PR DESCRIPTION
## Summary
- set Service description column type to `text`
- update the corresponding migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876030c00208329af358e821b2caa7d