### PR TITLE
Implement WhatsApp template messages

### DIFF
--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -45,4 +45,44 @@ describe('NotificationsService', () => {
             },
         );
     });
+
+    it('sendWhatsAppTemplate posts to WhatsApp API', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: jest.fn() });
+        // @ts-ignore
+        global.fetch = fetchMock;
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+        process.env.WHATSAPP_TEMPLATE_LANG = 'pl';
+
+        await service.sendWhatsAppTemplate('48123456789', 'template', ['X', 'Y']);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://graph.facebook.com/v18.0/123/messages',
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: 'Bearer t',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    messaging_product: 'whatsapp',
+                    to: '48123456789',
+                    type: 'template',
+                    template: {
+                        name: 'template',
+                        language: { code: 'pl' },
+                        components: [
+                            {
+                                type: 'body',
+                                parameters: [
+                                    { type: 'text', text: 'X' },
+                                    { type: 'text', text: 'Y' },
+                                ],
+                            },
+                        ],
+                    },
+                }),
+            },
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- support sending WhatsApp templates via new `sendWhatsAppTemplate` method
- add a unit test for the template message logic

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6878d520d7dc832984e1e8f7f397cbc1