### PR TITLE
Add onDelete constraints for appointments and commissions

### DIFF
--- a/backend/src/appointments/appointment.entity.ts
+++ b/backend/src/appointments/appointment.entity.ts
@@ -21,10 +21,10 @@ export class Appointment {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => User, { eager: true })
+    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
     client: User;
 
-    @ManyToOne(() => User, { eager: true })
+    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
     employee: User;
 
     @Column()
@@ -36,7 +36,7 @@ export class Appointment {
     @Column({ nullable: true })
     notes: string;
 
-    @ManyToOne(() => Service, { eager: true })
+    @ManyToOne(() => Service, { eager: true, onDelete: 'RESTRICT' })
     service: Service;
 
     @OneToMany(() => Formula, (formula) => formula.appointment)

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -51,13 +51,13 @@ describe('AppointmentsService', () => {
     repo.create.mockReturnValue(created);
     repo.save.mockResolvedValue(created);
 
-    const result = await service.create(1, 2, 3, '2025-07-01T10:00:00.000Z');
+    const result = await service.create(1, 2, 3, '2100-07-01T10:00:00.000Z');
 
     expect(repo.create).toHaveBeenCalledWith({
       client: { id: 1 },
       employee: { id: 2 },
       service: { id: 3 },
-      startTime: new Date('2025-07-01T10:00:00.000Z'),
+      startTime: new Date('2100-07-01T10:00:00.000Z'),
       status: AppointmentStatus.Scheduled,
     });
     expect(repo.save).toHaveBeenCalledWith(created);
@@ -67,12 +67,12 @@ describe('AppointmentsService', () => {
   it('create rejects conflicting appointment', async () => {
     repo.findOne.mockResolvedValue({ id: 9 });
     await expect(
-      service.create(1, 2, 3, '2025-07-01T10:00:00.000Z'),
+      service.create(1, 2, 3, '2100-07-01T10:00:00.000Z'),
     ).rejects.toThrow(ConflictException);
     expect(repo.findOne).toHaveBeenCalledWith({
       where: {
         employee: { id: 2 },
-        startTime: new Date('2025-07-01T10:00:00.000Z'),
+        startTime: new Date('2100-07-01T10:00:00.000Z'),
       },
     });
     expect(repo.create).not.toHaveBeenCalled();

--- a/backend/src/commissions/commission-record.entity.ts
+++ b/backend/src/commissions/commission-record.entity.ts
@@ -8,13 +8,13 @@ export class CommissionRecord {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => User, { eager: true })
+    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
     employee: User;
 
-    @ManyToOne(() => Appointment, { nullable: true })
+    @ManyToOne(() => Appointment, { nullable: true, onDelete: 'SET NULL' })
     appointment: Appointment | null;
 
-    @ManyToOne(() => Product, { nullable: true })
+    @ManyToOne(() => Product, { nullable: true, onDelete: 'SET NULL' })
     product: Product | null;
 
     @Column('decimal', { precision: 10, scale: 2 })

--- a/backend/src/migrations/20250711192012-AddOnDeleteConstraints.ts
+++ b/backend/src/migrations/20250711192012-AddOnDeleteConstraints.ts
@@ -1,0 +1,179 @@
+import { MigrationInterface, QueryRunner, TableForeignKey } from 'typeorm';
+
+export class AddOnDeleteConstraints20250711192012
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const appointment = await queryRunner.getTable('appointment');
+        if (appointment) {
+            const clientFk = appointment.foreignKeys.find((fk) =>
+                fk.columnNames.includes('clientId'),
+            );
+            if (clientFk)
+                await queryRunner.dropForeignKey('appointment', clientFk);
+            const employeeFk = appointment.foreignKeys.find((fk) =>
+                fk.columnNames.includes('employeeId'),
+            );
+            if (employeeFk)
+                await queryRunner.dropForeignKey('appointment', employeeFk);
+            const serviceFk = appointment.foreignKeys.find((fk) =>
+                fk.columnNames.includes('serviceId'),
+            );
+            if (serviceFk)
+                await queryRunner.dropForeignKey('appointment', serviceFk);
+            await queryRunner.createForeignKeys('appointment', [
+                new TableForeignKey({
+                    columnNames: ['clientId'],
+                    referencedTableName: 'user',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'RESTRICT',
+                }),
+                new TableForeignKey({
+                    columnNames: ['employeeId'],
+                    referencedTableName: 'user',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'RESTRICT',
+                }),
+                new TableForeignKey({
+                    columnNames: ['serviceId'],
+                    referencedTableName: 'service',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'RESTRICT',
+                }),
+            ]);
+        }
+
+        const commission = await queryRunner.getTable('commission_record');
+        if (commission) {
+            const employeeFk = commission.foreignKeys.find((fk) =>
+                fk.columnNames.includes('employeeId'),
+            );
+            if (employeeFk)
+                await queryRunner.dropForeignKey(
+                    'commission_record',
+                    employeeFk,
+                );
+            const appointmentFk = commission.foreignKeys.find((fk) =>
+                fk.columnNames.includes('appointmentId'),
+            );
+            if (appointmentFk)
+                await queryRunner.dropForeignKey(
+                    'commission_record',
+                    appointmentFk,
+                );
+            const productFk = commission.foreignKeys.find((fk) =>
+                fk.columnNames.includes('productId'),
+            );
+            if (productFk)
+                await queryRunner.dropForeignKey(
+                    'commission_record',
+                    productFk,
+                );
+            await queryRunner.createForeignKeys('commission_record', [
+                new TableForeignKey({
+                    columnNames: ['employeeId'],
+                    referencedTableName: 'user',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'RESTRICT',
+                }),
+                new TableForeignKey({
+                    columnNames: ['appointmentId'],
+                    referencedTableName: 'appointment',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+                new TableForeignKey({
+                    columnNames: ['productId'],
+                    referencedTableName: 'product',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+            ]);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const appointment = await queryRunner.getTable('appointment');
+        if (appointment) {
+            const clientFk = appointment.foreignKeys.find((fk) =>
+                fk.columnNames.includes('clientId'),
+            );
+            if (clientFk)
+                await queryRunner.dropForeignKey('appointment', clientFk);
+            const employeeFk = appointment.foreignKeys.find((fk) =>
+                fk.columnNames.includes('employeeId'),
+            );
+            if (employeeFk)
+                await queryRunner.dropForeignKey('appointment', employeeFk);
+            const serviceFk = appointment.foreignKeys.find((fk) =>
+                fk.columnNames.includes('serviceId'),
+            );
+            if (serviceFk)
+                await queryRunner.dropForeignKey('appointment', serviceFk);
+            await queryRunner.createForeignKeys('appointment', [
+                new TableForeignKey({
+                    columnNames: ['clientId'],
+                    referencedTableName: 'user',
+                    referencedColumnNames: ['id'],
+                }),
+                new TableForeignKey({
+                    columnNames: ['employeeId'],
+                    referencedTableName: 'user',
+                    referencedColumnNames: ['id'],
+                }),
+                new TableForeignKey({
+                    columnNames: ['serviceId'],
+                    referencedTableName: 'service',
+                    referencedColumnNames: ['id'],
+                }),
+            ]);
+        }
+
+        const commission = await queryRunner.getTable('commission_record');
+        if (commission) {
+            const employeeFk = commission.foreignKeys.find((fk) =>
+                fk.columnNames.includes('employeeId'),
+            );
+            if (employeeFk)
+                await queryRunner.dropForeignKey(
+                    'commission_record',
+                    employeeFk,
+                );
+            const appointmentFk = commission.foreignKeys.find((fk) =>
+                fk.columnNames.includes('appointmentId'),
+            );
+            if (appointmentFk)
+                await queryRunner.dropForeignKey(
+                    'commission_record',
+                    appointmentFk,
+                );
+            const productFk = commission.foreignKeys.find((fk) =>
+                fk.columnNames.includes('productId'),
+            );
+            if (productFk)
+                await queryRunner.dropForeignKey(
+                    'commission_record',
+                    productFk,
+                );
+            await queryRunner.createForeignKeys('commission_record', [
+                new TableForeignKey({
+                    columnNames: ['employeeId'],
+                    referencedTableName: 'user',
+                    referencedColumnNames: ['id'],
+                }),
+                new TableForeignKey({
+                    columnNames: ['appointmentId'],
+                    referencedTableName: 'appointment',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+                new TableForeignKey({
+                    columnNames: ['productId'],
+                    referencedTableName: 'product',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce onDelete behavior in appointments and commission record relations
- update tests to use far future dates
- add migration adding RESTRICT/SET NULL constraints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687614affa808329858092ab342bff68