### PR TITLE
Add frontend env example

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,6 +16,14 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Environment variables
+
+Create a `.env.local` file in this folder with the following placeholder. It configures the base URL for the backend API used by the app.
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:3001
+```
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.


### PR DESCRIPTION
## Summary
- create `.env.local` with placeholder
- document variable in frontend README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: tarball data corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687a301e779c8329b6eb9b6064de2b18