### PR TITLE
Add WhatsApp notifications service

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,3 +14,7 @@ DATABASE_URL=postgres://user:pass@localhost:5432/salonbw_dev
 JWT_SECRET=your-jwt-secret
 # Secret used to sign JWT refresh tokens
 JWT_REFRESH_SECRET=your-refresh-secret
+
+# WhatsApp Cloud API credentials
+WHATSAPP_TOKEN=your-whatsapp-token
+WHATSAPP_PHONE_ID=your-whatsapp-phone-id

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { CommunicationsModule } from './communications/communications.module';
 import { ReviewsModule } from './reviews/reviews.module';
 import { ChatModule } from './chat/chat.module';
 import { ChatMessagesModule } from './chat-messages/chat-messages.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
     imports: [
@@ -54,6 +55,7 @@ import { ChatMessagesModule } from './chat-messages/chat-messages.module';
         ChatModule,
         LogsModule,
         CommunicationsModule,
+        NotificationsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+    providers: [NotificationsService],
+    exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsService } from './notifications.service';
+
+describe('NotificationsService', () => {
+    let service: NotificationsService;
+
+    beforeEach(async () => {
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [NotificationsService],
+        }).compile();
+
+        service = module.get<NotificationsService>(NotificationsService);
+    });
+
+    afterEach(() => {
+        // @ts-ignore
+        delete global.fetch;
+    });
+
+    it('sendText posts to WhatsApp API', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: jest.fn() });
+        // @ts-ignore
+        global.fetch = fetchMock;
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+
+        await service.sendText('48123456789', 'hello');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://graph.facebook.com/v18.0/123/messages',
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: 'Bearer t',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    messaging_product: 'whatsapp',
+                    to: '48123456789',
+                    type: 'text',
+                    text: { body: 'hello' },
+                }),
+            },
+        );
+    });
+});

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+
+interface WhatsAppTextPayload {
+    messaging_product: 'whatsapp';
+    to: string;
+    type: 'text';
+    text: { body: string };
+}
+
+@Injectable()
+export class NotificationsService {
+    private readonly token = process.env.WHATSAPP_TOKEN;
+    private readonly phoneId = process.env.WHATSAPP_PHONE_ID;
+    private readonly baseUrl = 'https://graph.facebook.com/v18.0';
+
+    async sendText(to: string, text: string) {
+        if (!this.token || !this.phoneId) {
+            throw new Error('WhatsApp credentials not configured');
+        }
+        const payload: WhatsAppTextPayload = {
+            messaging_product: 'whatsapp',
+            to,
+            type: 'text',
+            text: { body: text },
+        };
+        const res = await fetch(`${this.baseUrl}/${this.phoneId}/messages`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+            const body = await res.text();
+            throw new Error(`WhatsApp API error: ${res.status} ${body}`);
+        }
+        return res.json();
+    }
+
+    async sendAppointmentConfirmation(to: string, when: Date) {
+        const text = `Twoja wizyta została umówiona na ${when.toLocaleString()}`;
+        return this.sendText(to, text);
+    }
+
+    async sendAppointmentReminder(to: string, when: Date) {
+        const text = `Przypomnienie: wizyta ${when.toLocaleString()}`;
+        return this.sendText(to, text);
+    }
+
+    async sendThankYou(to: string) {
+        const text = 'Dziękujemy za wizytę!';
+        return this.sendText(to, text);
+    }
+}


### PR DESCRIPTION
## Summary
- add WhatsApp credentials to environment example
- implement `NotificationsService` with WhatsApp Cloud API integration
- expose service via `NotificationsModule`
- include module in `AppModule`
- provide tests for the new service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ca82d9048329b9ccf16d37d9ed74