### PR TITLE
Add migration for new commissions tables

### DIFF
--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,0 +1,24 @@
+import { DataSource } from 'typeorm';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { config } from 'dotenv';
+
+config({ path: '.env' });
+const url = process.env.DATABASE_URL || 'sqlite:./dev.sqlite';
+const isSqlite = url.startsWith('sqlite:');
+const dir = dirname(fileURLToPath(import.meta.url));
+
+export const AppDataSource = new DataSource(
+  isSqlite
+    ? {
+        type: 'sqlite',
+        database: url.replace('sqlite:', ''),
+        entities: [join(dir, '**/*.entity.ts')],
+      }
+    : {
+        type: 'postgres',
+        url,
+        entities: [join(dir, '**/*.entity.ts')],
+        migrations: [join(dir, 'migrations/*.ts')],
+      },
+);

--- a/backend/src/migrations/20250711192015-AddCommissionsAndCommunications.ts
+++ b/backend/src/migrations/20250711192015-AddCommissionsAndCommunications.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class AddCommissionsAndCommunications20250711192015 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'employee_commission',
+                columns: [
+                    { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+                    { name: 'employeeId', type: 'int' },
+                    { name: 'amount', type: 'decimal', precision: 10, scale: 2 },
+                    { name: 'percent', type: 'float' },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                ],
+                indices: [
+                    { columnNames: ['employeeId'] },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'employee_commission',
+            new TableForeignKey({
+                columnNames: ['employeeId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+        );
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'communication',
+                columns: [
+                    { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+                    { name: 'customerId', type: 'int', isNullable: true },
+                    { name: 'medium', type: 'varchar' },
+                    { name: 'content', type: 'text' },
+                    { name: 'timestamp', type: 'timestamp', default: 'now()' },
+                ],
+                indices: [
+                    { columnNames: ['customerId'] },
+                    { columnNames: ['medium'] },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'communication',
+            new TableForeignKey({
+                columnNames: ['customerId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('communication');
+        await queryRunner.dropTable('employee_commission');
+    }
+}


### PR DESCRIPTION
## Summary
- add `data-source.ts` for TypeORM CLI
- add migration `AddCommissionsAndCommunications` creating `employee_commission` and `communication` tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876b97758ec8329a18d4e9a8fa83fa8