### PR TITLE
Log service deletions

### DIFF
--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -79,6 +79,8 @@ export class ServicesService {
         if (count > 0) {
             throw new BadRequestException('Service has existing appointments');
         }
-        return this.repo.delete(id);
+        const result = await this.repo.delete(id);
+        await this.logs.create(LogAction.DeleteService, JSON.stringify({ id }));
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
- record service deletion in logs once the service is removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68777b32f21083298913be0ac6dd1952