### PR TITLE
Make services list public

### DIFF
--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -17,6 +17,7 @@ import {
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
+import { Public } from '../auth/public.decorator';
 import { Role } from '../users/role.enum';
 import { ServicesService } from './services.service';
 import { CreateServiceDto } from './dto/create-service.dto';
@@ -29,8 +30,8 @@ import { UpdateServiceDto } from './dto/update-service.dto';
 export class ServicesController {
     constructor(private readonly service: ServicesService) {}
 
+    @Public()
     @Get()
-    @Roles(Role.Admin, Role.Client)
     @ApiOperation({ summary: 'List all services' })
     @ApiResponse({ status: 200 })
     list() {

--- a/backend/test/services-public.e2e-spec.ts
+++ b/backend/test/services-public.e2e-spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('ServicesController (public) (e2e)', () => {
+    let app: INestApplication<App>;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('/services (GET) allows anonymous access', () => {
+        return request(app.getHttpServer()).get('/services').expect(200);
+    });
+});
+


### PR DESCRIPTION
## Summary
- expose `/services` endpoint for anonymous users
- test that `/services` returns 200 without authentication

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_688918ba18248329a54d9f1f4270f362