### PR TITLE
Fix start time validation

### DIFF
--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -73,6 +73,7 @@ describe('AppointmentsModule (e2e)', () => {
             .expect(201);
         const token = login.body.access_token;
 
+        const futureTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
         const create = await request(app.getHttpServer())
             .post('/appointments/admin')
             .set('Authorization', `Bearer ${token}`)
@@ -80,7 +81,7 @@ describe('AppointmentsModule (e2e)', () => {
                 clientId: client.id,
                 employeeId: employee.id,
                 serviceId: 1,
-                startTime: '2025-07-01T10:00:00.000Z',
+                startTime: futureTime,
             })
             .expect(201);
 
@@ -120,7 +121,7 @@ describe('AppointmentsModule (e2e)', () => {
             .send({ email: 'client3@test.com', password: 'secret' })
             .expect(201);
         const token = login.body.access_token;
-        const startTime = '2025-07-01T11:00:00.000Z';
+        const startTime = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
 
         const res = await request(app.getHttpServer())
             .post('/appointments/client')
@@ -189,7 +190,7 @@ describe('AppointmentsModule (e2e)', () => {
             'E',
             Role.Employee,
         );
-        const startTime = '2025-07-02T11:00:00.000Z';
+        const startTime = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
         await request(app.getHttpServer())
             .post('/appointments/client')
             .send({

--- a/backend/test/formulas.e2e-spec.ts
+++ b/backend/test/formulas.e2e-spec.ts
@@ -39,7 +39,8 @@ describe('FormulasModule (e2e)', () => {
         await servicesRepo.save(servicesRepo.create({ name: 'cut', duration: 30, price: 10 }));
         const client = await users.createUser('cf@test.com', 'secret', 'C', Role.Client);
         const employee = await users.createUser('ef@test.com', 'secret', 'E', Role.Employee);
-        const appt = await appointments.create(client.id, employee.id, 1, '2025-07-01T10:00:00.000Z');
+        const startTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        const appt = await appointments.create(client.id, employee.id, 1, startTime);
 
         const loginEmp = await request(app.getHttpServer())
             .post('/auth/login')
@@ -72,7 +73,8 @@ describe('FormulasModule (e2e)', () => {
         const client = await users.createUser('cf2@test.com', 'secret', 'C', Role.Client);
         const emp1 = await users.createUser('emp1@test.com', 'secret', 'E1', Role.Employee);
         const emp2 = await users.createUser('emp2@test.com', 'secret', 'E2', Role.Employee);
-        const appt = await appointments.create(client.id, emp1.id, 1, '2025-07-01T10:00:00.000Z');
+        const startTime2 = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        const appt = await appointments.create(client.id, emp1.id, 1, startTime2);
 
         const loginEmp2 = await request(app.getHttpServer())
             .post('/auth/login')


### PR DESCRIPTION
## Summary
- check appointment start time is in the future
- use parsed time when creating appointments
- make e2e tests use dynamic future dates so validation passes

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_687607dacac88329a0cfe3721b002221