### PR TITLE
Use class-transformer for customer DTO

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, NotFoundException, UseGuards, ParseIntPipe } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Param,
+    NotFoundException,
+    UseGuards,
+    ParseIntPipe,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { CustomersService } from './customers.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -17,11 +24,7 @@ export class CustomersController {
 
     @Get()
     async list() {
-        const customers = await this.service.findAll();
-        return customers.map((c) => {
-            const { password, refreshToken, ...rest } = c as any;
-            return rest;
-        });
+        return this.service.findAll();
     }
 
     @Get(':id')
@@ -30,7 +33,6 @@ export class CustomersController {
         if (!customer) {
             throw new NotFoundException();
         }
-        const { password, refreshToken, ...rest } = customer as any;
-        return rest;
+        return customer;
     }
 }

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { plainToInstance } from 'class-transformer';
 import { Customer } from './customer.entity';
 import { Role } from '../users/role.enum';
+import { CustomerDto } from './dto/customer.dto';
 
 @Injectable()
 export class CustomersService {
@@ -11,11 +13,22 @@ export class CustomersService {
         private readonly repo: Repository<Customer>,
     ) {}
 
-    findAll() {
-        return this.repo.find({ where: { role: Role.Client } });
+    async findAll(): Promise<CustomerDto[]> {
+        const customers = await this.repo.find({
+            where: { role: Role.Client },
+        });
+        return plainToInstance(CustomerDto, customers, {
+            excludeExtraneousValues: true,
+        });
     }
 
-    findOne(id: number) {
-        return this.repo.findOne({ where: { id, role: Role.Client } });
+    async findOne(id: number): Promise<CustomerDto | undefined> {
+        const customer = await this.repo.findOne({
+            where: { id, role: Role.Client },
+        });
+        if (!customer) return undefined;
+        return plainToInstance(CustomerDto, customer, {
+            excludeExtraneousValues: true,
+        });
     }
 }

--- a/backend/src/customers/dto/customer.dto.ts
+++ b/backend/src/customers/dto/customer.dto.ts
@@ -1,0 +1,25 @@
+import { Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '../../users/role.enum';
+
+export class CustomerDto {
+    @ApiProperty()
+    @Expose()
+    id: number;
+
+    @ApiProperty()
+    @Expose()
+    email: string;
+
+    @ApiProperty()
+    @Expose()
+    name: string;
+
+    @ApiProperty({ nullable: true })
+    @Expose()
+    phone: string | null;
+
+    @ApiProperty({ enum: Role })
+    @Expose()
+    role: Role;
+}

--- a/backend/test/customers.e2e-spec.ts
+++ b/backend/test/customers.e2e-spec.ts
@@ -32,9 +32,24 @@ describe('CustomersController (e2e)', () => {
     });
 
     it('admin can list customers', async () => {
-        await usersService.createUser('admin@cust.com', 'secret', 'Admin', Role.Admin);
-        await usersService.createUser('c1@test.com', 'secret', 'C1', Role.Client);
-        await usersService.createUser('c2@test.com', 'secret', 'C2', Role.Client);
+        await usersService.createUser(
+            'admin@cust.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
+        await usersService.createUser(
+            'c1@test.com',
+            'secret',
+            'C1',
+            Role.Client,
+        );
+        await usersService.createUser(
+            'c2@test.com',
+            'secret',
+            'C2',
+            Role.Client,
+        );
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')
@@ -52,6 +67,9 @@ describe('CustomersController (e2e)', () => {
         res.body.forEach((c: any) => {
             expect(c).not.toHaveProperty('password');
             expect(c).not.toHaveProperty('refreshToken');
+            expect(c).toHaveProperty('email');
+            expect(c).toHaveProperty('name');
+            expect(c).toHaveProperty('phone');
             expect(c.role).toBe('client');
         });
     });
@@ -65,7 +83,10 @@ describe('CustomersController (e2e)', () => {
             'E',
             Role.Employee,
         );
-        const tokens = await authService.generateTokens(employee.id, EmployeeRole.FRYZJER);
+        const tokens = await authService.generateTokens(
+            employee.id,
+            EmployeeRole.FRYZJER,
+        );
         const token = tokens.access_token;
 
         await request(app.getHttpServer())
@@ -75,7 +96,12 @@ describe('CustomersController (e2e)', () => {
     });
 
     it('returns 404 for missing customer', async () => {
-        await usersService.createUser('admin2@cust.com', 'secret', 'Admin', Role.Admin);
+        await usersService.createUser(
+            'admin2@cust.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
         const login = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'admin2@cust.com', password: 'secret' })
@@ -89,7 +115,12 @@ describe('CustomersController (e2e)', () => {
     });
 
     it('returns 400 for invalid customer id', async () => {
-        await usersService.createUser('admin3@cust.com', 'secret', 'Admin', Role.Admin);
+        await usersService.createUser(
+            'admin3@cust.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
         const login = await request(app.getHttpServer())
             .post('/auth/login')
             .send({ email: 'admin3@cust.com', password: 'secret' })


### PR DESCRIPTION
## Summary
- add `CustomerDto`
- return `CustomerDto` instances from the `CustomersService`
- simplify controller logic
- update e2e expectations for customer data

## Testing
- `npm run test:e2e --silent` *(fails: SQLITE_BUSY errors)*

------
https://chatgpt.com/codex/tasks/task_e_68880fc537c88329bd92297c56747755