### PR TITLE
Fix review creation with appointment client

### DIFF
--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Review } from './review.entity';
+import { Appointment } from '../appointments/appointment.entity';
 import { ReviewsService } from './reviews.service';
 import { ReviewsController } from './reviews.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Review])],
+    imports: [TypeOrmModule.forFeature([Review, Appointment])],
     providers: [ReviewsService],
     controllers: [ReviewsController],
     exports: [TypeOrmModule, ReviewsService],


### PR DESCRIPTION
## Summary
- inject `Appointment` repo into `ReviewsService`
- include `Appointment` in reviews module
- fetch appointment with client when creating reviews

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877650ff6a88329b092df55c691b583