### PR TITLE
Add basic CI and Cypress setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: password
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install frontend deps
+        run: |
+          cd frontend
+          npm ci
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test -- --coverage
+      - name: Install backend deps
+        run: |
+          cd backend
+          npm ci
+      - name: Run backend tests
+        run: |
+          cd backend
+          npm test -- --coverage

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -1,0 +1,2 @@
+// Cypress support
+export {};


### PR DESCRIPTION
## Summary
- add a minimal Cypress support file
- configure a GitHub Actions workflow running unit tests for frontend and backend

## Testing
- `npm test -- --coverage` in `frontend`
- `npm test -- --coverage` in `backend`
- `npx cypress run` *(fails: Next.js compilation error)*


------
https://chatgpt.com/codex/tasks/task_e_687b5c0695f883299530399d14297abc