### PR TITLE
Add reviews entity and CRUD endpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
 import { LogsModule } from './logs/logs.module';
 import { CommunicationsModule } from './communications/communications.module';
+import { ReviewsModule } from './reviews/reviews.module';
 
 @Module({
     imports: [
@@ -44,6 +45,7 @@ import { CommunicationsModule } from './communications/communications.module';
         CommissionsModule,
         ServicesModule,
         ProductsModule,
+        ReviewsModule,
         LogsModule,
         CommunicationsModule,
     ],

--- a/backend/src/reviews/dto/create-review.dto.ts
+++ b/backend/src/reviews/dto/create-review.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class CreateReviewDto {
+    @IsInt()
+    reservationId: number;
+
+    @IsInt()
+    @Min(1)
+    @Max(5)
+    rating: number;
+
+    @IsOptional()
+    @IsString()
+    comment?: string;
+}

--- a/backend/src/reviews/dto/update-review.dto.ts
+++ b/backend/src/reviews/dto/update-review.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateReviewDto } from './create-review.dto';
+
+export class UpdateReviewDto extends PartialType(CreateReviewDto) {}

--- a/backend/src/reviews/review.entity.ts
+++ b/backend/src/reviews/review.entity.ts
@@ -1,0 +1,35 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+    Index,
+} from 'typeorm';
+import { Appointment } from '../appointments/appointment.entity';
+import { Customer } from '../customers/customer.entity';
+
+@Index(['reservationId'], { unique: true })
+@Entity()
+export class Review {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    reservationId: number;
+
+    @ManyToOne(() => Appointment, { onDelete: 'CASCADE' })
+    reservation: Appointment;
+
+    @ManyToOne(() => Customer, { eager: true })
+    client: Customer;
+
+    @Column('int')
+    rating: number;
+
+    @Column('text', { nullable: true })
+    comment?: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { ReviewsService } from './reviews.service';
+import { CreateReviewDto } from './dto/create-review.dto';
+import { UpdateReviewDto } from './dto/update-review.dto';
+
+@Controller('reviews')
+export class ReviewsController {
+    constructor(private readonly service: ReviewsService) {}
+
+    @Get()
+    list() {
+        return this.service.findAll();
+    }
+
+    @Get(':id')
+    get(@Param('id') id: number) {
+        return this.service.findOne(Number(id));
+    }
+
+    @Post()
+    create(@Body() dto: CreateReviewDto) {
+        return this.service.create(dto);
+    }
+
+    @Patch(':id')
+    update(@Param('id') id: number, @Body() dto: UpdateReviewDto) {
+        return this.service.update(Number(id), dto);
+    }
+
+    @Delete(':id')
+    remove(@Param('id') id: number) {
+        return this.service.remove(Number(id));
+    }
+}

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Review } from './review.entity';
+import { ReviewsService } from './reviews.service';
+import { ReviewsController } from './reviews.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Review])],
+    providers: [ReviewsService],
+    controllers: [ReviewsController],
+    exports: [TypeOrmModule, ReviewsService],
+})
+export class ReviewsModule {}

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Review } from './review.entity';
+import { UpdateReviewDto } from './dto/update-review.dto';
+import { CreateReviewDto } from './dto/create-review.dto';
+
+@Injectable()
+export class ReviewsService {
+    constructor(
+        @InjectRepository(Review)
+        private readonly repo: Repository<Review>,
+    ) {}
+
+    create(dto: CreateReviewDto) {
+        const review = this.repo.create({
+            reservation: { id: dto.reservationId } as any,
+            reservationId: dto.reservationId,
+            rating: dto.rating,
+            comment: dto.comment,
+        });
+        return this.repo.save(review);
+    }
+
+    findAll() {
+        return this.repo.find();
+    }
+
+    findOne(id: number) {
+        return this.repo.findOne({ where: { id } });
+    }
+
+    async update(id: number, dto: UpdateReviewDto) {
+        await this.repo.update(id, dto as any);
+        return this.findOne(id);
+    }
+
+    remove(id: number) {
+        return this.repo.delete(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Review` entity with a unique index on `reservationId`
- expose reviews via TypeORM with service and controller
- wire up `ReviewsModule` in `AppModule`

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6876adb863c48329bef9d729fbafc55d