### PR TITLE
Fix customer ID parsing

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, NotFoundException, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, NotFoundException, UseGuards, ParseIntPipe } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { CustomersService } from './customers.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -25,8 +25,8 @@ export class CustomersController {
     }
 
     @Get(':id')
-    async get(@Param('id') id: string) {
-        const customer = await this.service.findOne(Number(id));
+    async get(@Param('id', ParseIntPipe) id: number) {
+        const customer = await this.service.findOne(id);
         if (!customer) {
             throw new NotFoundException();
         }

--- a/backend/test/customers.e2e-spec.ts
+++ b/backend/test/customers.e2e-spec.ts
@@ -87,4 +87,18 @@ describe('CustomersController (e2e)', () => {
             .set('Authorization', `Bearer ${token}`)
             .expect(404);
     });
+
+    it('returns 400 for invalid customer id', async () => {
+        await usersService.createUser('admin3@cust.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin3@cust.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .get('/customers/abc')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(400);
+    });
 });


### PR DESCRIPTION
## Summary
- update CustomersController `get` to use `ParseIntPipe` for ID
- check for numeric ID in customers e2e tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: SQLITE_BUSY errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887dd0485b48329a5570f7be955d4d9