### PR TITLE
Configure Tailwind CSS

### DIFF
--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,7 +1,6 @@
-const config = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
 };
-export default config;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
-  content: ['./app/**/*.{ts,tsx}', './src/**/*.{ts,tsx}'],
+  content: ['./app/**/*.{js,ts,jsx,tsx}', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- adjust `tailwind.config.ts` to scan files under `app/` and `src/`
- export PostCSS config directly with Tailwind and Autoprefixer plugins

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2dc30f808329a23f9e9dd0dec005