### PR TITLE
Add NotFound handling for employee appointment endpoints

### DIFF
--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -6,6 +6,7 @@ import {
     Patch,
     Request,
     UseGuards,
+    NotFoundException,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -58,21 +59,29 @@ export class EmployeeAppointmentsController {
 
     @Patch(':id/cancel')
     @ApiOperation({ summary: 'Cancel appointment by employee' })
-    cancel(
-        @Param('id') id: string,
-        @Request() req: AuthRequest,
-    ) {
-         
-        return this.service.cancel(Number(id), req.user.id, req.user.role);
+    async cancel(@Param('id') id: string, @Request() req: AuthRequest) {
+        const result = await this.service.cancel(
+            Number(id),
+            req.user.id,
+            req.user.role,
+        );
+        if (result === undefined) {
+            throw new NotFoundException();
+        }
+        return result;
     }
 
     @Patch(':id/complete')
     @ApiOperation({ summary: 'Mark appointment completed by employee' })
-    complete(
-        @Param('id') id: string,
-        @Request() req: AuthRequest,
-    ) {
-         
-        return this.service.complete(Number(id), req.user.id, req.user.role);
+    async complete(@Param('id') id: string, @Request() req: AuthRequest) {
+        const result = await this.service.complete(
+            Number(id),
+            req.user.id,
+            req.user.role,
+        );
+        if (result === undefined) {
+            throw new NotFoundException();
+        }
+        return result;
     }
 }

--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -336,4 +336,46 @@ describe('AppointmentsModule (e2e)', () => {
             })
             .expect(401);
     });
+
+    it('returns 404 when employee cancels nonexistent appointment', async () => {
+        const employee = await usersService.createUser(
+            'nfemp1@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'nfemp1@test.com', password: 'secret' })
+            .expect(201);
+
+        const token = (login.body as { access_token: string }).access_token;
+
+        await request(app.getHttpServer())
+            .patch('/appointments/employee/9999/cancel')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+    });
+
+    it('returns 404 when employee completes nonexistent appointment', async () => {
+        const employee = await usersService.createUser(
+            'nfemp2@test.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'nfemp2@test.com', password: 'secret' })
+            .expect(201);
+
+        const token = (login.body as { access_token: string }).access_token;
+
+        await request(app.getHttpServer())
+            .patch('/appointments/employee/9999/complete')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+    });
 });


### PR DESCRIPTION
## Summary
- throw `NotFoundException` when employee cancels or completes non-existent appointments
- test 404 responses for employee cancel and complete endpoints

## Testing
- `npm --prefix backend run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6888fedf97f48329a7489ede5cf35f2d