### PR TITLE
Implement calendar view

### DIFF
--- a/frontend/cypress/e2e/appointments.cy.ts
+++ b/frontend/cypress/e2e/appointments.cy.ts
@@ -1,0 +1,18 @@
+describe('appointments calendar', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+  });
+
+  it('drag, add and edit appointment', () => {
+    cy.intercept('GET', '**/appointments', { fixture: 'appointments.json' }).as('getAppts');
+    cy.intercept('PATCH', '**/appointments/admin/*', { id: 1 }).as('updateAppt');
+    cy.intercept('POST', '**/appointments/admin', { id: 3 }).as('createAppt');
+    cy.visit('/appointments');
+    cy.wait('@getAppts');
+    cy.contains('A');
+    cy.get('.fc-daygrid-day').first().click();
+    cy.get('input[type="datetime-local"]').type('2024-01-01T10:00');
+    cy.contains('button', 'Save').click();
+    cy.wait('@createAppt');
+  });
+});

--- a/frontend/cypress/fixtures/appointments.json
+++ b/frontend/cypress/fixtures/appointments.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "startTime": "2024-01-02T10:00:00.000Z", "client": { "id": 1, "name": "A" } },
+  { "id": 2, "startTime": "2024-01-03T11:00:00.000Z", "client": { "id": 2, "name": "B" } }
+]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.18",
+        "@fullcalendar/daygrid": "^6.1.18",
+        "@fullcalendar/interaction": "^6.1.18",
+        "@fullcalendar/react": "^6.1.18",
+        "@fullcalendar/timegrid": "^6.1.18",
         "autoprefixer": "^10.4.21",
         "next": "15.4.1",
         "react": "19.1.0",
@@ -1020,6 +1025,56 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.18.tgz",
+      "integrity": "sha512-cD7XtZIZZ87Cg2+itnpsONCsZ89VIfLLDZ22pQX4IQVWlpYUB3bcCf878DhWkqyEen6dhi5ePtBoqYgm5K+0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.18.tgz",
+      "integrity": "sha512-s452Zle1SdMEzZDw+pDczm8m3JLIZzS9ANMThXTnqeqJewW1gqNFYas18aHypJSgF9Fh9rDJjTSUw04BpXB/Mg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.18"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.18.tgz",
+      "integrity": "sha512-f/mD5RTjzw+Q6MGTMZrLCgIrQLIUUO9NV/58aM2J6ZBQZeRlNizDqmqldqyG+j49zj2vFhUfZibPrVKWm5yA4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.18"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.18.tgz",
+      "integrity": "sha512-Jwvb+T+/1yGZKe+UYXn0id022HJm0Fq2X/PGFvVh/QRYAI/6xPMRvJrwercBkToxf6LjqYXrDO+/NhRN6IDlmg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.18",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.18.tgz",
+      "integrity": "sha512-T/ouhs+T1tM8JcW7Cjx+KiohL/qQWKqvRITwjol8ktJ1e1N/6noC40/obR1tyolqOxMRWHjJkYoj9fUqfoez9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.18"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.18"
       }
     },
     "node_modules/@humanfs/core": {
@@ -10862,6 +10917,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,11 @@
     "e2e": "cypress run"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.18",
+    "@fullcalendar/daygrid": "^6.1.18",
+    "@fullcalendar/interaction": "^6.1.18",
+    "@fullcalendar/react": "^6.1.18",
+    "@fullcalendar/timegrid": "^6.1.18",
     "autoprefixer": "^10.4.21",
     "next": "15.4.1",
     "react": "19.1.0",

--- a/frontend/src/__tests__/appointmentForm.test.tsx
+++ b/frontend/src/__tests__/appointmentForm.test.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import AppointmentForm from '@/components/AppointmentForm';
+
+const clients = [
+  { id: 1, name: 'A' },
+  { id: 2, name: 'B' },
+];
+const services = [
+  { id: 1, name: 'S' },
+];
+
+describe('AppointmentForm', () => {
+  it('shows conflict error', async () => {
+    const onSubmit = jest.fn().mockRejectedValue({ status: 409 });
+    render(
+      <AppointmentForm clients={clients} services={services} onSubmit={onSubmit} onCancel={() => {}} />
+    );
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: '1' } });
+    fireEvent.change(screen.getByDisplayValue('S'), { target: { value: '1' } });
+    fireEvent.change(screen.getByDisplayValue(''), { target: { value: '2024-01-01T10:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => screen.getByRole('alert'));
+  });
+});

--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -1,0 +1,27 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { Appointment } from '@/types';
+
+export function useAppointmentsApi() {
+  const { apiFetch } = useAuth();
+
+  const create = (data: {
+    clientId: number;
+    employeeId: number;
+    serviceId: number;
+    startTime: string;
+  }) =>
+    apiFetch<Appointment>('/appointments/admin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+  const update = (id: number, data: { startTime: string }) =>
+    apiFetch<Appointment>(`/appointments/admin/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+  return { create, update };
+}

--- a/frontend/src/components/AppointmentForm.tsx
+++ b/frontend/src/components/AppointmentForm.tsx
@@ -1,0 +1,66 @@
+import { FormEvent, useState } from 'react';
+import { Client, Service } from '@/types';
+
+interface Props {
+  clients: Client[];
+  services: Service[];
+  initial?: { clientId?: number; serviceId?: number; startTime?: string };
+  onSubmit: (data: { clientId: number; serviceId: number; startTime: string }) => Promise<void>;
+  onCancel: () => void;
+}
+
+export default function AppointmentForm({ clients, services, initial, onSubmit, onCancel }: Props) {
+  const [clientId, setClientId] = useState(initial?.clientId ?? clients[0]?.id);
+  const [serviceId, setServiceId] = useState(initial?.serviceId ?? services[0]?.id);
+  const [startTime, setStartTime] = useState(initial?.startTime ?? '');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await onSubmit({ clientId: Number(clientId), serviceId: Number(serviceId), startTime });
+    } catch (err: any) {
+      if (err.status === 409) setError('Conflict');
+      else setError(err.message || 'Error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <select value={clientId} onChange={(e) => setClientId(Number(e.target.value))} className="border p-1 w-full">
+        {clients.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      <select value={serviceId} onChange={(e) => setServiceId(Number(e.target.value))} className="border p-1 w-full">
+        {services.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+          </option>
+        ))}
+      </select>
+      <input
+        type="datetime-local"
+        value={startTime}
+        onChange={(e) => setStartTime(e.target.value)}
+        className="border p-1 w-full"
+      />
+      {error && (
+        <p role="alert" className="text-red-600 text-sm">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2 justify-end">
+        <button type="button" onClick={onCancel} className="border px-2 py-1">
+          Cancel
+        </button>
+        <button type="submit" className="border px-2 py-1">
+          Save
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/appointments/index.tsx
+++ b/frontend/src/pages/appointments/index.tsx
@@ -1,9 +1,87 @@
 import RouteGuard from '@/components/RouteGuard';
+import Layout from '@/components/Layout';
+import Modal from '@/components/Modal';
+import AppointmentForm from '@/components/AppointmentForm';
+import { useAppointments } from '@/hooks/useAppointments';
+import { useClients } from '@/hooks/useClients';
+import { useServices } from '@/hooks/useServices';
+import { useAppointmentsApi } from '@/api/appointments';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin, { DateClickArg, EventDropArg } from '@fullcalendar/interaction';
+import { useState } from 'react';
 
 export default function AppointmentsPage() {
+  const { data: appointments, loading, error } = useAppointments();
+  const { data: clients } = useClients();
+  const { data: services } = useServices();
+  const api = useAppointmentsApi();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editId, setEditId] = useState<number | null>(null);
+  const [startTime, setStartTime] = useState('');
+
+  if (loading || !clients || !services) return <div>Loading...</div>;
+  if (error) return <div>Error</div>;
+
+  const events = appointments?.map((a) => ({
+    id: String(a.id),
+    title: a.client?.name ?? String(a.id),
+    start: a.startTime,
+  }));
+
+  const handleDateClick = (arg: DateClickArg) => {
+    setEditId(null);
+    setStartTime(arg.dateStr);
+    setFormOpen(true);
+  };
+
+  const handleEventClick = (info: any) => {
+    setEditId(Number(info.event.id));
+    setStartTime(info.event.startStr);
+    setFormOpen(true);
+  };
+
+  const handleDrop = async (arg: EventDropArg) => {
+    try {
+      await api.update(Number(arg.event.id), { startTime: arg.event.start!.toISOString() });
+    } catch (err) {
+      alert('Conflict');
+      arg.revert();
+    }
+  };
+
+  const handleSubmit = async (data: { clientId: number; serviceId: number; startTime: string }) => {
+    if (editId) {
+      await api.update(editId, { startTime: data.startTime });
+    } else {
+      await api.create({ ...data, employeeId: 1 });
+    }
+    setFormOpen(false);
+  };
+
   return (
     <RouteGuard>
-      <div>Appointments</div>
+      <Layout>
+        <FullCalendar
+          plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+          initialView="timeGridWeek"
+          events={events}
+          dateClick={handleDateClick}
+          eventClick={handleEventClick}
+          eventDrop={handleDrop}
+          editable
+        />
+        <Modal open={formOpen} onClose={() => setFormOpen(false)}>
+          <AppointmentForm
+            clients={clients}
+            services={services}
+            initial={{ startTime }}
+            onSubmit={handleSubmit}
+            onCancel={() => setFormOpen(false)}
+          />
+        </Modal>
+      </Layout>
     </RouteGuard>
   );
 }


### PR DESCRIPTION
## Summary
- add FullCalendar dependencies
- create AppointmentForm component and API helpers
- implement `/appointments` page with FullCalendar
- add e2e tests for calendar
- handle API conflict errors in AppointmentForm
- test conflict handling

## Testing
- `npm test --silent` in `frontend`
- `npm run e2e --silent` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_687ad72127c48329a90efee9b7d18897