### PR TITLE
Add repo README with Next.js instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Salon Black & White
+
+This repository contains the Salon Black & White application.
+The Next.js frontend lives in [`frontend/`](frontend/), while the Nest.js backend
+is located in [`backend/`](backend/). The original Laravel-based frontend was
+moved to [`archive/laravel-frontend`](archive/laravel-frontend) and is no longer
+maintained.
+
+## Developing the frontend
+
+Run the Next.js development server with:
+
+```bash
+cd frontend
+npm install    # only required once
+npm run dev
+```
+
+Then open <http://localhost:3000> in your browser.
+


### PR DESCRIPTION
## Summary
- add a repository README
- explain how to start the Next.js frontend
- mention that the Laravel frontend is archived

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in frontend *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2cf91cb083299cea300544862ddf