### PR TITLE
Expand role unions

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -6,6 +6,7 @@ import { Service } from '../catalog/service.entity';
 import { FormulasService } from '../formulas/formulas.service';
 import { CommissionRecord } from '../commissions/commission-record.entity';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 import { UpdateAppointmentParams } from './dto/update-appointment-params';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
@@ -115,8 +116,12 @@ export class AppointmentsService {
     }
 
     async complete(id: number): Promise<Appointment | undefined>;
-    async complete(id: number, userId: number, role: Role): Promise<Appointment | undefined>;
-    async complete(id: number, userId?: number, role?: Role) {
+    async complete(
+        id: number,
+        userId: number,
+        role: Role | EmployeeRole,
+    ): Promise<Appointment | undefined>;
+    async complete(id: number, userId?: number, role?: Role | EmployeeRole) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {
             return undefined;
@@ -171,7 +176,7 @@ export class AppointmentsService {
     async updateForUser(
         id: number,
         userId: number,
-        role: Role,
+        role: Role | EmployeeRole,
         dto: UpdateAppointmentParams,
     ) {
         const appt = await this.repo.findOne({ where: { id } });
@@ -187,7 +192,7 @@ export class AppointmentsService {
         return this.applyUpdates(appt, dto);
     }
 
-    async cancel(id: number, userId: number, role: Role) {
+    async cancel(id: number, userId: number, role: Role | EmployeeRole) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {
             return undefined;
@@ -203,7 +208,11 @@ export class AppointmentsService {
         return this.repo.save(appt);
     }
 
-    async removeForUser(id: number, userId: number, role: Role) {
+    async removeForUser(
+        id: number,
+        userId: number,
+        role: Role | EmployeeRole,
+    ) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {
             return undefined;

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 import { RegisterClientDto } from './dto/register-client.dto';
 import { AuthTokensDto } from './dto/auth-tokens.dto';
 import { LogsService } from '../logs/logs.service';
@@ -35,7 +36,10 @@ export class AuthService {
         return result;
     }
 
-    async generateTokens(userId: number, role: Role): Promise<AuthTokensDto> {
+    async generateTokens(
+        userId: number,
+        role: Role | EmployeeRole,
+    ): Promise<AuthTokensDto> {
         const access = await this.jwtService.signAsync({ sub: userId, role });
         const refresh = await this.jwtService.signAsync(
             { sub: userId },

--- a/backend/src/formulas/formulas.service.ts
+++ b/backend/src/formulas/formulas.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Formula } from './formula.entity';
 import { AppointmentsService } from '../appointments/appointments.service';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 
 @Injectable()
 export class FormulasService {
@@ -32,7 +33,7 @@ export class FormulasService {
 
     async createForAppointment(
         userId: number,
-        role: Role,
+        role: Role | EmployeeRole,
         appointmentId: number,
         description: string,
     ) {


### PR DESCRIPTION
## Summary
- allow `EmployeeRole` in JWT generation
- update appointments and formulas services to accept union type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876aa9768b483298757b1c5079abe9f