### PR TITLE
Add basic client management page

### DIFF
--- a/frontend/cypress/e2e/clients.cy.ts
+++ b/frontend/cypress/e2e/clients.cy.ts
@@ -1,0 +1,17 @@
+describe('clients crud', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+  });
+
+  it('loads and creates client', () => {
+    cy.intercept('GET', '**/clients', { fixture: 'clients.json' }).as('getClients');
+    cy.intercept('POST', '**/clients', { id: 3, name: 'New' }).as('createClient');
+    cy.visit('/clients');
+    cy.wait('@getClients');
+    cy.contains('Add Client').click();
+    cy.get('input[placeholder="Name"]').type('New');
+    cy.contains('button', 'Save').click();
+    cy.wait('@createClient');
+    cy.contains('New');
+  });
+});

--- a/frontend/cypress/fixtures/clients.json
+++ b/frontend/cypress/fixtures/clients.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "name": "Alice" },
+  { "id": 2, "name": "Bob" }
+]

--- a/frontend/src/__tests__/clientForm.test.tsx
+++ b/frontend/src/__tests__/clientForm.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ClientForm from '@/components/ClientForm';
+
+describe('ClientForm', () => {
+  it('validates name', async () => {
+    const onSubmit = jest.fn();
+    render(<ClientForm onSubmit={onSubmit} onCancel={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits valid data', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(<ClientForm onSubmit={onSubmit} onCancel={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'John' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'John' }));
+  });
+});

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -1,0 +1,25 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { Client } from '@/types';
+
+export function useClientApi() {
+  const { apiFetch } = useAuth();
+
+  const create = (data: { name: string }) =>
+    apiFetch<Client>('/clients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+  const update = (id: number, data: { name: string }) =>
+    apiFetch<Client>(`/clients/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+  const remove = (id: number) =>
+    apiFetch<void>(`/clients/${id}`, { method: 'DELETE' });
+
+  return { create, update, remove };
+}

--- a/frontend/src/components/ClientForm.tsx
+++ b/frontend/src/components/ClientForm.tsx
@@ -1,0 +1,53 @@
+import { FormEvent, useState } from 'react';
+import { z } from 'zod';
+import { Client } from '@/types';
+
+const schema = z.object({
+  name: z.string().min(1, { message: 'Name is required' }),
+});
+
+interface Props {
+  initial?: Partial<Client>;
+  onSubmit: (data: { name: string }) => Promise<void>;
+  onCancel: () => void;
+}
+
+export default function ClientForm({ initial, onSubmit, onCancel }: Props) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = schema.parse({ name });
+      await onSubmit(data);
+    } catch (err: any) {
+      if (err.errors) setError(err.errors[0].message);
+      else setError('Error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="border p-1 w-full"
+        placeholder="Name"
+      />
+      {error && (
+        <p role="alert" className="text-red-600 text-sm">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2 justify-end">
+        <button type="button" onClick={onCancel} className="border px-2 py-1">
+          Cancel
+        </button>
+        <button type="submit" className="border px-2 py-1">
+          Save
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+
+export interface Column<T> {
+  header: string;
+  accessor: keyof T;
+}
+
+interface Props<T> {
+  data: T[];
+  columns: Column<T>[];
+  initialSort?: keyof T;
+  renderActions?: (row: T) => React.ReactNode;
+}
+
+export default function DataTable<T>({
+  data,
+  columns,
+  initialSort,
+  renderActions,
+}: Props<T>) {
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<keyof T | undefined>(initialSort);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [page, setPage] = useState(0);
+  const pageSize = 10;
+
+  const filtered = data.filter((item) =>
+    columns.some((c) =>
+      String(item[c.accessor])
+        .toLowerCase()
+        .includes(search.toLowerCase())
+    )
+  );
+
+  const sorted = sortKey
+    ? [...filtered].sort((a, b) => {
+        const av = a[sortKey];
+        const bv = b[sortKey];
+        if (av === bv) return 0;
+        if (sortDir === 'asc') return av > bv ? 1 : -1;
+        return av < bv ? 1 : -1;
+      })
+    : filtered;
+
+  const paginated = sorted.slice(page * pageSize, (page + 1) * pageSize);
+  const totalPages = Math.ceil(sorted.length / pageSize);
+
+  const toggleSort = (key: keyof T) => {
+    if (sortKey === key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  return (
+    <div>
+      <input
+        placeholder="Search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="border p-1 mb-2"
+      />
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-50">
+            {columns.map((col) => (
+              <th
+                key={String(col.accessor)}
+                className="p-2 text-left cursor-pointer"
+                onClick={() => toggleSort(col.accessor)}
+              >
+                {col.header}
+                {sortKey === col.accessor && (sortDir === 'asc' ? ' ▲' : ' ▼')}
+              </th>
+            ))}
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {paginated.map((row, i) => (
+            <tr key={i} className="border-t">
+              {columns.map((col) => (
+                <td key={String(col.accessor)} className="p-2">
+                  {String(row[col.accessor])}
+                </td>
+              ))}
+              <td className="p-2">{renderActions ? renderActions(row) : null}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-2 flex items-center gap-2">
+        <button
+          disabled={page === 0}
+          onClick={() => setPage((p) => Math.max(p - 1, 0))}
+          className="border px-2 py-1"
+        >
+          Prev
+        </button>
+        <span>
+          {page + 1} / {totalPages || 1}
+        </span>
+        <button
+          disabled={page + 1 >= totalPages}
+          onClick={() => setPage((p) => Math.min(p + 1, totalPages - 1))}
+          className="border px-2 py-1"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, useEffect } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: Props) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (open) document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
+      <div className="bg-white p-4 rounded shadow min-w-[300px]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/clients/index.tsx
+++ b/frontend/src/pages/clients/index.tsx
@@ -1,9 +1,105 @@
+import { useState } from 'react';
 import RouteGuard from '@/components/RouteGuard';
+import Layout from '@/components/Layout';
+import DataTable, { Column } from '@/components/DataTable';
+import Modal from '@/components/Modal';
+import ClientForm from '@/components/ClientForm';
+import { useClients } from '@/hooks/useClients';
+import { useClientApi } from '@/api/clients';
+import { Client } from '@/types';
 
 export default function ClientsPage() {
+  const { data } = useClients();
+  const api = useClientApi();
+  const [clients, setClients] = useState<Client[]>([]);
+  const [openForm, setOpenForm] = useState(false);
+  const [editing, setEditing] = useState<Client | null>(null);
+
+  // sync once data loads
+  if (data && clients.length === 0) setClients(data);
+
+  const columns: Column<Client>[] = [
+    { header: 'ID', accessor: 'id' },
+    { header: 'Name', accessor: 'name' },
+  ];
+
+  const handleCreate = async (values: { name: string }) => {
+    const created = await api.create(values);
+    setClients((c) => [...c, created]);
+    setOpenForm(false);
+  };
+
+  const handleUpdate = async (values: { name: string }) => {
+    if (!editing) return;
+    const updated = await api.update(editing.id, values);
+    setClients((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
+    setEditing(null);
+    setOpenForm(false);
+  };
+
+  const handleDelete = async (client: Client) => {
+    if (!confirm(`Delete ${client.name}?`)) return;
+    await api.remove(client.id);
+    setClients((c) => c.filter((cl) => cl.id !== client.id));
+  };
+
   return (
     <RouteGuard>
-      <div>Clients</div>
+      <Layout>
+        <div className="mb-2 flex justify-end">
+          <button
+            className="border px-2 py-1"
+            onClick={() => {
+              setEditing(null);
+              setOpenForm(true);
+            }}
+          >
+            Add Client
+          </button>
+        </div>
+        {clients && (
+          <DataTable
+            data={clients}
+            columns={columns}
+            initialSort="id"
+            renderActions={(c) => (
+              <span className="space-x-2">
+                <button
+                  className="border px-2 py-1"
+                  onClick={() => {
+                    setEditing(c);
+                    setOpenForm(true);
+                  }}
+                >
+                  Edit
+                </button>
+                <button
+                  className="border px-2 py-1"
+                  onClick={() => handleDelete(c)}
+                >
+                  Delete
+                </button>
+              </span>
+            )}
+          />
+        )}
+        <Modal
+          open={openForm || Boolean(editing)}
+          onClose={() => {
+            setOpenForm(false);
+            setEditing(null);
+          }}
+        >
+          <ClientForm
+            initial={editing ?? undefined}
+            onCancel={() => {
+              setOpenForm(false);
+              setEditing(null);
+            }}
+            onSubmit={editing ? handleUpdate : handleCreate}
+          />
+        </Modal>
+      </Layout>
     </RouteGuard>
   );
 }


### PR DESCRIPTION
## Summary
- add generic `DataTable` component with search, sort and pagination
- add reusable `Modal` and `ClientForm` components
- implement `/clients` page with create, edit and delete actions
- provide API helper for client CRUD
- add unit tests for `ClientForm`
- add Cypress spec for basic clients flow

## Testing
- `npm test`
- `npm run e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ad3721e0c8329b559f17def8161dd