### PR TITLE
Add simple PublicNav

### DIFF
--- a/frontend/src/components/PublicNav.tsx
+++ b/frontend/src/components/PublicNav.tsx
@@ -1,23 +1,15 @@
 'use client';
 import Link from 'next/link';
-import { useAuth } from '@/contexts/AuthContext';
 
 export default function PublicNav() {
-  const { isAuthenticated } = useAuth();
   return (
     <nav className="flex space-x-4 p-2 border-b">
       <Link href="/">Home</Link>
       <Link href="/services">Services</Link>
       <Link href="/gallery">Gallery</Link>
       <Link href="/contact">Contact</Link>
-      {isAuthenticated ? (
-        <Link href="/dashboard">Dashboard</Link>
-      ) : (
-        <>
-          <Link href="/auth/login">Login</Link>
-          <Link href="/auth/register">Register</Link>
-        </>
-      )}
+      <Link href="/auth/login">Login</Link>
+      <Link href="/auth/register">Register</Link>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- simplify PublicNav links so it always shows Login/Register
- keep Layout with PublicNav header and DashboardNav sidebar

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68879ea8b13c832995c9d4c40f94ec10