### PR TITLE
Implement dashboard page with stats

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { ReviewsModule } from './reviews/reviews.module';
 import { ChatModule } from './chat/chat.module';
 import { ChatMessagesModule } from './chat-messages/chat-messages.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
     imports: [
@@ -58,6 +59,7 @@ import { NotificationsModule } from './notifications/notifications.module';
         ChatModule,
         LogsModule,
         CommunicationsModule,
+        DashboardModule,
         NotificationsModule,
     ],
     controllers: [AppController, HealthController],

--- a/backend/src/dashboard/dashboard.controller.ts
+++ b/backend/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+@UseGuards(JwtAuthGuard)
+export class DashboardController {
+  constructor(private readonly service: DashboardService) {}
+
+  @Get()
+  getStats() {
+    return this.service.getStats();
+  }
+}

--- a/backend/src/dashboard/dashboard.module.ts
+++ b/backend/src/dashboard/dashboard.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { User } from '../users/user.entity';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Appointment])],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/backend/src/dashboard/dashboard.service.ts
+++ b/backend/src/dashboard/dashboard.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, MoreThan, Not } from 'typeorm';
+import { Appointment, AppointmentStatus } from '../appointments/appointment.entity';
+import { User } from '../users/user.entity';
+import { Role } from '../users/role.enum';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(User) private readonly users: Repository<User>,
+    @InjectRepository(Appointment) private readonly appts: Repository<Appointment>,
+  ) {}
+
+  async getStats() {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+
+    const clientCount = await this.users.count({ where: { role: Role.Client } });
+    const employeeCount = await this.users.count({ where: { role: Not(Role.Client) } });
+    const todayCount = await this.appts.count({
+      where: {
+        startTime: Between(start, end),
+        status: AppointmentStatus.Scheduled,
+      },
+    });
+    const upcoming = await this.appts.find({
+      where: {
+        startTime: MoreThan(now),
+        status: AppointmentStatus.Scheduled,
+      },
+      order: { startTime: 'ASC' },
+      take: 5,
+    });
+    return {
+      clientCount,
+      todayCount,
+      employeeCount,
+      upcoming,
+    };
+  }
+}

--- a/frontend/cypress/e2e/dashboard.cy.ts
+++ b/frontend/cypress/e2e/dashboard.cy.ts
@@ -1,0 +1,12 @@
+describe('dashboard access', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' });
+  });
+
+  it('loads after login', () => {
+    cy.visit('/dashboard');
+    cy.contains('Klienci');
+    cy.contains('Pracownicy');
+  });
+});

--- a/frontend/cypress/fixtures/dashboard.json
+++ b/frontend/cypress/fixtures/dashboard.json
@@ -1,0 +1,8 @@
+{
+  "clientCount": 2,
+  "todayCount": 1,
+  "employeeCount": 3,
+  "upcoming": [
+    {"id":1,"startTime":"2025-07-20T10:00:00Z","client":{"name":"Anna"}}
+  ]
+}

--- a/frontend/src/__tests__/dashboardWidget.test.tsx
+++ b/frontend/src/__tests__/dashboardWidget.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import DashboardWidget from '@/components/DashboardWidget';
+
+describe('DashboardWidget', () => {
+  it('renders value', () => {
+    render(<DashboardWidget label="Test" value={5} />);
+    expect(screen.getByText('Test')).toBeInTheDocument();
+    expect(screen.getByTestId('value').textContent).toBe('5');
+  });
+
+  it('shows loader', () => {
+    render(<DashboardWidget label="X" value={0} loading />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DashboardWidget.tsx
+++ b/frontend/src/components/DashboardWidget.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  label: string;
+  value: number | null;
+  loading?: boolean;
+}
+
+export default function DashboardWidget({ label, value, loading }: Props) {
+  return (
+    <div className="p-4 bg-white rounded shadow">
+      {loading ? (
+        <div role="status" className="h-6 bg-gray-200 animate-pulse" />
+      ) : (
+        <>
+          <div className="text-sm text-gray-500">{label}</div>
+          <div data-testid="value" className="text-2xl font-bold">
+            {value}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex">
+      <aside className="hidden md:block w-48 bg-gray-200 p-4">Menu</aside>
+      <div className="flex-1 flex flex-col">
+        <header className="bg-gray-100 border-b p-4 font-bold">Dashboard</header>
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { Appointment, DashboardResponse } from '@/types';
+
+export interface DashboardData extends DashboardResponse {}
+
+export function useDashboard() {
+  const { apiFetch } = useAuth();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    apiFetch<DashboardData>('/dashboard')
+      .then((d) => mounted && setData(d))
+      .finally(() => mounted && setLoading(false));
+    return () => {
+      mounted = false;
+    };
+  }, [apiFetch]);
+
+  return { data, loading };
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '@/contexts/AuthContext';
+import '@/app/globals.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -1,9 +1,56 @@
 import RouteGuard from '@/components/RouteGuard';
+import Layout from '@/components/Layout';
+import DashboardWidget from '@/components/DashboardWidget';
+import { useDashboard } from '@/hooks/useDashboard';
 
 export default function DashboardPage() {
+  const { data, loading } = useDashboard();
+
   return (
     <RouteGuard>
-      <div>Dashboard</div>
+      <Layout>
+        <div className="grid gap-4 md:grid-cols-3">
+          <DashboardWidget
+            label="Klienci"
+            value={data?.clientCount ?? 0}
+            loading={loading}
+          />
+          <DashboardWidget
+            label="Dzisiejsze rezerwacje"
+            value={data?.todayCount ?? 0}
+            loading={loading}
+          />
+          <DashboardWidget
+            label="Pracownicy"
+            value={data?.employeeCount ?? 0}
+            loading={loading}
+          />
+        </div>
+        <div className="mt-6">
+          {loading ? (
+            <div role="status" className="h-32 bg-gray-200 animate-pulse" />
+          ) : (
+            <table className="min-w-full border">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="p-2 text-left">ID</th>
+                  <th className="p-2 text-left">Data</th>
+                  <th className="p-2 text-left">Klient</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data?.upcoming.map((a) => (
+                  <tr key={a.id} className="border-t">
+                    <td className="p-2">{a.id}</td>
+                    <td className="p-2">{new Date(a.startTime).toLocaleString()}</td>
+                    <td className="p-2">{a.client?.name}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </Layout>
     </RouteGuard>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,11 +5,18 @@ export interface Client {
 
 export interface Appointment {
   id: number;
-  date: string;
-  clientId: number;
+  startTime: string;
+  client?: Client;
 }
 
 export interface Service {
   id: number;
   name: string;
+}
+
+export interface DashboardResponse {
+  clientCount: number;
+  todayCount: number;
+  employeeCount: number;
+  upcoming: Appointment[];
 }


### PR DESCRIPTION
## Summary
- add backend dashboard API returning client, employee and appointment stats
- build frontend dashboard with Tailwind layout and widgets
- load data from API with a custom hook
- cover widgets with unit tests and add cypress test

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`
- `npx cypress run --headless` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_687ac9f27be08329820e0f7d13b1420f