### PR TITLE
Implement Employees API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,6 +28,7 @@ import { CalendarModule } from './calendar/calendar.module';
 import { InvoicesModule } from './invoices/invoices.module';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { CustomersModule } from './customers/customers.module';
+import { EmployeesModule } from './employees/employees.module';
 
 @Module({
     imports: [
@@ -66,6 +67,7 @@ import { CustomersModule } from './customers/customers.module';
         LogsModule,
         CommunicationsModule,
         DashboardModule,
+        EmployeesModule,
         CustomersModule,
         NotificationsModule,
         PaymentsModule,

--- a/backend/src/employees/dto/employee.dto.ts
+++ b/backend/src/employees/dto/employee.dto.ts
@@ -1,0 +1,25 @@
+import { Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '../../users/role.enum';
+
+export class EmployeeDto {
+    @ApiProperty()
+    @Expose()
+    id: number;
+
+    @ApiProperty()
+    @Expose()
+    email: string;
+
+    @ApiProperty()
+    @Expose()
+    name: string;
+
+    @ApiProperty({ nullable: true })
+    @Expose()
+    phone: string | null;
+
+    @ApiProperty({ enum: Role })
+    @Expose()
+    role: Role;
+}

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -1,0 +1,37 @@
+import {
+    Controller,
+    Get,
+    Param,
+    NotFoundException,
+    ParseIntPipe,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { EmployeesService } from './employees.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+
+@ApiTags('Employees')
+@ApiBearerAuth()
+@Controller('employees')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
+export class EmployeesController {
+    constructor(private readonly service: EmployeesService) {}
+
+    @Get()
+    list() {
+        return this.service.findAll();
+    }
+
+    @Get(':id')
+    async get(@Param('id', ParseIntPipe) id: number) {
+        const employee = await this.service.findOne(id);
+        if (!employee) {
+            throw new NotFoundException();
+        }
+        return employee;
+    }
+}

--- a/backend/src/employees/employees.module.ts
+++ b/backend/src/employees/employees.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/user.entity';
+import { EmployeesService } from './employees.service';
+import { EmployeesController } from './employees.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([User])],
+    controllers: [EmployeesController],
+    providers: [EmployeesService],
+    exports: [TypeOrmModule, EmployeesService],
+})
+export class EmployeesModule {}

--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { plainToInstance } from 'class-transformer';
+import { User } from '../users/user.entity';
+import { Role } from '../users/role.enum';
+import { EmployeeDto } from './dto/employee.dto';
+
+@Injectable()
+export class EmployeesService {
+    constructor(
+        @InjectRepository(User)
+        private readonly repo: Repository<User>,
+    ) {}
+
+    async findAll(): Promise<EmployeeDto[]> {
+        const employees = await this.repo.find({
+            where: [{ role: Role.Employee }, { role: Role.Admin }],
+        });
+        return plainToInstance(EmployeeDto, employees, {
+            excludeExtraneousValues: true,
+        });
+    }
+
+    async findOne(id: number): Promise<EmployeeDto | undefined> {
+        const employee = await this.repo.findOne({
+            where: [
+                { id, role: Role.Employee },
+                { id, role: Role.Admin },
+            ],
+        });
+        if (!employee) return undefined;
+        return plainToInstance(EmployeeDto, employee, {
+            excludeExtraneousValues: true,
+        });
+    }
+}

--- a/backend/test/employees.e2e-spec.ts
+++ b/backend/test/employees.e2e-spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { AuthService } from './../src/auth/auth.service';
+import { Role } from './../src/users/role.enum';
+import { EmployeeRole } from './../src/employees/employee-role.enum';
+
+describe('EmployeesController (e2e)', () => {
+    let app: INestApplication<App>;
+    let usersService: UsersService;
+    let authService: AuthService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        usersService = moduleFixture.get(UsersService);
+        authService = moduleFixture.get(AuthService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('admin can list employees', async () => {
+        await usersService.createUser('admin@emp.com', 'secret', 'Admin', Role.Admin);
+        await usersService.createUser('e1@test.com', 'secret', 'E1', Role.Employee);
+        await usersService.createUser('e2@test.com', 'secret', 'E2', Role.Employee);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@emp.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        const res = await request(app.getHttpServer())
+            .get('/employees')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBe(3);
+        res.body.forEach((e: any) => {
+            expect(e).not.toHaveProperty('password');
+            expect(e).not.toHaveProperty('refreshToken');
+            expect(e).toHaveProperty('email');
+            expect(e).toHaveProperty('name');
+            expect(e).toHaveProperty('phone');
+            expect([Role.Employee, Role.Admin]).toContain(e.role);
+        });
+    });
+
+    it('rejects unauthorized access', async () => {
+        await request(app.getHttpServer()).get('/employees').expect(401);
+
+        const client = await usersService.createUser('client@emp.com', 'secret', 'C', Role.Client);
+        const loginClient = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'client@emp.com', password: 'secret' })
+            .expect(201);
+        const clientToken = loginClient.body.access_token as string;
+        await request(app.getHttpServer())
+            .get('/employees')
+            .set('Authorization', `Bearer ${clientToken}`)
+            .expect(403);
+
+        const employee = await usersService.createUser('emp@test.com', 'secret', 'E', Role.Employee);
+        const tokens = await authService.generateTokens(employee.id, EmployeeRole.FRYZJER);
+        await request(app.getHttpServer())
+            .get('/employees')
+            .set('Authorization', `Bearer ${tokens.access_token}`)
+            .expect(403);
+    });
+
+    it('returns 404 for missing employee', async () => {
+        await usersService.createUser('admin2@emp.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin2@emp.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .get('/employees/999')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+    });
+
+    it('returns 400 for invalid employee id', async () => {
+        await usersService.createUser('admin3@emp.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin3@emp.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .get('/employees/abc')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(400);
+    });
+});


### PR DESCRIPTION
## Summary
- add EmployeesModule with admin-only controller
- expose DTO and service for employees
- include EmployeesModule in AppModule
- provide e2e tests for employees endpoints

## Testing
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68889f538efc8329a438b8e563b5b394