### PR TITLE
Implement invoice generation adapter

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,3 +33,7 @@ EMAILS_ENABLED=true
 # Stripe credentials
 STRIPE_SECRET_KEY=sk_test
 STRIPE_WEBHOOK_SECRET=whsec_test
+
+# Invoicing API credentials
+INVOICE_API_URL=https://sandbox.example.com
+INVOICE_API_TOKEN=your-token

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { EmailsModule } from './emails/emails.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { PaymentsModule } from './payments/payments.module';
 import { CalendarModule } from './calendar/calendar.module';
+import { InvoicesModule } from './invoices/invoices.module';
 
 @Module({
     imports: [
@@ -66,6 +67,7 @@ import { CalendarModule } from './calendar/calendar.module';
         NotificationsModule,
         PaymentsModule,
         CalendarModule,
+        InvoicesModule,
         EmailsModule,
     ],
     controllers: [AppController, HealthController],

--- a/backend/src/invoices/invoice.entity.ts
+++ b/backend/src/invoices/invoice.entity.ts
@@ -1,0 +1,32 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+} from 'typeorm';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Entity()
+export class Invoice {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    reservationId: number;
+
+    @ManyToOne(() => Appointment, { onDelete: 'RESTRICT' })
+    reservation: Appointment;
+
+    @Column()
+    number: string;
+
+    @Column()
+    pdfUrl: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @Column({ default: 'issued' })
+    status: string;
+}

--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { InvoicesService } from './invoices.service';
+
+@Controller('invoices')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
+export class InvoicesController {
+    constructor(private readonly service: InvoicesService) {}
+
+    @Get()
+    list() {
+        return this.service.findAll();
+    }
+
+    @Post('generate/:reservationId')
+    generate(@Param('reservationId') id: number) {
+        return this.service.generate(Number(id));
+    }
+
+    @Get(':id/pdf')
+    getPdf(@Param('id') id: number) {
+        return this.service.getPdf(Number(id));
+    }
+}

--- a/backend/src/invoices/invoices.module.ts
+++ b/backend/src/invoices/invoices.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Invoice } from './invoice.entity';
+import { InvoicesService } from './invoices.service';
+import { InvoicesController } from './invoices.controller';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Invoice, Appointment])],
+    providers: [InvoicesService],
+    controllers: [InvoicesController],
+    exports: [InvoicesService],
+})
+export class InvoicesModule {}

--- a/backend/src/invoices/invoices.service.spec.ts
+++ b/backend/src/invoices/invoices.service.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import axios from 'axios';
+import { InvoicesService } from './invoices.service';
+import { Invoice } from './invoice.entity';
+import { Appointment } from '../appointments/appointment.entity';
+import { LogsService } from '../logs/logs.service';
+
+jest.mock('axios');
+const axiosMock = axios as jest.Mocked<typeof axios>;
+
+describe('InvoicesService', () => {
+    let service: InvoicesService;
+    const repo = {
+        create: jest.fn(),
+        save: jest.fn(),
+        find: jest.fn(),
+        findOne: jest.fn(),
+    } as any;
+    const appts = { findOne: jest.fn() } as any;
+    const logs = { create: jest.fn() } as any;
+
+    beforeEach(async () => {
+        axiosMock.post.mockReset();
+        repo.create.mockReset();
+        repo.save.mockReset();
+        appts.findOne.mockReset();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                InvoicesService,
+                { provide: getRepositoryToken(Invoice), useValue: repo },
+                { provide: getRepositoryToken(Appointment), useValue: appts },
+                { provide: LogsService, useValue: logs },
+            ],
+        }).compile();
+        service = module.get(InvoicesService);
+    });
+
+    it('generates invoice', async () => {
+        appts.findOne.mockResolvedValue({
+            id: 1,
+            client: { name: 'c' },
+            service: { name: 's', price: 10 },
+        });
+        axiosMock.post.mockResolvedValue({
+            data: { number: '1/2024', pdf_url: 'link' },
+        });
+        repo.create.mockImplementation((d: any) => d);
+        repo.save.mockImplementation((d: any) => d);
+        const inv = await service.generate(1);
+        expect(inv.number).toBe('1/2024');
+        expect(repo.save).toHaveBeenCalled();
+    });
+
+    it('returns pdf url', async () => {
+        repo.findOne.mockResolvedValue({ id: 1, pdfUrl: 'l' });
+        const res = await service.getPdf(1);
+        expect(res.pdfUrl).toBe('l');
+    });
+
+    it('logs on failure', async () => {
+        appts.findOne.mockResolvedValue({
+            id: 1,
+            client: { name: 'c' },
+            service: { name: 's', price: 10 },
+        });
+        axiosMock.post.mockRejectedValue(new Error('fail'));
+        await expect(service.generate(1)).rejects.toThrow('fail');
+    });
+});

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import axios from 'axios';
+import { Invoice } from './invoice.entity';
+import { Appointment } from '../appointments/appointment.entity';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+
+@Injectable()
+export class InvoicesService {
+    private readonly logger = new Logger(InvoicesService.name);
+    constructor(
+        @InjectRepository(Invoice)
+        private readonly repo: Repository<Invoice>,
+        @InjectRepository(Appointment)
+        private readonly appts: Repository<Appointment>,
+        private readonly logs: LogsService,
+    ) {}
+
+    async generate(reservationId: number) {
+        const appt = await this.appts.findOne({
+            where: { id: reservationId },
+            relations: { client: true, service: true },
+        });
+        if (!appt) throw new BadRequestException('Reservation not found');
+        try {
+            const res = await axios.post(
+                `${process.env.INVOICE_API_URL}/invoices`,
+                {
+                    client: { name: appt.client.name },
+                    items: [
+                        {
+                            name: appt.service.name,
+                            price: appt.service.price,
+                        },
+                    ],
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${process.env.INVOICE_API_TOKEN}`,
+                    },
+                },
+            );
+            const invoice = this.repo.create({
+                reservationId,
+                reservation: appt,
+                number: res.data.number,
+                pdfUrl: res.data.pdf_url,
+                status: 'issued',
+            });
+            const saved = await this.repo.save(invoice);
+            await this.logs.create(
+                LogAction.InvoiceGenerated,
+                JSON.stringify({ reservationId, number: saved.number }),
+            );
+            return saved;
+        } catch (err) {
+            this.logger.error(`Invoice generation failed: ${err}`);
+            throw err;
+        }
+    }
+
+    async findAll() {
+        return this.repo.find();
+    }
+
+    async getPdf(id: number) {
+        const invoice = await this.repo.findOne({ where: { id } });
+        if (!invoice) throw new BadRequestException('Invoice not found');
+        return { pdfUrl: invoice.pdfUrl };
+    }
+}

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -12,6 +12,7 @@ export enum LogAction {
     CommissionGranted = 'COMMISSION_GRANTED',
     PaymentInit = 'PAYMENT_INIT',
     PaymentPaid = 'PAYMENT_PAID',
+    InvoiceGenerated = 'INVOICE_GENERATED',
     CalendarAdd = 'CALENDAR_ADD',
     CalendarUpdate = 'CALENDAR_UPDATE',
     CalendarDelete = 'CALENDAR_DELETE',

--- a/frontend/src/api/invoices.ts
+++ b/frontend/src/api/invoices.ts
@@ -1,0 +1,14 @@
+import { useAuth } from '@/contexts/AuthContext';
+
+export function useInvoicesApi() {
+    const { apiFetch } = useAuth();
+
+    const generate = async (reservationId: number) => {
+        const res = await apiFetch('/invoices/generate/' + reservationId, {
+            method: 'POST',
+        });
+        return res;
+    };
+
+    return { generate };
+}

--- a/frontend/src/hooks/useInvoices.ts
+++ b/frontend/src/hooks/useInvoices.ts
@@ -1,0 +1,6 @@
+import { useList } from './useList';
+import { Invoice } from '@/types';
+
+export function useInvoices() {
+    return useList<Invoice>('/invoices');
+}

--- a/frontend/src/pages/invoices/index.tsx
+++ b/frontend/src/pages/invoices/index.tsx
@@ -1,0 +1,42 @@
+import RouteGuard from '@/components/RouteGuard';
+import Layout from '@/components/Layout';
+import { useInvoices } from '@/hooks/useInvoices';
+
+export default function InvoicesPage() {
+    const { data, loading } = useInvoices();
+
+    return (
+        <RouteGuard>
+            <Layout>
+                {loading ? (
+                    <div>Loading...</div>
+                ) : (
+                    <table className="min-w-full border">
+                        <thead>
+                            <tr className="bg-gray-50">
+                                <th className="p-2 text-left">Number</th>
+                                <th className="p-2 text-left">PDF</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data?.map((inv) => (
+                                <tr key={inv.id} className="border-t">
+                                    <td className="p-2">{inv.number}</td>
+                                    <td className="p-2">
+                                        <a
+                                            className="underline"
+                                            href={inv.pdfUrl}
+                                            target="_blank"
+                                        >
+                                            Pobierz
+                                        </a>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </Layout>
+        </RouteGuard>
+    );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -55,3 +55,12 @@ export interface EmailLog {
     status: string;
     sentAt: string;
 }
+
+export interface Invoice {
+    id: number;
+    reservationId: number;
+    number: string;
+    pdfUrl: string;
+    createdAt: string;
+    status: string;
+}


### PR DESCRIPTION
## Summary
- create backend invoices module with entity and controller
- expose `/invoices/generate/:reservationId` endpoint
- log invoice generation events
- add Invoice type and admin page to view invoices
- provide React hooks and API wrapper for invoices
- document invoicing env vars

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c0787dcb483299a4461750c9a26a7