### PR TITLE
Run eslint fix and address lint warnings

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,7 +38,8 @@ import { NotificationsModule } from './notifications/notifications.module';
                     autoLoadEntities: true,
                     migrations: [__dirname + '/migrations/*.ts'],
                     migrationsRun: !isSqlite,
-                    synchronize: isSqlite && process.env.NODE_ENV !== 'production',
+                    synchronize:
+                        isSqlite && process.env.NODE_ENV !== 'production',
                 } as any;
             },
         }),

--- a/backend/src/app.service.spec.ts
+++ b/backend/src/app.service.spec.ts
@@ -1,8 +1,8 @@
 import { AppService } from './app.service';
 
 describe('AppService', () => {
-  it('getHello returns greeting', () => {
-    const service = new AppService();
-    expect(service.getHello()).toBe('Hello World!');
-  });
+    it('getHello returns greeting', () => {
+        const service = new AppService();
+        expect(service.getHello()).toBe('Hello World!');
+    });
 });

--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards, Request } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+    Request,
+} from '@nestjs/common';
 import { AppointmentsService } from './appointments.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';

--- a/backend/src/appointments/appointment.entity.ts
+++ b/backend/src/appointments/appointment.entity.ts
@@ -43,6 +43,10 @@ export class Appointment {
     @OneToMany(() => Formula, (formula) => formula.appointment)
     formulas: Formula[];
 
-    @Column({ type: 'simple-enum', enum: AppointmentStatus, default: AppointmentStatus.Scheduled })
+    @Column({
+        type: 'simple-enum',
+        enum: AppointmentStatus,
+        default: AppointmentStatus.Scheduled,
+    })
     status: AppointmentStatus;
 }

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -2,9 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import {
-  ConflictException,
-  ForbiddenException,
-  BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    BadRequestException,
 } from '@nestjs/common';
 import { AppointmentsService } from './appointments.service';
 import { Appointment, AppointmentStatus } from './appointment.entity';
@@ -18,255 +18,284 @@ import { Role } from '../users/role.enum';
 import { NotificationsService } from '../notifications/notifications.service';
 
 describe('AppointmentsService', () => {
-  let service: AppointmentsService;
-  let repo: {
-    create: jest.Mock;
-    save: jest.Mock;
-    find: jest.Mock;
-    findOne: jest.Mock;
-    delete: jest.Mock;
-  };
-  let formulas: { create: jest.Mock };
-  let commissions: { getPercentForService: jest.Mock; calculateCommission: jest.Mock };
-  let logs: { create: jest.Mock };
-  let notifications: {
-    sendAppointmentConfirmation: jest.Mock;
-    sendThankYou: jest.Mock;
-    sendText: jest.Mock;
-  };
-
-  beforeEach(async () => {
-    repo = { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOne: jest.fn(), delete: jest.fn() };
-    formulas = { create: jest.fn() };
-    commissions = { getPercentForService: jest.fn(), calculateCommission: jest.fn() };
-    logs = { create: jest.fn() };
-    notifications = {
-      sendAppointmentConfirmation: jest.fn(),
-      sendThankYou: jest.fn(),
-      sendText: jest.fn(),
+    let service: AppointmentsService;
+    let repo: {
+        create: jest.Mock;
+        save: jest.Mock;
+        find: jest.Mock;
+        findOne: jest.Mock;
+        delete: jest.Mock;
+    };
+    let formulas: { create: jest.Mock };
+    let commissions: {
+        getPercentForService: jest.Mock;
+        calculateCommission: jest.Mock;
+    };
+    let logs: { create: jest.Mock };
+    let notifications: {
+        sendAppointmentConfirmation: jest.Mock;
+        sendThankYou: jest.Mock;
+        sendText: jest.Mock;
     };
 
+    beforeEach(async () => {
+        repo = {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            delete: jest.fn(),
+        };
+        formulas = { create: jest.fn() };
+        commissions = {
+            getPercentForService: jest.fn(),
+            calculateCommission: jest.fn(),
+        };
+        logs = { create: jest.fn() };
+        notifications = {
+            sendAppointmentConfirmation: jest.fn(),
+            sendThankYou: jest.fn(),
+            sendText: jest.fn(),
+        };
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        AppointmentsService,
-        { provide: getRepositoryToken(Appointment), useValue: repo },
-        { provide: getRepositoryToken(CommissionRecord), useValue: {} },
-        { provide: FormulasService, useValue: formulas },
-        { provide: CommissionsService, useValue: commissions },
-        { provide: LogsService, useValue: logs },
-        { provide: NotificationsService, useValue: notifications },
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                AppointmentsService,
+                { provide: getRepositoryToken(Appointment), useValue: repo },
+                { provide: getRepositoryToken(CommissionRecord), useValue: {} },
+                { provide: FormulasService, useValue: formulas },
+                { provide: CommissionsService, useValue: commissions },
+                { provide: LogsService, useValue: logs },
+                { provide: NotificationsService, useValue: notifications },
+            ],
+        }).compile();
 
-      ],
-    }).compile();
-
-    service = module.get<AppointmentsService>(AppointmentsService);
-  });
-
-  it('create builds and saves a new appointment', async () => {
-    const created: any = {
-      id: 1,
-      client: { phone: '111' },
-      employee: { phone: '222' },
-      startTime: new Date('2100-07-01T10:00:00.000Z'),
-    };
-    repo.create.mockReturnValue(created);
-    repo.save.mockResolvedValue(created);
-
-    const result = await service.create(1, 2, 3, '2100-07-01T10:00:00.000Z');
-
-    expect(repo.create).toHaveBeenCalledWith({
-      client: { id: 1 },
-      employee: { id: 2 },
-      service: { id: 3 },
-      startTime: new Date('2100-07-01T10:00:00.000Z'),
-      status: AppointmentStatus.Scheduled,
+        service = module.get<AppointmentsService>(AppointmentsService);
     });
-    expect(repo.save).toHaveBeenCalledWith(created);
-    expect(logs.create).toHaveBeenCalledWith(
-      LogAction.CreateAppointment,
-      JSON.stringify({
-        clientId: 1,
-        employeeId: 2,
-        serviceId: 3,
-        startTime: '2100-07-01T10:00:00.000Z',
-      }),
-      1,
-    );
-    expect(notifications.sendAppointmentConfirmation).toHaveBeenCalled();
-    expect(result).toBe(created);
-  });
 
-  it('create rejects conflicting appointment', async () => {
-    repo.findOne.mockResolvedValue({ id: 9 });
-    await expect(
-      service.create(1, 2, 3, '2100-07-01T10:00:00.000Z'),
-    ).rejects.toThrow(ConflictException);
-    expect(repo.findOne).toHaveBeenCalledWith({
-      where: {
-        employee: { id: 2 },
-        startTime: new Date('2100-07-01T10:00:00.000Z'),
-      },
+    it('create builds and saves a new appointment', async () => {
+        const created: any = {
+            id: 1,
+            client: { phone: '111' },
+            employee: { phone: '222' },
+            startTime: new Date('2100-07-01T10:00:00.000Z'),
+        };
+        repo.create.mockReturnValue(created);
+        repo.save.mockResolvedValue(created);
+
+        const result = await service.create(
+            1,
+            2,
+            3,
+            '2100-07-01T10:00:00.000Z',
+        );
+
+        expect(repo.create).toHaveBeenCalledWith({
+            client: { id: 1 },
+            employee: { id: 2 },
+            service: { id: 3 },
+            startTime: new Date('2100-07-01T10:00:00.000Z'),
+            status: AppointmentStatus.Scheduled,
+        });
+        expect(repo.save).toHaveBeenCalledWith(created);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.CreateAppointment,
+            JSON.stringify({
+                clientId: 1,
+                employeeId: 2,
+                serviceId: 3,
+                startTime: '2100-07-01T10:00:00.000Z',
+            }),
+            1,
+        );
+        expect(notifications.sendAppointmentConfirmation).toHaveBeenCalled();
+        expect(result).toBe(created);
     });
-    expect(repo.create).not.toHaveBeenCalled();
-    expect(repo.save).not.toHaveBeenCalled();
-  });
 
-  it('findClientAppointments queries by client id', async () => {
-    repo.find.mockResolvedValue([]);
-    await service.findClientAppointments(4);
-    expect(repo.find).toHaveBeenCalledWith({ where: { client: { id: 4 } } });
-  });
+    it('create rejects conflicting appointment', async () => {
+        repo.findOne.mockResolvedValue({ id: 9 });
+        await expect(
+            service.create(1, 2, 3, '2100-07-01T10:00:00.000Z'),
+        ).rejects.toThrow(ConflictException);
+        expect(repo.findOne).toHaveBeenCalledWith({
+            where: {
+                employee: { id: 2 },
+                startTime: new Date('2100-07-01T10:00:00.000Z'),
+            },
+        });
+        expect(repo.create).not.toHaveBeenCalled();
+        expect(repo.save).not.toHaveBeenCalled();
+    });
 
-  it('update modifies existing appointment', async () => {
-    const existing: any = { id: 2, status: AppointmentStatus.Scheduled };
-    repo.findOne.mockResolvedValue(existing);
-    repo.save.mockResolvedValue(existing);
+    it('findClientAppointments queries by client id', async () => {
+        repo.find.mockResolvedValue([]);
+        await service.findClientAppointments(4);
+        expect(repo.find).toHaveBeenCalledWith({
+            where: { client: { id: 4 } },
+        });
+    });
 
-    const updateParams: UpdateAppointmentParams = {
-      status: AppointmentStatus.Completed,
-      notes: 'done',
-    };
+    it('update modifies existing appointment', async () => {
+        const existing: any = { id: 2, status: AppointmentStatus.Scheduled };
+        repo.findOne.mockResolvedValue(existing);
+        repo.save.mockResolvedValue(existing);
 
-    await service.update(2, updateParams);
+        const updateParams: UpdateAppointmentParams = {
+            status: AppointmentStatus.Completed,
+            notes: 'done',
+        };
 
-    expect(existing.status).toBe(AppointmentStatus.Completed);
-    expect(existing.notes).toBe('done');
-    expect(repo.save).toHaveBeenCalledWith(existing);
-  });
+        await service.update(2, updateParams);
 
-  it('complete sets status and records commission', async () => {
-    const appt: any = {
-      id: 3,
-      status: AppointmentStatus.Scheduled,
-      service: { price: 40, defaultCommissionPercent: 0.15 },
-      employee: { id: 5 },
-    };
-    repo.findOne.mockResolvedValue(appt);
-    repo.save.mockResolvedValue(appt);
-    commissions.calculateCommission.mockResolvedValue({ amount: 6, percent: 15 } as any);
+        expect(existing.status).toBe(AppointmentStatus.Completed);
+        expect(existing.notes).toBe('done');
+        expect(repo.save).toHaveBeenCalledWith(existing);
+    });
 
-    const result = await service.complete(3);
+    it('complete sets status and records commission', async () => {
+        const appt: any = {
+            id: 3,
+            status: AppointmentStatus.Scheduled,
+            service: { price: 40, defaultCommissionPercent: 0.15 },
+            employee: { id: 5 },
+        };
+        repo.findOne.mockResolvedValue(appt);
+        repo.save.mockResolvedValue(appt);
+        commissions.calculateCommission.mockResolvedValue({
+            amount: 6,
+            percent: 15,
+        } as any);
 
-    expect(appt.status).toBe(AppointmentStatus.Completed);
-    expect(commissions.calculateCommission).toHaveBeenCalledWith(3);
-    expect(repo.save).toHaveBeenCalledWith(appt);
-    expect(logs.create).toHaveBeenCalledWith(
-      LogAction.CompleteAppointment,
-      JSON.stringify({
-        appointmentId: 3,
-        commissionAmount: 6,
-        percent: 15,
-      }),
-    );
-    expect(result).toEqual({ appointment: appt, commission: { amount: 6, percent: 15 } });
-  });
+        const result = await service.complete(3);
 
-  it('remove calls repository delete', async () => {
-    repo.delete.mockResolvedValue({});
-    await service.remove(5);
-    expect(repo.delete).toHaveBeenCalledWith(5);
-    expect(logs.create).toHaveBeenCalledWith(
-      LogAction.DeleteAppointment,
-      JSON.stringify({ appointmentId: 5 }),
-    );
-  });
+        expect(appt.status).toBe(AppointmentStatus.Completed);
+        expect(commissions.calculateCommission).toHaveBeenCalledWith(3);
+        expect(repo.save).toHaveBeenCalledWith(appt);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.CompleteAppointment,
+            JSON.stringify({
+                appointmentId: 3,
+                commissionAmount: 6,
+                percent: 15,
+            }),
+        );
+        expect(result).toEqual({
+            appointment: appt,
+            commission: { amount: 6, percent: 15 },
+        });
+    });
 
-  it('update rejects past start time', async () => {
-    const existing: any = {
-      id: 1,
-      employee: { id: 2 },
-      service: { duration: 30 },
-    };
-    repo.findOne.mockResolvedValue(existing);
-    await expect(
-      service.update(1, { startTime: '2000-01-01T00:00:00.000Z' })
-    ).rejects.toBeInstanceOf(BadRequestException);
-    expect(repo.save).not.toHaveBeenCalled();
-  });
+    it('remove calls repository delete', async () => {
+        repo.delete.mockResolvedValue({});
+        await service.remove(5);
+        expect(repo.delete).toHaveBeenCalledWith(5);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.DeleteAppointment,
+            JSON.stringify({ appointmentId: 5 }),
+        );
+    });
 
-  it('update rejects conflicting appointment', async () => {
-    const existing: any = {
-      id: 1,
-      employee: { id: 2 },
-      service: { duration: 30 },
-      startTime: new Date('2100-01-01T10:00:00.000Z'),
-    };
-    const other: any = {
-      id: 2,
-      employee: { id: 2 },
-      service: { duration: 30 },
-      startTime: new Date('2100-01-01T10:15:00.000Z'),
-    };
-    repo.findOne.mockResolvedValue(existing);
-    repo.find.mockResolvedValue([existing, other]);
-    await expect(
-      service.update(1, { startTime: '2100-01-01T10:20:00.000Z' })
-    ).rejects.toBeInstanceOf(ConflictException);
-  });
+    it('update rejects past start time', async () => {
+        const existing: any = {
+            id: 1,
+            employee: { id: 2 },
+            service: { duration: 30 },
+        };
+        repo.findOne.mockResolvedValue(existing);
+        await expect(
+            service.update(1, { startTime: '2000-01-01T00:00:00.000Z' }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(repo.save).not.toHaveBeenCalled();
+    });
 
-  it('cancel updates status when authorized', async () => {
-    const appt: any = {
-      id: 1,
-      status: AppointmentStatus.Scheduled,
-      client: { id: 2 },
-      employee: { id: 3 },
-    };
-    repo.findOne.mockResolvedValue(appt);
-    repo.save.mockResolvedValue(appt);
+    it('update rejects conflicting appointment', async () => {
+        const existing: any = {
+            id: 1,
+            employee: { id: 2 },
+            service: { duration: 30 },
+            startTime: new Date('2100-01-01T10:00:00.000Z'),
+        };
+        const other: any = {
+            id: 2,
+            employee: { id: 2 },
+            service: { duration: 30 },
+            startTime: new Date('2100-01-01T10:15:00.000Z'),
+        };
+        repo.findOne.mockResolvedValue(existing);
+        repo.find.mockResolvedValue([existing, other]);
+        await expect(
+            service.update(1, { startTime: '2100-01-01T10:20:00.000Z' }),
+        ).rejects.toBeInstanceOf(ConflictException);
+    });
 
-    await service.cancel(1, 2, Role.Client);
-    expect(appt.status).toBe(AppointmentStatus.Cancelled);
-    expect(repo.save).toHaveBeenCalledWith(appt);
-  });
+    it('cancel updates status when authorized', async () => {
+        const appt: any = {
+            id: 1,
+            status: AppointmentStatus.Scheduled,
+            client: { id: 2 },
+            employee: { id: 3 },
+        };
+        repo.findOne.mockResolvedValue(appt);
+        repo.save.mockResolvedValue(appt);
 
-  it('cancel logs action', async () => {
-    const appt: any = {
-      id: 2,
-      status: AppointmentStatus.Scheduled,
-      client: { id: 1 },
-      employee: { id: 3 },
-    };
-    repo.findOne.mockResolvedValue(appt);
-    repo.save.mockResolvedValue(appt);
+        await service.cancel(1, 2, Role.Client);
+        expect(appt.status).toBe(AppointmentStatus.Cancelled);
+        expect(repo.save).toHaveBeenCalledWith(appt);
+    });
 
-    await service.cancel(2, 1, Role.Client);
+    it('cancel logs action', async () => {
+        const appt: any = {
+            id: 2,
+            status: AppointmentStatus.Scheduled,
+            client: { id: 1 },
+            employee: { id: 3 },
+        };
+        repo.findOne.mockResolvedValue(appt);
+        repo.save.mockResolvedValue(appt);
 
-    expect(logs.create).toHaveBeenCalledWith(
-      LogAction.CancelAppointment,
-      JSON.stringify({ appointmentId: 2, userId: 1 }),
-      1,
-    );
-  });
+        await service.cancel(2, 1, Role.Client);
 
-  it('complete saves status and commission', async () => {
-    const appt: any = {
-      id: 2,
-      status: AppointmentStatus.Scheduled,
-      client: { id: 2, phone: '111' },
-      employee: { id: 3, commissionBase: 10 },
-      service: { price: 100, defaultCommissionPercent: 15 },
-      startTime: new Date('2100-07-01T10:00:00.000Z'),
-    };
-    repo.findOne.mockResolvedValue(appt);
-    repo.save.mockResolvedValue(appt);
-    commissions.calculateCommission.mockResolvedValue({ amount: 10, percent: 10 } as any);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.CancelAppointment,
+            JSON.stringify({ appointmentId: 2, userId: 1 }),
+            1,
+        );
+    });
 
-    const result = await service.complete(2, 3, Role.Employee);
+    it('complete saves status and commission', async () => {
+        const appt: any = {
+            id: 2,
+            status: AppointmentStatus.Scheduled,
+            client: { id: 2, phone: '111' },
+            employee: { id: 3, commissionBase: 10 },
+            service: { price: 100, defaultCommissionPercent: 15 },
+            startTime: new Date('2100-07-01T10:00:00.000Z'),
+        };
+        repo.findOne.mockResolvedValue(appt);
+        repo.save.mockResolvedValue(appt);
+        commissions.calculateCommission.mockResolvedValue({
+            amount: 10,
+            percent: 10,
+        } as any);
 
-    expect(appt.status).toBe(AppointmentStatus.Completed);
-    expect(commissions.calculateCommission).toHaveBeenCalledWith(2);
-    expect(repo.save).toHaveBeenCalledWith(appt);
-    expect(logs.create).toHaveBeenCalledWith(
-      LogAction.CompleteAppointment,
-      JSON.stringify({
-        appointmentId: 2,
-        commissionAmount: 10,
-        percent: 10,
-      }),
-      3,
-    );
-    expect(notifications.sendThankYou).toHaveBeenCalled();
-    expect(result).toEqual({ appointment: appt, commission: { amount: 10, percent: 10 } });
-  });
+        const result = await service.complete(2, 3, Role.Employee);
+
+        expect(appt.status).toBe(AppointmentStatus.Completed);
+        expect(commissions.calculateCommission).toHaveBeenCalledWith(2);
+        expect(repo.save).toHaveBeenCalledWith(appt);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.CompleteAppointment,
+            JSON.stringify({
+                appointmentId: 2,
+                commissionAmount: 10,
+                percent: 10,
+            }),
+            3,
+        );
+        expect(notifications.sendThankYou).toHaveBeenCalled();
+        expect(result).toEqual({
+            appointment: appt,
+            commission: { amount: 10, percent: 10 },
+        });
+    });
 });

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -1,4 +1,11 @@
-import { Injectable, Inject, forwardRef, ConflictException, ForbiddenException, BadRequestException } from '@nestjs/common';
+import {
+    Injectable,
+    Inject,
+    forwardRef,
+    ConflictException,
+    ForbiddenException,
+    BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Appointment, AppointmentStatus } from './appointment.entity';
@@ -103,7 +110,9 @@ export class AppointmentsService {
         if (dto.startTime) {
             const newStart = new Date(dto.startTime);
             if (newStart < new Date()) {
-                throw new BadRequestException('Start time must be in the future');
+                throw new BadRequestException(
+                    'Start time must be in the future',
+                );
             }
             const employeeId = dto.employeeId ?? appt.employee.id;
             let service = appt.service;
@@ -131,7 +140,9 @@ export class AppointmentsService {
                               other.service.duration * 60000,
                       );
                 if (newStart < otherEnd && newEnd > otherStart) {
-                    throw new ConflictException('Appointment time already taken');
+                    throw new ConflictException(
+                        'Appointment time already taken',
+                    );
                 }
             }
             appt.startTime = newStart;
@@ -162,12 +173,20 @@ export class AppointmentsService {
         return saved;
     }
 
-    async complete(id: number): Promise<{ appointment: Appointment; commission: CommissionRecord | null } | undefined>;
+    async complete(
+        id: number,
+    ): Promise<
+        | { appointment: Appointment; commission: CommissionRecord | null }
+        | undefined
+    >;
     async complete(
         id: number,
         userId: number,
         role: Role | EmployeeRole,
-    ): Promise<{ appointment: Appointment; commission: CommissionRecord | null } | undefined>;
+    ): Promise<
+        | { appointment: Appointment; commission: CommissionRecord | null }
+        | undefined
+    >;
     async complete(id: number, userId?: number, role?: Role | EmployeeRole) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {
@@ -217,9 +236,7 @@ export class AppointmentsService {
             userId,
         );
         if ((saved.client as any)?.phone) {
-            void this.notifications.sendThankYou(
-                (saved.client as any).phone,
-            );
+            void this.notifications.sendThankYou((saved.client as any).phone);
         }
         return { appointment: saved, commission: record };
     }
@@ -274,11 +291,7 @@ export class AppointmentsService {
         return saved;
     }
 
-    async removeForUser(
-        id: number,
-        userId: number,
-        role: Role | EmployeeRole,
-    ) {
+    async removeForUser(id: number, userId: number, role: Role | EmployeeRole) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {
             return undefined;

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Request, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
 import { AppointmentsService } from './appointments.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -19,7 +29,10 @@ export class ClientAppointmentsController {
     }
 
     @Post()
-    create(@Request() req, @Body() dto: Omit<CreateAppointmentDto, 'clientId'>) {
+    create(
+        @Request() req,
+        @Body() dto: Omit<CreateAppointmentDto, 'clientId'>,
+    ) {
         return this.service.create(
             req.user.id,
             dto.employeeId,

--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Patch, Request, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Patch,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
 import { AppointmentsService } from './appointments.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';

--- a/backend/src/appointments/reminder.service.ts
+++ b/backend/src/appointments/reminder.service.ts
@@ -39,4 +39,3 @@ export class ReminderService {
         }
     }
 }
-

--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -56,7 +56,10 @@ describe('AuthService.registerClient', () => {
             .mockResolvedValueOnce('refresh');
 
         const result = await service.registerClient(dto);
-        expect(result).toEqual({ access_token: 'access', refresh_token: 'refresh' });
+        expect(result).toEqual({
+            access_token: 'access',
+            refresh_token: 'refresh',
+        });
         expect(users.updateRefreshToken).toHaveBeenCalledWith(1, 'refresh');
         expect(jwt.signAsync).toHaveBeenNthCalledWith(1, {
             sub: 1,

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -95,7 +95,10 @@ describe('AuthService', () => {
             .mockResolvedValueOnce('refresh');
 
         const result = await service.login('b@test.com', 'secret');
-        expect(result).toEqual({ access_token: 'access', refresh_token: 'refresh' });
+        expect(result).toEqual({
+            access_token: 'access',
+            refresh_token: 'refresh',
+        });
         expect(users.updateRefreshToken).toHaveBeenCalledWith(2, 'refresh');
         expect(jwt.signAsync).toHaveBeenNthCalledWith(1, {
             sub: 2,
@@ -127,7 +130,10 @@ describe('AuthService', () => {
             .mockResolvedValueOnce('newRefresh');
 
         const result = await service.refresh('oldRefresh');
-        expect(result).toEqual({ access_token: 'newAccess', refresh_token: 'newRefresh' });
+        expect(result).toEqual({
+            access_token: 'newAccess',
+            refresh_token: 'newRefresh',
+        });
         expect(users.updateRefreshToken).toHaveBeenCalledWith(3, 'newRefresh');
     });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -29,7 +29,11 @@ export class AuthService {
         }
         const isValid = await bcrypt.compare(password, user.password);
         if (!isValid) {
-            await this.logs.create(LogAction.LoginFail, `email=${email}`, user.id);
+            await this.logs.create(
+                LogAction.LoginFail,
+                `email=${email}`,
+                user.id,
+            );
             throw new UnauthorizedException('Invalid credentials');
         }
         const { password: _pw, ...result } = user;

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -10,10 +10,10 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     }
 
     canActivate(context: ExecutionContext) {
-        const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-            context.getHandler(),
-            context.getClass(),
-        ]);
+        const isPublic = this.reflector.getAllAndOverride<boolean>(
+            IS_PUBLIC_KEY,
+            [context.getHandler(), context.getClass()],
+        );
         if (isPublic) {
             return true;
         }

--- a/backend/src/auth/roles.guard.ts
+++ b/backend/src/auth/roles.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import {
+    CanActivate,
+    ExecutionContext,
+    ForbiddenException,
+    Injectable,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY, AnyRole } from './roles.decorator';
 
@@ -7,10 +12,10 @@ export class RolesGuard implements CanActivate {
     constructor(private readonly reflector: Reflector) {}
 
     canActivate(context: ExecutionContext): boolean {
-        const requiredRoles = this.reflector.getAllAndOverride<AnyRole[]>(ROLES_KEY, [
-            context.getHandler(),
-            context.getClass(),
-        ]);
+        const requiredRoles = this.reflector.getAllAndOverride<AnyRole[]>(
+            ROLES_KEY,
+            [context.getHandler(), context.getClass()],
+        );
         if (!requiredRoles || requiredRoles.length === 0) {
             return true;
         }

--- a/backend/src/chat-messages/appointment-chat.controller.ts
+++ b/backend/src/chat-messages/appointment-chat.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, Request, ForbiddenException, UseGuards } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Param,
+    Request,
+    ForbiddenException,
+    UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';

--- a/backend/src/chat-messages/chat-message.entity.ts
+++ b/backend/src/chat-messages/chat-message.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
 import { Appointment } from '../appointments/appointment.entity';
 import { User } from '../users/user.entity';
 

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -98,9 +98,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
             userId,
             dto.content,
         );
-        this.server
-            .to(`chat-${dto.appointmentId}`)
-            .emit('message', saved);
+        this.server.to(`chat-${dto.appointmentId}`).emit('message', saved);
     }
 
     @SubscribeMessage('sendMessage')

--- a/backend/src/commissions/commission-record.entity.ts
+++ b/backend/src/commissions/commission-record.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+} from 'typeorm';
 import { Employee } from '../employees/employee.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { Product } from '../catalog/product.entity';

--- a/backend/src/commissions/commission-rule.entity.ts
+++ b/backend/src/commissions/commission-rule.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, Index } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    Index,
+} from 'typeorm';
 import { User } from '../users/user.entity';
 
 export enum CommissionTargetType {

--- a/backend/src/commissions/commissions.service.spec.ts
+++ b/backend/src/commissions/commissions.service.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CommissionsService, DEFAULT_COMMISSION_BASE } from './commissions.service';
+import {
+    CommissionsService,
+    DEFAULT_COMMISSION_BASE,
+} from './commissions.service';
 import { CommissionRecord } from './commission-record.entity';
 import { CommissionRule, CommissionTargetType } from './commission-rule.entity';
 import { Service } from '../catalog/service.entity';
@@ -10,133 +13,143 @@ import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
 
 describe('CommissionsService', () => {
-  let service: CommissionsService;
-  let repo: { create: jest.Mock; save: jest.Mock };
-  let ruleRepo: { findOne: jest.Mock };
-  let apptRepo: { findOne: jest.Mock };
-  let logs: { create: jest.Mock };
+    let service: CommissionsService;
+    let repo: { create: jest.Mock; save: jest.Mock };
+    let ruleRepo: { findOne: jest.Mock };
+    let apptRepo: { findOne: jest.Mock };
+    let logs: { create: jest.Mock };
 
-  beforeEach(async () => {
-    repo = { create: jest.fn(), save: jest.fn() };
-    ruleRepo = { findOne: jest.fn() };
-    apptRepo = { findOne: jest.fn() };
-    logs = { create: jest.fn() };
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        CommissionsService,
-        { provide: getRepositoryToken(CommissionRecord), useValue: repo },
-        { provide: getRepositoryToken(CommissionRule), useValue: ruleRepo },
-        { provide: getRepositoryToken(Appointment), useValue: apptRepo },
-        { provide: LogsService, useValue: logs },
-      ],
-    }).compile();
+    beforeEach(async () => {
+        repo = { create: jest.fn(), save: jest.fn() };
+        ruleRepo = { findOne: jest.fn() };
+        apptRepo = { findOne: jest.fn() };
+        logs = { create: jest.fn() };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CommissionsService,
+                {
+                    provide: getRepositoryToken(CommissionRecord),
+                    useValue: repo,
+                },
+                {
+                    provide: getRepositoryToken(CommissionRule),
+                    useValue: ruleRepo,
+                },
+                {
+                    provide: getRepositoryToken(Appointment),
+                    useValue: apptRepo,
+                },
+                { provide: LogsService, useValue: logs },
+            ],
+        }).compile();
 
-    service = module.get<CommissionsService>(CommissionsService);
-  });
-
-
-  it('getPercentForService uses service rule', async () => {
-    ruleRepo.findOne.mockResolvedValue({ commissionPercent: 25 });
-    const serviceObj = { id: 4, category: { id: 2 } } as Service;
-
-    const result = await service.getPercentForService(1, serviceObj, 10);
-
-    expect(ruleRepo.findOne).toHaveBeenCalledWith({
-      where: {
-        employee: { id: 1 },
-        targetType: CommissionTargetType.Service,
-        targetId: 4,
-      },
+        service = module.get<CommissionsService>(CommissionsService);
     });
-    expect(result).toBe(25);
-  });
 
-  it('getPercentForService falls back to category rule', async () => {
-    ruleRepo.findOne
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ commissionPercent: 15 });
-    const serviceObj = { id: 4, category: { id: 3 } } as Service;
+    it('getPercentForService uses service rule', async () => {
+        ruleRepo.findOne.mockResolvedValue({ commissionPercent: 25 });
+        const serviceObj = { id: 4, category: { id: 2 } } as Service;
 
-    const result = await service.getPercentForService(2, serviceObj, 5);
+        const result = await service.getPercentForService(1, serviceObj, 10);
 
-    expect(ruleRepo.findOne).toHaveBeenNthCalledWith(1, {
-      where: {
-        employee: { id: 2 },
-        targetType: CommissionTargetType.Service,
-        targetId: 4,
-      },
+        expect(ruleRepo.findOne).toHaveBeenCalledWith({
+            where: {
+                employee: { id: 1 },
+                targetType: CommissionTargetType.Service,
+                targetId: 4,
+            },
+        });
+        expect(result).toBe(25);
     });
-    expect(ruleRepo.findOne).toHaveBeenNthCalledWith(2, {
-      where: {
-        employee: { id: 2 },
-        targetType: CommissionTargetType.Category,
-        targetId: 3,
-      },
+
+    it('getPercentForService falls back to category rule', async () => {
+        ruleRepo.findOne
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ commissionPercent: 15 });
+        const serviceObj = { id: 4, category: { id: 3 } } as Service;
+
+        const result = await service.getPercentForService(2, serviceObj, 5);
+
+        expect(ruleRepo.findOne).toHaveBeenNthCalledWith(1, {
+            where: {
+                employee: { id: 2 },
+                targetType: CommissionTargetType.Service,
+                targetId: 4,
+            },
+        });
+        expect(ruleRepo.findOne).toHaveBeenNthCalledWith(2, {
+            where: {
+                employee: { id: 2 },
+                targetType: CommissionTargetType.Category,
+                targetId: 3,
+            },
+        });
+        expect(result).toBe(15);
     });
-    expect(result).toBe(15);
-  });
 
-  it('getPercentForService uses default base when none provided', async () => {
-    ruleRepo.findOne.mockResolvedValue(null);
-    const serviceObj = { id: 8 } as Service;
+    it('getPercentForService uses default base when none provided', async () => {
+        ruleRepo.findOne.mockResolvedValue(null);
+        const serviceObj = { id: 8 } as Service;
 
-    const result = await service.getPercentForService(2, serviceObj, null);
+        const result = await service.getPercentForService(2, serviceObj, null);
 
-    expect(result).toBe(DEFAULT_COMMISSION_BASE);
-  });
+        expect(result).toBe(DEFAULT_COMMISSION_BASE);
+    });
 
-  it('calculateCommission saves record and logs', async () => {
-    const appt: any = {
-      id: 5,
-      employee: { id: 7, commissionBase: 10 },
-      service: { price: 50, defaultCommissionPercent: 15 },
-    };
-    apptRepo.findOne.mockResolvedValue(appt);
-    jest
-      .spyOn(service, 'getPercentForService')
-      .mockResolvedValue(10);
-    repo.create.mockReturnValue({ amount: 5, percent: 10 });
-    repo.save.mockResolvedValue({ amount: 5, percent: 10 });
+    it('calculateCommission saves record and logs', async () => {
+        const appt: any = {
+            id: 5,
+            employee: { id: 7, commissionBase: 10 },
+            service: { price: 50, defaultCommissionPercent: 15 },
+        };
+        apptRepo.findOne.mockResolvedValue(appt);
+        jest.spyOn(service, 'getPercentForService').mockResolvedValue(10);
+        repo.create.mockReturnValue({ amount: 5, percent: 10 });
+        repo.save.mockResolvedValue({ amount: 5, percent: 10 });
 
-    const result = await service.calculateCommission(5);
+        const result = await service.calculateCommission(5);
 
-    expect(apptRepo.findOne).toHaveBeenCalledWith({ where: { id: 5 } });
-    expect(service.getPercentForService).toHaveBeenCalledWith(7, appt.service, 10);
-    expect(repo.save).toHaveBeenCalled();
-    expect(logs.create).toHaveBeenCalledWith(
-      LogAction.CommissionGranted,
-      JSON.stringify({ appointmentId: 5, amount: 5, percent: 10 }),
-      7,
-    );
-    expect(result).toEqual({ amount: 5, percent: 10 });
-  });
+        expect(apptRepo.findOne).toHaveBeenCalledWith({ where: { id: 5 } });
+        expect(service.getPercentForService).toHaveBeenCalledWith(
+            7,
+            appt.service,
+            10,
+        );
+        expect(repo.save).toHaveBeenCalled();
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.CommissionGranted,
+            JSON.stringify({ appointmentId: 5, amount: 5, percent: 10 }),
+            7,
+        );
+        expect(result).toEqual({ amount: 5, percent: 10 });
+    });
 
-  it('returns service-specific commission when rule exists', async () => {
-    ruleRepo.findOne.mockResolvedValueOnce({ commissionPercent: 20 });
-    const serviceObj = { id: 1, category: { id: 2 } } as Service;
+    it('returns service-specific commission when rule exists', async () => {
+        ruleRepo.findOne.mockResolvedValueOnce({ commissionPercent: 20 });
+        const serviceObj = { id: 1, category: { id: 2 } } as Service;
 
-    const result = await service.getPercentForService(3, serviceObj, 10);
+        const result = await service.getPercentForService(3, serviceObj, 10);
 
-    expect(result).toBe(20);
-  });
+        expect(result).toBe(20);
+    });
 
-  it('returns category commission when service rule missing', async () => {
-    ruleRepo.findOne
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ commissionPercent: 15 });
-    const serviceObj = { id: 5, category: { id: 2 } } as Service;
+    it('returns category commission when service rule missing', async () => {
+        ruleRepo.findOne
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ commissionPercent: 15 });
+        const serviceObj = { id: 5, category: { id: 2 } } as Service;
 
-    const result = await service.getPercentForService(3, serviceObj, 10);
+        const result = await service.getPercentForService(3, serviceObj, 10);
 
-    expect(result).toBe(15);
-  });
+        expect(result).toBe(15);
+    });
 
-  it('returns base commission when no matching rules', async () => {
-    ruleRepo.findOne.mockResolvedValue(null);
-    const serviceObj = { id: 6, category: { id: 9 } } as Service;
+    it('returns base commission when no matching rules', async () => {
+        ruleRepo.findOne.mockResolvedValue(null);
+        const serviceObj = { id: 6, category: { id: 9 } } as Service;
 
-    const result = await service.getPercentForService(3, serviceObj, 10);
+        const result = await service.getPercentForService(3, serviceObj, 10);
 
-    expect(result).toBe(10);
-  });
+        expect(result).toBe(10);
+    });
 });

--- a/backend/src/commissions/commissions.service.ts
+++ b/backend/src/commissions/commissions.service.ts
@@ -59,7 +59,9 @@ export class CommissionsService {
         if (base === null) {
             return DEFAULT_COMMISSION_BASE;
         }
-        return base ?? service.defaultCommissionPercent ?? DEFAULT_COMMISSION_BASE;
+        return (
+            base ?? service.defaultCommissionPercent ?? DEFAULT_COMMISSION_BASE
+        );
     }
 
     async getPercentForProduct(
@@ -85,7 +87,9 @@ export class CommissionsService {
     async calculateCommission(
         appointmentId: number,
     ): Promise<CommissionRecord | null> {
-        const appt = await this.appointments.findOne({ where: { id: appointmentId } });
+        const appt = await this.appointments.findOne({
+            where: { id: appointmentId },
+        });
         if (!appt) {
             return null;
         }
@@ -108,7 +112,11 @@ export class CommissionsService {
         const saved = await this.repo.save(record);
         await this.logs.create(
             LogAction.CommissionGranted,
-            JSON.stringify({ appointmentId: appt.id, amount: saved.amount, percent: saved.percent }),
+            JSON.stringify({
+                appointmentId: appt.id,
+                amount: saved.amount,
+                percent: saved.percent,
+            }),
             appt.employee.id,
         );
         return saved;

--- a/backend/src/commissions/employee-commission.entity.ts
+++ b/backend/src/commissions/employee-commission.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+} from 'typeorm';
 import { Employee } from '../employees/employee.entity';
 
 @Entity()

--- a/backend/src/communications/communication.entity.ts
+++ b/backend/src/communications/communication.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
 import { Customer } from '../customers/customer.entity';
 
 @Entity()

--- a/backend/src/communications/communications.service.spec.ts
+++ b/backend/src/communications/communications.service.spec.ts
@@ -38,6 +38,8 @@ describe('CommunicationsService', () => {
     it('findForCustomer queries by customer id', async () => {
         repo.find.mockResolvedValue([]);
         await service.findForCustomer(5);
-        expect(repo.find).toHaveBeenCalledWith({ where: { customer: { id: 5 } } });
+        expect(repo.find).toHaveBeenCalledWith({
+            where: { customer: { id: 5 } },
+        });
     });
 });

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -8,16 +8,16 @@ const isSqlite = url.startsWith('sqlite:');
 const dir = __dirname;
 
 export const AppDataSource = new DataSource(
-  isSqlite
-    ? {
-        type: 'sqlite',
-        database: url.replace('sqlite:', ''),
-        entities: [join(dir, '**/*.entity.ts')],
-      }
-    : {
-        type: 'postgres',
-        url,
-        entities: [join(dir, '**/*.entity.ts')],
-        migrations: [join(dir, 'migrations/*.ts')],
-      },
+    isSqlite
+        ? {
+              type: 'sqlite',
+              database: url.replace('sqlite:', ''),
+              entities: [join(dir, '**/*.entity.ts')],
+          }
+        : {
+              type: 'postgres',
+              url,
+              entities: [join(dir, '**/*.entity.ts')],
+              migrations: [join(dir, 'migrations/*.ts')],
+          },
 );

--- a/backend/src/formulas/appointment-formulas.controller.ts
+++ b/backend/src/formulas/appointment-formulas.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, ForbiddenException, Param, Post, Request, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    ForbiddenException,
+    Param,
+    Post,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -26,9 +34,16 @@ export class AppointmentFormulasController {
         if (!appointment) {
             throw new ForbiddenException();
         }
-        if (req.user.role !== Role.Admin && appointment.employee.id !== req.user.id) {
+        if (
+            req.user.role !== Role.Admin &&
+            appointment.employee.id !== req.user.id
+        ) {
             throw new ForbiddenException();
         }
-        return this.formulas.create(appointment.client.id, dto.description, appointment.id);
+        return this.formulas.create(
+            appointment.client.id,
+            dto.description,
+            appointment.id,
+        );
     }
 }

--- a/backend/src/formulas/clients-formulas.controller.ts
+++ b/backend/src/formulas/clients-formulas.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, Request, ForbiddenException, UseGuards } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Param,
+    Request,
+    ForbiddenException,
+    UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';

--- a/backend/src/formulas/formula.entity.ts
+++ b/backend/src/formulas/formula.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+} from 'typeorm';
 import { Customer } from '../customers/customer.entity';
 import { Appointment } from '../appointments/appointment.entity';
 

--- a/backend/src/formulas/formulas.controller.ts
+++ b/backend/src/formulas/formulas.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Post,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -26,6 +34,10 @@ export class FormulasController {
     @Post()
     @Roles(Role.Employee)
     create(@Body() dto: CreateFormulaDto) {
-        return this.service.create(dto.clientId, dto.description, dto.appointmentId);
+        return this.service.create(
+            dto.clientId,
+            dto.description,
+            dto.appointmentId,
+        );
     }
 }

--- a/backend/src/formulas/formulas.service.ts
+++ b/backend/src/formulas/formulas.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Inject, ForbiddenException, forwardRef } from '@nestjs/common';
+import {
+    Injectable,
+    Inject,
+    ForbiddenException,
+    forwardRef,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Formula } from './formula.entity';

--- a/backend/src/logs/log.entity.ts
+++ b/backend/src/logs/log.entity.ts
@@ -13,7 +13,11 @@ export class Log {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => User, { nullable: true, eager: true, onDelete: 'SET NULL' })
+    @ManyToOne(() => User, {
+        nullable: true,
+        eager: true,
+        onDelete: 'SET NULL',
+    })
     user: User | null;
 
     @Column({ type: 'simple-enum', enum: LogAction })

--- a/backend/src/messages/message.entity.ts
+++ b/backend/src/messages/message.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
 import { User } from '../users/user.entity';
 
 @Entity()

--- a/backend/src/messages/messages.controller.ts
+++ b/backend/src/messages/messages.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, Post, Request, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Post,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';

--- a/backend/src/messages/messages.service.spec.ts
+++ b/backend/src/messages/messages.service.spec.ts
@@ -4,44 +4,44 @@ import { MessagesService } from './messages.service';
 import { Message } from './message.entity';
 
 describe('MessagesService', () => {
-  let service: MessagesService;
-  let repo: { create: jest.Mock; save: jest.Mock; find: jest.Mock };
+    let service: MessagesService;
+    let repo: { create: jest.Mock; save: jest.Mock; find: jest.Mock };
 
-  beforeEach(async () => {
-    repo = { create: jest.fn(), save: jest.fn(), find: jest.fn() };
+    beforeEach(async () => {
+        repo = { create: jest.fn(), save: jest.fn(), find: jest.fn() };
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [MessagesService, { provide: getRepositoryToken(Message), useValue: repo }],
-    }).compile();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                MessagesService,
+                { provide: getRepositoryToken(Message), useValue: repo },
+            ],
+        }).compile();
 
-    service = module.get<MessagesService>(MessagesService);
-  });
-
-  it('create saves a new message', async () => {
-    const msg = { id: 1 } as Message;
-    repo.create.mockReturnValue(msg);
-    repo.save.mockResolvedValue(msg);
-
-    const result = await service.create(1, 2, 'hello');
-
-    expect(repo.create).toHaveBeenCalledWith({
-      sender: { id: 1 },
-      recipient: { id: 2 },
-      content: 'hello',
+        service = module.get<MessagesService>(MessagesService);
     });
-    expect(repo.save).toHaveBeenCalledWith(msg);
-    expect(result).toBe(msg);
-  });
 
-  it('findForUser queries for both sender and recipient', async () => {
-    repo.find.mockResolvedValue([]);
-    await service.findForUser(3);
-    expect(repo.find).toHaveBeenCalledWith({
-      where: [
-        { sender: { id: 3 } },
-        { recipient: { id: 3 } },
-      ],
-      order: { id: 'ASC' },
+    it('create saves a new message', async () => {
+        const msg = { id: 1 } as Message;
+        repo.create.mockReturnValue(msg);
+        repo.save.mockResolvedValue(msg);
+
+        const result = await service.create(1, 2, 'hello');
+
+        expect(repo.create).toHaveBeenCalledWith({
+            sender: { id: 1 },
+            recipient: { id: 2 },
+            content: 'hello',
+        });
+        expect(repo.save).toHaveBeenCalledWith(msg);
+        expect(result).toBe(msg);
     });
-  });
+
+    it('findForUser queries for both sender and recipient', async () => {
+        repo.find.mockResolvedValue([]);
+        await service.findForUser(3);
+        expect(repo.find).toHaveBeenCalledWith({
+            where: [{ sender: { id: 3 } }, { recipient: { id: 3 } }],
+            order: { id: 'ASC' },
+        });
+    });
 });

--- a/backend/src/messages/messages.service.ts
+++ b/backend/src/messages/messages.service.ts
@@ -21,10 +21,7 @@ export class MessagesService {
 
     findForUser(userId: number) {
         return this.repo.find({
-            where: [
-                { sender: { id: userId } },
-                { recipient: { id: userId } },
-            ],
+            where: [{ sender: { id: userId } }, { recipient: { id: userId } }],
             order: { id: 'ASC' },
         });
     }

--- a/backend/src/migrations/20250711192005-CreateServicesTable.ts
+++ b/backend/src/migrations/20250711192005-CreateServicesTable.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
 export class CreateServicesTable20250711192005 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/migrations/20250711192006-CreateProductsTable.ts
+++ b/backend/src/migrations/20250711192006-CreateProductsTable.ts
@@ -15,7 +15,12 @@ export class CreateProductsTable20250711192006 implements MigrationInterface {
                     },
                     { name: 'name', type: 'varchar' },
                     { name: 'brand', type: 'varchar', isNullable: true },
-                    { name: 'unitPrice', type: 'decimal', precision: 10, scale: 2 },
+                    {
+                        name: 'unitPrice',
+                        type: 'decimal',
+                        precision: 10,
+                        scale: 2,
+                    },
                     { name: 'stock', type: 'int' },
                 ],
             }),

--- a/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
+++ b/backend/src/migrations/20250711192007-CreateAppointmentsTable.ts
@@ -1,6 +1,13 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
-export class CreateAppointmentsTable20250711192007 implements MigrationInterface {
+export class CreateAppointmentsTable20250711192007
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.createTable(
             new Table({

--- a/backend/src/migrations/20250711192008-CreateFormulasTable.ts
+++ b/backend/src/migrations/20250711192008-CreateFormulasTable.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
 export class CreateFormulasTable20250711192008 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
+++ b/backend/src/migrations/20250711192009-CreateCommissionRecordsTable.ts
@@ -1,6 +1,13 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
-export class CreateCommissionRecordsTable20250711192009 implements MigrationInterface {
+export class CreateCommissionRecordsTable20250711192009
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.createTable(
             new Table({
@@ -16,7 +23,12 @@ export class CreateCommissionRecordsTable20250711192009 implements MigrationInte
                     { name: 'employeeId', type: 'int' },
                     { name: 'appointmentId', type: 'int', isNullable: true },
                     { name: 'productId', type: 'int', isNullable: true },
-                    { name: 'amount', type: 'decimal', precision: 10, scale: 2 },
+                    {
+                        name: 'amount',
+                        type: 'decimal',
+                        precision: 10,
+                        scale: 2,
+                    },
                     { name: 'percent', type: 'float' },
                     {
                         name: 'createdAt',

--- a/backend/src/migrations/20250711192010-AddCommissionBaseToUser.ts
+++ b/backend/src/migrations/20250711192010-AddCommissionBaseToUser.ts
@@ -1,6 +1,8 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddCommissionBaseToUser20250711192010 implements MigrationInterface {
+export class AddCommissionBaseToUser20250711192010
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.addColumn(
             'user',

--- a/backend/src/migrations/20250711192011-CreateMessagesTable.ts
+++ b/backend/src/migrations/20250711192011-CreateMessagesTable.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
 export class CreateMessagesTable20250711192011 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/migrations/20250711192013-CreateLogsTable.ts
+++ b/backend/src/migrations/20250711192013-CreateLogsTable.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
 export class CreateLogsTable20250711192013 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/migrations/20250711192015-AddCommissionsAndCommunications.ts
+++ b/backend/src/migrations/20250711192015-AddCommissionsAndCommunications.ts
@@ -1,20 +1,36 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
-export class AddCommissionsAndCommunications20250711192015 implements MigrationInterface {
+export class AddCommissionsAndCommunications20250711192015
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.createTable(
             new Table({
                 name: 'employee_commission',
                 columns: [
-                    { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
                     { name: 'employeeId', type: 'int' },
-                    { name: 'amount', type: 'decimal', precision: 10, scale: 2 },
+                    {
+                        name: 'amount',
+                        type: 'decimal',
+                        precision: 10,
+                        scale: 2,
+                    },
                     { name: 'percent', type: 'float' },
                     { name: 'createdAt', type: 'timestamp', default: 'now()' },
                 ],
-                indices: [
-                    { columnNames: ['employeeId'] },
-                ],
+                indices: [{ columnNames: ['employeeId'] }],
             }),
         );
         await queryRunner.createForeignKey(
@@ -31,7 +47,13 @@ export class AddCommissionsAndCommunications20250711192015 implements MigrationI
             new Table({
                 name: 'communication',
                 columns: [
-                    { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
                     { name: 'customerId', type: 'int', isNullable: true },
                     { name: 'medium', type: 'varchar' },
                     { name: 'content', type: 'text' },

--- a/backend/src/migrations/20250711192016-CreateReviewsTable.ts
+++ b/backend/src/migrations/20250711192016-CreateReviewsTable.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
 export class CreateReviewsTable20250711192016 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
@@ -19,9 +24,7 @@ export class CreateReviewsTable20250711192016 implements MigrationInterface {
                     { name: 'comment', type: 'text', isNullable: true },
                     { name: 'createdAt', type: 'timestamp', default: 'now()' },
                 ],
-                indices: [
-                    { columnNames: ['reservationId'], isUnique: true },
-                ],
+                indices: [{ columnNames: ['reservationId'], isUnique: true }],
             }),
         );
         await queryRunner.createForeignKeys('review', [

--- a/backend/src/migrations/20250711192017-CreateCommissionRulesTable.ts
+++ b/backend/src/migrations/20250711192017-CreateCommissionRulesTable.ts
@@ -1,6 +1,13 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
-export class CreateCommissionRulesTable20250711192017 implements MigrationInterface {
+export class CreateCommissionRulesTable20250711192017
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.createTable(
             new Table({

--- a/backend/src/migrations/20250711192018-CreateSalesTable.ts
+++ b/backend/src/migrations/20250711192018-CreateSalesTable.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
 export class CreateSalesTable20250711192018 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/migrations/20250711192019-CreateChatMessagesTable.ts
+++ b/backend/src/migrations/20250711192019-CreateChatMessagesTable.ts
@@ -1,6 +1,13 @@
-import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
 
-export class CreateChatMessagesTable20250711192019 implements MigrationInterface {
+export class CreateChatMessagesTable20250711192019
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.createTable(
             new Table({

--- a/backend/src/notifications/notifications.service.nock.spec.ts
+++ b/backend/src/notifications/notifications.service.nock.spec.ts
@@ -38,15 +38,24 @@ describe('NotificationsService with nock', () => {
         delete process.env.WHATSAPP_TOKEN;
         delete process.env.WHATSAPP_PHONE_ID;
         delete process.env.WHATSAPP_TEMPLATE_LANG;
-        if (httpProxy) process.env.http_proxy = httpProxy; else delete process.env.http_proxy;
-        if (httpsProxy) process.env.https_proxy = httpsProxy; else delete process.env.https_proxy;
-        if (HTTPProxy) process.env.HTTP_PROXY = HTTPProxy; else delete process.env.HTTP_PROXY;
-        if (HTTPSProxy) process.env.HTTPS_PROXY = HTTPSProxy; else delete process.env.HTTPS_PROXY;
-        if (npmHttpProxy) process.env.npm_config_http_proxy = npmHttpProxy; else delete process.env.npm_config_http_proxy;
-        if (npmHttpsProxy) process.env.npm_config_https_proxy = npmHttpsProxy; else delete process.env.npm_config_https_proxy;
-        if (yarnHttpProxy) process.env.YARN_HTTP_PROXY = yarnHttpProxy; else delete process.env.YARN_HTTP_PROXY;
-        if (yarnHttpsProxy) process.env.YARN_HTTPS_PROXY = yarnHttpsProxy; else delete process.env.YARN_HTTPS_PROXY;
-        if (globalProxy) process.env.GLOBAL_AGENT_HTTP_PROXY = globalProxy; else delete process.env.GLOBAL_AGENT_HTTP_PROXY;
+        if (httpProxy) process.env.http_proxy = httpProxy;
+        else delete process.env.http_proxy;
+        if (httpsProxy) process.env.https_proxy = httpsProxy;
+        else delete process.env.https_proxy;
+        if (HTTPProxy) process.env.HTTP_PROXY = HTTPProxy;
+        else delete process.env.HTTP_PROXY;
+        if (HTTPSProxy) process.env.HTTPS_PROXY = HTTPSProxy;
+        else delete process.env.HTTPS_PROXY;
+        if (npmHttpProxy) process.env.npm_config_http_proxy = npmHttpProxy;
+        else delete process.env.npm_config_http_proxy;
+        if (npmHttpsProxy) process.env.npm_config_https_proxy = npmHttpsProxy;
+        else delete process.env.npm_config_https_proxy;
+        if (yarnHttpProxy) process.env.YARN_HTTP_PROXY = yarnHttpProxy;
+        else delete process.env.YARN_HTTP_PROXY;
+        if (yarnHttpsProxy) process.env.YARN_HTTPS_PROXY = yarnHttpsProxy;
+        else delete process.env.YARN_HTTPS_PROXY;
+        if (globalProxy) process.env.GLOBAL_AGENT_HTTP_PROXY = globalProxy;
+        else delete process.env.GLOBAL_AGENT_HTTP_PROXY;
         nock.cleanAll();
     });
 
@@ -72,13 +81,19 @@ describe('NotificationsService with nock', () => {
 
         let received: any = null;
         nock('https://graph.facebook.com')
-            .post(`/v18.0/${process.env.WHATSAPP_PHONE_ID}/messages`, (body) => {
-                received = body;
-                return true;
-            })
+            .post(
+                `/v18.0/${process.env.WHATSAPP_PHONE_ID}/messages`,
+                (body) => {
+                    received = body;
+                    return true;
+                },
+            )
             .reply(200, {});
 
-        await service.sendWhatsAppTemplate('48123456789', 'template', ['X', 'Y']);
+        await service.sendWhatsAppTemplate('48123456789', 'template', [
+            'X',
+            'Y',
+        ]);
 
         expect(received).toEqual(expectedBody);
         expect(nock.isDone()).toBe(true);

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -20,7 +20,9 @@ describe('NotificationsService', () => {
     });
 
     it('sendText posts to WhatsApp API', async () => {
-        const postMock = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} } as any);
+        const postMock = jest
+            .spyOn(axios, 'post')
+            .mockResolvedValue({ data: {} } as any);
         process.env.WHATSAPP_TOKEN = 't';
         process.env.WHATSAPP_PHONE_ID = '123';
 
@@ -44,12 +46,17 @@ describe('NotificationsService', () => {
     });
 
     it('sendWhatsAppTemplate posts to WhatsApp API', async () => {
-        const postMock = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} } as any);
+        const postMock = jest
+            .spyOn(axios, 'post')
+            .mockResolvedValue({ data: {} } as any);
         process.env.WHATSAPP_TOKEN = 't';
         process.env.WHATSAPP_PHONE_ID = '123';
         process.env.WHATSAPP_TEMPLATE_LANG = 'pl';
 
-        await service.sendWhatsAppTemplate('48123456789', 'template', ['X', 'Y']);
+        await service.sendWhatsAppTemplate('48123456789', 'template', [
+            'X',
+            'Y',
+        ]);
 
         expect(postMock).toHaveBeenCalledWith(
             'https://graph.facebook.com/v18.0/123/messages',

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+} from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';

--- a/backend/src/sales/sale.entity.ts
+++ b/backend/src/sales/sale.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
 import { Customer } from '../customers/customer.entity';
 import { Employee } from '../employees/employee.entity';
 import { Product } from '../catalog/product.entity';

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -18,11 +18,18 @@ export class SalesService {
         private readonly commissionService: CommissionsService,
     ) {}
 
-    async create(clientId: number, employeeId: number, productId: number, quantity: number) {
+    async create(
+        clientId: number,
+        employeeId: number,
+        productId: number,
+        quantity: number,
+    ) {
         if (quantity <= 0) {
             throw new BadRequestException('quantity must be > 0');
         }
-        const product = await this.products.findOne({ where: { id: productId } });
+        const product = await this.products.findOne({
+            where: { id: productId },
+        });
         if (!product) {
             throw new BadRequestException('invalid product');
         }

--- a/backend/src/services/services.module.ts
+++ b/backend/src/services/services.module.ts
@@ -7,7 +7,10 @@ import { ServicesController } from './services.controller';
 import { LogsModule } from '../logs/logs.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ServiceEntity, Appointment]), LogsModule],
+    imports: [
+        TypeOrmModule.forFeature([ServiceEntity, Appointment]),
+        LogsModule,
+    ],
     controllers: [ServicesController],
     providers: [ServicesService],
 })

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+    Injectable,
+    NotFoundException,
+    BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Service as ServiceEntity } from '../catalog/service.entity';
@@ -45,7 +49,9 @@ export class ServicesService {
             return undefined;
         }
         if (dto.categoryId !== undefined) {
-            entity.category = dto.categoryId ? ({ id: dto.categoryId } as any) : null;
+            entity.category = dto.categoryId
+                ? ({ id: dto.categoryId } as any)
+                : null;
         }
         if (dto.name !== undefined) {
             entity.name = dto.name;
@@ -75,7 +81,9 @@ export class ServicesService {
         if (!entity) {
             throw new NotFoundException();
         }
-        const count = await this.appointments.count({ where: { service: { id } } });
+        const count = await this.appointments.count({
+            where: { service: { id } },
+        });
         if (count > 0) {
             throw new BadRequestException('Service has existing appointments');
         }

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,4 +1,11 @@
-import { IsEmail, IsEnum, IsOptional, IsString, IsNotEmpty, MinLength } from 'class-validator';
+import {
+    IsEmail,
+    IsEnum,
+    IsOptional,
+    IsString,
+    IsNotEmpty,
+    MinLength,
+} from 'class-validator';
 import { Role } from '../role.enum';
 
 export class CreateUserDto {

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -29,7 +29,10 @@ describe('UsersService', () => {
             providers: [
                 UsersService,
                 { provide: getRepositoryToken(User), useValue: repo },
-                { provide: getRepositoryToken(Appointment), useValue: appointments },
+                {
+                    provide: getRepositoryToken(Appointment),
+                    useValue: appointments,
+                },
             ],
         }).compile();
 
@@ -41,12 +44,19 @@ describe('UsersService', () => {
         repo.findOne.mockResolvedValue(user);
 
         await expect(service.findByEmail('a@test.com')).resolves.toEqual(user);
-        expect(repo.findOne).toHaveBeenCalledWith({ where: { email: 'a@test.com' } });
+        expect(repo.findOne).toHaveBeenCalledWith({
+            where: { email: 'a@test.com' },
+        });
     });
 
     it('createUser hashes the password before calling save', async () => {
         const plain = 'secret';
-        const created = { email: 'a@test.com', password: 'hashed', name: 'A', role: Role.Client } as User;
+        const created = {
+            email: 'a@test.com',
+            password: 'hashed',
+            name: 'A',
+            role: Role.Client,
+        } as User;
         repo.create.mockReturnValue(created);
         repo.save.mockResolvedValue(created);
 
@@ -67,7 +77,12 @@ describe('UsersService', () => {
     });
 
     it('updateCustomer hashes password and saves changes', async () => {
-        const user = { id: 1, email: 'old@test.com', password: 'p', name: 'Old' } as User;
+        const user = {
+            id: 1,
+            email: 'old@test.com',
+            password: 'p',
+            name: 'Old',
+        } as User;
         repo.findOne.mockResolvedValue(user);
         repo.save.mockResolvedValue(user);
 
@@ -80,6 +95,8 @@ describe('UsersService', () => {
 
     it('updateCustomer returns undefined when user missing', async () => {
         repo.findOne.mockResolvedValue(undefined);
-        await expect(service.updateCustomer(2, { name: 'x' })).resolves.toBeUndefined();
+        await expect(
+            service.updateCustomer(2, { name: 'x' }),
+        ).resolves.toBeUndefined();
     });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+    Injectable,
+    BadRequestException,
+    NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
@@ -81,9 +85,13 @@ export class UsersService {
         if (!user) {
             throw new NotFoundException();
         }
-        const count = await this.appointments.count({ where: { client: { id } } });
+        const count = await this.appointments.count({
+            where: { client: { id } },
+        });
         if (count > 0) {
-            throw new BadRequestException('Cannot delete user with appointments');
+            throw new BadRequestException(
+                'Cannot delete user with appointments',
+            );
         }
         return this.usersRepository.delete(id);
     }
@@ -96,9 +104,13 @@ export class UsersService {
         if (!user) {
             throw new NotFoundException();
         }
-        const count = await this.appointments.count({ where: { employee: { id } } });
+        const count = await this.appointments.count({
+            where: { employee: { id } },
+        });
         if (count > 0) {
-            throw new BadRequestException('Cannot delete user with appointments');
+            throw new BadRequestException(
+                'Cannot delete user with appointments',
+            );
         }
         return this.usersRepository.delete(id);
     }

--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -10,13 +10,11 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Service as CatalogService } from './../src/catalog/service.entity';
 import { Appointment } from './../src/appointments/appointment.entity';
 
-
 describe('AppointmentsModule (e2e)', () => {
     let app: INestApplication<App>;
     let usersService: UsersService;
     let servicesRepo: Repository<CatalogService>;
     let appointmentsRepo: Repository<Appointment>;
-
 
     beforeEach(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -29,7 +27,6 @@ describe('AppointmentsModule (e2e)', () => {
         usersService = moduleFixture.get(UsersService);
         servicesRepo = moduleFixture.get(getRepositoryToken(CatalogService));
         appointmentsRepo = moduleFixture.get(getRepositoryToken(Appointment));
-
     });
 
     afterEach(async () => {
@@ -41,7 +38,11 @@ describe('AppointmentsModule (e2e)', () => {
     it('client can list own appointments', async () => {
         const register = await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'client@test.com', password: 'secret', name: 'Client' })
+            .send({
+                email: 'client@test.com',
+                password: 'secret',
+                name: 'Client',
+            })
             .expect(201);
         const token = register.body.access_token;
         await request(app.getHttpServer())
@@ -53,7 +54,11 @@ describe('AppointmentsModule (e2e)', () => {
     it('client cannot access admin endpoints', async () => {
         const register = await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'client2@test.com', password: 'secret', name: 'Client' })
+            .send({
+                email: 'client2@test.com',
+                password: 'secret',
+                name: 'Client',
+            })
             .expect(201);
         const token = register.body.access_token;
         await request(app.getHttpServer())
@@ -63,8 +68,18 @@ describe('AppointmentsModule (e2e)', () => {
     });
 
     it('admin can CRUD appointments', async () => {
-        const client = await usersService.createUser('c@test.com', 'secret', 'C', Role.Client);
-        const employee = await usersService.createUser('e@test.com', 'secret', 'E', Role.Employee);
+        const client = await usersService.createUser(
+            'c@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await usersService.createUser(
+            'e@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
         await usersService.createUser('a@test.com', 'secret', 'A', Role.Admin);
 
         const login = await request(app.getHttpServer())
@@ -73,7 +88,9 @@ describe('AppointmentsModule (e2e)', () => {
             .expect(201);
         const token = login.body.access_token;
 
-        const futureTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        const futureTime = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+        ).toISOString();
         const create = await request(app.getHttpServer())
             .post('/appointments/admin')
             .set('Authorization', `Bearer ${token}`)
@@ -99,10 +116,10 @@ describe('AppointmentsModule (e2e)', () => {
             .expect(200);
     });
 
-      it('client can create an appointment', async () => {
-          await servicesRepo.save(
-              servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
-          );
+    it('client can create an appointment', async () => {
+        await servicesRepo.save(
+            servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
+        );
         const client = await usersService.createUser(
             'client3@test.com',
             'secret',
@@ -121,7 +138,9 @@ describe('AppointmentsModule (e2e)', () => {
             .send({ email: 'client3@test.com', password: 'secret' })
             .expect(201);
         const token = login.body.access_token;
-        const startTime = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
+        const startTime = new Date(
+            Date.now() + 48 * 60 * 60 * 1000,
+        ).toISOString();
 
         const res = await request(app.getHttpServer())
             .post('/appointments/client')
@@ -139,121 +158,157 @@ describe('AppointmentsModule (e2e)', () => {
         expect(saved).toBeDefined();
         expect(saved?.client.id).toBe(client.id);
         expect(saved?.employee.id).toBe(employee.id);
-          expect(saved?.service.id).toBe(1);
-      });
+        expect(saved?.service.id).toBe(1);
+    });
 
-      it('rejects appointment with past start time', async () => {
-          await servicesRepo.save(
-              servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
-          );
-          const client = await usersService.createUser(
-              'past@test.com',
-              'secret',
-              'P',
-              Role.Client,
-          );
-          const employee = await usersService.createUser(
-              'pastemp@test.com',
-              'secret',
-              'E',
-              Role.Employee,
-          );
+    it('rejects appointment with past start time', async () => {
+        await servicesRepo.save(
+            servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
+        );
+        const client = await usersService.createUser(
+            'past@test.com',
+            'secret',
+            'P',
+            Role.Client,
+        );
+        const employee = await usersService.createUser(
+            'pastemp@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
 
-          const login = await request(app.getHttpServer())
-              .post('/auth/login')
-              .send({ email: 'past@test.com', password: 'secret' })
-              .expect(201);
-          const token = login.body.access_token;
-          const startTime = '2020-01-01T11:00:00.000Z';
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'past@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+        const startTime = '2020-01-01T11:00:00.000Z';
 
-          await request(app.getHttpServer())
-              .post('/appointments/client')
-              .set('Authorization', `Bearer ${token}`)
-              .send({
-                  employeeId: employee.id,
-                  serviceId: 1,
-                  startTime,
-              })
-              .expect(400);
+        await request(app.getHttpServer())
+            .post('/appointments/client')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime,
+            })
+            .expect(400);
 
-          const appts = await appointmentsRepo.find();
-      expect(appts.length).toBe(0);
-      });
+        const appts = await appointmentsRepo.find();
+        expect(appts.length).toBe(0);
+    });
 
-      it('rejects updating appointment to past time', async () => {
-          const admin = await usersService.createUser('upadmin@test.com', 'secret', 'A', Role.Admin);
-          const client = await usersService.createUser('upclient@test.com', 'secret', 'C', Role.Client);
-          const employee = await usersService.createUser('upemp@test.com', 'secret', 'E', Role.Employee);
+    it('rejects updating appointment to past time', async () => {
+        const admin = await usersService.createUser(
+            'upadmin@test.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const client = await usersService.createUser(
+            'upclient@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await usersService.createUser(
+            'upemp@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
 
-          const login = await request(app.getHttpServer())
-              .post('/auth/login')
-              .send({ email: 'upadmin@test.com', password: 'secret' })
-              .expect(201);
-          const token = login.body.access_token;
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'upadmin@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
 
-          const futureTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
-          const create = await request(app.getHttpServer())
-              .post('/appointments/admin')
-              .set('Authorization', `Bearer ${token}`)
-              .send({
-                  clientId: client.id,
-                  employeeId: employee.id,
-                  serviceId: 1,
-                  startTime: futureTime,
-              })
-              .expect(201);
+        const futureTime = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+        ).toISOString();
+        const create = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: futureTime,
+            })
+            .expect(201);
 
-          const id = create.body.id;
+        const id = create.body.id;
 
-          await request(app.getHttpServer())
-              .patch(`/appointments/admin/${id}`)
-              .set('Authorization', `Bearer ${token}`)
-              .send({ startTime: '2020-01-01T11:00:00.000Z' })
-              .expect(400);
-      });
+        await request(app.getHttpServer())
+            .patch(`/appointments/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ startTime: '2020-01-01T11:00:00.000Z' })
+            .expect(400);
+    });
 
-      it('rejects conflicting appointment update', async () => {
-          const admin = await usersService.createUser('confadmin@test.com', 'secret', 'A', Role.Admin);
-          const client = await usersService.createUser('confclient@test.com', 'secret', 'C', Role.Client);
-          const employee = await usersService.createUser('confemp@test.com', 'secret', 'E', Role.Employee);
+    it('rejects conflicting appointment update', async () => {
+        const admin = await usersService.createUser(
+            'confadmin@test.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const client = await usersService.createUser(
+            'confclient@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await usersService.createUser(
+            'confemp@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
 
-          const login = await request(app.getHttpServer())
-              .post('/auth/login')
-              .send({ email: 'confadmin@test.com', password: 'secret' })
-              .expect(201);
-          const token = login.body.access_token;
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'confadmin@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
 
-          const start1 = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
-          const appt1 = await request(app.getHttpServer())
-              .post('/appointments/admin')
-              .set('Authorization', `Bearer ${token}`)
-              .send({
-                  clientId: client.id,
-                  employeeId: employee.id,
-                  serviceId: 1,
-                  startTime: start1,
-              })
-              .expect(201);
+        const start1 = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        const appt1 = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: start1,
+            })
+            .expect(201);
 
-          const start2 = new Date(Date.parse(start1) + 60 * 60 * 1000).toISOString();
-          const appt2 = await request(app.getHttpServer())
-              .post('/appointments/admin')
-              .set('Authorization', `Bearer ${token}`)
-              .send({
-                  clientId: client.id,
-                  employeeId: employee.id,
-                  serviceId: 1,
-                  startTime: start2,
-              })
-              .expect(201);
+        const start2 = new Date(
+            Date.parse(start1) + 60 * 60 * 1000,
+        ).toISOString();
+        const appt2 = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: start2,
+            })
+            .expect(201);
 
-          const conflictStart = new Date(Date.parse(start1) + 15 * 60 * 1000).toISOString();
-          await request(app.getHttpServer())
-              .patch(`/appointments/admin/${appt2.body.id}`)
-              .set('Authorization', `Bearer ${token}`)
-              .send({ startTime: conflictStart })
-              .expect(409);
-      });
+        const conflictStart = new Date(
+            Date.parse(start1) + 15 * 60 * 1000,
+        ).toISOString();
+        await request(app.getHttpServer())
+            .patch(`/appointments/admin/${appt2.body.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ startTime: conflictStart })
+            .expect(409);
+    });
 
     it('rejects unauthenticated appointment creation', async () => {
         await servicesRepo.save(
@@ -265,7 +320,9 @@ describe('AppointmentsModule (e2e)', () => {
             'E',
             Role.Employee,
         );
-        const startTime = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
+        const startTime = new Date(
+            Date.now() + 72 * 60 * 60 * 1000,
+        ).toISOString();
         await request(app.getHttpServer())
             .post('/appointments/client')
             .send({

--- a/backend/test/chat-messages.e2e-spec.ts
+++ b/backend/test/chat-messages.e2e-spec.ts
@@ -43,8 +43,18 @@ describe('ChatMessages (e2e)', () => {
         await servicesRepo.save(
             servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
         );
-        const client = await users.createUser('chatc@test.com', 'secret', 'C', Role.Client);
-        const emp = await users.createUser('chate@test.com', 'secret', 'E', Role.Employee);
+        const client = await users.createUser(
+            'chatc@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const emp = await users.createUser(
+            'chate@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
         const start = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
         const appt = await appointments.create(client.id, emp.id, 1, start);
 

--- a/backend/test/commissions.e2e-spec.ts
+++ b/backend/test/commissions.e2e-spec.ts
@@ -28,11 +28,18 @@ describe('CommissionsModule (e2e)', () => {
     });
 
     it('rejects unauthenticated requests', () => {
-        return request(app.getHttpServer()).get('/commissions/employee').expect(401);
+        return request(app.getHttpServer())
+            .get('/commissions/employee')
+            .expect(401);
     });
 
     it('employee can list own commissions', async () => {
-        await usersService.createUser('emp@comm.com', 'secret', 'Emp', Role.Employee);
+        await usersService.createUser(
+            'emp@comm.com',
+            'secret',
+            'Emp',
+            Role.Employee,
+        );
         const login = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'emp@comm.com', password: 'secret' })
@@ -45,7 +52,12 @@ describe('CommissionsModule (e2e)', () => {
     });
 
     it('employee cannot access admin commissions', async () => {
-        await usersService.createUser('emp2@comm.com', 'secret', 'Emp2', Role.Employee);
+        await usersService.createUser(
+            'emp2@comm.com',
+            'secret',
+            'Emp2',
+            Role.Employee,
+        );
         const login = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'emp2@comm.com', password: 'secret' })

--- a/backend/test/employee-reception.e2e-spec.ts
+++ b/backend/test/employee-reception.e2e-spec.ts
@@ -32,10 +32,23 @@ describe('Reception role restrictions (e2e)', () => {
     });
 
     it('rejects FRYZJER accessing reception-only endpoint', async () => {
-        const employee = await usersService.createUser('fry@test.com', 'secret', 'F', Role.Employee);
-        const client = await usersService.createUser('clientf@test.com', 'secret', 'C', Role.Client);
+        const employee = await usersService.createUser(
+            'fry@test.com',
+            'secret',
+            'F',
+            Role.Employee,
+        );
+        const client = await usersService.createUser(
+            'clientf@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const tokens = await authService.generateTokens(employee.id, EmployeeRole.FRYZJER);
+        const tokens = await authService.generateTokens(
+            employee.id,
+            EmployeeRole.FRYZJER,
+        );
         const token = tokens.access_token;
 
         await request(app.getHttpServer())
@@ -46,10 +59,23 @@ describe('Reception role restrictions (e2e)', () => {
     });
 
     it('allows RECEPCJA employee to update customer', async () => {
-        const reception = await usersService.createUser('rec@test.com', 'secret', 'R', Role.Employee);
-        const client = await usersService.createUser('clientr@test.com', 'secret', 'C', Role.Client);
+        const reception = await usersService.createUser(
+            'rec@test.com',
+            'secret',
+            'R',
+            Role.Employee,
+        );
+        const client = await usersService.createUser(
+            'clientr@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const tokens = await authService.generateTokens(reception.id, EmployeeRole.RECEPCJA);
+        const tokens = await authService.generateTokens(
+            reception.id,
+            EmployeeRole.RECEPCJA,
+        );
         const token = tokens.access_token;
 
         await request(app.getHttpServer())
@@ -60,8 +86,18 @@ describe('Reception role restrictions (e2e)', () => {
     });
 
     it('allows admin user to update customer', async () => {
-        await usersService.createUser('adminr@test.com', 'secret', 'A', Role.Admin);
-        const client = await usersService.createUser('clienta@test.com', 'secret', 'C', Role.Client);
+        await usersService.createUser(
+            'adminr@test.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const client = await usersService.createUser(
+            'clienta@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')

--- a/backend/test/formulas.e2e-spec.ts
+++ b/backend/test/formulas.e2e-spec.ts
@@ -36,11 +36,30 @@ describe('FormulasModule (e2e)', () => {
     });
 
     it('employee can create formula for their appointment', async () => {
-        await servicesRepo.save(servicesRepo.create({ name: 'cut', duration: 30, price: 10 }));
-        const client = await users.createUser('cf@test.com', 'secret', 'C', Role.Client);
-        const employee = await users.createUser('ef@test.com', 'secret', 'E', Role.Employee);
-        const startTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
-        const appt = await appointments.create(client.id, employee.id, 1, startTime);
+        await servicesRepo.save(
+            servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
+        );
+        const client = await users.createUser(
+            'cf@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await users.createUser(
+            'ef@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const startTime = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+        ).toISOString();
+        const appt = await appointments.create(
+            client.id,
+            employee.id,
+            1,
+            startTime,
+        );
 
         const loginEmp = await request(app.getHttpServer())
             .post('/auth/login')
@@ -69,12 +88,36 @@ describe('FormulasModule (e2e)', () => {
     });
 
     it('forbids other employees from adding formula', async () => {
-        await servicesRepo.save(servicesRepo.create({ name: 'cut', duration: 30, price: 10 }));
-        const client = await users.createUser('cf2@test.com', 'secret', 'C', Role.Client);
-        const emp1 = await users.createUser('emp1@test.com', 'secret', 'E1', Role.Employee);
-        const emp2 = await users.createUser('emp2@test.com', 'secret', 'E2', Role.Employee);
-        const startTime2 = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
-        const appt = await appointments.create(client.id, emp1.id, 1, startTime2);
+        await servicesRepo.save(
+            servicesRepo.create({ name: 'cut', duration: 30, price: 10 }),
+        );
+        const client = await users.createUser(
+            'cf2@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const emp1 = await users.createUser(
+            'emp1@test.com',
+            'secret',
+            'E1',
+            Role.Employee,
+        );
+        const emp2 = await users.createUser(
+            'emp2@test.com',
+            'secret',
+            'E2',
+            Role.Employee,
+        );
+        const startTime2 = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+        ).toISOString();
+        const appt = await appointments.create(
+            client.id,
+            emp1.id,
+            1,
+            startTime2,
+        );
 
         const loginEmp2 = await request(app.getHttpServer())
             .post('/auth/login')

--- a/backend/test/logs.e2e-spec.ts
+++ b/backend/test/logs.e2e-spec.ts
@@ -38,7 +38,11 @@ describe('LogsModule (e2e)', () => {
     it('forbids client from accessing logs', async () => {
         await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'client@logs.com', password: 'secret', name: 'Client' })
+            .send({
+                email: 'client@logs.com',
+                password: 'secret',
+                name: 'Client',
+            })
             .expect(201);
 
         const login = await request(app.getHttpServer())

--- a/backend/test/messages.e2e-spec.ts
+++ b/backend/test/messages.e2e-spec.ts
@@ -28,8 +28,18 @@ describe('MessagesModule (e2e)', () => {
     });
 
     it('allows sending and listing messages', async () => {
-        const client = await usersService.createUser('client@msg.com', 'secret', 'Client', Role.Client);
-        const employee = await usersService.createUser('emp@msg.com', 'secret', 'Emp', Role.Employee);
+        const client = await usersService.createUser(
+            'client@msg.com',
+            'secret',
+            'Client',
+            Role.Client,
+        );
+        const employee = await usersService.createUser(
+            'emp@msg.com',
+            'secret',
+            'Emp',
+            Role.Employee,
+        );
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')
@@ -51,7 +61,12 @@ describe('MessagesModule (e2e)', () => {
     });
 
     it('forbids admin from accessing messages endpoints', async () => {
-        await usersService.createUser('admin@msg.com', 'secret', 'Admin', Role.Admin);
+        await usersService.createUser(
+            'admin@msg.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')

--- a/backend/test/products.e2e-spec.ts
+++ b/backend/test/products.e2e-spec.ts
@@ -49,7 +49,12 @@ describe('ProductsModule (e2e)', () => {
     });
 
     it('rejects negative values on update', async () => {
-        await users.createUser('admin2@prod.com', 'secret', 'Admin', Role.Admin);
+        await users.createUser(
+            'admin2@prod.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')

--- a/backend/test/reviews.e2e-spec.ts
+++ b/backend/test/reviews.e2e-spec.ts
@@ -10,57 +10,67 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Appointment } from './../src/appointments/appointment.entity';
 
 describe('ReviewsModule (e2e)', () => {
-  let app: INestApplication<App>;
-  let users: UsersService;
-  let appointmentsRepo: Repository<Appointment>;
+    let app: INestApplication<App>;
+    let users: UsersService;
+    let appointmentsRepo: Repository<Appointment>;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
-    await app.init();
-    users = moduleFixture.get(UsersService);
-    appointmentsRepo = moduleFixture.get(getRepositoryToken(Appointment));
-  });
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        users = moduleFixture.get(UsersService);
+        appointmentsRepo = moduleFixture.get(getRepositoryToken(Appointment));
+    });
 
-  afterEach(async () => {
-    if (app) {
-      await app.close();
-    }
-  });
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
 
-  it('rejects duplicate reviews for a reservation', async () => {
-    const client = await users.createUser('client@review.com', 'secret', 'C', Role.Client);
-    const employee = await users.createUser('emp@review.com', 'secret', 'E', Role.Employee);
+    it('rejects duplicate reviews for a reservation', async () => {
+        const client = await users.createUser(
+            'client@review.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await users.createUser(
+            'emp@review.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
 
-    const appointment = await appointmentsRepo.save(
-      appointmentsRepo.create({
-        client: { id: client.id } as any,
-        employee: { id: employee.id } as any,
-        service: { id: 1 } as any,
-        startTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
-      }),
-    );
+        const appointment = await appointmentsRepo.save(
+            appointmentsRepo.create({
+                client: { id: client.id } as any,
+                employee: { id: employee.id } as any,
+                service: { id: 1 } as any,
+                startTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            }),
+        );
 
-    const login = await request(app.getHttpServer())
-      .post('/auth/login')
-      .send({ email: 'client@review.com', password: 'secret' })
-      .expect(201);
-    const token = login.body.access_token;
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'client@review.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
 
-    await request(app.getHttpServer())
-      .post('/reviews')
-      .set('Authorization', `Bearer ${token}`)
-      .send({ reservationId: appointment.id, rating: 5 })
-      .expect(201);
+        await request(app.getHttpServer())
+            .post('/reviews')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ reservationId: appointment.id, rating: 5 })
+            .expect(201);
 
-    await request(app.getHttpServer())
-      .post('/reviews')
-      .set('Authorization', `Bearer ${token}`)
-      .send({ reservationId: appointment.id, rating: 4 })
-      .expect(400);
-  });
+        await request(app.getHttpServer())
+            .post('/reviews')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ reservationId: appointment.id, rating: 4 })
+            .expect(400);
+    });
 });

--- a/backend/test/services.e2e-spec.ts
+++ b/backend/test/services.e2e-spec.ts
@@ -1,102 +1,136 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
+import { Response } from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 import { UsersService } from './../src/users/users.service';
 import { Role } from './../src/users/role.enum';
 
 describe('ServicesModule (e2e)', () => {
-  let app: INestApplication<App>;
-  let users: UsersService;
+    let app: INestApplication<App>;
+    let users: UsersService;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
-    await app.init();
-    users = moduleFixture.get(UsersService);
-  });
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        users = moduleFixture.get(UsersService);
+    });
 
-  afterEach(async () => {
-    if (app) {
-      await app.close();
-    }
-  });
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
 
-  it('rejects client creating a service', async () => {
-    const register = await request(app.getHttpServer())
-      .post('/auth/register')
-      .send({ email: 'client@services.com', password: 'secret', name: 'Client' })
-      .expect(201);
-    const token = register.body.access_token;
+    it('rejects client creating a service', async () => {
+        const register = await request(app.getHttpServer())
+            .post('/auth/register')
+            .send({
+                email: 'client@services.com',
+                password: 'secret',
+                name: 'Client',
+            })
+            .expect(201);
 
-    await request(app.getHttpServer())
-      .post('/services')
-      .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'cut', duration: 30, price: 10 })
-      .expect(403);
-  });
+        const token = (register.body as { access_token: string }).access_token;
 
-  it('returns 404 when deleting missing service', async () => {
-    await users.createUser('admin@services.com', 'secret', 'Admin', Role.Admin);
+        await request(app.getHttpServer())
+            .post('/services')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'cut', duration: 30, price: 10 })
+            .expect(403);
+    });
 
-    const login = await request(app.getHttpServer())
-      .post('/auth/login')
-      .send({ email: 'admin@services.com', password: 'secret' })
-      .expect(201);
-    const token = login.body.access_token;
+    it('returns 404 when deleting missing service', async () => {
+        await users.createUser(
+            'admin@services.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
 
-    await request(app.getHttpServer())
-      .delete('/services/9999')
-      .set('Authorization', `Bearer ${token}`)
-      .expect(404);
-  });
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@services.com', password: 'secret' })
+            .expect(201);
 
-  it('responds 404 for deleting a nonexistent service', async () => {
-    await users.createUser('otheradmin@services.com', 'secret', 'Admin', Role.Admin);
+        const token = (login.body as { access_token: string }).access_token;
 
-    const login = await request(app.getHttpServer())
-      .post('/auth/login')
-      .send({ email: 'otheradmin@services.com', password: 'secret' })
-      .expect(201);
-    const token = login.body.access_token;
+        await request(app.getHttpServer())
+            .delete('/services/9999')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+    });
 
-    await request(app.getHttpServer())
-      .delete('/services/8888')
-      .set('Authorization', `Bearer ${token}`)
-      .expect(404);
-  });
+    it('responds 404 for deleting a nonexistent service', async () => {
+        await users.createUser(
+            'otheradmin@services.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
 
-  it('rejects deleting service with appointments', async () => {
-    const client = await users.createUser('svcclient@test.com', 'secret', 'C', Role.Client);
-    const employee = await users.createUser('svcemp@test.com', 'secret', 'E', Role.Employee);
-    await users.createUser('svcadmin@test.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'otheradmin@services.com', password: 'secret' })
+            .expect(201);
 
-    const login = await request(app.getHttpServer())
-      .post('/auth/login')
-      .send({ email: 'svcadmin@test.com', password: 'secret' })
-      .expect(201);
-    const token = login.body.access_token;
+        const token = (login.body as { access_token: string }).access_token;
 
-    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
-    await request(app.getHttpServer())
-      .post('/appointments/admin')
-      .set('Authorization', `Bearer ${token}`)
-      .send({
-        clientId: client.id,
-        employeeId: employee.id,
-        serviceId: 1,
-        startTime: future,
-      })
-      .expect(201);
+        await request(app.getHttpServer())
+            .delete('/services/8888')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+    });
 
-    await request(app.getHttpServer())
-      .delete('/services/1')
-      .set('Authorization', `Bearer ${token}`)
-      .expect(400);
-  });
+    it('rejects deleting service with appointments', async () => {
+        const client = await users.createUser(
+            'svcclient@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+        const employee = await users.createUser(
+            'svcemp@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        await users.createUser(
+            'svcadmin@test.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'svcadmin@test.com', password: 'secret' })
+            .expect(201);
+
+        const token = (login.body as { access_token: string }).access_token;
+
+        const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: future,
+            })
+            .expect(201);
+
+        await request(app.getHttpServer())
+            .delete('/services/1')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(400);
+    });
 });

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -6,54 +6,54 @@ import { Service as CatalogService } from '../src/catalog/service.entity';
 
 config({ path: '.env' });
 if (!process.env.DATABASE_URL) {
-  process.env.DATABASE_URL = 'sqlite:./test.sqlite';
+    process.env.DATABASE_URL = 'sqlite:./test.sqlite';
 }
 
 let dataSource: DataSource;
 
 beforeAll(async () => {
-  const url = process.env.DATABASE_URL as string;
-  const isSqlite = url.startsWith('sqlite:');
-  dataSource = new DataSource(
-    isSqlite
-      ? {
-          type: 'sqlite',
-          database: url.replace('sqlite:', ''),
-          entities: [join(__dirname, '../src/**/*.entity.ts')],
-        }
-      : {
-          type: 'postgres',
-          url,
-          entities: [join(__dirname, '../src/**/*.entity.ts')],
-          migrations: [join(__dirname, '../src/migrations/*.ts')],
-        }
-  );
-  await dataSource.initialize();
-  if (isSqlite) {
-    await dataSource.synchronize();
-  } else {
-    await dataSource.runMigrations();
-  }
-  const repo = dataSource.getRepository(CatalogService);
-  await repo.save(repo.create({ name: 'cut', duration: 30, price: 10 }));
-  (dataSource as any).isSqlite = isSqlite;
-});
-
-afterEach(async () => {
-  if (dataSource?.isInitialized) {
-    if ((dataSource as any).isSqlite) {
-      await dataSource.synchronize(true);
+    const url = process.env.DATABASE_URL as string;
+    const isSqlite = url.startsWith('sqlite:');
+    dataSource = new DataSource(
+        isSqlite
+            ? {
+                  type: 'sqlite',
+                  database: url.replace('sqlite:', ''),
+                  entities: [join(__dirname, '../src/**/*.entity.ts')],
+              }
+            : {
+                  type: 'postgres',
+                  url,
+                  entities: [join(__dirname, '../src/**/*.entity.ts')],
+                  migrations: [join(__dirname, '../src/migrations/*.ts')],
+              },
+    );
+    await dataSource.initialize();
+    if (isSqlite) {
+        await dataSource.synchronize();
     } else {
-      await dataSource.dropDatabase();
-      await dataSource.runMigrations();
+        await dataSource.runMigrations();
     }
     const repo = dataSource.getRepository(CatalogService);
     await repo.save(repo.create({ name: 'cut', duration: 30, price: 10 }));
-  }
+    (dataSource as DataSource & { isSqlite?: boolean }).isSqlite = isSqlite;
+});
+
+afterEach(async () => {
+    if (dataSource?.isInitialized) {
+        if ((dataSource as DataSource & { isSqlite?: boolean }).isSqlite) {
+            await dataSource.synchronize(true);
+        } else {
+            await dataSource.dropDatabase();
+            await dataSource.runMigrations();
+        }
+        const repo = dataSource.getRepository(CatalogService);
+        await repo.save(repo.create({ name: 'cut', duration: 30, price: 10 }));
+    }
 });
 
 afterAll(async () => {
-  if (dataSource?.isInitialized) {
-    await dataSource.destroy();
-  }
+    if (dataSource?.isInitialized) {
+        await dataSource.destroy();
+    }
 });

--- a/backend/test/users-delete.e2e-spec.ts
+++ b/backend/test/users-delete.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
+import { Response } from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 import { UsersService } from './../src/users/users.service';
@@ -28,21 +29,42 @@ describe('User deletion (e2e)', () => {
     });
 
     it('rejects deleting customer with appointments', async () => {
-        const admin = await usersService.createUser('deladmin@test.com', 'secret', 'A', Role.Admin);
-        const employee = await usersService.createUser('delemployee@test.com', 'secret', 'E', Role.Employee);
-        const client = await usersService.createUser('delclient@test.com', 'secret', 'C', Role.Client);
+        await usersService.createUser(
+            'deladmin@test.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const employee = await usersService.createUser(
+            'delemployee@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const client = await usersService.createUser(
+            'delclient@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const login = await request(app.getHttpServer())
+        const login: Response = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'deladmin@test.com', password: 'secret' })
             .expect(201);
-        const token = login.body.access_token;
+
+        const token = (login.body as { access_token: string }).access_token;
 
         const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
         await request(app.getHttpServer())
             .post('/appointments/admin')
             .set('Authorization', `Bearer ${token}`)
-            .send({ clientId: client.id, employeeId: employee.id, serviceId: 1, startTime: future })
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: future,
+            })
             .expect(201);
 
         await request(app.getHttpServer())
@@ -52,21 +74,42 @@ describe('User deletion (e2e)', () => {
     });
 
     it('rejects deleting employee with appointments', async () => {
-        const admin = await usersService.createUser('empadmin@test.com', 'secret', 'A', Role.Admin);
-        const employee = await usersService.createUser('empdel@test.com', 'secret', 'E', Role.Employee);
-        const client = await usersService.createUser('empclient@test.com', 'secret', 'C', Role.Client);
+        await usersService.createUser(
+            'empadmin@test.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const employee = await usersService.createUser(
+            'empdel@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const client = await usersService.createUser(
+            'empclient@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const login = await request(app.getHttpServer())
+        const login: Response = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'empadmin@test.com', password: 'secret' })
             .expect(201);
-        const token = login.body.access_token;
+
+        const token = (login.body as { access_token: string }).access_token;
 
         const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
         await request(app.getHttpServer())
             .post('/appointments/admin')
             .set('Authorization', `Bearer ${token}`)
-            .send({ clientId: client.id, employeeId: employee.id, serviceId: 1, startTime: future })
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                serviceId: 1,
+                startTime: future,
+            })
             .expect(201);
 
         await request(app.getHttpServer())
@@ -76,12 +119,18 @@ describe('User deletion (e2e)', () => {
     });
 
     it('prevents admin from deleting self', async () => {
-        const admin = await usersService.createUser('self@test.com', 'secret', 'Self', Role.Admin);
-        const login = await request(app.getHttpServer())
+        const admin = await usersService.createUser(
+            'self@test.com',
+            'secret',
+            'Self',
+            Role.Admin,
+        );
+        const login: Response = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'self@test.com', password: 'secret' })
             .expect(201);
-        const token = login.body.access_token;
+
+        const token = (login.body as { access_token: string }).access_token;
 
         await request(app.getHttpServer())
             .delete(`/users/employees/${admin.id}`)

--- a/backend/test/users-update.e2e-spec.ts
+++ b/backend/test/users-update.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
+import { Response } from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 import { UsersService } from './../src/users/users.service';
@@ -32,28 +33,53 @@ describe('Customer update (e2e)', () => {
     });
 
     it('allows admin to update customer', async () => {
-        await usersService.createUser('admupd@test.com', 'secret', 'A', Role.Admin);
-        const client = await usersService.createUser('custupd@test.com', 'secret', 'C', Role.Client);
+        await usersService.createUser(
+            'admupd@test.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const client = await usersService.createUser(
+            'custupd@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const login = await request(app.getHttpServer())
+        const login: Response = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'admupd@test.com', password: 'secret' })
             .expect(201);
-        const token = login.body.access_token;
+
+        const token = (login.body as { access_token: string }).access_token;
 
         await request(app.getHttpServer())
             .patch(`/users/customers/${client.id}`)
             .set('Authorization', `Bearer ${token}`)
             .send({ name: 'Updated' })
             .expect(200)
-            .expect(res => expect(res.body.name).toBe('Updated'));
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            .expect((res) => expect(res.body.name).toBe('Updated'));
     });
 
     it('allows reception role to update customer', async () => {
-        const reception = await usersService.createUser('recupd@test.com', 'secret', 'R', Role.Employee);
-        const client = await usersService.createUser('custrec@test.com', 'secret', 'C', Role.Client);
+        const reception = await usersService.createUser(
+            'recupd@test.com',
+            'secret',
+            'R',
+            Role.Employee,
+        );
+        const client = await usersService.createUser(
+            'custrec@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const tokens = await authService.generateTokens(reception.id, EmployeeRole.RECEPCJA);
+        const tokens: AuthTokensDto = await authService.generateTokens(
+            reception.id,
+            EmployeeRole.RECEPCJA,
+        );
         const token = tokens.access_token;
 
         await request(app.getHttpServer())
@@ -64,14 +90,25 @@ describe('Customer update (e2e)', () => {
     });
 
     it('rejects other roles updating customer', async () => {
-        await usersService.createUser('empupd@test.com', 'secret', 'E', Role.Employee);
-        const client = await usersService.createUser('custfail@test.com', 'secret', 'C', Role.Client);
+        await usersService.createUser(
+            'empupd@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const client = await usersService.createUser(
+            'custfail@test.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
 
-        const login = await request(app.getHttpServer())
+        const login: Response = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'empupd@test.com', password: 'secret' })
             .expect(201);
-        const token = login.body.access_token;
+
+        const token = (login.body as { access_token: string }).access_token;
 
         await request(app.getHttpServer())
             .patch(`/users/customers/${client.id}`)


### PR DESCRIPTION
## Summary
- run `eslint --fix`
- clean up unused variables in tests
- suppress unsafe `any` warnings in e2e tests
- type `isSqlite` flag in test setup

## Testing
- `npm run lint --fix`

------
https://chatgpt.com/codex/tasks/task_e_687a34ae38f483299abdaedd7e3ca2b4