### PR TITLE
Prevent deleting account with appointments

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileUpdateRequest;
+use App\Models\Appointment;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\View\View;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class ProfileController extends Controller
 {
@@ -47,6 +50,20 @@ class ProfileController extends Controller
         ]);
 
         $user = $request->user();
+
+        $hasAppointments = $user->appointments()->exists();
+        if (!$hasAppointments && Schema::hasColumn('appointments', 'employee_id')) {
+            $hasAppointments = Appointment::where('employee_id', $user->id)->exists();
+        }
+
+        if ($hasAppointments) {
+            if ($request->expectsJson()) {
+                throw new BadRequestHttpException('User has active appointments');
+            }
+            return Redirect::back()->withErrors([
+                'user' => 'Nie można usunąć konta z rezerwacjami.',
+            ]);
+        }
 
         Auth::logout();
 

--- a/tests/Feature/ProfileDeleteWithAppointmentsTest.php
+++ b/tests/Feature/ProfileDeleteWithAppointmentsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\ServiceVariant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProfileDeleteWithAppointmentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_account_deletion_fails_when_user_has_appointments(): void
+    {
+        $user = User::factory()->create();
+        $service = Service::factory()->create();
+        $variant = ServiceVariant::factory()->for($service)->create();
+        Appointment::factory()->for($user)->for($service)->for($variant)->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->from('/profile')
+            ->delete('/profile', [
+                'password' => 'password',
+            ]);
+
+        $response->assertSessionHasErrors('user');
+        $this->assertNotNull($user->fresh());
+    }
+}


### PR DESCRIPTION
## Summary
- add appointment check before deleting user accounts
- throw BadRequest when API request tries to delete user with appointments
- prevent deletion via UI and display error
- add feature test for account deletion when appointments exist

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68764e87214c83298429aab3d7e979fb