### PR TITLE
Add calendar integration

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,8 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "googleapis": "^153.0.0",
+        "ics": "^3.8.1",
         "jsonwebtoken": "^9.0.2",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -5777,6 +5779,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bin-version": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
@@ -6712,6 +6723,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/dayjs": {
@@ -7667,6 +7687,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -7816,6 +7842,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -8133,6 +8182,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -8256,6 +8317,56 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -8416,6 +8527,83 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.1.0.tgz",
+      "integrity": "sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "153.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-153.0.0.tgz",
+      "integrity": "sha512-QT9Tdy9lx7KuZx620RaR/YsjwZTSw/dqlPKQRVLnMKTzOEghN0uZaKvpsm8aXjK+yEKWhJ8HQ6qOXRsJPLZHpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.1.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.0.tgz",
+      "integrity": "sha512-66if47It7y+Sab3HMkwEXx1kCq9qUC9px8ZXoj1CMrmLmUw81GpbnsNlXnlyZyGbGPGcj+tDD9XsZ23m7GLaJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8467,6 +8655,40 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/gtoken/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -8658,6 +8880,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/ics/-/ics-3.8.1.tgz",
+      "integrity": "sha512-UqQlfkajfhrS4pUGQfGIJMYz/Jsl/ob3LqcfEhUmLbwumg+ZNkU0/6S734Vsjq3/FYNpEcZVKodLBoe+zBM69g==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^3.1.23",
+        "runes2": "^1.1.2",
+        "yup": "^1.2.0"
       }
     },
     "node_modules/ieee754": {
@@ -9912,6 +10145,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -10831,6 +11073,24 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -10919,6 +11179,26 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -10927,6 +11207,24 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp": {
@@ -11928,6 +12226,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12337,6 +12641,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/runes2": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/runes2/-/runes2-1.1.4.tgz",
+      "integrity": "sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==",
+      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -13759,6 +14069,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -13848,6 +14164,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -14537,6 +14859,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14650,6 +14978,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webpack": {
@@ -15133,6 +15470,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,8 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "googleapis": "^153.0.0",
+    "ics": "^3.8.1",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
@@ -46,8 +48,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
-    "typeorm": "^0.3.25",
-    "stripe": "^14.23.0"
+    "stripe": "^14.23.0",
+    "typeorm": "^0.3.25"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { ChatMessagesModule } from './chat-messages/chat-messages.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { PaymentsModule } from './payments/payments.module';
+import { CalendarModule } from './calendar/calendar.module';
 
 @Module({
     imports: [
@@ -63,6 +64,7 @@ import { PaymentsModule } from './payments/payments.module';
         DashboardModule,
         NotificationsModule,
         PaymentsModule,
+        CalendarModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/src/calendar/calendar.controller.ts
+++ b/backend/src/calendar/calendar.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param, Query, Headers } from '@nestjs/common';
+import { CalendarService } from './calendar.service';
+
+@Controller('calendar')
+export class CalendarController {
+    constructor(private readonly service: CalendarService) {}
+
+    @Get('add/:id')
+    async add(
+        @Param('id') id: number,
+        @Query('provider') provider = 'ics',
+        @Headers('authorization') auth?: string,
+    ) {
+        const token = auth?.startsWith('Bearer ') ? auth.slice(7) : undefined;
+        return this.service.add(Number(id), provider, token);
+    }
+}

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Appointment } from '../appointments/appointment.entity';
+import { CalendarController } from './calendar.controller';
+import { CalendarService } from './calendar.service';
+import { GoogleCalendarAdapter } from './google-calendar.adapter';
+import { OutlookCalendarAdapter } from './outlook-calendar.adapter';
+import { LogsModule } from '../logs/logs.module';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Appointment]), LogsModule],
+    controllers: [CalendarController],
+    providers: [CalendarService, GoogleCalendarAdapter, OutlookCalendarAdapter],
+})
+export class CalendarModule {}

--- a/backend/src/calendar/calendar.service.spec.ts
+++ b/backend/src/calendar/calendar.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as nock from 'nock';
+import { CalendarService } from './calendar.service';
+import { GoogleCalendarAdapter } from './google-calendar.adapter';
+import { OutlookCalendarAdapter } from './outlook-calendar.adapter';
+import { Appointment } from '../appointments/appointment.entity';
+import { LogsService } from '../logs/logs.service';
+
+describe('CalendarService', () => {
+    let service: CalendarService;
+    const repo = {
+        findOne: jest.fn(),
+    } as any;
+    const logs = { create: jest.fn() } as any;
+
+    beforeEach(async () => {
+        nock.cleanAll();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CalendarService,
+                GoogleCalendarAdapter,
+                OutlookCalendarAdapter,
+                { provide: getRepositoryToken(Appointment), useValue: repo },
+                { provide: LogsService, useValue: logs },
+            ],
+        }).compile();
+        service = module.get(CalendarService);
+    });
+
+    it('creates google event', async () => {
+        repo.findOne.mockResolvedValue({
+            id: 1,
+            startTime: new Date('2024-01-01T10:00:00Z'),
+            service: { name: 'cut', duration: 60 },
+            client: { name: 'c' },
+        });
+        const scope = nock('https://www.googleapis.com')
+            .post('/calendar/v3/calendars/primary/events')
+            .reply(200, { id: 'e1' });
+        const result = await service.add(1, 'google', 'token');
+        expect(result).toEqual({ eventId: 'e1' });
+        expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns ics', async () => {
+        repo.findOne.mockResolvedValue({
+            id: 1,
+            startTime: new Date('2024-01-01T10:00:00Z'),
+            service: { name: 'cut', duration: 60 },
+            client: { name: 'c' },
+        });
+        const result = await service.add(1, 'ics');
+        expect(result?.ics).toContain('BEGIN:VCALENDAR');
+    });
+});

--- a/backend/src/calendar/calendar.service.ts
+++ b/backend/src/calendar/calendar.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Appointment } from '../appointments/appointment.entity';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+import { GoogleCalendarAdapter } from './google-calendar.adapter';
+import { OutlookCalendarAdapter } from './outlook-calendar.adapter';
+import { createEvent } from 'ics';
+
+@Injectable()
+export class CalendarService {
+    constructor(
+        @InjectRepository(Appointment)
+        private readonly appts: Repository<Appointment>,
+        private readonly logs: LogsService,
+        private readonly google: GoogleCalendarAdapter,
+        private readonly outlook: OutlookCalendarAdapter,
+    ) {}
+
+    async generateEventData(id: number) {
+        const appt = await this.appts.findOne({
+            where: { id },
+            relations: { service: true, client: true },
+        });
+        if (!appt) return null;
+        const end =
+            appt.endTime ||
+            new Date(appt.startTime.getTime() + appt.service.duration * 60000);
+        return {
+            title: appt.service.name,
+            description: `Wizyta z ${appt.client?.name ?? ''}`,
+            startTime: appt.startTime,
+            endTime: end,
+        };
+    }
+
+    async add(id: number, provider: string, token?: string) {
+        const data = await this.generateEventData(id);
+        if (!data) return null;
+        try {
+            if (provider === 'google' && token) {
+                const event = await this.google.addEvent(token, {
+                    summary: data.title,
+                    description: data.description,
+                    start: { dateTime: data.startTime.toISOString() },
+                    end: { dateTime: data.endTime.toISOString() },
+                });
+                await this.logs.create(
+                    LogAction.CalendarAdd,
+                    JSON.stringify({ id, provider }),
+                );
+                return { eventId: event.id };
+            }
+            if (provider === 'outlook' && token) {
+                const event = await this.outlook.addEvent(token, {
+                    subject: data.title,
+                    body: { contentType: 'HTML', content: data.description },
+                    start: { dateTime: data.startTime.toISOString(), timeZone: 'UTC' },
+                    end: { dateTime: data.endTime.toISOString(), timeZone: 'UTC' },
+                });
+                await this.logs.create(
+                    LogAction.CalendarAdd,
+                    JSON.stringify({ id, provider }),
+                );
+                return { eventId: event.id };
+            }
+            const { error, value } = createEvent({
+                title: data.title,
+                description: data.description,
+                start: [
+                    data.startTime.getUTCFullYear(),
+                    data.startTime.getUTCMonth() + 1,
+                    data.startTime.getUTCDate(),
+                    data.startTime.getUTCHours(),
+                    data.startTime.getUTCMinutes(),
+                ],
+                end: [
+                    data.endTime.getUTCFullYear(),
+                    data.endTime.getUTCMonth() + 1,
+                    data.endTime.getUTCDate(),
+                    data.endTime.getUTCHours(),
+                    data.endTime.getUTCMinutes(),
+                ],
+            });
+            if (error) throw error;
+            await this.logs.create(
+                LogAction.CalendarAdd,
+                JSON.stringify({ id, provider: 'ics' }),
+            );
+            return { ics: value };
+        } catch (e: any) {
+            await this.logs.create(
+                LogAction.CalendarAdd,
+                JSON.stringify({ id, provider, error: e.message }),
+            );
+            throw e;
+        }
+    }
+
+    async update(id: number, provider: string, token: string, eventId: string) {
+        const data = await this.generateEventData(id);
+        if (!data) return null;
+        try {
+            if (provider === 'google') {
+                await this.google.updateEvent(token, eventId, {
+                    summary: data.title,
+                });
+            } else if (provider === 'outlook') {
+                await this.outlook.updateEvent(token, eventId, {
+                    subject: data.title,
+                });
+            }
+            await this.logs.create(
+                LogAction.CalendarUpdate,
+                JSON.stringify({ id, provider }),
+            );
+        } catch (e: any) {
+            await this.logs.create(
+                LogAction.CalendarUpdate,
+                JSON.stringify({ id, provider, error: e.message }),
+            );
+            throw e;
+        }
+    }
+
+    async remove(provider: string, token: string, eventId: string) {
+        try {
+            if (provider === 'google') {
+                await this.google.removeEvent(token, eventId);
+            } else if (provider === 'outlook') {
+                await this.outlook.removeEvent(token, eventId);
+            }
+            await this.logs.create(
+                LogAction.CalendarDelete,
+                JSON.stringify({ provider, eventId }),
+            );
+        } catch (e: any) {
+            await this.logs.create(
+                LogAction.CalendarDelete,
+                JSON.stringify({ provider, eventId, error: e.message }),
+            );
+            throw e;
+        }
+    }
+}

--- a/backend/src/calendar/google-calendar.adapter.ts
+++ b/backend/src/calendar/google-calendar.adapter.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+
+export class GoogleCalendarAdapter {
+    async addEvent(token: string, event: any) {
+        try {
+            const res = await axios.post(
+                'https://www.googleapis.com/calendar/v3/calendars/primary/events',
+                event,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    proxy: false,
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            throw new Error(`Google API error: ${err.response?.status}`);
+        }
+    }
+
+    async updateEvent(token: string, eventId: string, event: any) {
+        try {
+            const res = await axios.patch(
+                `https://www.googleapis.com/calendar/v3/calendars/primary/events/${eventId}`,
+                event,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    proxy: false,
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            throw new Error(`Google API error: ${err.response?.status}`);
+        }
+    }
+
+    async removeEvent(token: string, eventId: string) {
+        try {
+            await axios.delete(
+                `https://www.googleapis.com/calendar/v3/calendars/primary/events/${eventId}`,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    proxy: false,
+                },
+            );
+        } catch (err: any) {
+            throw new Error(`Google API error: ${err.response?.status}`);
+        }
+    }
+}

--- a/backend/src/calendar/outlook-calendar.adapter.ts
+++ b/backend/src/calendar/outlook-calendar.adapter.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+
+export class OutlookCalendarAdapter {
+    async addEvent(token: string, event: any) {
+        try {
+            const res = await axios.post(
+                'https://graph.microsoft.com/v1.0/me/events',
+                event,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    proxy: false,
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            throw new Error(`Outlook API error: ${err.response?.status}`);
+        }
+    }
+
+    async updateEvent(token: string, eventId: string, event: any) {
+        try {
+            const res = await axios.patch(
+                `https://graph.microsoft.com/v1.0/me/events/${eventId}`,
+                event,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    proxy: false,
+                },
+            );
+            return res.data;
+        } catch (err: any) {
+            throw new Error(`Outlook API error: ${err.response?.status}`);
+        }
+    }
+
+    async removeEvent(token: string, eventId: string) {
+        try {
+            await axios.delete(
+                `https://graph.microsoft.com/v1.0/me/events/${eventId}`,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    proxy: false,
+                },
+            );
+        } catch (err: any) {
+            throw new Error(`Outlook API error: ${err.response?.status}`);
+        }
+    }
+}

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -12,4 +12,7 @@ export enum LogAction {
     CommissionGranted = 'COMMISSION_GRANTED',
     PaymentInit = 'PAYMENT_INIT',
     PaymentPaid = 'PAYMENT_PAID',
+    CalendarAdd = 'CALENDAR_ADD',
+    CalendarUpdate = 'CALENDAR_UPDATE',
+    CalendarDelete = 'CALENDAR_DELETE',
 }

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -38,6 +38,7 @@ export default function DashboardPage() {
                   <th className="p-2 text-left">ID</th>
                   <th className="p-2 text-left">Data</th>
                   <th className="p-2 text-left">Klient</th>
+                  <th className="p-2 text-left">&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
@@ -58,6 +59,15 @@ export default function DashboardPage() {
                           Opłać online
                         </button>
                       )}
+                    </td>
+                    <td className="p-2">
+                      <a
+                        className="underline"
+                        href={`${process.env.NEXT_PUBLIC_API_URL}/calendar/add/${a.id}`}
+                        target="_blank"
+                      >
+                        Dodaj do kalendarza
+                      </a>
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- integrate Google/Outlook calendar adapters
- expose `/calendar/add/:id` endpoint
- log calendar actions
- unit test calendar service using mocked HTTP calls
- allow dashboard users to add appointments to their calendars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bfa0f037883299a70a341b5cfaab7