### PR TITLE
Implement appointment chat rooms

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -100,6 +100,12 @@ $ npm install
 $ DATABASE_URL=sqlite::memory: npm run test:e2e
 ```
 
+## WebSocket chat
+
+After connecting with a JWT token, emit `joinRoom` with an `appointmentId` to
+enter the chat for that appointment. Only the client or assigned employee may
+join. Send messages by emitting `message` with `{ appointmentId, content }`.
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/backend/src/chat/chat.gateway.spec.ts
+++ b/backend/src/chat/chat.gateway.spec.ts
@@ -1,0 +1,69 @@
+import { ChatGateway } from './chat.gateway';
+
+describe('ChatGateway', () => {
+    let gateway: ChatGateway;
+    let appointments: { findOne: jest.Mock };
+    let server: any;
+    let socket: any;
+
+    beforeEach(() => {
+        appointments = { findOne: jest.fn() };
+        gateway = new ChatGateway({} as any, {} as any, appointments as any);
+        server = { to: jest.fn(() => ({ emit: jest.fn() })) } as any;
+        gateway.server = server;
+        socket = {
+            data: { userId: 1 },
+            join: jest.fn(),
+            emit: jest.fn(),
+        } as any;
+    });
+
+    it('joins room for valid appointment participant', async () => {
+        appointments.findOne.mockResolvedValue({
+            client: { id: 1 },
+            employee: { id: 2 },
+        });
+        await gateway.joinRoom(socket, { appointmentId: 5 });
+        expect(socket.join).toHaveBeenCalledWith('chat-5');
+    });
+
+    it('rejects join when user not participant', async () => {
+        appointments.findOne.mockResolvedValue({
+            client: { id: 3 },
+            employee: { id: 2 },
+        });
+        await gateway.joinRoom(socket, { appointmentId: 5 });
+        expect(socket.join).not.toHaveBeenCalled();
+        expect(socket.emit).toHaveBeenCalledWith('error', 'unauthorized');
+    });
+
+    it('broadcasts message to room for valid user', async () => {
+        const emitMock = jest.fn();
+        server.to = jest.fn(() => ({ emit: emitMock }));
+        appointments.findOne.mockResolvedValue({
+            client: { id: 1 },
+            employee: { id: 2 },
+        });
+        await gateway.handleChatMessage(socket, {
+            appointmentId: 5,
+            content: 'hi',
+        });
+        expect(server.to).toHaveBeenCalledWith('chat-5');
+        expect(emitMock).toHaveBeenCalledWith('message', {
+            userId: 1,
+            content: 'hi',
+        });
+    });
+
+    it('rejects message from non-member', async () => {
+        appointments.findOne.mockResolvedValue({
+            client: { id: 3 },
+            employee: { id: 2 },
+        });
+        await gateway.handleChatMessage(socket, {
+            appointmentId: 5,
+            content: 'hi',
+        });
+        expect(socket.emit).toHaveBeenCalledWith('error', 'unauthorized');
+    });
+});

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { MessagesModule } from '../messages/messages.module';
+import { AppointmentsModule } from '../appointments/appointments.module';
 import { ChatGateway } from './chat.gateway';
 
 @Module({
     imports: [
         MessagesModule,
+        AppointmentsModule,
         JwtModule.register({ secret: process.env.JWT_SECRET ?? 'secret' }),
     ],
     providers: [ChatGateway],


### PR DESCRIPTION
## Summary
- enable chat rooms for appointments
- import AppointmentsModule for ChatModule
- add unit tests for ChatGateway
- document websocket usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d81b0fb483298cf643db5cba11e1