### PR TITLE
Add customer listing endpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { PaymentsModule } from './payments/payments.module';
 import { CalendarModule } from './calendar/calendar.module';
 import { InvoicesModule } from './invoices/invoices.module';
 import { IntegrationsModule } from './integrations/integrations.module';
+import { CustomersModule } from './customers/customers.module';
 
 @Module({
     imports: [
@@ -65,6 +66,7 @@ import { IntegrationsModule } from './integrations/integrations.module';
         LogsModule,
         CommunicationsModule,
         DashboardModule,
+        CustomersModule,
         NotificationsModule,
         PaymentsModule,
         CalendarModule,

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Param, NotFoundException, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { CustomersService } from './customers.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { EmployeeRole } from '../employees/employee-role.enum';
+
+@ApiTags('Customers')
+@ApiBearerAuth()
+@Controller('customers')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin, EmployeeRole.RECEPCJA)
+export class CustomersController {
+    constructor(private readonly service: CustomersService) {}
+
+    @Get()
+    async list() {
+        const customers = await this.service.findAll();
+        return customers.map((c) => {
+            const { password, refreshToken, ...rest } = c as any;
+            return rest;
+        });
+    }
+
+    @Get(':id')
+    async get(@Param('id') id: string) {
+        const customer = await this.service.findOne(Number(id));
+        if (!customer) {
+            throw new NotFoundException();
+        }
+        const { password, refreshToken, ...rest } = customer as any;
+        return rest;
+    }
+}

--- a/backend/src/customers/customers.module.ts
+++ b/backend/src/customers/customers.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Customer } from './customer.entity';
+import { CustomersController } from './customers.controller';
+import { CustomersService } from './customers.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Customer])],
+    controllers: [CustomersController],
+    providers: [CustomersService],
+    exports: [TypeOrmModule, CustomersService],
+})
+export class CustomersModule {}

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Customer } from './customer.entity';
+import { Role } from '../users/role.enum';
+
+@Injectable()
+export class CustomersService {
+    constructor(
+        @InjectRepository(Customer)
+        private readonly repo: Repository<Customer>,
+    ) {}
+
+    findAll() {
+        return this.repo.find({ where: { role: Role.Client } });
+    }
+
+    findOne(id: number) {
+        return this.repo.findOne({ where: { id, role: Role.Client } });
+    }
+}

--- a/backend/src/emails/email-log.entity.ts
+++ b/backend/src/emails/email-log.entity.ts
@@ -29,7 +29,7 @@ export class EmailLog {
     @Column({ type: 'simple-enum', enum: EmailStatus })
     status: EmailStatus;
 
-    @Column({ nullable: true })
+    @Column('text', { nullable: true })
     error: string | null;
 
     @CreateDateColumn()

--- a/backend/test/customers.e2e-spec.ts
+++ b/backend/test/customers.e2e-spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { AuthService } from './../src/auth/auth.service';
+import { Role } from './../src/users/role.enum';
+import { EmployeeRole } from './../src/employees/employee-role.enum';
+
+describe('CustomersController (e2e)', () => {
+    let app: INestApplication<App>;
+    let usersService: UsersService;
+    let authService: AuthService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        usersService = moduleFixture.get(UsersService);
+        authService = moduleFixture.get(AuthService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('admin can list customers', async () => {
+        await usersService.createUser('admin@cust.com', 'secret', 'Admin', Role.Admin);
+        await usersService.createUser('c1@test.com', 'secret', 'C1', Role.Client);
+        await usersService.createUser('c2@test.com', 'secret', 'C2', Role.Client);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@cust.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        const res = await request(app.getHttpServer())
+            .get('/customers')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBe(2);
+        res.body.forEach((c: any) => {
+            expect(c).not.toHaveProperty('password');
+            expect(c).not.toHaveProperty('refreshToken');
+            expect(c.role).toBe('client');
+        });
+    });
+
+    it('rejects unauthorized access', async () => {
+        await request(app.getHttpServer()).get('/customers').expect(401);
+
+        const employee = await usersService.createUser(
+            'emp@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const tokens = await authService.generateTokens(employee.id, EmployeeRole.FRYZJER);
+        const token = tokens.access_token;
+
+        await request(app.getHttpServer())
+            .get('/customers')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403);
+    });
+
+    it('returns 404 for missing customer', async () => {
+        await usersService.createUser('admin2@cust.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin2@cust.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .get('/customers/999')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+    });
+});


### PR DESCRIPTION
## Summary
- implement CustomersService/Controller/Module
- expose customers routes with admin or receptionist roles
- sanitize customer output fields
- register module in AppModule
- add e2e tests
- fix EmailLog entity to be sqlite-compatible

## Testing
- `npm run lint --prefix backend`
- `npm run test:e2e --silent --prefix backend` *(fails: database locked)*

------
https://chatgpt.com/codex/tasks/task_e_6887d5749da0832999b60337fb71e4d2