### PR TITLE
Add duplicate register e2e test

### DIFF
--- a/backend/test/register.e2e-spec.ts
+++ b/backend/test/register.e2e-spec.ts
@@ -40,4 +40,16 @@ describe('AuthController (e2e)', () => {
             .send({ email: 'bad', password: '123', name: 'T' })
             .expect(400);
     });
+
+    it('/auth/register (POST) rejects duplicates', async () => {
+        await request(app.getHttpServer())
+            .post('/auth/register')
+            .send({ email: 'dup@test.com', password: 'secret', name: 'One' })
+            .expect(201);
+
+        await request(app.getHttpServer())
+            .post('/auth/register')
+            .send({ email: 'dup@test.com', password: 'other', name: 'Two' })
+            .expect(400);
+    });
 });


### PR DESCRIPTION
## Summary
- verify `/auth/register` rejects duplicate emails via new e2e test

## Testing
- `npm test --prefix backend`
- `npm run test:e2e --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68761fe618208329a4a9a6ddddceaf2a