### PR TITLE
Add salon branding colors and meta tags

### DIFF
--- a/frontend/src/pages/contact.tsx
+++ b/frontend/src/pages/contact.tsx
@@ -1,17 +1,27 @@
 import ContactForm from '@/components/ContactForm';
+import Head from 'next/head';
 
 export default function ContactPage() {
-  return (
-    <div className="p-4 space-y-4 max-w-md">
-      <h1 className="text-2xl font-bold">Contact Us</h1>
-      <p>
-        You can reach us at{' '}
-        <a className="underline" href="mailto:contact@example.com">
-          contact@example.com
-        </a>
-      </p>
-      <p>Phone: 123-456-789</p>
-      <ContactForm />
-    </div>
-  );
+    return (
+        <>
+            <Head>
+                <title>Contact Us | Salon Black &amp; White</title>
+                <meta
+                    name="description"
+                    content="Reach out to Salon Black &amp; White to book appointments or ask questions."
+                />
+            </Head>
+            <div className="p-4 space-y-4 max-w-md">
+                <h1 className="text-2xl font-bold">Contact Us</h1>
+                <p>
+                    You can reach us at{' '}
+                    <a className="underline" href="mailto:contact@example.com">
+                        contact@example.com
+                    </a>
+                </p>
+                <p>Phone: 123-456-789</p>
+                <ContactForm />
+            </div>
+        </>
+    );
 }

--- a/frontend/src/pages/faq.tsx
+++ b/frontend/src/pages/faq.tsx
@@ -1,25 +1,39 @@
 import FAQAccordion, { FAQItem } from '@/components/FAQAccordion';
+import Head from 'next/head';
 
 const faqs: FAQItem[] = [
-  {
-    question: 'What are your opening hours?',
-    answer: 'We are open from 9AM to 5PM Monday through Friday.'
-  },
-  {
-    question: 'How can I book an appointment?',
-    answer: 'You can call us or use the contact form to schedule an appointment.'
-  },
-  {
-    question: 'Do you accept walk-ins?',
-    answer: 'Yes, walk-ins are welcome when availability permits.'
-  }
+    {
+        question: 'What are your opening hours?',
+        answer: 'We are open from 9AM to 5PM Monday through Friday.',
+    },
+    {
+        question: 'How can I book an appointment?',
+        answer: 'You can call us or use the contact form to schedule an appointment.',
+    },
+    {
+        question: 'Do you accept walk-ins?',
+        answer: 'Yes, walk-ins are welcome when availability permits.',
+    },
 ];
 
 export default function FAQPage() {
-  return (
-    <div className="p-4 space-y-4 max-w-md">
-      <h1 className="text-2xl font-bold">Frequently Asked Questions</h1>
-      <FAQAccordion items={faqs} />
-    </div>
-  );
+    return (
+        <>
+            <Head>
+                <title>
+                    Frequently Asked Questions | Salon Black &amp; White
+                </title>
+                <meta
+                    name="description"
+                    content="Answers to common questions about Salon Black &amp; White."
+                />
+            </Head>
+            <div className="p-4 space-y-4 max-w-md">
+                <h1 className="text-2xl font-bold">
+                    Frequently Asked Questions
+                </h1>
+                <FAQAccordion items={faqs} />
+            </div>
+        </>
+    );
 }

--- a/frontend/src/pages/gallery.tsx
+++ b/frontend/src/pages/gallery.tsx
@@ -1,40 +1,52 @@
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 
 interface GalleryItem {
-  id: number;
-  imageUrl: string;
-  caption?: string;
+    id: number;
+    imageUrl: string;
+    caption?: string;
 }
 
 interface GalleryPageProps {
-  items: GalleryItem[];
+    items: GalleryItem[];
 }
 
 export default function GalleryPage({ items }: GalleryPageProps) {
-  return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Gallery</h1>
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-        {items.map((item) => (
-          <img
-            key={item.id}
-            src={item.imageUrl}
-            alt={item.caption ?? 'Gallery image'}
-            className="w-full h-auto object-cover"
-          />
-        ))}
-      </div>
-    </div>
-  );
+    return (
+        <>
+            <Head>
+                <title>Gallery | Salon Black &amp; White</title>
+                <meta
+                    name="description"
+                    content="See examples of our work in the Salon Black &amp; White gallery."
+                />
+            </Head>
+            <div className="p-4 space-y-4">
+                <h1 className="text-2xl font-bold">Gallery</h1>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    {items.map((item) => (
+                        <img
+                            key={item.id}
+                            src={item.imageUrl}
+                            alt={item.caption ?? 'Gallery image'}
+                            className="w-full h-auto object-cover"
+                        />
+                    ))}
+                </div>
+            </div>
+        </>
+    );
 }
 
-export const getServerSideProps: GetServerSideProps<GalleryPageProps> = async () => {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
-  try {
-    const res = await fetch(`${apiUrl}/gallery`);
-    const data = await res.json();
-    return { props: { items: data } };
-  } catch {
-    return { props: { items: [] } };
-  }
+export const getServerSideProps: GetServerSideProps<
+    GalleryPageProps
+> = async () => {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
+    try {
+        const res = await fetch(`${apiUrl}/gallery`);
+        const data = await res.json();
+        return { props: { items: data } };
+    } catch {
+        return { props: { items: [] } };
+    }
 };

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,8 +1,23 @@
+import Head from 'next/head';
+
 export default function HomePage() {
-  return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Welcome to Salon Black &amp; White</h1>
-      <p>Professional hair and beauty services for every occasion.</p>
-    </div>
-  );
+    return (
+        <>
+            <Head>
+                <title>
+                    Salon Black &amp; White | Professional Hair &amp; Beauty
+                </title>
+                <meta
+                    name="description"
+                    content="Home of Salon Black &amp; White offering professional hair and beauty services."
+                />
+            </Head>
+            <div className="p-4 space-y-4">
+                <h1 className="text-2xl font-bold">
+                    Welcome to Salon Black &amp; White
+                </h1>
+                <p>Professional hair and beauty services for every occasion.</p>
+            </div>
+        </>
+    );
 }

--- a/frontend/src/pages/services.tsx
+++ b/frontend/src/pages/services.tsx
@@ -1,37 +1,49 @@
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 
 interface Service {
-  id: number;
-  name: string;
-  price?: number;
+    id: number;
+    name: string;
+    price?: number;
 }
 
 interface ServicesPageProps {
-  services: Service[];
+    services: Service[];
 }
 
 export default function ServicesPage({ services }: ServicesPageProps) {
-  return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Our Services</h1>
-      <ul className="space-y-2">
-        {services.map((s) => (
-          <li key={s.id} className="border-b pb-1">
-            {s.name} {s.price ? `- ${s.price} zł` : ''}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+    return (
+        <>
+            <Head>
+                <title>Our Services | Salon Black &amp; White</title>
+                <meta
+                    name="description"
+                    content="Browse the full list of hair and beauty services offered at Salon Black &amp; White."
+                />
+            </Head>
+            <div className="p-4 space-y-4">
+                <h1 className="text-2xl font-bold">Our Services</h1>
+                <ul className="space-y-2">
+                    {services.map((s) => (
+                        <li key={s.id} className="border-b pb-1">
+                            {s.name} {s.price ? `- ${s.price} zł` : ''}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </>
+    );
 }
 
-export const getServerSideProps: GetServerSideProps<ServicesPageProps> = async () => {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
-  try {
-    const res = await fetch(`${apiUrl}/services`);
-    const data = await res.json();
-    return { props: { services: data } };
-  } catch {
-    return { props: { services: [] } };
-  }
+export const getServerSideProps: GetServerSideProps<
+    ServicesPageProps
+> = async () => {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
+    try {
+        const res = await fetch(`${apiUrl}/services`);
+        const data = await res.json();
+        return { props: { services: data } };
+    } catch {
+        return { props: { services: [] } };
+    }
 };

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,14 +1,26 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
-  content: [
-    './app/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/**/*.{js,ts,jsx,tsx,mdx}',
-    './components/**/*.{js,ts,jsx,tsx,mdx}',
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-}
-export default config
+    content: [
+        './app/**/*.{js,ts,jsx,tsx,mdx}',
+        './src/**/*.{js,ts,jsx,tsx,mdx}',
+        './components/**/*.{js,ts,jsx,tsx,mdx}',
+    ],
+    theme: {
+        extend: {
+            colors: {
+                brand: {
+                    black: '#000000',
+                    white: '#ffffff',
+                    gold: '#c5a880',
+                },
+            },
+            fontFamily: {
+                heading: ['"Playfair Display"', 'serif'],
+                body: ['"Open Sans"', 'sans-serif'],
+            },
+        },
+    },
+    plugins: [],
+};
+export default config;


### PR DESCRIPTION
## Summary
- extend Tailwind with salon colors and fonts
- add page `<Head>` tags for marketing pages
- verify pages compile with `npm run dev`

## Testing
- `npx --yes lint-staged`
- `npm install` (frontend)
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688925e69a6883299c1c65606a223fe3