### PR TITLE
Update frontend docs for npm integrity errors

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,3 +42,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Recovering from integrity errors
+
+If `npm` reports integrity errors, clean the cache and reinstall dependencies:
+
+```bash
+npm cache clean --force && npm install
+```
+
+Make sure you have a working internet connection. If issues persist, delete the
+`node_modules` directory and run `npm install` again.


### PR DESCRIPTION
## Summary
- document recovery steps for npm integrity errors in `frontend/README.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a5208ec348329bdba26f56ff8226a