### PR TITLE
Update WebSocket chat docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -105,6 +105,7 @@ $ DATABASE_URL=sqlite::memory: npm run test:e2e
 After connecting with a JWT token, emit `joinRoom` with an `appointmentId` to
 enter the chat for that appointment. Only the client or assigned employee may
 join. Send messages by emitting `message` with `{ appointmentId, content }`.
+Chat history can be fetched with `GET /appointments/:id/chat` using the same JWT authentication (client or employee).
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- document how to fetch chat history in the WebSocket chat section

## Testing
- `scripts/install_and_test.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877e490e1a0832998b4b92f1e721273