### PR TITLE
Add reusable ContactForm with tests

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -18,6 +18,14 @@ process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
   removeEventListener() {}
 };
 
+// polyfill window.matchMedia used by react-hot-toast
+(global as any).matchMedia = (query: string) => ({
+  media: query,
+  matches: false,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+});
+
 jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
 }));

--- a/frontend/src/__tests__/contactForm.test.tsx
+++ b/frontend/src/__tests__/contactForm.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import ContactForm from '@/components/ContactForm';
+import { ToastProvider } from '@/contexts/ToastContext';
+
+describe('ContactForm', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) }) as any;
+  });
+
+  it('posts form data', async () => {
+    render(
+      <ToastProvider>
+        <ContactForm />
+      </ToastProvider>
+    );
+    fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'John' } });
+    fireEvent.change(screen.getByPlaceholderText('Your email'), { target: { value: 'john@example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Message'), { target: { value: 'Hello' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          to: 'contact@example.com',
+          subject: 'Contact form',
+          template: '<p>{{message}}</p>',
+          data: { name: 'John', email: 'john@example.com', message: 'Hello' },
+        }),
+      })
+    );
+  });
+});

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -1,0 +1,94 @@
+import { FormEvent, useState } from 'react';
+import { z } from 'zod';
+import { useToast } from '@/contexts/ToastContext';
+
+const schema = z.object({
+  name: z.string().min(1, { message: 'Name is required' }),
+  email: z.string().email({ message: 'Email is invalid' }),
+  message: z.string().min(1, { message: 'Message is required' }),
+});
+
+export default function ContactForm() {
+  const toast = useToast();
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const isValid = schema.safeParse(form).success;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const result = schema.safeParse(form);
+    if (!result.success) {
+      setError(result.error.errors[0].message);
+      return;
+    }
+    setError('');
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            to: 'contact@example.com',
+            subject: 'Contact form',
+            template: '<p>{{message}}</p>',
+            data: form,
+          }),
+        }
+      );
+      if (!res.ok) throw new Error('Failed');
+      toast.success('Message sent');
+      setForm({ name: '', email: '', message: '' });
+    } catch (err: any) {
+      toast.error(err.message || 'Error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        name="name"
+        value={form.name}
+        onChange={handleChange}
+        placeholder="Your name"
+        className="w-full border p-2 rounded"
+      />
+      <input
+        name="email"
+        type="email"
+        value={form.email}
+        onChange={handleChange}
+        placeholder="Your email"
+        className="w-full border p-2 rounded"
+      />
+      <textarea
+        name="message"
+        value={form.message}
+        onChange={handleChange}
+        placeholder="Message"
+        className="w-full border p-2 rounded"
+        rows={4}
+      />
+      {error && (
+        <p role="alert" className="text-red-600 text-sm">
+          {error}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={!isValid}
+        className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+      >
+        Send
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/contact.tsx
+++ b/frontend/src/pages/contact.tsx
@@ -1,3 +1,5 @@
+import ContactForm from '@/components/ContactForm';
+
 export default function ContactPage() {
   return (
     <div className="p-4 space-y-4 max-w-md">
@@ -9,29 +11,7 @@ export default function ContactPage() {
         </a>
       </p>
       <p>Phone: 123-456-789</p>
-      <form className="space-y-2">
-        <input
-          type="text"
-          placeholder="Your name"
-          className="w-full border p-2 rounded"
-        />
-        <input
-          type="email"
-          placeholder="Your email"
-          className="w-full border p-2 rounded"
-        />
-        <textarea
-          placeholder="Message"
-          className="w-full border p-2 rounded"
-          rows={4}
-        />
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-500 text-white rounded"
-        >
-          Send
-        </button>
-      </form>
+      <ContactForm />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `ContactForm` component with internal validation and API POST
- hook up `/contact` page to use the new component
- polyfill `matchMedia` in Jest setup
- add unit test verifying request payload

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68891aba31ec8329ae850724c9f60182