### PR TITLE
Add login/register success logs

### DIFF
--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -6,6 +6,7 @@ import { UsersService } from '../users/users.service';
 import { Role } from '../users/role.enum';
 import { RegisterClientDto } from './dto/register-client.dto';
 import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
 
 describe('AuthService.registerClient', () => {
     let service: AuthService;
@@ -65,6 +66,12 @@ describe('AuthService.registerClient', () => {
             2,
             { sub: 1 },
             expect.objectContaining({ secret: expect.any(String) }),
+        );
+
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.RegisterSuccess,
+            'email=a@test.com',
+            1,
         );
 
         const passed = users.createUser.mock.calls[0][1];

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { Role } from '../users/role.enum';
 import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
 
 describe('AuthService', () => {
     let service: AuthService;
@@ -104,6 +105,11 @@ describe('AuthService', () => {
             2,
             { sub: 2 },
             expect.objectContaining({ secret: expect.any(String) }),
+        );
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.LoginSuccess,
+            'email=b@test.com',
+            2,
         );
     });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -54,7 +54,13 @@ export class AuthService {
 
     async login(email: string, password: string): Promise<AuthTokensDto> {
         const user = await this.validateUser(email, password);
-        return this.generateTokens(user.id, user.role);
+        const tokens = await this.generateTokens(user.id, user.role);
+        await this.logs.create(
+            LogAction.LoginSuccess,
+            `email=${email}`,
+            user.id,
+        );
+        return tokens;
     }
 
     async registerClient(dto: RegisterClientDto): Promise<AuthTokensDto> {
@@ -67,6 +73,11 @@ export class AuthService {
             dto.password,
             dto.name,
             Role.Client,
+        );
+        await this.logs.create(
+            LogAction.RegisterSuccess,
+            `email=${dto.email}`,
+            user.id,
         );
         return this.generateTokens(user.id, user.role);
     }


### PR DESCRIPTION
## Summary
- log a `LOGIN_SUCCESS` action after successful login
- log a `REGISTER_SUCCESS` action after client registration
- test both log entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687776f80ff083299a7a937927f0c8d7