### PR TITLE
Switch to simple-enum

### DIFF
--- a/backend/src/employees/employee.entity.ts
+++ b/backend/src/employees/employee.entity.ts
@@ -9,7 +9,7 @@ import { EmployeeCommission } from '../commissions/employee-commission.entity';
 @Entity('user')
 export class Employee extends User {
     @Column({
-        type: 'enum',
+        type: 'simple-enum',
         enum: EmployeeRole,
         default: EmployeeRole.FRYZJER,
     })

--- a/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
+++ b/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
@@ -21,7 +21,7 @@ export class CreateAppointmentsTable20250711192007 implements MigrationInterface
                     { name: 'serviceId', type: 'int' },
                     {
                         name: 'status',
-                        type: 'enum',
+                        type: 'varchar',
                         enum: ['scheduled', 'completed', 'cancelled'],
                         default: "'scheduled'",
                     },


### PR DESCRIPTION
## Summary
- allow Employee entity to store enum values on sqlite by using `simple-enum`
- update appointments table migration to match enum storage

## Testing
- `DATABASE_URL=sqlite::memory: npm run test:e2e` *(fails: FOREIGN KEY constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878c7975e4c8329a4b2cdde74fa3170