### PR TITLE
Fix injection by adding Commissions module

### DIFF
--- a/backend/src/appointments/appointments.module.ts
+++ b/backend/src/appointments/appointments.module.ts
@@ -14,6 +14,7 @@ import { LogsModule } from '../logs/logs.module';
     imports: [
         TypeOrmModule.forFeature([Appointment, CommissionRecord]),
         forwardRef(() => FormulasModule),
+        CommissionsModule,
         LogsModule,
     ],
 


### PR DESCRIPTION
## Summary
- include `CommissionsModule` in the appointments module imports

## Testing
- `npm run test:e2e` *(fails: DataTypeNotSupportedError for sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_6877c87577a48329870e40081c155bb4