### PR TITLE
Fix import.meta usage in data-source

### DIFF
--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,12 +1,11 @@
 import { DataSource } from 'typeorm';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 import { config } from 'dotenv';
 
 config({ path: '.env' });
 const url = process.env.DATABASE_URL || 'sqlite:./dev.sqlite';
 const isSqlite = url.startsWith('sqlite:');
-const dir = dirname(fileURLToPath(import.meta.url));
+const dir = __dirname;
 
 export const AppDataSource = new DataSource(
   isSqlite


### PR DESCRIPTION
## Summary
- remove import.meta to keep TS compiling with CommonJS

## Testing
- `npm run build` *(fails: nest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6876bde2276483298f507c91f40f559a