### PR TITLE
Add FAQ page

### DIFF
--- a/frontend/src/__tests__/faq.test.tsx
+++ b/frontend/src/__tests__/faq.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FAQPage from '@/pages/faq';
+
+describe('FAQ page', () => {
+  it('renders without crashing', () => {
+    render(<FAQPage />);
+    expect(
+      screen.getByText(/Frequently Asked Questions/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FAQAccordion.tsx
+++ b/frontend/src/components/FAQAccordion.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useState } from 'react';
+
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export default function FAQAccordion({ items }: { items: FAQItem[] }) {
+  const [open, setOpen] = useState<number | null>(null);
+
+  const toggle = (index: number) => {
+    setOpen(index === open ? null : index);
+  };
+
+  return (
+    <div className="space-y-2">
+      {items.map((item, i) => (
+        <div key={i} className="border rounded">
+          <button
+            type="button"
+            onClick={() => toggle(i)}
+            className="w-full p-2 text-left font-medium"
+          >
+            {item.question}
+          </button>
+          {open === i && <div className="p-2 border-t">{item.answer}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/PublicNav.tsx
+++ b/frontend/src/components/PublicNav.tsx
@@ -7,6 +7,7 @@ export default function PublicNav() {
       <Link href="/">Home</Link>
       <Link href="/services">Services</Link>
       <Link href="/gallery">Gallery</Link>
+      <Link href="/faq">FAQ</Link>
       <Link href="/contact">Contact</Link>
       <Link href="/auth/login">Login</Link>
       <Link href="/auth/register">Register</Link>

--- a/frontend/src/pages/faq.tsx
+++ b/frontend/src/pages/faq.tsx
@@ -1,0 +1,25 @@
+import FAQAccordion, { FAQItem } from '@/components/FAQAccordion';
+
+const faqs: FAQItem[] = [
+  {
+    question: 'What are your opening hours?',
+    answer: 'We are open from 9AM to 5PM Monday through Friday.'
+  },
+  {
+    question: 'How can I book an appointment?',
+    answer: 'You can call us or use the contact form to schedule an appointment.'
+  },
+  {
+    question: 'Do you accept walk-ins?',
+    answer: 'Yes, walk-ins are welcome when availability permits.'
+  }
+];
+
+export default function FAQPage() {
+  return (
+    <div className="p-4 space-y-4 max-w-md">
+      <h1 className="text-2xl font-bold">Frequently Asked Questions</h1>
+      <FAQAccordion items={faqs} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable FAQ accordion component
- create `/faq` page with questions and answers
- show FAQ link in the public navigation
- test that the FAQ page renders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68892005634c83299c9decb69c279c55