### PR TITLE
Add guest appointment auth test

### DIFF
--- a/tests/Feature/AppointmentGuestTest.php
+++ b/tests/Feature/AppointmentGuestTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AppointmentGuestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_create_appointment(): void
+    {
+        $response = $this->postJson('/rezerwacje', []);
+
+        $response->assertUnauthorized();
+        $this->assertSame(0, Appointment::count());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add feature test ensuring guests cannot create appointments

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68765ee544e883298c4717f43537fbb1