### PR TITLE
Add exception logging filter

### DIFF
--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -4,6 +4,7 @@ export enum LogAction {
     LoginFail = 'LOGIN_FAIL',
     LoginSuccess = 'LOGIN_SUCCESS',
     RegisterSuccess = 'REGISTER_SUCCESS',
+    ForbiddenAccess = 'FORBIDDEN_ACCESS',
     CancelAppointment = 'CANCEL_APPOINTMENT',
     CompleteAppointment = 'COMPLETE_APPOINTMENT',
     DeleteAppointment = 'DELETE_APPOINTMENT',

--- a/backend/src/logs/logging-exception.filter.ts
+++ b/backend/src/logs/logging-exception.filter.ts
@@ -1,0 +1,38 @@
+import {
+    ArgumentsHost,
+    Catch,
+    ExceptionFilter,
+    ForbiddenException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { LogsService } from './logs.service';
+import { LogAction } from './action.enum';
+
+@Catch(ForbiddenException, UnauthorizedException)
+export class LoggingExceptionFilter
+    implements ExceptionFilter<ForbiddenException | UnauthorizedException>
+{
+    constructor(private readonly logs: LogsService) {}
+
+    catch(
+        exception: ForbiddenException | UnauthorizedException,
+        host: ArgumentsHost,
+    ) {
+        const ctx = host.switchToHttp();
+        const request = ctx.getRequest<Request>();
+        const response = ctx.getResponse<Response>();
+        const description = `${request.method} ${request.url}`;
+        const userId = (request as any).user?.id as number | undefined;
+        if (exception instanceof ForbiddenException) {
+            void this.logs.create(
+                LogAction.ForbiddenAccess,
+                description,
+                userId,
+            );
+        } else if (exception instanceof UnauthorizedException) {
+            void this.logs.create(LogAction.LoginFail, description, userId);
+        }
+        response.status(exception.getStatus()).json(exception.getResponse());
+    }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,11 +2,16 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
 import { ValidationPipe } from '@nestjs/common';
+import { LogsService } from './logs/logs.service';
+import { LoggingExceptionFilter } from './logs/logging-exception.filter';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
 
     app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+
+    const logsService = app.get(LogsService);
+    app.useGlobalFilters(new LoggingExceptionFilter(logsService));
 
     const configService = app.get(ConfigService);
     app.enableCors({ origin: configService.get<string>('FRONTEND_URL') });


### PR DESCRIPTION
## Summary
- add `ForbiddenAccess` action type for logs
- implement `LoggingExceptionFilter` to log unauthorized or forbidden requests
- register the filter globally in `main.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68777c74dbfc83298d02a9cefc34efde