### PR TITLE
Prevent self-delete for admin accounts

### DIFF
--- a/app/Http/Controllers/AdminUserController.php
+++ b/app/Http/Controllers/AdminUserController.php
@@ -10,12 +10,14 @@ class AdminUserController extends Controller
     public function index()
     {
         $users = User::orderBy('created_at', 'desc')->paginate(20);
+
         return view('admin.users.index', compact('users'));
     }
 
     public function edit($id)
     {
         $user = User::findOrFail($id);
+
         return view('admin.users.edit', compact('user'));
     }
 
@@ -36,5 +38,18 @@ class AdminUserController extends Controller
         $user->save();
 
         return redirect()->route('admin.users.index')->with('success', 'Rola użytkownika została zaktualizowana.');
+    }
+
+    public function destroy(User $user)
+    {
+        if (auth()->id() === $user->id) {
+            return back()->withErrors([
+                'user' => 'Nie możesz usunąć własnego konta.',
+            ]);
+        }
+
+        $user->delete();
+
+        return redirect()->route('admin.users.index')->with('success', 'Użytkownik został usunięty.');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,19 +1,19 @@
 <?php
 
 use App\Http\Controllers\AdminAppointmentController;
+use App\Http\Controllers\AdminBlockerController;
+use App\Http\Controllers\AdminCouponController;
+use App\Http\Controllers\AdminDashboardController;
 use App\Http\Controllers\AdminKontaktController;
 use App\Http\Controllers\AdminServiceController;
 use App\Http\Controllers\AdminUserController;
-use App\Http\Controllers\AdminCouponController;
-use App\Http\Controllers\AdminDashboardController;
-use App\Http\Controllers\AdminBlockerController;
 use App\Http\Controllers\AppointmentController;
-use App\Http\Controllers\KontaktController;
 use App\Http\Controllers\ContactController;
-use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\ReservationEntryController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\GalleryController;
+use App\Http\Controllers\KontaktController;
+use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ReservationEntryController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -24,11 +24,13 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function (GalleryController $gallery) {
     $instagramPhotos = $gallery->latest();
     $contactInfo = \App\Models\ContactInfo::getDefault();
+
     return view('pages.home', compact('instagramPhotos', 'contactInfo'));
 })->name('home');
 
 Route::get('/uslugi', function () {
     $services = \App\Models\Service::with('variants')->orderBy('name')->get();
+
     return view('pages.uslugi', compact('services'));
 })->name('uslugi');
 
@@ -94,11 +96,11 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
     Route::get('/uslugi/{service}/edytuj', [AdminServiceController::class, 'edit'])->name('services.edit');
     Route::put('/uslugi/{service}', [AdminServiceController::class, 'update'])->name('services.update');
     Route::delete('/uslugi/{service}', [AdminServiceController::class, 'destroy'])->name('services.destroy');
-    
+
     // Kontakt
     Route::get('/kontakt', [AdminKontaktController::class, 'edit'])->name('kontakt.edit');
     Route::put('/kontakt', [AdminKontaktController::class, 'update'])->name('kontakt.update');
-    
+
     // Rezerwacje i kalendarz
     Route::get('/rezerwacje', [AdminAppointmentController::class, 'index'])->name('appointments.index');
     Route::get('/rezerwacje/{appointment}/edit', [AdminAppointmentController::class, 'edit'])->name('appointments.edit');
@@ -118,23 +120,24 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
     // Blokady
     Route::get('/blokady', [AdminBlockerController::class, 'calendar'])->name('blockers.calendar');
     Route::get('/blokady/api', [AdminBlockerController::class, 'api'])->name('blockers.api');
-    
+
     // API do dropdownów i godzin pracy
     Route::get('/api/users', [AdminAppointmentController::class, 'users'])->name('appointments.users');
     Route::get('/api/variants', [AdminAppointmentController::class, 'variants'])->name('appointments.variants');
     Route::get('/api/services', [AdminAppointmentController::class, 'services'])->name('appointments.services');
     Route::get('/api/services/{service}/variants', [AdminAppointmentController::class, 'variantsForService'])->name('appointments.serviceVariants');
     Route::get('/api/working-hours', [AdminAppointmentController::class, 'workingHours'])->name('appointments.workingHours');
-    
+
     // Wiadomości
     Route::get('/wiadomosci', [AdminKontaktController::class, 'index'])->name('messages.index');
     Route::get('/wiadomosci/{id}', [AdminKontaktController::class, 'show'])->name('messages.show');
     Route::post('/wiadomosci/{id}/reply', [AdminKontaktController::class, 'reply'])->name('messages.reply');
-    
+
     // Użytkownicy
     Route::get('/users', [AdminUserController::class, 'index'])->name('users.index');
     Route::get('/users/{user}/edit', [AdminUserController::class, 'edit'])->name('users.edit');
     Route::put('/users/{user}', [AdminUserController::class, 'update'])->name('users.update');
+    Route::delete('/users/{user}', [AdminUserController::class, 'destroy'])->name('users.destroy');
 
     // Kupony
     Route::get('/kupony', [AdminCouponController::class, 'index'])->name('coupons.index');
@@ -152,7 +155,7 @@ Route::middleware(['auth', 'is_admin'])->prefix('admin')->name('admin.')->group(
 */
 Route::get('/zarezerwuj', [ReservationEntryController::class, 'index'])->name('reservation.entry');
 
-require __DIR__ . '/auth.php';
+require __DIR__.'/auth.php';
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/AdminUserDeleteTest.php
+++ b/tests/Feature/AdminUserDeleteTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminUserDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_cannot_delete_self(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $response = $this
+            ->actingAs($admin)
+            ->from('/admin/users')
+            ->delete(route('admin.users.destroy', $admin, absolute: false));
+
+        $response->assertSessionHasErrors('user');
+        $this->assertNotNull($admin->fresh());
+    }
+}


### PR DESCRIPTION
## Summary
- add destroy method to `AdminUserController` with a self-delete guard
- expose new destroy route for admin users
- add feature test for admin self-deletion

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_687651e4d2a08329944e36f7f072c6e1