### PR TITLE
Fix commission calculations

### DIFF
--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -129,7 +129,7 @@ describe('AppointmentsService', () => {
     repo.findOne.mockResolvedValue(appt);
     repo.save.mockResolvedValue(appt);
     commissions.getPercentForService.mockResolvedValue(15);
-    commissionRepo.create.mockReturnValue({ amount: 40, percent: 15 });
+    commissionRepo.create.mockReturnValue({ amount: 6, percent: 15 });
 
     await service.complete(3);
 
@@ -141,7 +141,7 @@ describe('AppointmentsService', () => {
       LogAction.CompleteAppointment,
       JSON.stringify({
         appointmentId: 3,
-        commissionAmount: 40,
+        commissionAmount: 6,
         percent: 15,
       }),
     );

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -165,17 +165,18 @@ export class AppointmentsService {
             appt.status = AppointmentStatus.Completed;
             appt.endTime = new Date();
             const saved = await this.repo.save(appt);
-            const percent = await this.commissions.getPercentForService(
-                appt.employee.id,
-                appt.service,
-                appt.employee.commissionBase ?? null,
-            );
+            const percent =
+                (await this.commissions.getPercentForService(
+                    appt.employee.id,
+                    appt.service,
+                    appt.employee.commissionBase ?? null,
+                )) / 100;
             const record = this.commissionRepo.create({
                 employee: appt.employee,
                 appointment: appt,
                 product: null,
-                amount: appt.service.price,
-                percent,
+                amount: Number(appt.service.price) * percent,
+                percent: percent * 100,
             });
             await this.commissionRepo.save(record);
             await this.logs.create(


### PR DESCRIPTION
## Summary
- compute commission amount with a percent of service price in unauthenticated `complete`
- adjust unit tests for new calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877b17a93108329b3c73ac085e90f43