### PR TITLE
Fix CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Salon Black & White
 
-[![CI](https://github.com/OWNER/salonbw/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/OWNER/salonbw/actions/workflows/test.yml)
+[![CI](https://github.com/gniewkob/salonbw/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/gniewkob/salonbw/actions/workflows/test.yml)
 
 Salon Black & White now consists of a
 [NestJS](https://nestjs.com) backend in [`backend/`](backend/) and a


### PR DESCRIPTION
## Summary
- point CI badge to gniewkob/salonbw instead of placeholder

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687bc35a567c8329b607da6f740a54d1