### PR TITLE
Fix email opt-out parameter

### DIFF
--- a/backend/src/emails/emails.controller.ts
+++ b/backend/src/emails/emails.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Get,
+    Param,
+    Post,
+} from '@nestjs/common';
 import { Public } from '../auth/public.decorator';
 import { EmailsService, EmailPayload } from './emails.service';
 
@@ -27,7 +34,11 @@ export class EmailsController {
     @Post('opt-out')
     @Public()
     optOut(@Body() body: { token?: string; email?: string }) {
-        return this.service.optOut(body.token || body.email);
+        const tokenOrEmail = body.token || body.email;
+        if (!tokenOrEmail) {
+            throw new BadRequestException('token or email is required');
+        }
+        return this.service.optOut(tokenOrEmail);
     }
 
     @Get('unsubscribe/:token')


### PR DESCRIPTION
## Summary
- validate required token/email param in opt-out endpoint

## Testing
- `npm run lint` in `backend`
- `npm test -- --coverage` in `backend`
- `npm run build` in `backend`
- `npm run lint` in `frontend`
- `npm test -- --coverage` in `frontend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687c09d72fec832996ef23fdcabf5aa4