### PR TITLE
Add employee role enum and migration

### DIFF
--- a/backend/src/employees/employee-role.enum.ts
+++ b/backend/src/employees/employee-role.enum.ts
@@ -1,0 +1,6 @@
+export enum EmployeeRole {
+    ADMIN = 'ADMIN',
+    FRYZJER = 'FRYZJER',
+    RECEPCJA = 'RECEPCJA',
+    POMOCNIK = 'POMOCNIK',
+}

--- a/backend/src/employees/employee.entity.ts
+++ b/backend/src/employees/employee.entity.ts
@@ -1,7 +1,15 @@
-import { Entity } from 'typeorm';
+import { Entity, Column } from 'typeorm';
 import { User } from '../users/user.entity';
+import { EmployeeRole } from './employee-role.enum';
 
 // Employee accounts share the same table as regular users
 // but are typed separately for clarity.
 @Entity('user')
-export class Employee extends User {}
+export class Employee extends User {
+    @Column({
+        type: 'enum',
+        enum: EmployeeRole,
+        default: EmployeeRole.FRYZJER,
+    })
+    declare role: EmployeeRole;
+}

--- a/backend/src/migrations/20250711192014-MigrateEmployeeRoles.ts
+++ b/backend/src/migrations/20250711192014-MigrateEmployeeRoles.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MigrateEmployeeRoles20250711192014 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE "user" SET role = 'ADMIN' WHERE role = 'admin'`,
+        );
+        await queryRunner.query(
+            `UPDATE "user" SET role = 'FRYZJER' WHERE role = 'employee'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE "user" SET role = 'employee' WHERE role = 'FRYZJER'`,
+        );
+        await queryRunner.query(
+            `UPDATE "user" SET role = 'admin' WHERE role = 'ADMIN'`,
+        );
+    }
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { Role } from './role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 
 @Entity()
 export class User {
@@ -16,7 +17,7 @@ export class User {
     name: string;
 
     @Column({ type: 'simple-enum', enum: Role })
-    role: Role;
+    role: Role | EmployeeRole;
 
     @Column({ type: 'varchar', nullable: true })
     refreshToken: string | null;


### PR DESCRIPTION
## Summary
- add `EmployeeRole` enum
- store employee role on the `Employee` entity
- allow `User` role to accept employee role values
- migrate existing users to new enum values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687699d480cc8329b35438b02456c17b