### PR TITLE
Swap fetch for axios in WhatsApp service

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/schedule": "^6.0.0",
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.1.4",
+        "axios": "^1.6.8",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -5212,7 +5213,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -5228,6 +5228,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/b4a": {
@@ -6137,7 +6148,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -6510,7 +6520,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6916,7 +6925,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7663,6 +7671,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7726,7 +7754,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
       "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7753,7 +7780,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7763,7 +7789,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -11520,6 +11545,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,8 @@
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
     "typeorm": "^0.3.25",
-    "@nestjs/mapped-types": "^2.1.0"
+    "@nestjs/mapped-types": "^2.1.0",
+    "axios": "^1.6.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationsService } from './notifications.service';
+import axios from 'axios';
 
 describe('NotificationsService', () => {
     let service: NotificationsService;
@@ -15,73 +16,66 @@ describe('NotificationsService', () => {
     });
 
     afterEach(() => {
-        // @ts-ignore
-        delete global.fetch;
+        jest.resetAllMocks();
     });
 
     it('sendText posts to WhatsApp API', async () => {
-        const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: jest.fn() });
-        // @ts-ignore
-        global.fetch = fetchMock;
+        const postMock = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} } as any);
         process.env.WHATSAPP_TOKEN = 't';
         process.env.WHATSAPP_PHONE_ID = '123';
 
         await service.sendText('48123456789', 'hello');
 
-        expect(fetchMock).toHaveBeenCalledWith(
+        expect(postMock).toHaveBeenCalledWith(
             'https://graph.facebook.com/v18.0/123/messages',
             {
-                method: 'POST',
+                messaging_product: 'whatsapp',
+                to: '48123456789',
+                type: 'text',
+                text: { body: 'hello' },
+            },
+            {
                 headers: {
                     Authorization: 'Bearer t',
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({
-                    messaging_product: 'whatsapp',
-                    to: '48123456789',
-                    type: 'text',
-                    text: { body: 'hello' },
-                }),
             },
         );
     });
 
     it('sendWhatsAppTemplate posts to WhatsApp API', async () => {
-        const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: jest.fn() });
-        // @ts-ignore
-        global.fetch = fetchMock;
+        const postMock = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} } as any);
         process.env.WHATSAPP_TOKEN = 't';
         process.env.WHATSAPP_PHONE_ID = '123';
         process.env.WHATSAPP_TEMPLATE_LANG = 'pl';
 
         await service.sendWhatsAppTemplate('48123456789', 'template', ['X', 'Y']);
 
-        expect(fetchMock).toHaveBeenCalledWith(
+        expect(postMock).toHaveBeenCalledWith(
             'https://graph.facebook.com/v18.0/123/messages',
             {
-                method: 'POST',
+                messaging_product: 'whatsapp',
+                to: '48123456789',
+                type: 'template',
+                template: {
+                    name: 'template',
+                    language: { code: 'pl' },
+                    components: [
+                        {
+                            type: 'body',
+                            parameters: [
+                                { type: 'text', text: 'X' },
+                                { type: 'text', text: 'Y' },
+                            ],
+                        },
+                    ],
+                },
+            },
+            {
                 headers: {
                     Authorization: 'Bearer t',
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({
-                    messaging_product: 'whatsapp',
-                    to: '48123456789',
-                    type: 'template',
-                    template: {
-                        name: 'template',
-                        language: { code: 'pl' },
-                        components: [
-                            {
-                                type: 'body',
-                                parameters: [
-                                    { type: 'text', text: 'X' },
-                                    { type: 'text', text: 'Y' },
-                                ],
-                            },
-                        ],
-                    },
-                }),
             },
         );
     });

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import axios from 'axios';
 
 interface WhatsAppTextPayload {
     messaging_product: 'whatsapp';
@@ -37,19 +38,23 @@ export class NotificationsService {
             type: 'text',
             text: { body: text },
         };
-        const res = await fetch(`${this.baseUrl}/${this.phoneId}/messages`, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${this.token}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(payload),
-        });
-        if (!res.ok) {
-            const body = await res.text();
-            throw new Error(`WhatsApp API error: ${res.status} ${body}`);
+        try {
+            const res = await axios.post(
+                `${this.baseUrl}/${this.phoneId}/messages`,
+                payload,
+                {
+                    headers: {
+                        Authorization: `Bearer ${this.token}`,
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            const status = err.response?.status;
+            const body = err.response?.data;
+            throw new Error(`WhatsApp API error: ${status} ${body}`);
         }
-        return res.json();
     }
 
     async sendWhatsAppTemplate(
@@ -79,19 +84,23 @@ export class NotificationsService {
                 ],
             },
         };
-        const res = await fetch(`${this.baseUrl}/${this.phoneId}/messages`, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${this.token}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(payload),
-        });
-        if (!res.ok) {
-            const body = await res.text();
-            throw new Error(`WhatsApp API error: ${res.status} ${body}`);
+        try {
+            const res = await axios.post(
+                `${this.baseUrl}/${this.phoneId}/messages`,
+                payload,
+                {
+                    headers: {
+                        Authorization: `Bearer ${this.token}`,
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            const status = err.response?.status;
+            const body = err.response?.data;
+            throw new Error(`WhatsApp API error: ${status} ${body}`);
         }
-        return res.json();
     }
 
     async sendAppointmentConfirmation(to: string, when: Date) {


### PR DESCRIPTION
## Summary
- add `axios` dependency to backend package
- use `axios.post` for WhatsApp requests
- mock `axios.post` in notifications service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687921ebb0b48329be21d5fdd35da573