### PR TITLE
Add Stripe payments

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,3 +25,7 @@ NOTIFICATIONS_ENABLED=true # set to "false" to disable sending messages
 TWILIO_ACCOUNT_SID=your-twilio-account-sid
 TWILIO_AUTH_TOKEN=your-twilio-auth-token
 TWILIO_FROM_NUMBER=+48123123123
+
+# Stripe credentials
+STRIPE_SECRET_KEY=sk_test
+STRIPE_WEBHOOK_SECRET=whsec_test

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "sqlite3": "^5.1.7",
+        "stripe": "^14.23.0",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
@@ -13332,6 +13333,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "14.25.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-14.25.0.tgz",
+      "integrity": "sha512-wQS3GNMofCXwH8TSje8E1SE8zr6ODiGtHQgPtO95p9Mb4FhKC9jvXR2NUTpZ9ZINlckJcFidCmaTFV4P6vsb9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/strtok3": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,7 +46,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
-    "typeorm": "^0.3.25"
+    "typeorm": "^0.3.25",
+    "stripe": "^14.23.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { ChatModule } from './chat/chat.module';
 import { ChatMessagesModule } from './chat-messages/chat-messages.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { DashboardModule } from './dashboard/dashboard.module';
+import { PaymentsModule } from './payments/payments.module';
 
 @Module({
     imports: [
@@ -61,6 +62,7 @@ import { DashboardModule } from './dashboard/dashboard.module';
         CommunicationsModule,
         DashboardModule,
         NotificationsModule,
+        PaymentsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/appointments/appointment.entity.ts
+++ b/backend/src/appointments/appointment.entity.ts
@@ -16,6 +16,13 @@ export enum AppointmentStatus {
     Completed = 'completed',
     Cancelled = 'cancelled',
 }
+
+export enum PaymentStatus {
+    Pending = 'pending',
+    Paid = 'paid',
+    Failed = 'failed',
+    Refunded = 'refunded',
+}
 @Index(['employee', 'startTime'], { unique: true })
 @Entity()
 export class Appointment {
@@ -49,4 +56,11 @@ export class Appointment {
         default: AppointmentStatus.Scheduled,
     })
     status: AppointmentStatus;
+
+    @Column({
+        type: 'simple-enum',
+        enum: PaymentStatus,
+        default: PaymentStatus.Pending,
+    })
+    paymentStatus: PaymentStatus;
 }

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -10,4 +10,6 @@ export enum LogAction {
     DeleteAppointment = 'DELETE_APPOINTMENT',
     DeleteService = 'DELETE_SERVICE',
     CommissionGranted = 'COMMISSION_GRANTED',
+    PaymentInit = 'PAYMENT_INIT',
+    PaymentPaid = 'PAYMENT_PAID',
 }

--- a/backend/src/migrations/20250711192022-AddPaymentStatusToAppointments.ts
+++ b/backend/src/migrations/20250711192022-AddPaymentStatusToAppointments.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddPaymentStatusToAppointments20250711192022 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'appointment',
+            new TableColumn({
+                name: 'paymentStatus',
+                type: 'varchar',
+                isNullable: false,
+                default: `'pending'`,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('appointment', 'paymentStatus');
+    }
+}

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Post, Req, Headers } from '@nestjs/common';
+import { PaymentsService } from './payments.service';
+
+@Controller('payments')
+export class PaymentsController {
+    constructor(private readonly payments: PaymentsService) {}
+
+    @Post('create-session')
+    async create(@Body('appointmentId') appointmentId: number) {
+        const url = await this.payments.createCheckoutSession(appointmentId);
+        return { url };
+    }
+
+    @Post('webhook')
+    async webhook(@Req() req: any, @Headers('stripe-signature') sig: string) {
+        const buf = req.rawBody as Buffer;
+        await this.payments.handleWebhook(buf, sig);
+        return {};
+    }
+}

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Appointment } from '../appointments/appointment.entity';
+import { PaymentsService } from './payments.service';
+import { PaymentsController } from './payments.controller';
+import { LogsModule } from '../logs/logs.module';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Appointment]), LogsModule],
+    providers: [PaymentsService],
+    controllers: [PaymentsController],
+})
+export class PaymentsModule {}

--- a/backend/src/payments/payments.service.spec.ts
+++ b/backend/src/payments/payments.service.spec.ts
@@ -1,0 +1,67 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PaymentsService } from './payments.service';
+import { Appointment, PaymentStatus } from '../appointments/appointment.entity';
+import { LogsService } from '../logs/logs.service';
+import Stripe from 'stripe';
+
+jest.mock('stripe');
+
+const StripeMock = Stripe as jest.MockedClass<typeof Stripe>;
+
+describe('PaymentsService', () => {
+    let service: PaymentsService;
+    const repo = {
+        findOne: jest.fn(),
+        save: jest.fn(),
+    } as any;
+    const logs = { create: jest.fn() } as any;
+
+    beforeEach(async () => {
+        StripeMock.mockClear();
+        repo.findOne.mockReset();
+        repo.save.mockReset();
+        logs.create.mockReset();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PaymentsService,
+                { provide: getRepositoryToken(Appointment), useValue: repo },
+                { provide: LogsService, useValue: logs },
+            ],
+        }).compile();
+        service = module.get(PaymentsService);
+        (service as any).stripe.checkout = { sessions: { create: jest.fn() } } as any;
+        (service as any).stripe.webhooks = { constructEvent: jest.fn() } as any;
+    });
+
+    it('creates checkout session', async () => {
+        repo.findOne.mockResolvedValue({ id: 1, service: { name: 'cut', price: 10 } });
+        (service as any).stripe.checkout.sessions.create.mockResolvedValue({ id: 's', url: 'u' });
+        const url = await service.createCheckoutSession(1);
+        expect(url).toBe('u');
+        expect(logs.create).toHaveBeenCalled();
+    });
+
+    it('updates appointment on successful webhook', async () => {
+        const appt = { id: 1, paymentStatus: PaymentStatus.Pending };
+        repo.findOne.mockResolvedValue(appt);
+        (service as any).stripe.webhooks.constructEvent.mockReturnValue({
+            type: 'checkout.session.completed',
+            data: { object: { id: 's', metadata: { appointmentId: '1' } } },
+        });
+        await service.handleWebhook(Buffer.from(''), 'sig');
+        expect(appt.paymentStatus).toBe(PaymentStatus.Paid);
+        expect(repo.save).toHaveBeenCalledWith(appt);
+    });
+
+    it('ignores duplicate webhook', async () => {
+        const appt = { id: 1, paymentStatus: PaymentStatus.Paid };
+        repo.findOne.mockResolvedValue(appt);
+        (service as any).stripe.webhooks.constructEvent.mockReturnValue({
+            type: 'checkout.session.completed',
+            data: { object: { id: 's', metadata: { appointmentId: '1' } } },
+        });
+        await service.handleWebhook(Buffer.from(''), 'sig');
+        expect(repo.save).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Stripe from 'stripe';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Appointment, PaymentStatus } from '../appointments/appointment.entity';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+
+@Injectable()
+export class PaymentsService {
+    private readonly stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+        apiVersion: '2024-04-10' as any,
+    });
+    private readonly logger = new Logger(PaymentsService.name);
+    constructor(
+        @InjectRepository(Appointment)
+        private readonly appts: Repository<Appointment>,
+        private readonly logs: LogsService,
+    ) {}
+
+    async createCheckoutSession(appointmentId: number) {
+        const appt = await this.appts.findOne({ where: { id: appointmentId } });
+        if (!appt) throw new Error('Appointment not found');
+        if (!appt.service) {
+            await this.appts.findOne({ where: { id: appointmentId }, relations: { service: true } });
+        }
+        const service = appt.service;
+        const session = await this.stripe.checkout.sessions.create({
+            mode: 'payment',
+            payment_method_types: ['card'],
+            line_items: [
+                {
+                    price_data: {
+                        currency: 'pln',
+                        unit_amount: Math.round(Number(service.price) * 100),
+                        product_data: { name: service.name },
+                    },
+                    quantity: 1,
+                },
+            ],
+            metadata: { appointmentId: String(appt.id) },
+            success_url: `${process.env.FRONTEND_URL}/success`,
+            cancel_url: `${process.env.FRONTEND_URL}/cancel`,
+        });
+        await this.logs.create(
+            LogAction.PaymentInit,
+            JSON.stringify({ appointmentId: appt.id, sessionId: session.id }),
+        );
+        return session.url;
+    }
+
+    async handleWebhook(payload: Buffer, signature: string) {
+        const secret = process.env.STRIPE_WEBHOOK_SECRET || '';
+        let event: Stripe.Event;
+        try {
+            event = this.stripe.webhooks.constructEvent(payload, signature, secret);
+        } catch (err) {
+            this.logger.error(`Signature verification failed: ${err}`);
+            throw err;
+        }
+        if (event.type === 'checkout.session.completed') {
+            const session = event.data.object as Stripe.Checkout.Session;
+            const apptId = Number(session.metadata?.appointmentId);
+            const appt = await this.appts.findOne({ where: { id: apptId } });
+            if (!appt || appt.paymentStatus === PaymentStatus.Paid) return;
+            appt.paymentStatus = PaymentStatus.Paid;
+            await this.appts.save(appt);
+            await this.logs.create(
+                LogAction.PaymentPaid,
+                JSON.stringify({ appointmentId: appt.id, sessionId: session.id }),
+            );
+        } else if (event.type === 'payment_intent.payment_failed') {
+            const intent = event.data.object as Stripe.PaymentIntent;
+            const apptId = Number(intent.metadata?.appointmentId);
+            const appt = await this.appts.findOne({ where: { id: apptId } });
+            if (!appt) return;
+            appt.paymentStatus = PaymentStatus.Failed;
+            await this.appts.save(appt);
+        } else if (event.type === 'charge.refunded') {
+            const charge = event.data.object as Stripe.Charge;
+            const apptId = Number(charge.metadata?.appointmentId);
+            const appt = await this.appts.findOne({ where: { id: apptId } });
+            if (!appt) return;
+            appt.paymentStatus = PaymentStatus.Refunded;
+            await this.appts.save(appt);
+        }
+    }
+}

--- a/backend/test/payments.e2e-spec.ts
+++ b/backend/test/payments.e2e-spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+import { PaymentsService } from './../src/payments/payments.service';
+import { PaymentStatus } from './../src/appointments/appointment.entity';
+
+describe('Payments (e2e)', () => {
+    let app: INestApplication<App>;
+    let users: UsersService;
+    let payments: PaymentsService;
+
+    beforeEach(async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test';
+        process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        users = moduleFixture.get(UsersService);
+        payments = moduleFixture.get(PaymentsService);
+        (payments as any).stripe.checkout = { sessions: { create: jest.fn().mockResolvedValue({ id: 's', url: 'u' }) } };
+        (payments as any).stripe.webhooks = { constructEvent: jest.fn().mockReturnValue({
+            type: 'checkout.session.completed',
+            data: { object: { id: 's', metadata: { appointmentId: '1' } } },
+        }) };
+    });
+
+    afterEach(async () => {
+        if (app) await app.close();
+    });
+
+    it('creates session and processes webhook', async () => {
+        const client = await users.createUser('p@test.com','secret','P',Role.Client);
+        const employee = await users.createUser('e@test.com','secret','E',Role.Employee);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'p@test.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token;
+        const start = new Date(Date.now()+86400000).toISOString();
+        const appt = await request(app.getHttpServer())
+            .post('/appointments/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ clientId: client.id, employeeId: employee.id, serviceId: 1, startTime: start })
+            .expect(201);
+        const id = appt.body.id;
+        await request(app.getHttpServer())
+            .post('/payments/create-session')
+            .send({ appointmentId: id })
+            .expect(201);
+        await payments.handleWebhook(Buffer.from(''), 'sig');
+        const updated = await request(app.getHttpServer())
+            .get(`/appointments/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+        expect(updated.body.paymentStatus).toBe(PaymentStatus.Paid);
+    });
+});

--- a/frontend/src/__tests__/paymentsApi.test.tsx
+++ b/frontend/src/__tests__/paymentsApi.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { usePaymentsApi } from '@/api/payments';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/contexts/AuthContext');
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+describe('usePaymentsApi', () => {
+  it('creates session and returns url', async () => {
+    const apiFetch = jest.fn().mockResolvedValue({ url: 'u' });
+    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    const { result } = renderHook(() => usePaymentsApi());
+    let url: string | null = null;
+    await act(async () => { url = await result.current.createSession(1); });
+    expect(url).toBe('u');
+  });
+});

--- a/frontend/src/api/payments.ts
+++ b/frontend/src/api/payments.ts
@@ -1,0 +1,16 @@
+import { useAuth } from '@/contexts/AuthContext';
+
+export function usePaymentsApi() {
+  const { apiFetch } = useAuth();
+
+  const createSession = async (appointmentId: number) => {
+    const res = await apiFetch<{ url: string }>('/payments/create-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appointmentId }),
+    });
+    return res.url;
+  };
+
+  return { createSession };
+}

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -2,9 +2,11 @@ import RouteGuard from '@/components/RouteGuard';
 import Layout from '@/components/Layout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
+import { usePaymentsApi } from '@/api/payments';
 
 export default function DashboardPage() {
   const { data, loading } = useDashboard();
+  const payments = usePaymentsApi();
 
   return (
     <RouteGuard>
@@ -43,7 +45,20 @@ export default function DashboardPage() {
                   <tr key={a.id} className="border-t">
                     <td className="p-2">{a.id}</td>
                     <td className="p-2">{new Date(a.startTime).toLocaleString()}</td>
-                    <td className="p-2">{a.client?.name}</td>
+                    <td className="p-2">
+                      {a.client?.name}{' '}
+                      {a.paymentStatus === 'pending' && (
+                        <button
+                          className="ml-2 underline"
+                          onClick={async () => {
+                            const url = await payments.createSession(a.id);
+                            window.location.href = url;
+                          }}
+                        >
+                          Opłać online
+                        </button>
+                      )}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,7 @@ export interface Appointment {
   id: number;
   startTime: string;
   client?: Client;
+  paymentStatus?: string;
 }
 
 export interface Service {


### PR DESCRIPTION
## Summary
- integrate Stripe checkout and webhook handling
- log payment events and track paymentStatus on appointments
- expose `/payments/create-session` API
- support payment in dashboard with "Opłać online" button
- test payments api and service

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687bf608de688329b51d9084ef36b531