### PR TITLE
Add frontend build dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ yarn-error.log
 node_modules/
 dist/
 
+# Ignore Next.js build output and dependencies
+frontend/node_modules/
+frontend/.next/
+
 # tailwindcss binary
 tailwindcss
 


### PR DESCRIPTION
## Summary
- ignore frontend `node_modules` and `.next` build output

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a377638d08329bf52e5b6b1f47de5