### PR TITLE
Add phone column to user

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,6 +40,8 @@ for example SQLite, when running tests locally.
 
 ```bash
 $ npm install
+$ npx typeorm-ts-node-commonjs migration:run -d src/data-source.ts
+# creates all tables including the optional `phone` column on `user`
 ```
 
 ## Compile and run the project

--- a/backend/src/migrations/20250711192020-AddPhoneToUser.ts
+++ b/backend/src/migrations/20250711192020-AddPhoneToUser.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddPhoneToUser20250711192020 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'user',
+            new TableColumn({
+                name: 'phone',
+                type: 'varchar',
+                isNullable: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('user', 'phone');
+    }
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -16,7 +16,7 @@ export class User {
     @Column()
     name: string;
 
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     phone: string | null;
 
     @Column({ type: 'simple-enum', enum: Role })


### PR DESCRIPTION
## Summary
- make `phone` column varchar
- add migration for phone column
- mention running migrations in setup docs

## Testing
- `DATABASE_URL=sqlite::memory: npm run test:e2e` *(fails: QueryFailedError SQLITE_CONSTRAINT)*

------
https://chatgpt.com/codex/tasks/task_e_6879486585708329961e4d47c989d9bb