### PR TITLE
Add employee commission entity

### DIFF
--- a/backend/src/commissions/commissions.module.ts
+++ b/backend/src/commissions/commissions.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommissionRecord } from './commission-record.entity';
+import { EmployeeCommission } from './employee-commission.entity';
 import { CommissionsService } from './commissions.service';
 import { CommissionsController } from './commissions.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([CommissionRecord])],
+    imports: [TypeOrmModule.forFeature([CommissionRecord, EmployeeCommission])],
     controllers: [CommissionsController],
     providers: [CommissionsService],
     exports: [TypeOrmModule, CommissionsService],

--- a/backend/src/commissions/employee-commission.entity.ts
+++ b/backend/src/commissions/employee-commission.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { Employee } from '../employees/employee.entity';
+
+@Entity()
+export class EmployeeCommission {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Employee, (employee) => employee.commissions, { onDelete: 'CASCADE' })
+    employee: Employee;
+
+    @Column('decimal', { precision: 10, scale: 2 })
+    amount: number;
+
+    @Column('float')
+    percent: number;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/backend/src/employees/employee.entity.ts
+++ b/backend/src/employees/employee.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, OneToMany } from 'typeorm';
 import { User } from '../users/user.entity';
 import { EmployeeRole } from './employee-role.enum';
+import { EmployeeCommission } from '../commissions/employee-commission.entity';
 
 // Employee accounts share the same table as regular users
 // but are typed separately for clarity.
@@ -12,4 +13,7 @@ export class Employee extends User {
         default: EmployeeRole.FRYZJER,
     })
     declare role: EmployeeRole;
+
+    @OneToMany(() => EmployeeCommission, (commission) => commission.employee)
+    commissions: EmployeeCommission[];
 }


### PR DESCRIPTION
## Summary
- add `EmployeeCommission` entity
- register the new entity in the commissions module
- expose employee commission relation on `Employee`

## Testing
- `npm test` *(fails: Role | EmployeeRole not assignable to Role)*

------
https://chatgpt.com/codex/tasks/task_e_68769c7d8074832996d451c8ddfb4903