### PR TITLE
Add support for employee roles in auth guard

### DIFF
--- a/backend/src/auth/roles.decorator.ts
+++ b/backend/src/auth/roles.decorator.ts
@@ -1,5 +1,8 @@
 import { SetMetadata } from '@nestjs/common';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
+
+export type AnyRole = Role | EmployeeRole;
 
 export const ROLES_KEY = 'roles';
-export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);
+export const Roles = (...roles: AnyRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/auth/roles.guard.spec.ts
+++ b/backend/src/auth/roles.guard.spec.ts
@@ -1,6 +1,8 @@
 import { ForbiddenException, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
+import { AnyRole } from './roles.decorator';
 import { RolesGuard } from './roles.guard';
 
 describe('RolesGuard', () => {
@@ -12,7 +14,7 @@ describe('RolesGuard', () => {
         guard = new RolesGuard(reflector as unknown as Reflector);
     });
 
-    function createContext(role?: Role): ExecutionContext {
+    function createContext(role?: AnyRole): ExecutionContext {
         return {
             switchToHttp: () => ({
                 getRequest: () => (role ? { user: { role } } : {}),
@@ -34,6 +36,12 @@ describe('RolesGuard', () => {
         expect(guard.canActivate(ctx)).toBe(true);
     });
 
+    it('allows user with matching employee role', () => {
+        reflector.getAllAndOverride.mockReturnValue([EmployeeRole.FRYZJER]);
+        const ctx = createContext(EmployeeRole.FRYZJER);
+        expect(guard.canActivate(ctx)).toBe(true);
+    });
+
     it('throws when user missing', () => {
         reflector.getAllAndOverride.mockReturnValue([Role.Admin]);
         const ctx = createContext(undefined);
@@ -43,6 +51,12 @@ describe('RolesGuard', () => {
     it('throws when role does not match', () => {
         reflector.getAllAndOverride.mockReturnValue([Role.Admin]);
         const ctx = createContext(Role.Client);
+        expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+
+    it('throws when employee role does not match', () => {
+        reflector.getAllAndOverride.mockReturnValue([EmployeeRole.RECEPCJA]);
+        const ctx = createContext(EmployeeRole.FRYZJER);
         expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
     });
 });

--- a/backend/src/auth/roles.guard.ts
+++ b/backend/src/auth/roles.guard.ts
@@ -1,14 +1,13 @@
 import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ROLES_KEY } from './roles.decorator';
-import { Role } from '../users/role.enum';
+import { ROLES_KEY, AnyRole } from './roles.decorator';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
     constructor(private readonly reflector: Reflector) {}
 
     canActivate(context: ExecutionContext): boolean {
-        const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+        const requiredRoles = this.reflector.getAllAndOverride<AnyRole[]>(ROLES_KEY, [
             context.getHandler(),
             context.getClass(),
         ]);


### PR DESCRIPTION
## Summary
- extend Roles decorator to accept both Role and EmployeeRole
- update RolesGuard to use union role type
- add tests for employee role handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687793f8cd648329ae80d8f56445ce9e