### PR TITLE
Remove unused createForAppointment

### DIFF
--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -26,14 +26,14 @@ describe('AppointmentsService', () => {
     delete: jest.Mock;
   };
   let formulas: { create: jest.Mock };
-  let commissions: { createForAppointment: jest.Mock; getPercentForService: jest.Mock };
+  let commissions: { getPercentForService: jest.Mock };
   let commissionRepo: { create: jest.Mock; save: jest.Mock };
   let logs: { create: jest.Mock };
 
   beforeEach(async () => {
     repo = { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOne: jest.fn(), delete: jest.fn() };
     formulas = { create: jest.fn() };
-    commissions = { createForAppointment: jest.fn(), getPercentForService: jest.fn() };
+    commissions = { getPercentForService: jest.fn() };
     commissionRepo = { create: jest.fn(), save: jest.fn() };
     logs = { create: jest.fn() };
 

--- a/backend/src/commissions/commissions.service.spec.ts
+++ b/backend/src/commissions/commissions.service.spec.ts
@@ -4,8 +4,6 @@ import { Repository } from 'typeorm';
 import { CommissionsService } from './commissions.service';
 import { CommissionRecord } from './commission-record.entity';
 import { CommissionRule, CommissionTargetType } from './commission-rule.entity';
-import { Appointment } from '../appointments/appointment.entity';
-import { Employee } from '../employees/employee.entity';
 import { Service } from '../catalog/service.entity';
 
 describe('CommissionsService', () => {
@@ -27,28 +25,6 @@ describe('CommissionsService', () => {
     service = module.get<CommissionsService>(CommissionsService);
   });
 
-  it('createForAppointment builds and saves a commission record', async () => {
-    const appt = {
-      id: 1,
-      service: { price: 50, defaultCommissionPercent: 0.2 } as Service,
-      employee: { id: 2 } as Employee,
-    } as Appointment;
-    const created = { id: 99 } as CommissionRecord;
-    repo.create.mockReturnValue(created);
-    repo.save.mockResolvedValue(created);
-
-    const result = await service.createForAppointment(appt);
-
-    expect(repo.create).toHaveBeenCalledWith({
-      employee: appt.employee,
-      appointment: appt,
-      product: null,
-      amount: appt.service.price,
-      percent: appt.service.defaultCommissionPercent,
-    });
-    expect(repo.save).toHaveBeenCalledWith(created);
-    expect(result).toBe(created);
-  });
 
   it('getPercentForService uses service rule', async () => {
     ruleRepo.findOne.mockResolvedValue({ commissionPercent: 25 });

--- a/backend/src/commissions/commissions.service.ts
+++ b/backend/src/commissions/commissions.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CommissionRecord } from './commission-record.entity';
-import { Appointment } from '../appointments/appointment.entity';
 import { CommissionRule, CommissionTargetType } from './commission-rule.entity';
 import { Service } from '../catalog/service.entity';
 
@@ -51,14 +50,4 @@ export class CommissionsService {
         return base ?? service.defaultCommissionPercent ?? 0;
     }
 
-    createForAppointment(appointment: Appointment) {
-        const record = this.repo.create({
-            employee: appointment.employee,
-            appointment,
-            product: null,
-            amount: appointment.service.price,
-            percent: appointment.service.defaultCommissionPercent ?? 0,
-        });
-        return this.repo.save(record);
-    }
 }


### PR DESCRIPTION
## Summary
- delete `createForAppointment` method and its test
- adjust appointment tests to remove unused mock

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877b28d34d48329baa2e0435a3a8d31