### PR TITLE
Add Instagram gallery integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,14 @@ npm run start:prod
 
 Use `npm run lint` to check the code and `npm run format` to apply Prettier. A
 pre‑commit hook powered by Husky runs Prettier on staged files automatically.
+
+## Instagram integration
+
+The backend fetches the latest posts from Instagram for the gallery page.
+Set a long‑lived token in `backend/.env`:
+
+```bash
+INSTAGRAM_ACCESS_TOKEN=your-instagram-token
+```
+
+Remember to refresh this token periodically so the gallery keeps working.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,3 +37,6 @@ STRIPE_WEBHOOK_SECRET=whsec_test
 # Invoicing API credentials
 INVOICE_API_URL=https://sandbox.example.com
 INVOICE_API_TOKEN=your-token
+
+# Instagram Basic Display API token
+INSTAGRAM_ACCESS_TOKEN=your-instagram-token

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { DashboardModule } from './dashboard/dashboard.module';
 import { PaymentsModule } from './payments/payments.module';
 import { CalendarModule } from './calendar/calendar.module';
 import { InvoicesModule } from './invoices/invoices.module';
+import { IntegrationsModule } from './integrations/integrations.module';
 
 @Module({
     imports: [
@@ -68,6 +69,7 @@ import { InvoicesModule } from './invoices/invoices.module';
         PaymentsModule,
         CalendarModule,
         InvoicesModule,
+        IntegrationsModule,
         EmailsModule,
     ],
     controllers: [AppController, HealthController],

--- a/backend/src/integrations/gallery.controller.ts
+++ b/backend/src/integrations/gallery.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { InstagramService } from './instagram.service';
+
+@Controller('gallery')
+export class GalleryController {
+    constructor(private readonly instagram: InstagramService) {}
+
+    @Get()
+    getGallery(@Query('count') count = '9') {
+        const num = parseInt(count, 10) || 9;
+        return this.instagram.fetchLatestPosts(num);
+    }
+}

--- a/backend/src/integrations/instagram.service.spec.ts
+++ b/backend/src/integrations/instagram.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InstagramService } from './instagram.service';
+import * as nock from 'nock';
+
+describe('InstagramService', () => {
+    let service: InstagramService;
+    const httpProxy = process.env.http_proxy;
+    const httpsProxy = process.env.https_proxy;
+    const HTTPProxy = process.env.HTTP_PROXY;
+    const HTTPSProxy = process.env.HTTPS_PROXY;
+    const npmHttpProxy = process.env.npm_config_http_proxy;
+    const npmHttpsProxy = process.env.npm_config_https_proxy;
+    const yarnHttpProxy = process.env.YARN_HTTP_PROXY;
+    const yarnHttpsProxy = process.env.YARN_HTTPS_PROXY;
+    const globalProxy = process.env.GLOBAL_AGENT_HTTP_PROXY;
+
+    beforeEach(async () => {
+        process.env.INSTAGRAM_ACCESS_TOKEN = 'token';
+        delete process.env.http_proxy;
+        delete process.env.https_proxy;
+        delete process.env.HTTP_PROXY;
+        delete process.env.HTTPS_PROXY;
+        delete process.env.npm_config_http_proxy;
+        delete process.env.npm_config_https_proxy;
+        delete process.env.YARN_HTTP_PROXY;
+        delete process.env.YARN_HTTPS_PROXY;
+        delete process.env.GLOBAL_AGENT_HTTP_PROXY;
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [InstagramService],
+        }).compile();
+
+        service = module.get<InstagramService>(InstagramService);
+    });
+
+    afterEach(() => {
+        delete process.env.INSTAGRAM_ACCESS_TOKEN;
+        if (httpProxy) process.env.http_proxy = httpProxy;
+        else delete process.env.http_proxy;
+        if (httpsProxy) process.env.https_proxy = httpsProxy;
+        else delete process.env.https_proxy;
+        if (HTTPProxy) process.env.HTTP_PROXY = HTTPProxy;
+        else delete process.env.HTTP_PROXY;
+        if (HTTPSProxy) process.env.HTTPS_PROXY = HTTPSProxy;
+        else delete process.env.HTTPS_PROXY;
+        if (npmHttpProxy) process.env.npm_config_http_proxy = npmHttpProxy;
+        else delete process.env.npm_config_http_proxy;
+        if (npmHttpsProxy) process.env.npm_config_https_proxy = npmHttpsProxy;
+        else delete process.env.npm_config_https_proxy;
+        if (yarnHttpProxy) process.env.YARN_HTTP_PROXY = yarnHttpProxy;
+        else delete process.env.YARN_HTTP_PROXY;
+        if (yarnHttpsProxy) process.env.YARN_HTTPS_PROXY = yarnHttpsProxy;
+        else delete process.env.YARN_HTTPS_PROXY;
+        if (globalProxy) process.env.GLOBAL_AGENT_HTTP_PROXY = globalProxy;
+        else delete process.env.GLOBAL_AGENT_HTTP_PROXY;
+        nock.cleanAll();
+    });
+
+    it('fetchLatestPosts parses API response', async () => {
+        nock('https://graph.instagram.com')
+            .get('/me/media')
+            .query(true)
+            .reply(200, {
+                data: [
+                    {
+                        id: '1',
+                        caption: 'A',
+                        media_url: 'img1.jpg',
+                        thumbnail_url: 'thumb1.jpg',
+                        permalink: 'link1',
+                        media_type: 'IMAGE',
+                    },
+                    {
+                        id: '2',
+                        caption: 'B',
+                        media_url: 'img2.jpg',
+                        thumbnail_url: 'thumb2.jpg',
+                        permalink: 'link2',
+                        media_type: 'VIDEO',
+                    },
+                ],
+            });
+
+        const posts = await service.fetchLatestPosts(1);
+        expect(posts).toEqual([
+            {
+                imageUrl: 'img1.jpg',
+                caption: 'A',
+                link: 'link1',
+                thumbnailUrl: 'thumb1.jpg',
+            },
+        ]);
+        expect(nock.isDone()).toBe(true);
+    });
+});

--- a/backend/src/integrations/instagram.service.ts
+++ b/backend/src/integrations/instagram.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+
+interface InstagramApiItem {
+    id: string;
+    caption?: string;
+    media_url: string;
+    thumbnail_url?: string;
+    permalink: string;
+    media_type: string;
+}
+
+export interface InstagramPost {
+    imageUrl: string;
+    caption?: string;
+    link: string;
+    thumbnailUrl: string;
+}
+
+@Injectable()
+export class InstagramService {
+    private readonly token = process.env.INSTAGRAM_ACCESS_TOKEN;
+    private cache: { timestamp: number; posts: InstagramPost[] } | null = null;
+    private readonly baseUrl = 'https://graph.instagram.com';
+    private readonly cacheMs = 10 * 60 * 1000; // 10 minutes
+
+    async fetchLatestPosts(count: number): Promise<InstagramPost[]> {
+        if (this.cache && Date.now() - this.cache.timestamp < this.cacheMs) {
+            return this.cache.posts.slice(0, count);
+        }
+        if (!this.token) {
+            Logger.error('INSTAGRAM_ACCESS_TOKEN not set');
+            return [];
+        }
+        try {
+            const res = await axios.get<{ data: InstagramApiItem[] }>(
+                `${this.baseUrl}/me/media`,
+                {
+                    params: {
+                        fields: 'id,caption,media_url,thumbnail_url,permalink,media_type',
+                        access_token: this.token,
+                    },
+                },
+            );
+            const posts = res.data.data
+                .filter((p) => p.media_type === 'IMAGE')
+                .map((p) => ({
+                    imageUrl: p.media_url,
+                    caption: p.caption,
+                    link: p.permalink,
+                    thumbnailUrl: p.thumbnail_url || p.media_url,
+                }));
+            this.cache = { timestamp: Date.now(), posts };
+            return posts.slice(0, count);
+        } catch (err) {
+            Logger.error('Instagram API error', err as any);
+            return [];
+        }
+    }
+}

--- a/backend/src/integrations/integrations.module.ts
+++ b/backend/src/integrations/integrations.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { InstagramService } from './instagram.service';
+import { GalleryController } from './gallery.controller';
+
+@Module({
+    providers: [InstagramService],
+    controllers: [GalleryController],
+    exports: [InstagramService],
+})
+export class IntegrationsModule {}


### PR DESCRIPTION
## Summary
- integrate Instagram API to fetch gallery images
- expose `/gallery` endpoint returning latest posts
- provide integration module and unit test
- document Instagram token requirement
- add environment variable example

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0ba36ba48329bdfcb02fc0948b0e