### PR TITLE
Add notification system with polling

### DIFF
--- a/frontend/cypress/e2e/clients.cy.ts
+++ b/frontend/cypress/e2e/clients.cy.ts
@@ -13,5 +13,6 @@ describe('clients crud', () => {
     cy.contains('button', 'Save').click();
     cy.wait('@createClient');
     cy.contains('New');
+    cy.contains('Client created');
   });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "next": "15.4.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-hot-toast": "^2.4.0",
         "zod": "^4.0.5"
       },
       "devDependencies": {
@@ -5199,7 +5200,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cypress": {
@@ -7170,6 +7170,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -11161,6 +11170,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.0.tgz",
+      "integrity": "sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==",
+      "license": "MIT",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "next": "15.4.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-hot-toast": "^2.4.0",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/frontend/src/__tests__/clientApi.test.tsx
+++ b/frontend/src/__tests__/clientApi.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { useClientApi } from '@/api/clients';
+import { useAuth } from '@/contexts/AuthContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+
+jest.mock('@/contexts/AuthContext');
+jest.mock('react-hot-toast', () => ({
+  Toaster: () => null,
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const toast = require('react-hot-toast').toast;
+
+describe('useClientApi', () => {
+  it('shows success toast on create', async () => {
+    const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
+    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ToastProvider>{children}</ToastProvider>
+    );
+    const { result } = renderHook(() => useClientApi(), { wrapper });
+    await act(async () => {
+      await result.current.create({ name: 'A' });
+    });
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('shows error toast on failure', async () => {
+    const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
+    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ToastProvider>{children}</ToastProvider>
+    );
+    const { result } = renderHook(() => useClientApi(), { wrapper });
+    await expect(act(async () => {
+      await result.current.create({ name: 'A' });
+    })).rejects.toThrow();
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -1,27 +1,45 @@
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 import { Appointment } from '@/types';
 
 export function useAppointmentsApi() {
   const { apiFetch } = useAuth();
+  const toast = useToast();
 
-  const create = (data: {
+  const create = async (data: {
     clientId: number;
     employeeId: number;
     serviceId: number;
     startTime: string;
-  }) =>
-    apiFetch<Appointment>('/appointments/admin', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+  }) => {
+    try {
+      const res = await apiFetch<Appointment>('/appointments/admin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      toast.success('Appointment created');
+      return res;
+    } catch (err: any) {
+      toast.error(err.message || 'Error');
+      throw err;
+    }
+  };
 
-  const update = (id: number, data: { startTime: string }) =>
-    apiFetch<Appointment>(`/appointments/admin/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+  const update = async (id: number, data: { startTime: string }) => {
+    try {
+      const res = await apiFetch<Appointment>(`/appointments/admin/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      toast.success('Appointment updated');
+      return res;
+    } catch (err: any) {
+      toast.error(err.message || 'Error');
+      throw err;
+    }
+  };
 
   return { create, update };
 }

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -1,25 +1,50 @@
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 import { Client } from '@/types';
 
 export function useClientApi() {
   const { apiFetch } = useAuth();
+  const toast = useToast();
 
-  const create = (data: { name: string }) =>
-    apiFetch<Client>('/clients', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+  const create = async (data: { name: string }) => {
+    try {
+      const res = await apiFetch<Client>('/clients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      toast.success('Client created');
+      return res;
+    } catch (err: any) {
+      toast.error(err.message || 'Error');
+      throw err;
+    }
+  };
 
-  const update = (id: number, data: { name: string }) =>
-    apiFetch<Client>(`/clients/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+  const update = async (id: number, data: { name: string }) => {
+    try {
+      const res = await apiFetch<Client>(`/clients/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      toast.success('Client updated');
+      return res;
+    } catch (err: any) {
+      toast.error(err.message || 'Error');
+      throw err;
+    }
+  };
 
-  const remove = (id: number) =>
-    apiFetch<void>(`/clients/${id}`, { method: 'DELETE' });
+  const remove = async (id: number) => {
+    try {
+      await apiFetch<void>(`/clients/${id}`, { method: 'DELETE' });
+      toast.success('Client deleted');
+    } catch (err: any) {
+      toast.error(err.message || 'Error');
+      throw err;
+    }
+  };
 
   return { create, update, remove };
 }

--- a/frontend/src/components/NotificationList.tsx
+++ b/frontend/src/components/NotificationList.tsx
@@ -1,0 +1,17 @@
+import { useNotifications } from '@/hooks/useNotifications';
+
+export default function NotificationList() {
+  const { data } = useNotifications();
+  return (
+    <ul className="space-y-2">
+      {data.map((n) => (
+        <li key={n.id} className="border p-2">
+          <div>{n.message}</div>
+          <div className="text-xs text-gray-500">
+            {new Date(n.createdAt).toLocaleString()}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+import { Toaster, toast } from 'react-hot-toast';
+
+interface ToastContextValue {
+  success: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({
+  success: () => {},
+  error: () => {},
+});
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <ToastContext.Provider value={{ success: toast.success, error: toast.error }}>
+      {children}
+      <Toaster position="top-right" />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { Notification } from '@/types';
+
+export function useNotifications() {
+  const { apiFetch } = useAuth();
+  const [data, setData] = useState<Notification[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const fetchData = () =>
+      apiFetch<Notification[]>('/notifications')
+        .then((d) => active && setData(d))
+        .catch((e) => active && setError(e));
+    fetchData();
+    const id = setInterval(fetchData, 30000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [apiFetch]);
+
+  return { data, error };
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { ToastProvider } from '@/contexts/ToastContext';
 import '@/app/globals.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <ToastProvider>
+        <Component {...pageProps} />
+      </ToastProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/pages/notifications/index.tsx
+++ b/frontend/src/pages/notifications/index.tsx
@@ -1,0 +1,13 @@
+import RouteGuard from '@/components/RouteGuard';
+import Layout from '@/components/Layout';
+import NotificationList from '@/components/NotificationList';
+
+export default function NotificationsPage() {
+  return (
+    <RouteGuard>
+      <Layout>
+        <NotificationList />
+      </Layout>
+    </RouteGuard>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,3 +20,9 @@ export interface DashboardResponse {
   employeeCount: number;
   upcoming: Appointment[];
 }
+
+export interface Notification {
+  id: number;
+  message: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- install `react-hot-toast`
- create ToastProvider context for showing success/error toasts
- wrap application with ToastProvider
- show toast messages in client and appointment API helpers
- implement polling hook and components to display backend notifications
- expose new `/notifications` page
- test toast behavior in `useClientApi`
- verify toast appears in clients e2e flow

## Testing
- `npm test`
- `npm run e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b484a41a08329bfd8f108bfd2de78