### PR TITLE
Use phone-aware interfaces in appointment service

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -10,7 +10,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Appointment, AppointmentStatus } from './appointment.entity';
 import { Service } from '../catalog/service.entity';
-import { Employee } from '../employees/employee.entity';
 import { FormulasService } from '../formulas/formulas.service';
 import { CommissionRecord } from '../commissions/commission-record.entity';
 import { CommissionsService } from '../commissions/commissions.service';
@@ -20,16 +19,7 @@ import { UpdateAppointmentParams } from './dto/update-appointment-params';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
 import { NotificationsService } from '../notifications/notifications.service';
-
-interface ClientWithPhone {
-    id: number;
-    phone?: string | null;
-}
-
-interface EmployeeWithPhone {
-    id: number;
-    phone?: string | null;
-}
+import { ClientWithPhone, EmployeeWithPhone } from './phone-interfaces';
 
 @Injectable()
 export class AppointmentsService {
@@ -169,7 +159,7 @@ export class AppointmentsService {
             appt.service = { id: dto.serviceId } as Service;
         }
         if (dto.employeeId) {
-            appt.employee = { id: dto.employeeId } as Employee;
+            appt.employee = { id: dto.employeeId } as EmployeeWithPhone;
         }
         if (dto.status) {
             appt.status = dto.status;

--- a/backend/src/appointments/phone-interfaces.ts
+++ b/backend/src/appointments/phone-interfaces.ts
@@ -1,0 +1,9 @@
+export interface ClientWithPhone {
+    id: number;
+    phone?: string | null;
+}
+
+export interface EmployeeWithPhone {
+    id: number;
+    phone?: string | null;
+}

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -46,7 +46,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
                 secret: process.env.JWT_SECRET ?? 'secret',
             });
             client.data.userId = payload.sub;
-            await client.join(this.roomForUser(client.data.userId));
+            await client.join(
+                this.roomForUser(client.data.userId as number),
+            );
         } catch {
             client.disconnect();
         }


### PR DESCRIPTION
## Summary
- add `ClientWithPhone` and `EmployeeWithPhone` interfaces
- use these interfaces instead of `as any` in AppointmentsService
- fix lint warning in ChatGateway

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887a9a5134c8329b3b2767b23c62c82