### PR TITLE
Fix service deletion not found handling

### DIFF
--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -58,14 +58,11 @@ export class ServicesService {
     }
 
     async remove(id: number) {
-        const entity = await this.repo.findOne({ where: { id } });
+        const entity = await this.findOne(id);
         if (!entity) {
             throw new NotFoundException();
         }
-        await this.repo.manager.count(
-            'appointment',
-            { where: { service: { id } } } as any,
-        );
+        await this.appointments.count({ where: { service: { id } } });
         return this.repo.delete(id);
     }
 }

--- a/backend/test/services.e2e-spec.ts
+++ b/backend/test/services.e2e-spec.ts
@@ -55,4 +55,19 @@ describe('ServicesModule (e2e)', () => {
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });
+
+  it('responds 404 for deleting a nonexistent service', async () => {
+    await users.createUser('otheradmin@services.com', 'secret', 'Admin', Role.Admin);
+
+    const login = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'otheradmin@services.com', password: 'secret' })
+      .expect(201);
+    const token = login.body.access_token;
+
+    await request(app.getHttpServer())
+      .delete('/services/8888')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure service deletion checks the entity exists before counting appointments
- add end-to-end test for deleting nonexistent services

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_687654f051d48329b01517270c4647fa