### PR TITLE
Add duplicate email check in user creation

### DIFF
--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { UsersService } from './users.service';
 import { User } from './user.entity';
@@ -50,5 +51,14 @@ describe('UsersService', () => {
         const passed = repo.create.mock.calls[0][0].password;
         expect(await bcrypt.compare(plain, passed)).toBe(true);
         expect(repo.save).toHaveBeenCalledWith(created);
+    });
+
+    it('createUser throws BadRequest if email already exists', async () => {
+        repo.findOne.mockResolvedValue({ id: 2 } as User);
+
+        await expect(
+            service.createUser('a@test.com', 'secret', 'Alice', Role.Client),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(repo.save).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
@@ -26,6 +26,10 @@ export class UsersService {
         name: string,
         role: Role = Role.Client,
     ) {
+        const existing = await this.findByEmail(email);
+        if (existing) {
+            throw new BadRequestException('Email already registered');
+        }
         const hashed = await bcrypt.hash(password, 10);
         const user = this.usersRepository.create({
             email,


### PR DESCRIPTION
## Summary
- prevent duplicate emails in `UsersService.createUser`
- test that duplicates throw `BadRequestException`

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68761c78c6548329a968c58f01b935d0