### PR TITLE
Prevent duplicate reviews

### DIFF
--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Review } from './review.entity';
@@ -12,7 +12,15 @@ export class ReviewsService {
         private readonly repo: Repository<Review>,
     ) {}
 
-    create(dto: CreateReviewDto) {
+    async create(dto: CreateReviewDto) {
+        const existing = await this.repo.findOne({
+            where: { reservation: { id: dto.reservationId } },
+        });
+        if (existing) {
+            throw new BadRequestException(
+                'Review already exists for this reservation',
+            );
+        }
         const review = this.repo.create({
             reservation: { id: dto.reservationId } as any,
             reservationId: dto.reservationId,

--- a/backend/test/reviews.e2e-spec.ts
+++ b/backend/test/reviews.e2e-spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Appointment } from './../src/appointments/appointment.entity';
+
+describe('ReviewsModule (e2e)', () => {
+  let app: INestApplication<App>;
+  let users: UsersService;
+  let appointmentsRepo: Repository<Appointment>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+    users = moduleFixture.get(UsersService);
+    appointmentsRepo = moduleFixture.get(getRepositoryToken(Appointment));
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('rejects duplicate reviews for a reservation', async () => {
+    const client = await users.createUser('client@review.com', 'secret', 'C', Role.Client);
+    const employee = await users.createUser('emp@review.com', 'secret', 'E', Role.Employee);
+
+    const appointment = await appointmentsRepo.save(
+      appointmentsRepo.create({
+        client: { id: client.id } as any,
+        employee: { id: employee.id } as any,
+        service: { id: 1 } as any,
+        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      }),
+    );
+
+    const login = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'client@review.com', password: 'secret' })
+      .expect(201);
+    const token = login.body.access_token;
+
+    await request(app.getHttpServer())
+      .post('/reviews')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ reservationId: appointment.id, rating: 5 })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post('/reviews')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ reservationId: appointment.id, rating: 4 })
+      .expect(400);
+  });
+});


### PR DESCRIPTION
## Summary
- check for existing reservation reviews before creating new review
- raise BadRequestException if a duplicate review exists
- add e2e test to ensure duplicate reviews return HTTP 400

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6876d230d7448329ac36985fccc83b4b