### PR TITLE
Fix migration defaults for PostgreSQL

### DIFF
--- a/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
+++ b/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
@@ -23,7 +23,7 @@ export class CreateAppointmentsTable20250711192007 implements MigrationInterface
                         name: 'status',
                         type: 'enum',
                         enum: ['scheduled', 'completed', 'cancelled'],
-                        default: `'scheduled'`,
+                        default: "'scheduled'",
                     },
                 ],
             }),

--- a/backend/src/migrations/20250711192008-CreateFormulasTable.ts
+++ b/backend/src/migrations/20250711192008-CreateFormulasTable.ts
@@ -17,7 +17,7 @@ export class CreateFormulasTable20250711192008 implements MigrationInterface {
                     {
                         name: 'date',
                         type: 'timestamp',
-                        default: 'CURRENT_TIMESTAMP',
+                        default: 'now()',
                     },
                     { name: 'clientId', type: 'int' },
                     { name: 'appointmentId', type: 'int', isNullable: true },

--- a/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
+++ b/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
@@ -21,7 +21,7 @@ export class CreateCommissionRecordsTable20250711192009 implements MigrationInte
                     {
                         name: 'createdAt',
                         type: 'timestamp',
-                        default: 'CURRENT_TIMESTAMP',
+                        default: 'now()',
                     },
                 ],
             }),


### PR DESCRIPTION
## Summary
- correct default quoting for appointment status
- use `now()` defaults for formula and commission timestamps
- verify migrations run on PostgreSQL

## Testing
- `npm test`
- `node dist/main.js` (startup + migrations)

------
https://chatgpt.com/codex/tasks/task_e_687603dab99883299e575922183196f5