### PR TITLE
Implement daily appointment reminders

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.4",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.1.4",
         "bcrypt": "^5.1.1",
@@ -2716,6 +2717,19 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -3673,6 +3687,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -6328,6 +6348,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9783,6 +9816,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@nestjs/platform-socket.io": "^11.1.4",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.1.4",
+    "@nestjs/schedule": "^6.0.0",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
@@ -24,6 +25,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 @Module({
     imports: [
         ConfigModule.forRoot({ envFilePath: '.env' }),
+        ScheduleModule.forRoot(),
         TypeOrmModule.forRootAsync({
             useFactory: () => {
                 const url = process.env.DATABASE_URL || 'sqlite::memory:';

--- a/backend/src/appointments/appointments.module.ts
+++ b/backend/src/appointments/appointments.module.ts
@@ -9,6 +9,7 @@ import { FormulasModule } from '../formulas/formulas.module';
 import { CommissionsModule } from '../commissions/commissions.module';
 import { LogsModule } from '../logs/logs.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { ReminderService } from './reminder.service';
 
 @Module({
     imports: [
@@ -24,7 +25,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         EmployeeAppointmentsController,
         AdminAppointmentsController,
     ],
-    providers: [AppointmentsService],
+    providers: [AppointmentsService, ReminderService],
     exports: [AppointmentsService],
 })
 export class AppointmentsModule {}

--- a/backend/src/appointments/reminder.service.ts
+++ b/backend/src/appointments/reminder.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import { Appointment, AppointmentStatus } from './appointment.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+
+@Injectable()
+export class ReminderService {
+    constructor(
+        @InjectRepository(Appointment)
+        private readonly repo: Repository<Appointment>,
+        private readonly notifications: NotificationsService,
+    ) {}
+
+    @Cron('0 7 * * *')
+    async handleCron() {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        tomorrow.setHours(0, 0, 0, 0);
+        const dayAfter = new Date(tomorrow);
+        dayAfter.setDate(dayAfter.getDate() + 1);
+
+        const appointments = await this.repo.find({
+            where: {
+                startTime: Between(tomorrow, dayAfter),
+                status: AppointmentStatus.Scheduled,
+            },
+        });
+
+        for (const appt of appointments) {
+            const phone = (appt.client as any)?.phone;
+            if (phone) {
+                await this.notifications.sendAppointmentReminder(
+                    phone,
+                    appt.startTime,
+                );
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- include `@nestjs/schedule` for cron support
- initialize schedule module in `AppModule`
- create a reminder service that sends appointment reminders every day
- provide the reminder service from `AppointmentsModule`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e4bd99888329b1a38ec7669f3943