### PR TITLE
Fix E2E SQLite initialization

### DIFF
--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -6,11 +6,11 @@ import { dirSync, DirResult } from 'tmp';
 import { Service as CatalogService } from '../src/catalog/service.entity';
 
 config({ path: '.env' });
-let tmpDir: DirResult | undefined;
-if (!process.env.DATABASE_URL) {
-    tmpDir = dirSync({ prefix: `jest-${process.env.JEST_WORKER_ID ?? ''}-`, unsafeCleanup: true });
-    process.env.DATABASE_URL = `sqlite:${join(tmpDir.name, 'test.sqlite')}`;
-}
+export const TEST_DB: DirResult = dirSync({
+    prefix: `jest-${process.env.JEST_WORKER_ID ?? ''}-`,
+    unsafeCleanup: true,
+});
+process.env.DATABASE_URL = `sqlite:${join(TEST_DB.name, 'test.sqlite')}`;
 
 let dataSource: DataSource;
 
@@ -59,5 +59,5 @@ afterAll(async () => {
     if (dataSource?.isInitialized) {
         await dataSource.destroy();
     }
-    tmpDir?.removeCallback();
+    TEST_DB.removeCallback();
 });


### PR DESCRIPTION
## Summary
- always create a temporary SQLite DB for end-to-end tests
- expose the directory used for the DB so other helpers can reuse it

## Testing
- `npm run test:e2e` *(fails: Payments (e2e) – expected 201 Created got 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688890f9193c83299d280258fe2fb36d