### PR TITLE
Add nock-based WhatsApp test

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^16.0.0",
         "jest": "^29.7.0",
+        "nock": "^14.0.5",
         "prettier": "^3.4.2",
         "socket.io-client": "^4.8.1",
         "source-map-support": "^0.5.21",
@@ -2007,6 +2008,24 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.38.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.7.tgz",
+      "integrity": "sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.4.tgz",
@@ -2998,6 +3017,31 @@
         "node": "^14.18.0 || >=16.10.0",
         "npm": ">=5.10.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
@@ -8620,6 +8664,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9553,6 +9604,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10475,6 +10533,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.5.tgz",
+      "integrity": "sha512-R49fALR9caB6vxuSWUIaK2eBYeTloZQUFBZ4rHO+TbhMGQHtwnhdqKLYki+o+8qMgLvoBYWrp/2KzGPhxL4S6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.38.7",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.75.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
@@ -10879,6 +10952,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
@@ -11531,6 +11611,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -12769,6 +12859,13 @@
       "optionalDependencies": {
         "bare-events": "^2.2.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -76,7 +76,8 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.20.0"
+    "typescript-eslint": "^8.20.0",
+    "nock": "^14.0.5"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/backend/src/notifications/notifications.service.nock.spec.ts
+++ b/backend/src/notifications/notifications.service.nock.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsService } from './notifications.service';
+import * as nock from 'nock';
+
+describe('NotificationsService with nock', () => {
+    let service: NotificationsService;
+    const httpProxy = process.env.http_proxy;
+    const httpsProxy = process.env.https_proxy;
+    const HTTPProxy = process.env.HTTP_PROXY;
+    const HTTPSProxy = process.env.HTTPS_PROXY;
+    const npmHttpProxy = process.env.npm_config_http_proxy;
+    const npmHttpsProxy = process.env.npm_config_https_proxy;
+    const yarnHttpProxy = process.env.YARN_HTTP_PROXY;
+    const yarnHttpsProxy = process.env.YARN_HTTPS_PROXY;
+    const globalProxy = process.env.GLOBAL_AGENT_HTTP_PROXY;
+
+    beforeEach(async () => {
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+        process.env.WHATSAPP_TEMPLATE_LANG = 'pl';
+        delete process.env.http_proxy;
+        delete process.env.https_proxy;
+        delete process.env.HTTP_PROXY;
+        delete process.env.HTTPS_PROXY;
+        delete process.env.npm_config_http_proxy;
+        delete process.env.npm_config_https_proxy;
+        delete process.env.YARN_HTTP_PROXY;
+        delete process.env.YARN_HTTPS_PROXY;
+        delete process.env.GLOBAL_AGENT_HTTP_PROXY;
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [NotificationsService],
+        }).compile();
+
+        service = module.get<NotificationsService>(NotificationsService);
+    });
+
+    afterEach(() => {
+        delete process.env.WHATSAPP_TOKEN;
+        delete process.env.WHATSAPP_PHONE_ID;
+        delete process.env.WHATSAPP_TEMPLATE_LANG;
+        if (httpProxy) process.env.http_proxy = httpProxy; else delete process.env.http_proxy;
+        if (httpsProxy) process.env.https_proxy = httpsProxy; else delete process.env.https_proxy;
+        if (HTTPProxy) process.env.HTTP_PROXY = HTTPProxy; else delete process.env.HTTP_PROXY;
+        if (HTTPSProxy) process.env.HTTPS_PROXY = HTTPSProxy; else delete process.env.HTTPS_PROXY;
+        if (npmHttpProxy) process.env.npm_config_http_proxy = npmHttpProxy; else delete process.env.npm_config_http_proxy;
+        if (npmHttpsProxy) process.env.npm_config_https_proxy = npmHttpsProxy; else delete process.env.npm_config_https_proxy;
+        if (yarnHttpProxy) process.env.YARN_HTTP_PROXY = yarnHttpProxy; else delete process.env.YARN_HTTP_PROXY;
+        if (yarnHttpsProxy) process.env.YARN_HTTPS_PROXY = yarnHttpsProxy; else delete process.env.YARN_HTTPS_PROXY;
+        if (globalProxy) process.env.GLOBAL_AGENT_HTTP_PROXY = globalProxy; else delete process.env.GLOBAL_AGENT_HTTP_PROXY;
+        nock.cleanAll();
+    });
+
+    it('sendWhatsAppTemplate posts to WhatsApp API', async () => {
+        const expectedBody = {
+            messaging_product: 'whatsapp',
+            to: '48123456789',
+            type: 'template',
+            template: {
+                name: 'template',
+                language: { code: 'pl' },
+                components: [
+                    {
+                        type: 'body',
+                        parameters: [
+                            { type: 'text', text: 'X' },
+                            { type: 'text', text: 'Y' },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        let received: any = null;
+        nock('https://graph.facebook.com')
+            .post(`/v18.0/${process.env.WHATSAPP_PHONE_ID}/messages`, (body) => {
+                received = body;
+                return true;
+            })
+            .reply(200, {});
+
+        await service.sendWhatsAppTemplate('48123456789', 'template', ['X', 'Y']);
+
+        expect(received).toEqual(expectedBody);
+        expect(nock.isDone()).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- install `nock` for backend testing
- create `notifications.service.nock.spec.ts` using `nock`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68794d2ae4b88329b22b81c417a7bef0