### PR TITLE
Rename recepcja role

### DIFF
--- a/backend/src/auth/roles.guard.spec.ts
+++ b/backend/src/auth/roles.guard.spec.ts
@@ -55,7 +55,7 @@ describe('RolesGuard', () => {
     });
 
     it('throws when employee role does not match', () => {
-        reflector.getAllAndOverride.mockReturnValue([EmployeeRole.RECEPCJA]);
+        reflector.getAllAndOverride.mockReturnValue([EmployeeRole.RECEPTIONIST]);
         const ctx = createContext(EmployeeRole.FRYZJER);
         expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
     });

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -11,7 +11,7 @@ import { EmployeeRole } from '../employees/employee-role.enum';
 @ApiBearerAuth()
 @Controller('customers')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(Role.Admin, EmployeeRole.RECEPCJA)
+@Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
 export class CustomersController {
     constructor(private readonly service: CustomersService) {}
 

--- a/backend/src/employees/employee-role.enum.ts
+++ b/backend/src/employees/employee-role.enum.ts
@@ -1,6 +1,6 @@
 export enum EmployeeRole {
     ADMIN = 'ADMIN',
     FRYZJER = 'FRYZJER',
-    RECEPCJA = 'RECEPCJA',
+    RECEPTIONIST = 'RECEPTIONIST',
     POMOCNIK = 'POMOCNIK',
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -54,7 +54,7 @@ export class UsersController {
     }
 
     @Patch('customers/:id')
-    @Roles(EmployeeRole.RECEPCJA, EmployeeRole.ADMIN, Role.Admin)
+    @Roles(EmployeeRole.RECEPTIONIST, EmployeeRole.ADMIN, Role.Admin)
     @ApiOperation({ summary: 'Update customer data' })
     @ApiResponse({ status: 200 })
     updateCustomer(@Param('id') id: string, @Body() dto: UpdateCustomerDto) {

--- a/backend/test/employee-reception.e2e-spec.ts
+++ b/backend/test/employee-reception.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('Reception role restrictions (e2e)', () => {
             .expect(403);
     });
 
-    it('allows RECEPCJA employee to update customer', async () => {
+    it('allows RECEPTIONIST employee to update customer', async () => {
         const reception = await usersService.createUser(
             'rec@test.com',
             'secret',
@@ -74,7 +74,7 @@ describe('Reception role restrictions (e2e)', () => {
 
         const tokens = await authService.generateTokens(
             reception.id,
-            EmployeeRole.RECEPCJA,
+            EmployeeRole.RECEPTIONIST,
         );
         const token = tokens.access_token;
 

--- a/backend/test/users-update.e2e-spec.ts
+++ b/backend/test/users-update.e2e-spec.ts
@@ -63,7 +63,7 @@ describe('Customer update (e2e)', () => {
             .expect((res) => expect(res.body.name).toBe('Updated'));
     });
 
-    it('allows reception role to update customer', async () => {
+    it('allows receptionist role to update customer', async () => {
         const reception = await usersService.createUser(
             'recupd@test.com',
             'secret',
@@ -79,7 +79,7 @@ describe('Customer update (e2e)', () => {
 
         const tokens: AuthTokensDto = await authService.generateTokens(
             reception.id,
-            EmployeeRole.RECEPCJA,
+            EmployeeRole.RECEPTIONIST,
         );
         const { access_token: token } = tokens;
 


### PR DESCRIPTION
## Summary
- rename RECEPCJA enum value to RECEPTIONIST
- adjust controllers and guard spec
- update e2e tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68880e7188d88329ab0f21188fb1a988