### PR TITLE
Add customer update endpoint

### DIFF
--- a/backend/src/users/dto/update-customer.dto.ts
+++ b/backend/src/users/dto/update-customer.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateCustomerDto extends PartialType(CreateUserDto) {}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -6,11 +6,14 @@ import {
     Request,
     Delete,
     Param,
+    Patch,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateCustomerDto } from './dto/update-customer.dto';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from './role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 
 @Controller('users')
 export class UsersController {
@@ -31,6 +34,12 @@ export class UsersController {
         }
         const { password: _p, refreshToken: _r, ...result } = user as any;
         return result;
+    }
+
+    @Patch('customers/:id')
+    @Roles(EmployeeRole.RECEPCJA, EmployeeRole.ADMIN, Role.Admin)
+    updateCustomer(@Param('id') id: number, @Body() dto: UpdateCustomerDto) {
+        return this.usersService.updateCustomer(Number(id), dto);
     }
 
     @Delete('customers/:id')

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -65,4 +65,21 @@ describe('UsersService', () => {
         ).rejects.toBeInstanceOf(BadRequestException);
         expect(repo.save).not.toHaveBeenCalled();
     });
+
+    it('updateCustomer hashes password and saves changes', async () => {
+        const user = { id: 1, email: 'old@test.com', password: 'p', name: 'Old' } as User;
+        repo.findOne.mockResolvedValue(user);
+        repo.save.mockResolvedValue(user);
+
+        await service.updateCustomer(1, { password: 'new', name: 'New' });
+
+        const passed = repo.save.mock.calls[0][0].password;
+        expect(await bcrypt.compare('new', passed)).toBe(true);
+        expect(repo.save).toHaveBeenCalled();
+    });
+
+    it('updateCustomer returns undefined when user missing', async () => {
+        repo.findOne.mockResolvedValue(undefined);
+        await expect(service.updateCustomer(2, { name: 'x' })).resolves.toBeUndefined();
+    });
 });

--- a/backend/test/users-update.e2e-spec.ts
+++ b/backend/test/users-update.e2e-spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { AuthService } from './../src/auth/auth.service';
+import { Role } from './../src/users/role.enum';
+import { EmployeeRole } from './../src/employees/employee-role.enum';
+
+describe('Customer update (e2e)', () => {
+    let app: INestApplication<App>;
+    let usersService: UsersService;
+    let authService: AuthService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        usersService = moduleFixture.get(UsersService);
+        authService = moduleFixture.get(AuthService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('allows admin to update customer', async () => {
+        await usersService.createUser('admupd@test.com', 'secret', 'A', Role.Admin);
+        const client = await usersService.createUser('custupd@test.com', 'secret', 'C', Role.Client);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admupd@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        await request(app.getHttpServer())
+            .patch(`/users/customers/${client.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'Updated' })
+            .expect(200)
+            .expect(res => expect(res.body.name).toBe('Updated'));
+    });
+
+    it('allows reception role to update customer', async () => {
+        const reception = await usersService.createUser('recupd@test.com', 'secret', 'R', Role.Employee);
+        const client = await usersService.createUser('custrec@test.com', 'secret', 'C', Role.Client);
+
+        const tokens = await authService.generateTokens(reception.id, EmployeeRole.RECEPCJA);
+        const token = tokens.access_token;
+
+        await request(app.getHttpServer())
+            .patch(`/users/customers/${client.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'New' })
+            .expect(200);
+    });
+
+    it('rejects other roles updating customer', async () => {
+        await usersService.createUser('empupd@test.com', 'secret', 'E', Role.Employee);
+        const client = await usersService.createUser('custfail@test.com', 'secret', 'C', Role.Client);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'empupd@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+
+        await request(app.getHttpServer())
+            .patch(`/users/customers/${client.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'Fail' })
+            .expect(403);
+    });
+});


### PR DESCRIPTION
## Summary
- enable editing of customer accounts
- implement customer update logic and DTO
- test authorization for updating customers via admin or reception roles

## Testing
- `npm run test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68779564e63083298ee470101128c358