### PR TITLE
Add forbidden service creation test

### DIFF
--- a/tests/Feature/AdminServiceStoreForbiddenTest.php
+++ b/tests/Feature/AdminServiceStoreForbiddenTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminServiceStoreForbiddenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_non_admin_cannot_create_service(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('admin.services.store', absolute: false), [
+            'name' => 'Test Service',
+            'description' => 'Sample description',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertSame(0, Service::count());
+    }
+}


### PR DESCRIPTION
## Summary
- add feature test ensuring regular users get 403 when posting to admin service store route

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6876600e56bc83299792430490de871c