### PR TITLE
Add additional log actions

### DIFF
--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -2,4 +2,10 @@ export enum LogAction {
     CreateAppointment = 'CREATE_APPOINTMENT',
     UpdateService = 'UPDATE_SERVICE',
     LoginFail = 'LOGIN_FAIL',
+    LoginSuccess = 'LOGIN_SUCCESS',
+    RegisterSuccess = 'REGISTER_SUCCESS',
+    CancelAppointment = 'CANCEL_APPOINTMENT',
+    CompleteAppointment = 'COMPLETE_APPOINTMENT',
+    DeleteAppointment = 'DELETE_APPOINTMENT',
+    DeleteService = 'DELETE_SERVICE',
 }


### PR DESCRIPTION
## Summary
- extend `LogAction` enum with values for login, registration, and appointment/service operations
- keep all tests passing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877757072f483299a7cc018eab1696d