### PR TITLE
Add EmployeeRole imports in appointment controllers

### DIFF
--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -20,6 +20,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 import { Request as ExpressRequest } from 'express';
@@ -68,7 +69,7 @@ export class AdminAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         return this.service.cancel(Number(id), req.user.id, req.user.role);
     }
 
@@ -78,7 +79,7 @@ export class AdminAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         return this.service.complete(Number(id), req.user.id, req.user.role);
     }
 

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -20,6 +20,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 import { Request as ExpressRequest } from 'express';
@@ -79,7 +80,7 @@ export class ClientAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         return this.service.cancel(Number(id), req.user.id, req.user.role);
     }
 
@@ -89,7 +90,7 @@ export class ClientAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         return this.service.complete(Number(id), req.user.id, req.user.role);
     }
 

--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -18,6 +18,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 import { Request as ExpressRequest } from 'express';
 
@@ -61,7 +62,7 @@ export class EmployeeAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         return this.service.cancel(Number(id), req.user.id, req.user.role);
     }
 
@@ -71,7 +72,7 @@ export class EmployeeAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         return this.service.complete(Number(id), req.user.id, req.user.role);
     }
 }


### PR DESCRIPTION
## Summary
- fix missing `EmployeeRole` imports in appointment controllers
- verify builds with `npm run lint` and `npm test`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688796ef8fa083299259712a9e312b17