### PR TITLE
Add initial sales endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { FormulasModule } from './formulas/formulas.module';
 import { CommissionsModule } from './commissions/commissions.module';
 import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
+import { SalesModule } from './sales/sales.module';
 import { LogsModule } from './logs/logs.module';
 import { CommunicationsModule } from './communications/communications.module';
 import { ReviewsModule } from './reviews/reviews.module';
@@ -45,6 +46,7 @@ import { ReviewsModule } from './reviews/reviews.module';
         CommissionsModule,
         ServicesModule,
         ProductsModule,
+        SalesModule,
         ReviewsModule,
         LogsModule,
         CommunicationsModule,

--- a/backend/src/commissions/commissions.service.ts
+++ b/backend/src/commissions/commissions.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { CommissionRecord } from './commission-record.entity';
 import { CommissionRule, CommissionTargetType } from './commission-rule.entity';
 import { Service } from '../catalog/service.entity';
+import { Product } from '../catalog/product.entity';
 
 export const DEFAULT_COMMISSION_BASE = 13;
 
@@ -55,4 +56,23 @@ export class CommissionsService {
         return base ?? service.defaultCommissionPercent ?? DEFAULT_COMMISSION_BASE;
     }
 
+    async getPercentForProduct(
+        employeeId: number,
+        product: Product,
+        base?: number | null,
+    ): Promise<number> {
+        const rule = await this.rules.findOne({
+            where: {
+                employee: { id: employeeId } as any,
+                targetType: CommissionTargetType.Product,
+                targetId: product.id,
+            },
+        });
+        if (rule) return rule.commissionPercent;
+
+        if (base === null) {
+            return DEFAULT_COMMISSION_BASE;
+        }
+        return base ?? DEFAULT_COMMISSION_BASE;
+    }
 }

--- a/backend/src/migrations/20250711192018-CreateSalesTable.ts
+++ b/backend/src/migrations/20250711192018-CreateSalesTable.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateSalesTable20250711192018 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'sale',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'clientId', type: 'int' },
+                    { name: 'employeeId', type: 'int' },
+                    { name: 'productId', type: 'int' },
+                    { name: 'quantity', type: 'int' },
+                    { name: 'soldAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('sale', [
+            new TableForeignKey({
+                columnNames: ['clientId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+            new TableForeignKey({
+                columnNames: ['employeeId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+            new TableForeignKey({
+                columnNames: ['productId'],
+                referencedTableName: 'product',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('sale');
+    }
+}

--- a/backend/src/sales/dto/create-sale.dto.ts
+++ b/backend/src/sales/dto/create-sale.dto.ts
@@ -1,0 +1,16 @@
+import { IsInt, Min } from 'class-validator';
+
+export class CreateSaleDto {
+    @IsInt()
+    clientId: number;
+
+    @IsInt()
+    employeeId: number;
+
+    @IsInt()
+    productId: number;
+
+    @IsInt()
+    @Min(1)
+    quantity: number;
+}

--- a/backend/src/sales/sale.entity.ts
+++ b/backend/src/sales/sale.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import { Customer } from '../customers/customer.entity';
+import { Employee } from '../employees/employee.entity';
+import { Product } from '../catalog/product.entity';
+
+@Entity()
+export class Sale {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Customer, { eager: true, onDelete: 'RESTRICT' })
+    client: Customer;
+
+    @ManyToOne(() => Employee, { eager: true, onDelete: 'RESTRICT' })
+    employee: Employee;
+
+    @ManyToOne(() => Product, { eager: true, onDelete: 'RESTRICT' })
+    product: Product;
+
+    @Column('int')
+    quantity: number;
+
+    @CreateDateColumn()
+    soldAt: Date;
+}

--- a/backend/src/sales/sales.controller.ts
+++ b/backend/src/sales/sales.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { SalesService } from './sales.service';
+import { CreateSaleDto } from './dto/create-sale.dto';
+
+@Controller('sales')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class SalesController {
+    constructor(private readonly service: SalesService) {}
+
+    @Post()
+    @Roles(Role.Admin, Role.Employee)
+    create(@Body() dto: CreateSaleDto) {
+        return this.service.create(
+            dto.clientId,
+            dto.employeeId,
+            dto.productId,
+            dto.quantity,
+        );
+    }
+}

--- a/backend/src/sales/sales.module.ts
+++ b/backend/src/sales/sales.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Sale } from './sale.entity';
+import { SalesService } from './sales.service';
+import { SalesController } from './sales.controller';
+import { Product } from '../catalog/product.entity';
+import { CommissionRecord } from '../commissions/commission-record.entity';
+import { CommissionsModule } from '../commissions/commissions.module';
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([Sale, Product, CommissionRecord]),
+        CommissionsModule,
+    ],
+    controllers: [SalesController],
+    providers: [SalesService],
+    exports: [TypeOrmModule, SalesService],
+})
+export class SalesModule {}

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Sale } from './sale.entity';
+import { Product } from '../catalog/product.entity';
+import { CommissionRecord } from '../commissions/commission-record.entity';
+import { CommissionsService } from '../commissions/commissions.service';
+
+@Injectable()
+export class SalesService {
+    constructor(
+        @InjectRepository(Sale)
+        private readonly repo: Repository<Sale>,
+        @InjectRepository(Product)
+        private readonly products: Repository<Product>,
+        @InjectRepository(CommissionRecord)
+        private readonly commissions: Repository<CommissionRecord>,
+        private readonly commissionService: CommissionsService,
+    ) {}
+
+    async create(clientId: number, employeeId: number, productId: number, quantity: number) {
+        if (quantity <= 0) {
+            throw new BadRequestException('quantity must be > 0');
+        }
+        const product = await this.products.findOne({ where: { id: productId } });
+        if (!product) {
+            throw new BadRequestException('invalid product');
+        }
+        if (product.stock < quantity) {
+            throw new BadRequestException('insufficient stock');
+        }
+        product.stock -= quantity;
+        await this.products.save(product);
+
+        const sale = this.repo.create({
+            client: { id: clientId } as any,
+            employee: { id: employeeId } as any,
+            product: { id: productId } as any,
+            quantity,
+        });
+        const saved = await this.repo.save(sale);
+
+        const percent =
+            (await this.commissionService.getPercentForProduct(
+                employeeId,
+                product,
+                null,
+            )) / 100;
+        if (percent > 0) {
+            const record = this.commissions.create({
+                employee: { id: employeeId } as any,
+                appointment: null,
+                product: { id: productId } as any,
+                amount: Number(product.unitPrice) * quantity * percent,
+                percent: percent * 100,
+            });
+            await this.commissions.save(record);
+        }
+
+        return saved;
+    }
+}


### PR DESCRIPTION
## Summary
- implement Sales module for recording product sales
- allow commission percent retrieval for products
- expose `/sales` POST endpoint
- register new Sales module in application setup
- create database table for product sales

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877b7123570832987a19a2456f016ef