### PR TITLE
Introduce dedicated employee and customer entities

### DIFF
--- a/backend/src/appointments/appointment.entity.ts
+++ b/backend/src/appointments/appointment.entity.ts
@@ -6,7 +6,8 @@ import {
     OneToMany,
     Index,
 } from 'typeorm';
-import { User } from '../users/user.entity';
+import { Employee } from '../employees/employee.entity';
+import { Customer } from '../customers/customer.entity';
 import { Service } from '../catalog/service.entity';
 import { Formula } from '../formulas/formula.entity';
 
@@ -21,11 +22,11 @@ export class Appointment {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
-    client: User;
+    @ManyToOne(() => Customer, { eager: true, onDelete: 'RESTRICT' })
+    client: Customer;
 
-    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
-    employee: User;
+    @ManyToOne(() => Employee, { eager: true, onDelete: 'RESTRICT' })
+    employee: Employee;
 
     @Column()
     startTime: Date;

--- a/backend/src/commissions/commission-record.entity.ts
+++ b/backend/src/commissions/commission-record.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
-import { User } from '../users/user.entity';
+import { Employee } from '../employees/employee.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { Product } from '../catalog/product.entity';
 
@@ -8,8 +8,8 @@ export class CommissionRecord {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
-    employee: User;
+    @ManyToOne(() => Employee, { eager: true, onDelete: 'RESTRICT' })
+    employee: Employee;
 
     @ManyToOne(() => Appointment, { nullable: true, onDelete: 'SET NULL' })
     appointment: Appointment | null;

--- a/backend/src/commissions/commissions.service.spec.ts
+++ b/backend/src/commissions/commissions.service.spec.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { CommissionsService } from './commissions.service';
 import { CommissionRecord } from './commission-record.entity';
 import { Appointment } from '../appointments/appointment.entity';
-import { User } from '../users/user.entity';
+import { Employee } from '../employees/employee.entity';
 import { Service } from '../catalog/service.entity';
 
 describe('CommissionsService', () => {
@@ -27,7 +27,7 @@ describe('CommissionsService', () => {
     const appt = {
       id: 1,
       service: { price: 50, defaultCommissionPercent: 0.2 } as Service,
-      employee: { id: 2 } as User,
+      employee: { id: 2 } as Employee,
     } as Appointment;
     const created = { id: 99 } as CommissionRecord;
     repo.create.mockReturnValue(created);

--- a/backend/src/customers/customer.entity.ts
+++ b/backend/src/customers/customer.entity.ts
@@ -1,0 +1,7 @@
+import { Entity } from 'typeorm';
+import { User } from '../users/user.entity';
+
+// Customer accounts share the same table as regular users
+// but are typed separately for clarity.
+@Entity('user')
+export class Customer extends User {}

--- a/backend/src/employees/employee.entity.ts
+++ b/backend/src/employees/employee.entity.ts
@@ -1,0 +1,7 @@
+import { Entity } from 'typeorm';
+import { User } from '../users/user.entity';
+
+// Employee accounts share the same table as regular users
+// but are typed separately for clarity.
+@Entity('user')
+export class Employee extends User {}

--- a/backend/src/formulas/formula.entity.ts
+++ b/backend/src/formulas/formula.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
-import { User } from '../users/user.entity';
+import { Customer } from '../customers/customer.entity';
 import { Appointment } from '../appointments/appointment.entity';
 
 @Entity()
@@ -13,8 +13,8 @@ export class Formula {
     @CreateDateColumn()
     date: Date;
 
-    @ManyToOne(() => User, { eager: true })
-    client: User;
+    @ManyToOne(() => Customer, { eager: true })
+    client: Customer;
 
     @ManyToOne(() => Appointment, (appointment) => appointment.formulas, { nullable: true })
     appointment: Appointment | null;

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
+import { Employee } from '../employees/employee.entity';
+import { Customer } from '../customers/customer.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([User])],
+    imports: [TypeOrmModule.forFeature([User, Employee, Customer])],
     providers: [UsersService],
     controllers: [UsersController],
     exports: [TypeOrmModule, UsersService],


### PR DESCRIPTION
## Summary
- add Employee and Customer entity classes
- update appointments, formulas and commissions to use the new models
- register Employee and Customer in the Users module
- adjust related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687697fb8c1c8329bb47f269bbfdf2a2