### PR TITLE
Add role-based dashboard navigation

### DIFF
--- a/frontend/src/components/DashboardNav.tsx
+++ b/frontend/src/components/DashboardNav.tsx
@@ -1,18 +1,59 @@
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 
+type Role = 'client' | 'employee' | 'admin';
+
+const navLinks: Record<Role, { href: string; label: string }[]> = {
+    client: [
+        { href: '/dashboard/client', label: 'Home' },
+        { href: '/appointments', label: 'Appointments' },
+        { href: '/invoices', label: 'Invoices' },
+        { href: '/reviews', label: 'Reviews' },
+    ],
+    employee: [
+        { href: '/dashboard/employee', label: 'Home' },
+        { href: '/appointments', label: 'Appointments' },
+        { href: '/clients', label: 'Clients' },
+    ],
+    admin: [
+        { href: '/dashboard/admin', label: 'Home' },
+        { href: '/appointments', label: 'Appointments' },
+        { href: '/clients', label: 'Clients' },
+        { href: '/employees', label: 'Employees' },
+        { href: '/products', label: 'Products' },
+        { href: '/emails', label: 'Emails' },
+    ],
+};
+
 export default function DashboardNav() {
-  const { logout } = useAuth();
-  return (
-    <aside className="w-48 bg-gray-200 p-4 space-y-2">
-      <h2 className="font-bold mb-2">Menu</h2>
-      <nav className="space-y-1">
-        <Link href="/dashboard">Home</Link>
-        <Link href="/dashboard/services">Services</Link>
-        <button className="block text-left" onClick={logout}>
-          Logout
-        </button>
-      </nav>
-    </aside>
-  );
+    const { logout } = useAuth();
+    const [role, setRole] = useState<Role>('client');
+
+    useEffect(() => {
+        const stored = localStorage.getItem('role');
+        if (
+            stored === 'client' ||
+            stored === 'employee' ||
+            stored === 'admin'
+        ) {
+            setRole(stored);
+        }
+    }, []);
+
+    return (
+        <aside className="w-48 bg-gray-200 p-4 space-y-2">
+            <h2 className="font-bold mb-2">Menu</h2>
+            <nav className="space-y-1">
+                {navLinks[role].map((l) => (
+                    <Link key={l.href} href={l.href} className="block">
+                        {l.label}
+                    </Link>
+                ))}
+                <button className="block text-left" onClick={logout}>
+                    Logout
+                </button>
+            </nav>
+        </aside>
+    );
 }


### PR DESCRIPTION
## Summary
- create a `DashboardNav` that renders links for client, employee, or admin based on `localStorage`
- keep existing `PublicNav` and `Layout` components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68878803294483298e04a02434a0bc6f