### PR TITLE
Add default commission base

### DIFF
--- a/backend/src/commissions/commissions.service.spec.ts
+++ b/backend/src/commissions/commissions.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CommissionsService } from './commissions.service';
+import { CommissionsService, DEFAULT_COMMISSION_BASE } from './commissions.service';
 import { CommissionRecord } from './commission-record.entity';
 import { CommissionRule, CommissionTargetType } from './commission-rule.entity';
 import { Service } from '../catalog/service.entity';
@@ -65,5 +65,14 @@ describe('CommissionsService', () => {
       },
     });
     expect(result).toBe(15);
+  });
+
+  it('getPercentForService uses default base when none provided', async () => {
+    ruleRepo.findOne.mockResolvedValue(null);
+    const serviceObj = { id: 8 } as Service;
+
+    const result = await service.getPercentForService(2, serviceObj, null);
+
+    expect(result).toBe(DEFAULT_COMMISSION_BASE);
   });
 });

--- a/backend/src/commissions/commissions.service.ts
+++ b/backend/src/commissions/commissions.service.ts
@@ -5,6 +5,8 @@ import { CommissionRecord } from './commission-record.entity';
 import { CommissionRule, CommissionTargetType } from './commission-rule.entity';
 import { Service } from '../catalog/service.entity';
 
+export const DEFAULT_COMMISSION_BASE = 13;
+
 @Injectable()
 export class CommissionsService {
     constructor(
@@ -47,7 +49,10 @@ export class CommissionsService {
             if (catRule) return catRule.commissionPercent;
         }
 
-        return base ?? service.defaultCommissionPercent ?? 0;
+        if (base === null) {
+            return DEFAULT_COMMISSION_BASE;
+        }
+        return base ?? service.defaultCommissionPercent ?? DEFAULT_COMMISSION_BASE;
     }
 
 }


### PR DESCRIPTION
## Summary
- add `DEFAULT_COMMISSION_BASE` constant
- use it when no commission overrides exist
- test default fallback logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877b51ef35c8329806c74369343962b