### PR TITLE
Integrate SMS/WhatsApp notifications

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,3 +20,8 @@ WHATSAPP_TOKEN=your-whatsapp-token
 WHATSAPP_PHONE_ID=your-whatsapp-phone-id
 WHATSAPP_TEMPLATE_LANG=pl # language for WhatsApp templates
 NOTIFICATIONS_ENABLED=true # set to "false" to disable sending messages
+
+# Twilio SMS credentials
+TWILIO_ACCOUNT_SID=your-twilio-account-sid
+TWILIO_AUTH_TOKEN=your-twilio-auth-token
+TWILIO_FROM_NUMBER=+48123123123

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -35,7 +35,7 @@ describe('AppointmentsService', () => {
     let notifications: {
         sendAppointmentConfirmation: jest.Mock;
         sendThankYou: jest.Mock;
-        sendText: jest.Mock;
+        sendNotification: jest.Mock;
     };
 
     beforeEach(async () => {
@@ -55,7 +55,7 @@ describe('AppointmentsService', () => {
         notifications = {
             sendAppointmentConfirmation: jest.fn(),
             sendThankYou: jest.fn(),
-            sendText: jest.fn(),
+            sendNotification: jest.fn(),
         };
 
         const module: TestingModule = await Test.createTestingModule({

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -71,9 +71,10 @@ export class AppointmentsService {
             );
         }
         if ((saved.employee as any)?.phone) {
-            void this.notifications.sendText(
+            void this.notifications.sendNotification(
                 (saved.employee as any).phone,
                 `Nowa rezerwacja ${saved.startTime.toLocaleString()}`,
+                'whatsapp',
             );
         }
         return saved;

--- a/backend/src/migrations/20250711192021-CreateNotificationsTable.ts
+++ b/backend/src/migrations/20250711192021-CreateNotificationsTable.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateNotificationsTable20250711192021
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'notification',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'recipient', type: 'varchar' },
+                    { name: 'type', type: 'varchar' },
+                    { name: 'message', type: 'text' },
+                    { name: 'status', type: 'varchar' },
+                    { name: 'sentAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('notification');
+    }
+}

--- a/backend/src/notifications/notification.entity.ts
+++ b/backend/src/notifications/notification.entity.ts
@@ -1,0 +1,33 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
+
+export enum NotificationStatus {
+    Pending = 'pending',
+    Sent = 'sent',
+    Failed = 'failed',
+}
+
+@Entity()
+export class Notification {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    recipient: string;
+
+    @Column()
+    type: string;
+
+    @Column('text')
+    message: string;
+
+    @Column({ type: 'simple-enum', enum: NotificationStatus })
+    status: NotificationStatus;
+
+    @CreateDateColumn()
+    sentAt: Date;
+}

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Public } from '../auth/public.decorator';
+import {
+    NotificationsService,
+    NotificationType,
+} from './notifications.service';
+
+@Controller('notifications')
+export class NotificationsController {
+    constructor(private readonly service: NotificationsService) {}
+
+    @Get()
+    @Public()
+    list() {
+        return this.service.findAll();
+    }
+
+    @Post('test')
+    @Public()
+    test(
+        @Body() body: { to: string; message: string; type: NotificationType },
+    ) {
+        return this.service.sendNotification(body.to, body.message, body.type);
+    }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,8 +1,15 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
+import { WhatsappService } from './whatsapp.service';
+import { SmsService } from './sms.service';
+import { Notification } from './notification.entity';
 
 @Module({
-    providers: [NotificationsService],
-    exports: [NotificationsService],
+    imports: [TypeOrmModule.forFeature([Notification])],
+    controllers: [NotificationsController],
+    providers: [WhatsappService, SmsService, NotificationsService],
+    exports: [NotificationsService, TypeOrmModule],
 })
 export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1,97 +1,51 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { NotificationsService } from './notifications.service';
-import axios from 'axios';
+import { SmsService } from './sms.service';
+import { WhatsappService } from './whatsapp.service';
+import { Notification, NotificationStatus } from './notification.entity';
 
 describe('NotificationsService', () => {
     let service: NotificationsService;
+    let sms: { sendSms: jest.Mock };
+    let whatsapp: { sendText: jest.Mock };
+    let repo: Partial<Repository<Notification>>;
 
     beforeEach(async () => {
-        process.env.WHATSAPP_TOKEN = 't';
-        process.env.WHATSAPP_PHONE_ID = '123';
+        sms = { sendSms: jest.fn() };
+        whatsapp = { sendText: jest.fn() };
+        repo = { create: jest.fn((x) => x), save: jest.fn() } as any;
         const module: TestingModule = await Test.createTestingModule({
-            providers: [NotificationsService],
+            providers: [
+                NotificationsService,
+                { provide: SmsService, useValue: sms },
+                { provide: WhatsappService, useValue: whatsapp },
+                { provide: getRepositoryToken(Notification), useValue: repo },
+            ],
         }).compile();
-
         service = module.get<NotificationsService>(NotificationsService);
     });
 
-    afterEach(() => {
-        jest.resetAllMocks();
+    it('uses SMS adapter when type sms', async () => {
+        await service.sendNotification('1', 'msg', 'sms');
+        expect(sms.sendSms).toHaveBeenCalledWith('1', 'msg');
+        expect(whatsapp.sendText).not.toHaveBeenCalled();
     });
 
-    it('sendText posts to WhatsApp API', async () => {
-        const postMock = jest
-            .spyOn(axios, 'post')
-            .mockResolvedValue({ data: {} } as any);
-        process.env.WHATSAPP_TOKEN = 't';
-        process.env.WHATSAPP_PHONE_ID = '123';
-
-        await service.sendText('48123456789', 'hello');
-
-        expect(postMock).toHaveBeenCalledWith(
-            'https://graph.facebook.com/v18.0/123/messages',
-            {
-                messaging_product: 'whatsapp',
-                to: '48123456789',
-                type: 'text',
-                text: { body: 'hello' },
-            },
-            {
-                headers: {
-                    Authorization: 'Bearer t',
-                    'Content-Type': 'application/json',
-                },
-            },
-        );
+    it('uses WhatsApp adapter when type whatsapp', async () => {
+        await service.sendNotification('1', 'msg', 'whatsapp');
+        expect(whatsapp.sendText).toHaveBeenCalledWith('1', 'msg');
+        expect(sms.sendSms).not.toHaveBeenCalled();
     });
 
-    it('sendWhatsAppTemplate posts to WhatsApp API', async () => {
-        const postMock = jest
-            .spyOn(axios, 'post')
-            .mockResolvedValue({ data: {} } as any);
-        process.env.WHATSAPP_TOKEN = 't';
-        process.env.WHATSAPP_PHONE_ID = '123';
-        process.env.WHATSAPP_TEMPLATE_LANG = 'pl';
-
-        await service.sendWhatsAppTemplate('48123456789', 'template', [
-            'X',
-            'Y',
-        ]);
-
-        expect(postMock).toHaveBeenCalledWith(
-            'https://graph.facebook.com/v18.0/123/messages',
-            {
-                messaging_product: 'whatsapp',
-                to: '48123456789',
-                type: 'template',
-                template: {
-                    name: 'template',
-                    language: { code: 'pl' },
-                    components: [
-                        {
-                            type: 'body',
-                            parameters: [
-                                { type: 'text', text: 'X' },
-                                { type: 'text', text: 'Y' },
-                            ],
-                        },
-                    ],
-                },
-            },
-            {
-                headers: {
-                    Authorization: 'Bearer t',
-                    'Content-Type': 'application/json',
-                },
-            },
-        );
-    });
-
-    it('does nothing when notifications are disabled', async () => {
-        const postMock = jest.spyOn(axios, 'post');
-        process.env.NOTIFICATIONS_ENABLED = 'false';
-        await service.sendText('48123456789', 'hello');
-        expect(postMock).not.toHaveBeenCalled();
-        delete process.env.NOTIFICATIONS_ENABLED;
+    it('records failed status on error', async () => {
+        whatsapp.sendText.mockRejectedValue(new Error('fail'));
+        const notif = (await service.sendNotification(
+            '1',
+            'msg',
+            'whatsapp',
+        )) as Notification;
+        expect(notif.status).toBe(NotificationStatus.Failed);
     });
 });

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,126 +1,76 @@
-import { Injectable } from '@nestjs/common';
-import axios from 'axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SmsService } from './sms.service';
+import { WhatsappService } from './whatsapp.service';
+import { Notification, NotificationStatus } from './notification.entity';
 
-interface WhatsAppTextPayload {
-    messaging_product: 'whatsapp';
-    to: string;
-    type: 'text';
-    text: { body: string };
-}
-
-interface WhatsAppTemplatePayload {
-    messaging_product: 'whatsapp';
-    to: string;
-    type: 'template';
-    template: {
-        name: string;
-        language: { code: string };
-        components: {
-            type: 'body';
-            parameters: { type: 'text'; text: string }[];
-        }[];
-    };
-}
+export type NotificationType = 'sms' | 'whatsapp';
 
 @Injectable()
 export class NotificationsService {
-    private readonly token = process.env.WHATSAPP_TOKEN;
-    private readonly phoneId = process.env.WHATSAPP_PHONE_ID;
-    private readonly baseUrl = 'https://graph.facebook.com/v18.0';
+    private readonly logger = new Logger(NotificationsService.name);
+    constructor(
+        private readonly sms: SmsService,
+        private readonly whatsapp: WhatsappService,
+        @InjectRepository(Notification)
+        private readonly repo: Repository<Notification>,
+    ) {}
 
-    async sendText(to: string, text: string) {
-        if (process.env.NOTIFICATIONS_ENABLED === 'false') {
-            return;
-        }
-        if (!this.token || !this.phoneId) {
-            throw new Error('WhatsApp credentials not configured');
-        }
-        const payload: WhatsAppTextPayload = {
-            messaging_product: 'whatsapp',
-            to,
-            type: 'text',
-            text: { body: text },
-        };
-        try {
-            const res = await axios.post(
-                `${this.baseUrl}/${this.phoneId}/messages`,
-                payload,
-                {
-                    headers: {
-                        Authorization: `Bearer ${this.token}`,
-                        'Content-Type': 'application/json',
-                    },
-                },
-            );
-            return res.data;
-        } catch (err: any) {
-            const status = err.response?.status;
-            const body = err.response?.data;
-            throw new Error(`WhatsApp API error: ${status} ${body}`);
-        }
-    }
-
-    async sendWhatsAppTemplate(
+    async sendNotification(
         to: string,
-        templateName: string,
-        parameters: string[],
+        message: string,
+        type: NotificationType,
     ) {
         if (process.env.NOTIFICATIONS_ENABLED === 'false') {
-            return;
+            const fake = this.repo.create({
+                recipient: to,
+                type,
+                message,
+                status: NotificationStatus.Sent,
+                sentAt: new Date(),
+            });
+            return this.repo.save(fake);
         }
-        if (!this.token || !this.phoneId) {
-            throw new Error('WhatsApp credentials not configured');
-        }
-        const lang = process.env.WHATSAPP_TEMPLATE_LANG || 'pl';
-        const payload: WhatsAppTemplatePayload = {
-            messaging_product: 'whatsapp',
-            to,
-            type: 'template',
-            template: {
-                name: templateName,
-                language: { code: lang },
-                components: [
-                    {
-                        type: 'body',
-                        parameters: parameters.map((text) => ({
-                            type: 'text',
-                            text,
-                        })),
-                    },
-                ],
-            },
-        };
+        const notif = this.repo.create({
+            recipient: to,
+            type,
+            message,
+            status: NotificationStatus.Pending,
+        });
+        await this.repo.save(notif);
         try {
-            const res = await axios.post(
-                `${this.baseUrl}/${this.phoneId}/messages`,
-                payload,
-                {
-                    headers: {
-                        Authorization: `Bearer ${this.token}`,
-                        'Content-Type': 'application/json',
-                    },
-                },
-            );
-            return res.data;
-        } catch (err: any) {
-            const status = err.response?.status;
-            const body = err.response?.data;
-            throw new Error(`WhatsApp API error: ${status} ${body}`);
+            if (type === 'sms') {
+                await this.sms.sendSms(to, message);
+            } else {
+                await this.whatsapp.sendText(to, message);
+            }
+            notif.status = NotificationStatus.Sent;
+        } catch (err) {
+            notif.status = NotificationStatus.Failed;
+            this.logger.error(`Notification send failed: ${err}`);
         }
+        notif.sentAt = new Date();
+        await this.repo.save(notif);
+        return notif;
     }
 
-    async sendAppointmentConfirmation(to: string, when: Date) {
+    sendAppointmentConfirmation(to: string, when: Date) {
         const text = `Twoja wizyta została umówiona na ${when.toLocaleString()}`;
-        return this.sendText(to, text);
+        return this.sendNotification(to, text, 'whatsapp');
     }
 
-    async sendAppointmentReminder(to: string, when: Date) {
+    sendAppointmentReminder(to: string, when: Date) {
         const text = `Przypomnienie: wizyta ${when.toLocaleString()}`;
-        return this.sendText(to, text);
+        return this.sendNotification(to, text, 'whatsapp');
     }
 
-    async sendThankYou(to: string) {
+    sendThankYou(to: string) {
         const text = 'Dziękujemy za wizytę!';
-        return this.sendText(to, text);
+        return this.sendNotification(to, text, 'whatsapp');
+    }
+
+    findAll() {
+        return this.repo.find();
     }
 }

--- a/backend/src/notifications/sms.service.spec.ts
+++ b/backend/src/notifications/sms.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SmsService } from './sms.service';
+import axios from 'axios';
+
+describe('SmsService', () => {
+    let service: SmsService;
+
+    beforeEach(async () => {
+        process.env.TWILIO_ACCOUNT_SID = 'AC123';
+        process.env.TWILIO_AUTH_TOKEN = 'auth';
+        process.env.TWILIO_FROM_NUMBER = '+111';
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [SmsService],
+        }).compile();
+        service = module.get<SmsService>(SmsService);
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('sendSms posts to Twilio API', async () => {
+        const postMock = jest
+            .spyOn(axios, 'post')
+            .mockResolvedValue({ data: {} } as any);
+        await service.sendSms('+222', 'hi');
+        expect(postMock).toHaveBeenCalledWith(
+            'https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json',
+            'To=%2B222&From=%2B111&Body=hi',
+            {
+                auth: { username: 'AC123', password: 'auth' },
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+            },
+        );
+    });
+
+    it('does nothing when notifications are disabled', async () => {
+        const postMock = jest.spyOn(axios, 'post');
+        process.env.NOTIFICATIONS_ENABLED = 'false';
+        await service.sendSms('+222', 'hi');
+        expect(postMock).not.toHaveBeenCalled();
+        delete process.env.NOTIFICATIONS_ENABLED;
+    });
+});

--- a/backend/src/notifications/sms.service.ts
+++ b/backend/src/notifications/sms.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class SmsService {
+    private readonly accountSid = process.env.TWILIO_ACCOUNT_SID;
+    private readonly authToken = process.env.TWILIO_AUTH_TOKEN;
+    private readonly fromNumber = process.env.TWILIO_FROM_NUMBER;
+
+    async sendSms(to: string, body: string) {
+        if (process.env.NOTIFICATIONS_ENABLED === 'false') {
+            return;
+        }
+        if (!this.accountSid || !this.authToken || !this.fromNumber) {
+            throw new Error('Twilio credentials not configured');
+        }
+        const url = `https://api.twilio.com/2010-04-01/Accounts/${this.accountSid}/Messages.json`;
+        const params = new URLSearchParams({
+            To: to,
+            From: this.fromNumber,
+            Body: body,
+        });
+        await axios.post(url, params.toString(), {
+            auth: { username: this.accountSid, password: this.authToken },
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        });
+    }
+}

--- a/backend/src/notifications/whatsapp.service.nock.spec.ts
+++ b/backend/src/notifications/whatsapp.service.nock.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotificationsService } from './notifications.service';
+import { WhatsappService } from './whatsapp.service';
 import * as nock from 'nock';
 
-describe('NotificationsService with nock', () => {
-    let service: NotificationsService;
+describe('WhatsappService with nock', () => {
+    let service: WhatsappService;
     const httpProxy = process.env.http_proxy;
     const httpsProxy = process.env.https_proxy;
     const HTTPProxy = process.env.HTTP_PROXY;
@@ -28,10 +28,10 @@ describe('NotificationsService with nock', () => {
         delete process.env.YARN_HTTPS_PROXY;
         delete process.env.GLOBAL_AGENT_HTTP_PROXY;
         const module: TestingModule = await Test.createTestingModule({
-            providers: [NotificationsService],
+            providers: [WhatsappService],
         }).compile();
 
-        service = module.get<NotificationsService>(NotificationsService);
+        service = module.get<WhatsappService>(WhatsappService);
     });
 
     afterEach(() => {

--- a/backend/src/notifications/whatsapp.service.spec.ts
+++ b/backend/src/notifications/whatsapp.service.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WhatsappService } from './whatsapp.service';
+import axios from 'axios';
+
+describe('WhatsappService', () => {
+    let service: WhatsappService;
+
+    beforeEach(async () => {
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [WhatsappService],
+        }).compile();
+
+        service = module.get<WhatsappService>(WhatsappService);
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('sendText posts to WhatsApp API', async () => {
+        const postMock = jest
+            .spyOn(axios, 'post')
+            .mockResolvedValue({ data: {} } as any);
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+
+        await service.sendText('48123456789', 'hello');
+
+        expect(postMock).toHaveBeenCalledWith(
+            'https://graph.facebook.com/v18.0/123/messages',
+            {
+                messaging_product: 'whatsapp',
+                to: '48123456789',
+                type: 'text',
+                text: { body: 'hello' },
+            },
+            {
+                headers: {
+                    Authorization: 'Bearer t',
+                    'Content-Type': 'application/json',
+                },
+            },
+        );
+    });
+
+    it('sendWhatsAppTemplate posts to WhatsApp API', async () => {
+        const postMock = jest
+            .spyOn(axios, 'post')
+            .mockResolvedValue({ data: {} } as any);
+        process.env.WHATSAPP_TOKEN = 't';
+        process.env.WHATSAPP_PHONE_ID = '123';
+        process.env.WHATSAPP_TEMPLATE_LANG = 'pl';
+
+        await service.sendWhatsAppTemplate('48123456789', 'template', [
+            'X',
+            'Y',
+        ]);
+
+        expect(postMock).toHaveBeenCalledWith(
+            'https://graph.facebook.com/v18.0/123/messages',
+            {
+                messaging_product: 'whatsapp',
+                to: '48123456789',
+                type: 'template',
+                template: {
+                    name: 'template',
+                    language: { code: 'pl' },
+                    components: [
+                        {
+                            type: 'body',
+                            parameters: [
+                                { type: 'text', text: 'X' },
+                                { type: 'text', text: 'Y' },
+                            ],
+                        },
+                    ],
+                },
+            },
+            {
+                headers: {
+                    Authorization: 'Bearer t',
+                    'Content-Type': 'application/json',
+                },
+            },
+        );
+    });
+
+    it('does nothing when notifications are disabled', async () => {
+        const postMock = jest.spyOn(axios, 'post');
+        process.env.NOTIFICATIONS_ENABLED = 'false';
+        await service.sendText('48123456789', 'hello');
+        expect(postMock).not.toHaveBeenCalled();
+        delete process.env.NOTIFICATIONS_ENABLED;
+    });
+});

--- a/backend/src/notifications/whatsapp.service.ts
+++ b/backend/src/notifications/whatsapp.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+interface WhatsAppTextPayload {
+    messaging_product: 'whatsapp';
+    to: string;
+    type: 'text';
+    text: { body: string };
+}
+
+interface WhatsAppTemplatePayload {
+    messaging_product: 'whatsapp';
+    to: string;
+    type: 'template';
+    template: {
+        name: string;
+        language: { code: string };
+        components: {
+            type: 'body';
+            parameters: { type: 'text'; text: string }[];
+        }[];
+    };
+}
+
+@Injectable()
+export class WhatsappService {
+    private readonly token = process.env.WHATSAPP_TOKEN;
+    private readonly phoneId = process.env.WHATSAPP_PHONE_ID;
+    private readonly baseUrl = 'https://graph.facebook.com/v18.0';
+
+    async sendText(to: string, text: string) {
+        if (process.env.NOTIFICATIONS_ENABLED === 'false') {
+            return;
+        }
+        if (!this.token || !this.phoneId) {
+            throw new Error('WhatsApp credentials not configured');
+        }
+        const payload: WhatsAppTextPayload = {
+            messaging_product: 'whatsapp',
+            to,
+            type: 'text',
+            text: { body: text },
+        };
+        try {
+            const res = await axios.post(
+                `${this.baseUrl}/${this.phoneId}/messages`,
+                payload,
+                {
+                    headers: {
+                        Authorization: `Bearer ${this.token}`,
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            const status = err.response?.status;
+            const body = err.response?.data;
+            throw new Error(`WhatsApp API error: ${status} ${body}`);
+        }
+    }
+
+    async sendWhatsAppTemplate(
+        to: string,
+        templateName: string,
+        parameters: string[],
+    ) {
+        if (process.env.NOTIFICATIONS_ENABLED === 'false') {
+            return;
+        }
+        if (!this.token || !this.phoneId) {
+            throw new Error('WhatsApp credentials not configured');
+        }
+        const lang = process.env.WHATSAPP_TEMPLATE_LANG || 'pl';
+        const payload: WhatsAppTemplatePayload = {
+            messaging_product: 'whatsapp',
+            to,
+            type: 'template',
+            template: {
+                name: templateName,
+                language: { code: lang },
+                components: [
+                    {
+                        type: 'body',
+                        parameters: parameters.map((text) => ({
+                            type: 'text',
+                            text,
+                        })),
+                    },
+                ],
+            },
+        };
+        try {
+            const res = await axios.post(
+                `${this.baseUrl}/${this.phoneId}/messages`,
+                payload,
+                {
+                    headers: {
+                        Authorization: `Bearer ${this.token}`,
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            const status = err.response?.status;
+            const body = err.response?.data;
+            throw new Error(`WhatsApp API error: ${status} ${body}`);
+        }
+    }
+
+    async sendAppointmentConfirmation(to: string, when: Date) {
+        const text = `Twoja wizyta została umówiona na ${when.toLocaleString()}`;
+        return this.sendText(to, text);
+    }
+
+    async sendAppointmentReminder(to: string, when: Date) {
+        const text = `Przypomnienie: wizyta ${when.toLocaleString()}`;
+        return this.sendText(to, text);
+    }
+
+    async sendThankYou(to: string) {
+        const text = 'Dziękujemy za wizytę!';
+        return this.sendText(to, text);
+    }
+}

--- a/backend/test/notifications.e2e-spec.ts
+++ b/backend/test/notifications.e2e-spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('Notifications (e2e)', () => {
+    let app: INestApplication<App>;
+
+    beforeEach(async () => {
+        process.env.NOTIFICATIONS_ENABLED = 'false';
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+        delete process.env.NOTIFICATIONS_ENABLED;
+    });
+
+    it('creates log entry when sending test notification', async () => {
+        await request(app.getHttpServer())
+            .post('/notifications/test')
+            .send({ to: '+111', message: 'hi', type: 'sms' })
+            .expect(201);
+
+        const res = await request(app.getHttpServer())
+            .get('/notifications')
+            .expect(200);
+        expect(res.body.length).toBeGreaterThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
## Summary
- add Twilio SMS adapter and WhatsApp adapter
- create notifications service orchestrating adapters
- log notifications to database via new Notification entity and migration
- expose public endpoints for listing and test sending
- adjust appointment service to use new notification service
- extend `.env.example` with SMS credentials
- add unit and e2e tests for notifications

## Testing
- `npm test --silent`
- `npm run test:e2e --silent`


------
https://chatgpt.com/codex/tasks/task_e_687bddc6937883298fb2ed9da835b592