### PR TITLE
Add role to auth context

### DIFF
--- a/frontend/src/components/DashboardNav.tsx
+++ b/frontend/src/components/DashboardNav.tsx
@@ -1,6 +1,5 @@
 'use client';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import type { Role } from '@/types';
 
@@ -27,25 +26,17 @@ const navLinks: Record<Role, { href: string; label: string }[]> = {
 };
 
 export default function DashboardNav() {
-    const { logout } = useAuth();
-    const [role, setRole] = useState<Role>('client');
-
-    useEffect(() => {
-        const stored = localStorage.getItem('role');
-        if (
-            stored === 'client' ||
-            stored === 'employee' ||
-            stored === 'admin'
-        ) {
-            setRole(stored);
-        }
-    }, []);
+    const { logout, role } = useAuth();
+    const currentRole: Role =
+        role === 'client' || role === 'employee' || role === 'admin'
+            ? role
+            : 'client';
 
     return (
         <aside className="w-48 bg-gray-200 p-4 space-y-2">
             <h2 className="font-bold mb-2">Menu</h2>
             <nav className="space-y-1">
-                {navLinks[role].map((l) => (
+                {navLinks[currentRole].map((l) => (
                     <Link key={l.href} href={l.href} className="block">
                         {l.label}
                     </Link>

--- a/frontend/src/components/SidebarMenu.tsx
+++ b/frontend/src/components/SidebarMenu.tsx
@@ -1,6 +1,5 @@
 'use client';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import type { Role } from '@/types';
 
@@ -32,23 +31,15 @@ interface Props {
 }
 
 export default function SidebarMenu({ open, onClose }: Props) {
-    const { logout } = useAuth();
-    const [role, setRole] = useState<Role>('client');
-
-    useEffect(() => {
-        const stored = localStorage.getItem('role');
-        if (
-            stored === 'client' ||
-            stored === 'employee' ||
-            stored === 'admin'
-        ) {
-            setRole(stored);
-        }
-    }, []);
+    const { logout, role } = useAuth();
+    const currentRole: Role =
+        role === 'client' || role === 'employee' || role === 'admin'
+            ? role
+            : 'client';
 
     const content = (
         <nav className="space-y-1 px-4">
-            {links[role].map((l) => (
+            {links[currentRole].map((l) => (
                 <Link
                     key={l.href}
                     href={l.href}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,9 +2,11 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { ApiClient } from '@/api/apiClient';
+import type { Role } from '@/types';
 
 interface AuthContextValue {
   token: string | null;
+  role: Role | null;
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
@@ -15,23 +17,48 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const TOKEN_KEY = 'jwtToken';
+const ROLE_KEY = 'role';
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<Role | null>(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem(TOKEN_KEY);
-    if (stored) setToken(stored);
+    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedRole = localStorage.getItem(ROLE_KEY) as Role | null;
+    if (storedToken) setToken(storedToken);
+    if (
+      storedRole === 'client' ||
+      storedRole === 'employee' ||
+      storedRole === 'admin'
+    ) {
+      setRole(storedRole);
+    }
   }, []);
 
   const handleLogout = () => {
     setToken(null);
+    setRole(null);
     localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(ROLE_KEY);
     router.push('/auth/login');
   };
 
   const client = useMemo(() => new ApiClient(() => token, handleLogout), [token]);
+
+  const decodeRole = (jwt: string): Role | null => {
+    try {
+      const payload = JSON.parse(atob(jwt.split('.')[1]));
+      const r = payload.role as Role | undefined;
+      if (r === 'client' || r === 'employee' || r === 'admin') {
+        return r;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  };
 
   const login = async (email: string, password: string) => {
     const data = await client.request<{ access_token: string }>('/auth/login', {
@@ -41,6 +68,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
     setToken(data.access_token);
     localStorage.setItem(TOKEN_KEY, data.access_token);
+    const r = decodeRole(data.access_token);
+    setRole(r);
+    if (r) localStorage.setItem(ROLE_KEY, r);
   };
 
   const refreshToken = async () => {
@@ -49,10 +79,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
     setToken(data.access_token);
     localStorage.setItem(TOKEN_KEY, data.access_token);
+    const r = decodeRole(data.access_token);
+    setRole(r);
+    if (r) localStorage.setItem(ROLE_KEY, r);
   };
 
   const value: AuthContextValue = {
     token,
+    role,
     isAuthenticated: Boolean(token),
     login,
     logout: handleLogout,

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -1,16 +1,17 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useAuth } from '@/contexts/AuthContext';
 import type { Role } from '@/types';
 
 export default function DashboardRedirect() {
   const router = useRouter();
+  const { role } = useAuth();
   useEffect(() => {
-    const stored = localStorage.getItem('role');
-    const role: Role =
-      stored === 'client' || stored === 'employee' || stored === 'admin'
-        ? (stored as Role)
+    const current: Role =
+      role === 'client' || role === 'employee' || role === 'admin'
+        ? role
         : 'client';
-    router.replace(`/dashboard/${role}`);
-  }, [router]);
+    router.replace(`/dashboard/${current}`);
+  }, [router, role]);
   return null;
 }


### PR DESCRIPTION
## Summary
- decode JWT to capture role and expose via `AuthContext`
- store role in `localStorage`
- reference context role in dashboard components
- remove leftover direct localStorage access

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a035d409083298e47e739d229eea9