### PR TITLE
Add user deletion guards and tests

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -4,6 +4,8 @@ import {
     Get,
     Post,
     Request,
+    Delete,
+    Param,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -29,5 +31,17 @@ export class UsersController {
         }
         const { password: _p, refreshToken: _r, ...result } = user as any;
         return result;
+    }
+
+    @Delete('customers/:id')
+    @Roles(Role.Admin)
+    removeCustomer(@Param('id') id: number, @Request() req) {
+        return this.usersService.removeCustomer(Number(id), req.user.id);
+    }
+
+    @Delete('employees/:id')
+    @Roles(Role.Admin)
+    removeEmployee(@Param('id') id: number, @Request() req) {
+        return this.usersService.removeEmployee(Number(id), req.user.id);
     }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,11 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { Employee } from '../employees/employee.entity';
 import { Customer } from '../customers/customer.entity';
+import { Appointment } from '../appointments/appointment.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([User, Employee, Customer])],
+    imports: [
+        TypeOrmModule.forFeature([User, Employee, Customer, Appointment]),
+    ],
     providers: [UsersService],
     controllers: [UsersController],
     exports: [TypeOrmModule, UsersService],

--- a/backend/test/users-delete.e2e-spec.ts
+++ b/backend/test/users-delete.e2e-spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+
+describe('User deletion (e2e)', () => {
+    let app: INestApplication<App>;
+    let usersService: UsersService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        usersService = moduleFixture.get(UsersService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('rejects deleting customer with appointments', async () => {
+        const admin = await usersService.createUser('deladmin@test.com', 'secret', 'A', Role.Admin);
+        const employee = await usersService.createUser('delemployee@test.com', 'secret', 'E', Role.Employee);
+        const client = await usersService.createUser('delclient@test.com', 'secret', 'C', Role.Client);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'deladmin@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ clientId: client.id, employeeId: employee.id, serviceId: 1, startTime: future })
+            .expect(201);
+
+        await request(app.getHttpServer())
+            .delete(`/users/customers/${client.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(400);
+    });
+
+    it('rejects deleting employee with appointments', async () => {
+        const admin = await usersService.createUser('empadmin@test.com', 'secret', 'A', Role.Admin);
+        const employee = await usersService.createUser('empdel@test.com', 'secret', 'E', Role.Employee);
+        const client = await usersService.createUser('empclient@test.com', 'secret', 'C', Role.Client);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'empadmin@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ clientId: client.id, employeeId: employee.id, serviceId: 1, startTime: future })
+            .expect(201);
+
+        await request(app.getHttpServer())
+            .delete(`/users/employees/${employee.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(400);
+    });
+
+    it('prevents admin from deleting self', async () => {
+        const admin = await usersService.createUser('self@test.com', 'secret', 'Self', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'self@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        await request(app.getHttpServer())
+            .delete(`/users/employees/${admin.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(400);
+    });
+});


### PR DESCRIPTION
## Summary
- allow admins to delete customers and employees through new endpoints
- deny deletion when the target has appointments or matches the acting admin
- cover the new behaviours with e2e tests

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_687766931274832999fc285806a6b19c