### PR TITLE
Add guards to commissions controller

### DIFF
--- a/backend/src/commissions/commissions.controller.ts
+++ b/backend/src/commissions/commissions.controller.ts
@@ -1,9 +1,12 @@
-import { Controller, Get, Request } from '@nestjs/common';
+import { Controller, Get, Request, UseGuards } from '@nestjs/common';
 import { CommissionsService } from './commissions.service';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
 
 @Controller('commissions')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class CommissionsController {
     constructor(private readonly service: CommissionsService) {}
 

--- a/backend/test/commissions.e2e-spec.ts
+++ b/backend/test/commissions.e2e-spec.ts
@@ -27,6 +27,10 @@ describe('CommissionsModule (e2e)', () => {
         }
     });
 
+    it('rejects unauthenticated requests', () => {
+        return request(app.getHttpServer()).get('/commissions/employee').expect(401);
+    });
+
     it('employee can list own commissions', async () => {
         await usersService.createUser('emp@comm.com', 'secret', 'Emp', Role.Employee);
         const login = await request(app.getHttpServer())


### PR DESCRIPTION
## Summary
- protect commissions endpoints with `JwtAuthGuard` and `RolesGuard`
- verify unauthenticated access is rejected in commissions tests

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6876740c09e08329b60ebd57239721eb