### PR TITLE
Add websocket chat e2e tests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,6 +55,7 @@
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
+        "socket.io-client": "^4.8.1",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
@@ -6699,6 +6700,38 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -12304,6 +12337,40 @@
         }
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -14493,6 +14560,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -66,6 +66,7 @@
     "globals": "^16.0.0",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
+    "socket.io-client": "^4.8.1",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/backend/src/commissions/commission-rule.entity.ts
+++ b/backend/src/commissions/commission-rule.entity.ts
@@ -16,7 +16,7 @@ export class CommissionRule {
     @ManyToOne(() => User, { onDelete: 'RESTRICT' })
     employee: User;
 
-    @Column({ type: 'enum', enum: CommissionTargetType })
+    @Column({ type: 'simple-enum', enum: CommissionTargetType })
     targetType: CommissionTargetType;
 
     @Column('int')

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1,0 +1,127 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from './../src/app.module';
+import * as request from 'supertest';
+import { io as Client } from 'socket.io-client';
+import { UsersService } from './../src/users/users.service';
+import { AppointmentsService } from './../src/appointments/appointments.service';
+import { Role } from './../src/users/role.enum';
+
+describe('ChatGateway (e2e)', () => {
+    let app: INestApplication;
+    let users: UsersService;
+    let appointments: AppointmentsService;
+    let url: string;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.listen(0);
+        const address: any = app.getHttpServer().address();
+        url = `http://localhost:${address.port}`;
+        users = moduleFixture.get(UsersService);
+        appointments = moduleFixture.get(AppointmentsService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('delivers chat messages to all room members', async () => {
+        const client = await users.createUser(
+            'cgclient@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await users.createUser(
+            'cgemp@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const start = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        const appt = await appointments.create(
+            client.id,
+            employee.id,
+            1,
+            start,
+        );
+
+        const loginC = await request(url)
+            .post('/auth/login')
+            .send({ email: 'cgclient@test.com', password: 'secret' })
+            .expect(201);
+        const loginE = await request(url)
+            .post('/auth/login')
+            .send({ email: 'cgemp@test.com', password: 'secret' })
+            .expect(201);
+
+        const socketC = Client(url, {
+            auth: { token: loginC.body.access_token },
+            transports: ['websocket'],
+            reconnection: false,
+        });
+        const socketE = Client(url, {
+            auth: { token: loginE.body.access_token },
+            transports: ['websocket'],
+            reconnection: false,
+        });
+
+        await new Promise<void>((resolve) =>
+            socketC.on('connect', () => resolve()),
+        );
+        await new Promise<void>((resolve) =>
+            socketE.on('connect', () => resolve()),
+        );
+
+        socketC.emit('joinRoom', { appointmentId: appt.id });
+        socketE.emit('joinRoom', { appointmentId: appt.id });
+
+        const receivedC: any[] = [];
+        const receivedE: any[] = [];
+        socketC.on('message', (m) => receivedC.push(m));
+        socketE.on('message', (m) => receivedE.push(m));
+
+        socketC.emit('message', { appointmentId: appt.id, content: 'hello' });
+        socketE.emit('message', { appointmentId: appt.id, content: 'hi' });
+
+        await new Promise((res) => setTimeout(res, 200));
+
+        expect(receivedC.length).toBe(2);
+        expect(receivedE.length).toBe(2);
+        const messages = receivedC.map((m) => m.message).sort();
+        expect(messages).toEqual(['hello', 'hi']);
+
+        socketC.close();
+        socketE.close();
+
+        const history = await request(url)
+            .get(`/appointments/${appt.id}/chat`)
+            .set('Authorization', `Bearer ${loginC.body.access_token}`)
+            .expect(200);
+        const bodyMessages = history.body.map((m: any) => m.message).sort();
+        expect(bodyMessages).toEqual(['hello', 'hi']);
+    });
+
+    it('disconnects when token is invalid', (done) => {
+        const bad = Client(url, {
+            auth: { token: 'invalid' },
+            transports: ['websocket'],
+            reconnection: false,
+        });
+        bad.on('connect', () => {
+            bad.on('disconnect', () => done());
+        });
+        bad.on('connect_error', () => {
+            bad.close();
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add `socket.io-client` dev dependency
- support sqlite in `CommissionRule` entity
- test chat gateway end-to-end

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6878c045c0a083298e9ae14a34a16186