### PR TITLE
Add reviews table migration

### DIFF
--- a/backend/src/migrations/20250711192016-CreateReviewsTable.ts
+++ b/backend/src/migrations/20250711192016-CreateReviewsTable.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateReviewsTable20250711192016 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'review',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'reservationId', type: 'int' },
+                    { name: 'clientId', type: 'int' },
+                    { name: 'rating', type: 'int' },
+                    { name: 'comment', type: 'text', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                ],
+                indices: [
+                    { columnNames: ['reservationId'], isUnique: true },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('review', [
+            new TableForeignKey({
+                columnNames: ['reservationId'],
+                referencedTableName: 'appointment',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+            new TableForeignKey({
+                columnNames: ['clientId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('review');
+    }
+}


### PR DESCRIPTION
## Summary
- add migration for `review` table with unique reservation link
- hook up foreign keys to `appointment` and `user`

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68776023285c8329bf3535feadb52c82