### PR TITLE
Add logs controller and log filters

### DIFF
--- a/backend/src/logs/logs.controller.ts
+++ b/backend/src/logs/logs.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { LogsService } from './logs.service';
+import { LogAction } from './action.enum';
+
+@Controller('logs')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
+export class LogsController {
+    constructor(private readonly service: LogsService) {}
+
+    @Get()
+    list(
+        @Query('startDate') startDate?: string,
+        @Query('endDate') endDate?: string,
+        @Query('action') action?: LogAction,
+        @Query('userId') userId?: string,
+    ) {
+        return this.service.findAll({
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            action,
+            userId: userId ? Number(userId) : undefined,
+        });
+    }
+}

--- a/backend/src/logs/logs.module.ts
+++ b/backend/src/logs/logs.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Log } from './log.entity';
 import { LogsService } from './logs.service';
+import { LogsController } from './logs.controller';
 
 @Module({
     imports: [TypeOrmModule.forFeature([Log])],
     providers: [LogsService],
+    controllers: [LogsController],
     exports: [LogsService, TypeOrmModule],
 })
 export class LogsModule {}

--- a/backend/src/logs/logs.service.ts
+++ b/backend/src/logs/logs.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Between, FindOptionsWhere, Repository } from 'typeorm';
 import { Log } from './log.entity';
 import { LogAction } from './action.enum';
 
@@ -17,5 +17,27 @@ export class LogsService {
             user: userId ? ({ id: userId } as any) : null,
         });
         return this.repo.save(log);
+    }
+
+    findAll(filters: {
+        startDate?: Date;
+        endDate?: Date;
+        action?: LogAction;
+        userId?: number;
+    }) {
+        const where: FindOptionsWhere<Log> = {};
+        if (filters.action) {
+            where.action = filters.action;
+        }
+        if (filters.userId) {
+            where.user = { id: filters.userId } as any;
+        }
+        if (filters.startDate || filters.endDate) {
+            where.timestamp = Between(
+                filters.startDate ?? new Date(0),
+                filters.endDate ?? new Date(),
+            );
+        }
+        return this.repo.find({ where, order: { timestamp: 'DESC' } });
     }
 }

--- a/backend/test/logs.e2e-spec.ts
+++ b/backend/test/logs.e2e-spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { LogsService } from './../src/logs/logs.service';
+import { Role } from './../src/users/role.enum';
+import { LogAction } from './../src/logs/action.enum';
+
+describe('LogsModule (e2e)', () => {
+    let app: INestApplication<App>;
+    let usersService: UsersService;
+    let logsService: LogsService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        usersService = moduleFixture.get(UsersService);
+        logsService = moduleFixture.get(LogsService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('admin can fetch logs with filters', async () => {
+        const admin = await usersService.createUser(
+            'admin@logs.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
+        const other = await usersService.createUser(
+            'other@logs.com',
+            'secret',
+            'Other',
+            Role.Client,
+        );
+
+        const log = await logsService.create(
+            LogAction.LoginSuccess,
+            'admin logged in',
+            admin.id,
+        );
+        await logsService.create(LogAction.LoginFail, 'other fail', other.id);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@logs.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        const res = await request(app.getHttpServer())
+            .get('/logs')
+            .set('Authorization', `Bearer ${token}`)
+            .query({ userId: admin.id, action: LogAction.LoginSuccess })
+            .expect(200);
+
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBe(1);
+        expect(res.body[0].id).toBe(log.id);
+    });
+});


### PR DESCRIPTION
## Summary
- expose logs retrieval endpoint for admins with filtering
- extend LogsService with filter support
- register controller in logs module
- test logs retrieval

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68778e5b3a3083299530f9d068a14343