### PR TITLE
Add unique index on user email

### DIFF
--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,7 +1,8 @@
-import { IsEmail, MinLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 
 export class LoginDto {
     @IsEmail()
+    @IsNotEmpty()
     email: string;
 
     @MinLength(6)

--- a/backend/src/auth/dto/register-client.dto.ts
+++ b/backend/src/auth/dto/register-client.dto.ts
@@ -1,7 +1,8 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, IsNotEmpty, MinLength } from 'class-validator';
 
 export class RegisterClientDto {
     @IsEmail()
+    @IsNotEmpty()
     email: string;
 
     @MinLength(6)

--- a/backend/src/customers/customer.entity.ts
+++ b/backend/src/customers/customer.entity.ts
@@ -1,7 +1,8 @@
-import { Entity } from 'typeorm';
+import { Entity, Index } from 'typeorm';
 import { User } from '../users/user.entity';
 
 // Customer accounts share the same table as regular users
 // but are typed separately for clarity.
+@Index(['email'], { unique: true })
 @Entity('user')
 export class Customer extends User {}

--- a/backend/src/employees/employee.entity.ts
+++ b/backend/src/employees/employee.entity.ts
@@ -1,10 +1,11 @@
-import { Entity, Column, OneToMany } from 'typeorm';
+import { Entity, Column, OneToMany, Index } from 'typeorm';
 import { User } from '../users/user.entity';
 import { EmployeeRole } from './employee-role.enum';
 import { EmployeeCommission } from '../commissions/employee-commission.entity';
 
 // Employee accounts share the same table as regular users
 // but are typed separately for clarity.
+@Index(['email'], { unique: true })
 @Entity('user')
 export class Employee extends User {
     @Column({

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,8 +1,9 @@
-import { IsEmail, IsEnum, IsOptional, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsEnum, IsOptional, IsString, IsNotEmpty, MinLength } from 'class-validator';
 import { Role } from '../role.enum';
 
 export class CreateUserDto {
     @IsEmail()
+    @IsNotEmpty()
     email: string;
 
     @MinLength(6)


### PR DESCRIPTION
## Summary
- index employee and customer email columns
- validate email presence in login/register/user DTOs

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876b047db0c83298b5fb6252de03853