### PR TITLE
Add Jest setup and sample test

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],

--- a/frontend/src/__tests__/sample.test.tsx
+++ b/frontend/src/__tests__/sample.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+function Sample() {
+  return <div>Hello Jest</div>;
+}
+
+describe('Sample component', () => {
+  it('renders text', () => {
+    render(<Sample />);
+    expect(screen.getByText('Hello Jest')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `jest.config.js` and remove previous MJS config
- include a simple sample test
- ensure Jest runs from `npm test`

## Testing
- `npm test --silent -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_68879ca440888329b5d756965e0a05a8