### PR TITLE
Add migration for messages table

### DIFF
--- a/backend/src/migrations/20250711192011-CreateMessagesTable.ts
+++ b/backend/src/migrations/20250711192011-CreateMessagesTable.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateMessagesTable20250711192011 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'message',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'senderId', type: 'int' },
+                    { name: 'recipientId', type: 'int' },
+                    { name: 'content', type: 'varchar' },
+                    {
+                        name: 'sentAt',
+                        type: 'timestamp',
+                        default: 'now()',
+                    },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('message', [
+            new TableForeignKey({
+                columnNames: ['senderId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+            }),
+            new TableForeignKey({
+                columnNames: ['recipientId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('message');
+    }
+}


### PR DESCRIPTION
## Summary
- add migration to create `message` table with foreign keys to `user`
- run e2e tests

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_687609515bf08329a333ecc8353bb2b1