### PR TITLE
Update docs for frontend pages and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,22 @@ To get each part running, follow
 [`backend/README.md`](backend/README.md) for backend instructions and
 [`frontend/README.md`](frontend/README.md) for the frontend.
 
-The frontend provides marketing pages (home, services, gallery and contact),
-authentication under `/auth`, and a role-based dashboard located in `/dashboard`.
+## Frontend overview
+
+The Next.js app offers several publicly accessible marketing pages:
+
+- `/` – home page
+- `/services` – list of available services fetched from the API
+- `/gallery` – photo gallery populated from Instagram
+- `/contact` – contact details and a simple form
+
+Authentication is handled under `/auth` (`/auth/login` and `/auth/register`).
+After signing in, users are redirected to `/dashboard` which renders different
+sub‑pages depending on the user role:
+
+- `client` – personal appointments and profile management
+- `employee` – manage bookings and availability
+- `admin` – administration tools for managing users and services
 
 
 The old Laravel-based frontend has been archived in

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,7 +11,8 @@ cd frontend
 npm install
 ```
 
-Create a `.env.local` file with the API URL used by the frontend:
+Create a `.env.local` file with the API URL used by the frontend. This value is
+read by Next.js at build and runtime and should point to the running backend:
 
 ```bash
 NEXT_PUBLIC_API_URL=http://localhost:3001
@@ -21,9 +22,13 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 
 Run these commands from the `frontend` folder:
 
-- `npm run dev` – start the development server
+- `npm run dev` – start the development server with Tailwind watching for changes
 - `npm run lint` – check the code with ESLint
 - `npm run format` – format source files with Prettier
+
+When `npm run dev` is running, Tailwind CSS classes are compiled on the fly
+using the configuration in `tailwind.config.ts` and the global styles in
+`src/styles/globals.css`.
 
 ## Features
 
@@ -31,4 +36,4 @@ Run these commands from the `frontend` folder:
 - **Authentication** routes in `src/pages/auth` with login and registration forms.
 - **Role-based dashboard** pages under `src/pages/dashboard` for clients, employees and admins.
 - Navigation components in `src/components` (`PublicNav` and `DashboardNav`) rendered via the global `Layout`.
-- Configure the backend API URL via `NEXT_PUBLIC_API_URL`.
+- Configure the backend API URL via `NEXT_PUBLIC_API_URL` in `.env.local`.


### PR DESCRIPTION
## Summary
- explain marketing pages, auth routes and dashboard roles
- document running the frontend with Tailwind
- clarify where `NEXT_PUBLIC_API_URL` is configured

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a1e91cf08329a1e7cd8e1dcd8f50