### PR TITLE
Add non-negative constraints for products

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { CatalogModule } from './catalog/catalog.module';
 import { FormulasModule } from './formulas/formulas.module';
 import { CommissionsModule } from './commissions/commissions.module';
 import { ServicesModule } from './services/services.module';
+import { ProductsModule } from './products/products.module';
 
 @Module({
     imports: [
@@ -40,6 +41,7 @@ import { ServicesModule } from './services/services.module';
         FormulasModule,
         CommissionsModule,
         ServicesModule,
+        ProductsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/catalog/product.entity.ts
+++ b/backend/src/catalog/product.entity.ts
@@ -1,5 +1,7 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, Check } from 'typeorm';
 
+@Check('CHK_product_unit_price', '"unitPrice" >= 0')
+@Check('CHK_product_stock', '"stock" >= 0')
 @Entity()
 export class Product {
     @PrimaryGeneratedColumn()

--- a/backend/src/products/dto/create-product.dto.ts
+++ b/backend/src/products/dto/create-product.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNumber, IsInt, IsOptional } from 'class-validator';
+import { IsString, IsNumber, IsInt, IsOptional, Min } from 'class-validator';
 
 export class CreateProductDto {
     @IsString()
@@ -9,8 +9,10 @@ export class CreateProductDto {
     brand?: string;
 
     @IsNumber()
+    @Min(0)
     unitPrice: number;
 
     @IsInt()
+    @Min(0)
     stock: number;
 }

--- a/backend/test/products.e2e-spec.ts
+++ b/backend/test/products.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+
+describe('ProductsModule (e2e)', () => {
+    let app: INestApplication<App>;
+    let users: UsersService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        users = moduleFixture.get(UsersService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('rejects negative values on create', async () => {
+        await users.createUser('admin@prod.com', 'secret', 'Admin', Role.Admin);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@prod.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        await request(app.getHttpServer())
+            .post('/products/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'bad', unitPrice: -1, stock: 1 })
+            .expect(400);
+
+        await request(app.getHttpServer())
+            .post('/products/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'bad', unitPrice: 1, stock: -1 })
+            .expect(400);
+    });
+
+    it('rejects negative values on update', async () => {
+        await users.createUser('admin2@prod.com', 'secret', 'Admin', Role.Admin);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin2@prod.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        const res = await request(app.getHttpServer())
+            .post('/products/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'good', unitPrice: 5, stock: 2 })
+            .expect(201);
+        const id = res.body.id;
+
+        await request(app.getHttpServer())
+            .patch(`/products/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ unitPrice: -3 })
+            .expect(400);
+
+        await request(app.getHttpServer())
+            .patch(`/products/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ stock: -2 })
+            .expect(400);
+    });
+});


### PR DESCRIPTION
## Summary
- require non-negative pricing and stock in `Product`
- validate these constraints in `CreateProductDto`
- expose product routes in `AppModule`
- test negative values during product create/update

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6876126f6b548329b0b44b9db0d611ab