### PR TITLE
Add format script to frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,3 +53,11 @@ npm cache clean --force && npm install
 
 Make sure you have a working internet connection. If issues persist, delete the
 `node_modules` directory and run `npm install` again.
+
+## Formatting code
+
+Run the Prettier script to automatically format source files:
+
+```bash
+npm run format
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write '**/*.{ts,tsx,js,jsx,css,md}'"
   },
   "dependencies": {
     "autoprefixer": "^10.4.21",
@@ -28,6 +29,7 @@
     "eslint-config-next": "15.4.1",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",
+    "prettier": "^3.4.2",
     "tailwindcss": "^4",
     "typescript": "^5",
     "typescript-eslint": "^8.37.0"


### PR DESCRIPTION
## Summary
- add `npm run format` script to `frontend/package.json`
- include `prettier` in frontend dev deps
- document formatting instructions in frontend README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ab5db5dac8329b82dfd89ec52d480