### PR TITLE
Add dashboard e2e tests

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -1,0 +1,49 @@
+describe('admin dashboard navigation', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'admin');
+  });
+
+  it('redirects to admin dashboard and shows widgets', () => {
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
+    cy.visit('/dashboard');
+    cy.wait('@dash');
+    cy.url().should('include', '/dashboard/admin');
+    cy.contains('Clients');
+    cy.contains('Employees');
+  });
+
+  it('navigates to employees via sidebar', () => {
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
+    cy.visit('/dashboard/admin');
+    cy.wait('@dash');
+    cy.contains('Employees').click();
+    cy.url().should('include', '/employees');
+  });
+});
+
+describe('admin dashboard services crud', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'admin');
+    cy.intercept('GET', '**/services', { fixture: 'services.json' }).as('getSvc');
+  });
+
+  it('creates a service', () => {
+    cy.intercept('POST', '**/services', { id: 3, name: 'Wax' }).as('createSvc');
+    cy.visit('/dashboard/services');
+    cy.wait('@getSvc');
+    cy.contains('Add Service').click();
+    cy.get('input[placeholder="Name"]').type('Wax');
+    cy.contains('button', 'Save').click();
+    cy.wait('@createSvc');
+    cy.contains('Wax');
+  });
+});
+
+describe('admin dashboard permissions', () => {
+  it('redirects anonymous user', () => {
+    cy.visit('/dashboard/admin');
+    cy.url().should('include', '/auth/login');
+  });
+});

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -1,0 +1,49 @@
+describe('client dashboard navigation', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'client');
+  });
+
+  it('redirects to client dashboard and shows widgets', () => {
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
+    cy.visit('/dashboard');
+    cy.wait('@dash');
+    cy.url().should('include', '/dashboard/client');
+    cy.contains('Upcoming');
+  });
+
+  it('navigates to reviews via sidebar', () => {
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
+    cy.visit('/dashboard/client');
+    cy.wait('@dash');
+    cy.contains('Reviews').click();
+    cy.url().should('include', '/reviews');
+  });
+});
+
+describe('client dashboard reviews crud', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'client');
+    cy.intercept('GET', '**/reviews', { fixture: 'reviews.json' }).as('getReviews');
+  });
+
+  it('creates a review', () => {
+    cy.intercept('POST', '**/reviews', { id: 2, reservationId: 1, rating: 5 }).as('createReview');
+    cy.visit('/reviews');
+    cy.wait('@getReviews');
+    cy.contains('Add Review').click();
+    cy.get('input[placeholder="Reservation"]').type('1');
+    cy.get('input[placeholder="Rating"]').type('5');
+    cy.contains('button', 'Save').click();
+    cy.wait('@createReview');
+    cy.contains('Review created');
+  });
+});
+
+describe('client dashboard permissions', () => {
+  it('redirects anonymous user', () => {
+    cy.visit('/dashboard/client');
+    cy.url().should('include', '/auth/login');
+  });
+});

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -1,0 +1,49 @@
+describe('employee dashboard navigation', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'employee');
+  });
+
+  it('redirects to employee dashboard and shows widgets', () => {
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
+    cy.visit('/dashboard');
+    cy.wait('@dash');
+    cy.url().should('include', '/dashboard/employee');
+    cy.contains('Today Appointments');
+    cy.contains('Clients');
+  });
+
+  it('navigates to clients via sidebar', () => {
+    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
+    cy.visit('/dashboard/employee');
+    cy.wait('@dash');
+    cy.contains('Clients').click();
+    cy.url().should('include', '/clients');
+  });
+});
+
+describe('employee dashboard clients crud', () => {
+  beforeEach(() => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'employee');
+    cy.intercept('GET', '**/clients', { fixture: 'clients.json' }).as('getClients');
+  });
+
+  it('creates a client', () => {
+    cy.intercept('POST', '**/clients', { id: 3, name: 'New' }).as('createClient');
+    cy.visit('/clients');
+    cy.wait('@getClients');
+    cy.contains('Add Client').click();
+    cy.get('input[placeholder="Name"]').type('New');
+    cy.contains('button', 'Save').click();
+    cy.wait('@createClient');
+    cy.contains('New');
+  });
+});
+
+describe('employee dashboard permissions', () => {
+  it('redirects anonymous user', () => {
+    cy.visit('/dashboard/employee');
+    cy.url().should('include', '/auth/login');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,8 @@
     "lint": "next lint",
     "format": "prettier --write '**/*.{ts,tsx,js,jsx,css,md}'",
     "test": "jest",
-    "e2e": "xvfb-run -a cypress run",
-    "e2e:ci": "NEXT_PUBLIC_API_URL=/api npm run build && NEXT_PUBLIC_API_URL=/api start-server-and-test start http://localhost:3000 'xvfb-run -a cypress run'"
+    "e2e": "NEXT_PUBLIC_API_URL=/api npm run build && NEXT_PUBLIC_API_URL=/api start-server-and-test start http://localhost:3000 'cypress run'",
+    "e2e:ci": "NEXT_PUBLIC_API_URL=/api npm run build && NEXT_PUBLIC_API_URL=/api start-server-and-test start http://localhost:3000 'cypress run'"
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.18",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "private": true,
     "version": "1.0.0",
     "scripts": {
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "e2e": "npm --prefix frontend run e2e"
     },
     "devDependencies": {
         "husky": "^9.0.0",


### PR DESCRIPTION
## Summary
- add Cypress specs for admin, employee, and client dashboards
- run dashboard CRUD tests and permission checks
- ensure root runs frontend tests via npm script
- run Cypress using start-server-and-test

## Testing
- `npm run e2e` *(fails: Cypress failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_688a2476e20483298277175796ba9bb4