### PR TITLE
Add communications entity and module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { CommissionsModule } from './commissions/commissions.module';
 import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
 import { LogsModule } from './logs/logs.module';
+import { CommunicationsModule } from './communications/communications.module';
 
 @Module({
     imports: [
@@ -44,6 +45,7 @@ import { LogsModule } from './logs/logs.module';
         ServicesModule,
         ProductsModule,
         LogsModule,
+        CommunicationsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/communications/communication.entity.ts
+++ b/backend/src/communications/communication.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import { Customer } from '../customers/customer.entity';
+
+@Entity()
+export class Communication {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Customer, { eager: true, onDelete: 'CASCADE' })
+    customer: Customer;
+
+    @Column()
+    medium: string;
+
+    @Column('text')
+    content: string;
+
+    @CreateDateColumn()
+    timestamp: Date;
+}

--- a/backend/src/communications/communications.controller.ts
+++ b/backend/src/communications/communications.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { CommunicationsService } from './communications.service';
+import { CreateCommunicationDto } from './dto/create-communication.dto';
+
+@Controller('communications')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class CommunicationsController {
+    constructor(private readonly service: CommunicationsService) {}
+
+    @Get(':customerId')
+    @Roles(Role.Employee, Role.Admin)
+    list(@Param('customerId') customerId: number) {
+        return this.service.findForCustomer(Number(customerId));
+    }
+
+    @Post()
+    @Roles(Role.Employee, Role.Admin)
+    create(@Body() dto: CreateCommunicationDto) {
+        return this.service.create(dto.customerId, dto.medium, dto.content);
+    }
+}

--- a/backend/src/communications/communications.module.ts
+++ b/backend/src/communications/communications.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Communication } from './communication.entity';
+import { CommunicationsService } from './communications.service';
+import { CommunicationsController } from './communications.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Communication])],
+    controllers: [CommunicationsController],
+    providers: [CommunicationsService],
+    exports: [TypeOrmModule, CommunicationsService],
+})
+export class CommunicationsModule {}

--- a/backend/src/communications/communications.service.spec.ts
+++ b/backend/src/communications/communications.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CommunicationsService } from './communications.service';
+import { Communication } from './communication.entity';
+
+describe('CommunicationsService', () => {
+    let service: CommunicationsService;
+    let repo: { create: jest.Mock; save: jest.Mock; find: jest.Mock };
+
+    beforeEach(async () => {
+        repo = { create: jest.fn(), save: jest.fn(), find: jest.fn() };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CommunicationsService,
+                { provide: getRepositoryToken(Communication), useValue: repo },
+            ],
+        }).compile();
+
+        service = module.get<CommunicationsService>(CommunicationsService);
+    });
+
+    it('create builds and saves a communication', async () => {
+        const created = { id: 1 } as Communication;
+        repo.create.mockReturnValue(created);
+        repo.save.mockResolvedValue(created);
+
+        const result = await service.create(2, 'email', 'hi');
+
+        expect(repo.create).toHaveBeenCalledWith({
+            customer: { id: 2 },
+            medium: 'email',
+            content: 'hi',
+        });
+        expect(repo.save).toHaveBeenCalledWith(created);
+        expect(result).toBe(created);
+    });
+
+    it('findForCustomer queries by customer id', async () => {
+        repo.find.mockResolvedValue([]);
+        await service.findForCustomer(5);
+        expect(repo.find).toHaveBeenCalledWith({ where: { customer: { id: 5 } } });
+    });
+});

--- a/backend/src/communications/communications.service.ts
+++ b/backend/src/communications/communications.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Communication } from './communication.entity';
+
+@Injectable()
+export class CommunicationsService {
+    constructor(
+        @InjectRepository(Communication)
+        private readonly repo: Repository<Communication>,
+    ) {}
+
+    create(customerId: number, medium: string, content: string) {
+        const comm = this.repo.create({
+            customer: { id: customerId } as any,
+            medium,
+            content,
+        });
+        return this.repo.save(comm);
+    }
+
+    findForCustomer(customerId: number) {
+        return this.repo.find({ where: { customer: { id: customerId } } });
+    }
+}

--- a/backend/src/communications/dto/create-communication.dto.ts
+++ b/backend/src/communications/dto/create-communication.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsString } from 'class-validator';
+
+export class CreateCommunicationDto {
+    @IsInt()
+    customerId: number;
+
+    @IsString()
+    medium: string;
+
+    @IsString()
+    content: string;
+}


### PR DESCRIPTION
## Summary
- add a Communication entity referencing Customer
- expose endpoints to create and list communications
- provide module and service
- wire up module in AppModule
- unit tests for communications service

## Testing
- `npm test --silent` *(fails: auth.service tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6876a8e446fc8329ab2e818084516a10