### PR TITLE
Implement commission calculation service

### DIFF
--- a/backend/src/appointments/appointments.module.ts
+++ b/backend/src/appointments/appointments.module.ts
@@ -7,12 +7,11 @@ import { EmployeeAppointmentsController } from './employee-appointments.controll
 import { AdminAppointmentsController } from './admin-appointments.controller';
 import { FormulasModule } from '../formulas/formulas.module';
 import { CommissionsModule } from '../commissions/commissions.module';
-import { CommissionRecord } from '../commissions/commission-record.entity';
 import { LogsModule } from '../logs/logs.module';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([Appointment, CommissionRecord]),
+        TypeOrmModule.forFeature([Appointment]),
         forwardRef(() => FormulasModule),
         CommissionsModule,
         LogsModule,

--- a/backend/src/commissions/commissions.module.ts
+++ b/backend/src/commissions/commissions.module.ts
@@ -5,10 +5,18 @@ import { EmployeeCommission } from './employee-commission.entity';
 import { CommissionRule } from './commission-rule.entity';
 import { CommissionsService } from './commissions.service';
 import { CommissionsController } from './commissions.controller';
+import { Appointment } from '../appointments/appointment.entity';
+import { LogsModule } from '../logs/logs.module';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([CommissionRecord, EmployeeCommission, CommissionRule]),
+        TypeOrmModule.forFeature([
+            CommissionRecord,
+            EmployeeCommission,
+            CommissionRule,
+            Appointment,
+        ]),
+        LogsModule,
     ],
     controllers: [CommissionsController],
     providers: [CommissionsService],

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -9,4 +9,5 @@ export enum LogAction {
     CompleteAppointment = 'COMPLETE_APPOINTMENT',
     DeleteAppointment = 'DELETE_APPOINTMENT',
     DeleteService = 'DELETE_SERVICE',
+    CommissionGranted = 'COMMISSION_GRANTED',
 }


### PR DESCRIPTION
## Summary
- implement `CommissionsService.calculateCommission` to compute commission for an appointment
- log commission grant via new `COMMISSION_GRANTED` action
- update appointment completion to use the service and return commission info
- adjust modules and tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877ca3ebe60832987edfcefbc40afbf