### PR TITLE
Implement dashboard role routing

### DIFF
--- a/frontend/src/components/DashboardNav.tsx
+++ b/frontend/src/components/DashboardNav.tsx
@@ -2,8 +2,7 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-
-type Role = 'client' | 'employee' | 'admin';
+import type { Role } from '@/types';
 
 const navLinks: Record<Role, { href: string; label: string }[]> = {
     client: [

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -1,13 +1,14 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import type { Role } from '@/types';
 
 export default function DashboardRedirect() {
   const router = useRouter();
   useEffect(() => {
     const stored = localStorage.getItem('role');
-    const role =
+    const role: Role =
       stored === 'client' || stored === 'employee' || stored === 'admin'
-        ? stored
+        ? (stored as Role)
         : 'client';
     router.replace(`/dashboard/${role}`);
   }, [router]);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,6 +3,8 @@ export interface Client {
     name: string;
 }
 
+export type Role = 'client' | 'employee' | 'admin';
+
 export interface Appointment {
     id: number;
     startTime: string;


### PR DESCRIPTION
## Summary
- define `Role` type in frontend types
- share the `Role` type in `DashboardNav`
- update dashboard index redirect to use the shared `Role` type

## Testing
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6887a0de17ac8329a527a6060c90d11f