### PR TITLE
Add client registration with consents

### DIFF
--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -42,9 +42,11 @@ describe('AuthService.registerClient', () => {
     it('returns tokens and creates user with provided password', async () => {
         const dto: RegisterClientDto = {
             email: 'a@test.com',
-            password: 'secret',
-            name: 'Alice',
-        };
+            password: 'Secret123!',
+            fullName: 'Alice',
+            phone: '+48123123132',
+            consentRODO: true,
+        } as RegisterClientDto;
         users.findByEmail.mockResolvedValue(null);
         users.createUser.mockResolvedValue({
             id: 1,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -75,8 +75,11 @@ export class AuthService {
         const user = await this.usersService.createUser(
             dto.email,
             dto.password,
-            dto.name,
+            dto.fullName,
             Role.Client,
+            dto.phone,
+            dto.consentRODO,
+            dto.consentMarketing ?? false,
         );
         await this.logs.create(
             LogAction.RegisterSuccess,

--- a/backend/src/auth/dto/register-client.dto.ts
+++ b/backend/src/auth/dto/register-client.dto.ts
@@ -1,17 +1,41 @@
-import { IsEmail, IsString, IsNotEmpty, MinLength } from 'class-validator';
+import {
+    IsEmail,
+    IsString,
+    IsNotEmpty,
+    MinLength,
+    Matches,
+    IsBoolean,
+    IsOptional,
+    Equals,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterClientDto {
+    @ApiProperty()
+    @IsString()
+    @MinLength(3)
+    fullName: string;
+
     @ApiProperty()
     @IsEmail()
     @IsNotEmpty()
     email: string;
 
     @ApiProperty()
-    @MinLength(6)
+    @Matches(/^\+48\d{9}$/)
+    phone: string;
+
+    @ApiProperty()
+    @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)
     password: string;
 
     @ApiProperty()
-    @IsString()
-    name: string;
+    @IsBoolean()
+    @Equals(true)
+    consentRODO: boolean;
+
+    @ApiProperty({ required: false })
+    @IsBoolean()
+    @IsOptional()
+    consentMarketing?: boolean;
 }

--- a/backend/src/migrations/20250711192023-AddConsentsToUser.ts
+++ b/backend/src/migrations/20250711192023-AddConsentsToUser.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddConsentsToUser20250711192023 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumns('user', [
+            new TableColumn({
+                name: 'consentRODO',
+                type: 'boolean',
+                isNullable: false,
+                default: false,
+            }),
+            new TableColumn({
+                name: 'consentMarketing',
+                type: 'boolean',
+                isNullable: false,
+                default: false,
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('user', 'consentRODO');
+        await queryRunner.dropColumn('user', 'consentMarketing');
+    }
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -19,6 +19,12 @@ export class User {
     @Column({ type: 'varchar', nullable: true })
     phone: string | null;
 
+    @Column({ type: 'boolean', default: false })
+    consentRODO: boolean;
+
+    @Column({ type: 'boolean', default: false })
+    consentMarketing: boolean;
+
     @Column({ type: 'simple-enum', enum: Role })
     role: Role | EmployeeRole;
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -33,6 +33,9 @@ export class UsersService {
         password: string,
         name: string,
         role: Role = Role.Client,
+        phone?: string | null,
+        consentRODO?: boolean,
+        consentMarketing?: boolean,
     ) {
         const existing = await this.findByEmail(email);
         if (existing) {
@@ -44,6 +47,9 @@ export class UsersService {
             password: hashed,
             name,
             role,
+            phone: phone ?? null,
+            consentRODO: consentRODO ?? false,
+            consentMarketing: consentMarketing ?? false,
         });
         return this.usersRepository.save(user);
     }

--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -40,8 +40,10 @@ describe('AppointmentsModule (e2e)', () => {
             .post('/auth/register')
             .send({
                 email: 'client@test.com',
-                password: 'secret',
-                name: 'Client',
+                password: 'Secret123!',
+                fullName: 'Client',
+                phone: '+48123123128',
+                consentRODO: true,
             })
             .expect(201);
         const { access_token: token } = register.body as {
@@ -58,8 +60,10 @@ describe('AppointmentsModule (e2e)', () => {
             .post('/auth/register')
             .send({
                 email: 'client2@test.com',
-                password: 'secret',
-                name: 'Client',
+                password: 'Secret123!',
+                fullName: 'Client',
+                phone: '+48123123129',
+                consentRODO: true,
             })
             .expect(201);
         const { access_token: token } = register.body as {

--- a/backend/test/login.e2e-spec.ts
+++ b/backend/test/login.e2e-spec.ts
@@ -26,12 +26,18 @@ describe('AuthController.login (e2e)', () => {
     it('/auth/login (POST) authenticates seeded user', async () => {
         await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'test@test.com', password: 'secret', name: 'Test' })
+            .send({
+                email: 'test@test.com',
+                password: 'Secret123!',
+                fullName: 'Test',
+                phone: '+48123123123',
+                consentRODO: true,
+            })
             .expect(201);
 
         return request(app.getHttpServer())
             .post('/auth/login')
-            .send({ email: 'test@test.com', password: 'secret' })
+            .send({ email: 'test@test.com', password: 'Secret123!' })
             .expect(201)
             .expect((res) => {
                 expect(res.body).toHaveProperty('access_token');
@@ -42,7 +48,13 @@ describe('AuthController.login (e2e)', () => {
     it('/auth/login (POST) rejects wrong password', async () => {
         await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'test@test.com', password: 'secret', name: 'Test' })
+            .send({
+                email: 'test@test.com',
+                password: 'Secret123!',
+                fullName: 'Test',
+                phone: '+48123123123',
+                consentRODO: true,
+            })
             .expect(201);
 
         return request(app.getHttpServer())

--- a/backend/test/logs.e2e-spec.ts
+++ b/backend/test/logs.e2e-spec.ts
@@ -40,14 +40,16 @@ describe('LogsModule (e2e)', () => {
             .post('/auth/register')
             .send({
                 email: 'client@logs.com',
-                password: 'secret',
-                name: 'Client',
+                password: 'Secret123!',
+                fullName: 'Client',
+                phone: '+48123123131',
+                consentRODO: true,
             })
             .expect(201);
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')
-            .send({ email: 'client@logs.com', password: 'secret' })
+            .send({ email: 'client@logs.com', password: 'Secret123!' })
             .expect(201);
 
         const token = login.body.access_token;

--- a/backend/test/profile.e2e-spec.ts
+++ b/backend/test/profile.e2e-spec.ts
@@ -30,7 +30,13 @@ describe('UsersController (e2e)', () => {
     it('returns profile for authenticated user', async () => {
         const register = await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'test@test.com', password: 'secret', name: 'Test' })
+            .send({
+                email: 'test@test.com',
+                password: 'Secret123!',
+                fullName: 'Test',
+                phone: '+48123123130',
+                consentRODO: true,
+            })
             .expect(201);
 
         const token = register.body.access_token;
@@ -52,12 +58,18 @@ describe('UsersController (e2e)', () => {
     it('returns profile for user logged in via /auth/login', async () => {
         await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'test@test.com', password: 'secret', name: 'Test' })
+            .send({
+                email: 'test@test.com',
+                password: 'Secret123!',
+                fullName: 'Test',
+                phone: '+48123123130',
+                consentRODO: true,
+            })
             .expect(201);
 
         const login = await request(app.getHttpServer())
             .post('/auth/login')
-            .send({ email: 'test@test.com', password: 'secret' })
+            .send({ email: 'test@test.com', password: 'Secret123!' })
             .expect(201);
 
         const token = login.body.access_token;

--- a/backend/test/register.e2e-spec.ts
+++ b/backend/test/register.e2e-spec.ts
@@ -26,7 +26,13 @@ describe('AuthController (e2e)', () => {
     it('/auth/register (POST)', () => {
         return request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'test@test.com', password: 'secret', name: 'Test' })
+            .send({
+                email: 'test@test.com',
+                password: 'Secret123!',
+                fullName: 'Test',
+                phone: '+48123123123',
+                consentRODO: true,
+            })
             .expect(201)
             .expect((res) => {
                 expect(res.body).toHaveProperty('access_token');
@@ -37,19 +43,37 @@ describe('AuthController (e2e)', () => {
     it('/auth/register (POST) invalid data', () => {
         return request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'bad', password: '123', name: 'T' })
+            .send({
+                email: 'bad',
+                password: '123',
+                fullName: 'T',
+                phone: '123',
+                consentRODO: false,
+            })
             .expect(400);
     });
 
     it('/auth/register (POST) rejects duplicates', async () => {
         await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'dup@test.com', password: 'secret', name: 'One' })
+            .send({
+                email: 'dup@test.com',
+                password: 'Secret123!',
+                fullName: 'One',
+                phone: '+48123123124',
+                consentRODO: true,
+            })
             .expect(201);
 
         await request(app.getHttpServer())
             .post('/auth/register')
-            .send({ email: 'dup@test.com', password: 'other', name: 'Two' })
+            .send({
+                email: 'dup@test.com',
+                password: 'Other123!',
+                fullName: 'Two',
+                phone: '+48123123125',
+                consentRODO: true,
+            })
             .expect(400);
     });
 });

--- a/backend/test/roles.e2e-spec.ts
+++ b/backend/test/roles.e2e-spec.ts
@@ -32,8 +32,10 @@ describe('RolesGuard (e2e)', () => {
             .post('/auth/register')
             .send({
                 email: 'client@test.com',
-                password: 'secret',
-                name: 'Client',
+                password: 'Secret123!',
+                fullName: 'Client',
+                phone: '+48123123126',
+                consentRODO: true,
             })
             .expect(201);
 

--- a/backend/test/services.e2e-spec.ts
+++ b/backend/test/services.e2e-spec.ts
@@ -33,8 +33,10 @@ describe('ServicesModule (e2e)', () => {
             .post('/auth/register')
             .send({
                 email: 'client@services.com',
-                password: 'secret',
-                name: 'Client',
+                password: 'Secret123!',
+                fullName: 'Client',
+                phone: '+48123123127',
+                consentRODO: true,
             })
             .expect(201);
 


### PR DESCRIPTION
## Summary
- support phone and marketing/RODO consents on register
- validate phone, password strength and RODO checkbox
- store consents on `User`
- tests updated for new fields
- migration for new consent columns

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND])*
- `npx prettier --check "src/**/*.ts" "test/**/*.ts"`

------
https://chatgpt.com/codex/tasks/task_e_688a3944e2148329bbe7f4b261bc883f