### PR TITLE
Implement categories feature

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { InvoicesModule } from './invoices/invoices.module';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { CustomersModule } from './customers/customers.module';
 import { EmployeesModule } from './employees/employees.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
     imports: [
@@ -56,6 +57,7 @@ import { EmployeesModule } from './employees/employees.module';
         AppointmentsModule,
         MessagesModule,
         CatalogModule,
+        CategoriesModule,
         FormulasModule,
         CommissionsModule,
         ServicesModule,

--- a/backend/src/catalog/category.entity.ts
+++ b/backend/src/catalog/category.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    OneToMany,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
 import { Service } from './service.entity';
 
 @Entity()
@@ -6,8 +13,17 @@ export class Category {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({ unique: true, length: 50 })
     name: string;
+
+    @Column({ type: 'text', nullable: true })
+    description?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
 
     @OneToMany(() => Service, (service) => service.category)
     services: Service[];

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -1,0 +1,72 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Post,
+    Put,
+    UseGuards,
+    NotFoundException,
+} from '@nestjs/common';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Public } from '../auth/public.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@ApiTags('Categories')
+@ApiBearerAuth()
+@Controller('categories')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class CategoriesController {
+    constructor(private readonly service: CategoriesService) {}
+
+    @Public()
+    @Get()
+    @ApiOperation({ summary: 'List categories' })
+    list() {
+        return this.service.findAll();
+    }
+
+    @Public()
+    @Get(':id')
+    @ApiOperation({ summary: 'Get category by id' })
+    async get(@Param('id') id: number) {
+        const cat = await this.service.findOne(Number(id));
+        if (!cat) {
+            throw new NotFoundException();
+        }
+        return cat;
+    }
+
+    @Post()
+    @Roles(Role.Admin)
+    @ApiOperation({ summary: 'Create category' })
+    create(@Body() dto: CreateCategoryDto) {
+        return this.service.create(dto);
+    }
+
+    @Put(':id')
+    @Roles(Role.Admin)
+    @ApiOperation({ summary: 'Update category' })
+    update(@Param('id') id: number, @Body() dto: UpdateCategoryDto) {
+        return this.service.update(Number(id), dto);
+    }
+
+    @Delete(':id')
+    @Roles(Role.Admin)
+    @ApiOperation({ summary: 'Delete category' })
+    remove(@Param('id') id: number) {
+        return this.service.remove(Number(id));
+    }
+}

--- a/backend/src/categories/categories.module.ts
+++ b/backend/src/categories/categories.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from '../catalog/category.entity';
+import { Service } from '../catalog/service.entity';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { LogsModule } from '../logs/logs.module';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Category, Service]), LogsModule],
+    controllers: [CategoriesController],
+    providers: [CategoriesService],
+    exports: [TypeOrmModule],
+})
+export class CategoriesModule {}

--- a/backend/src/categories/categories.service.spec.ts
+++ b/backend/src/categories/categories.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CategoriesService } from './categories.service';
+import { Category } from '../catalog/category.entity';
+import { Service } from '../catalog/service.entity';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+
+describe('CategoriesService', () => {
+    let service: CategoriesService;
+    const repo = {
+        create: jest.fn(),
+        save: jest.fn(),
+        findOne: jest.fn(),
+        find: jest.fn(),
+        count: jest.fn(),
+        delete: jest.fn(),
+    } as any;
+    const svcRepo = { count: jest.fn() } as any;
+    const logs = { create: jest.fn() } as any;
+
+    beforeEach(async () => {
+        repo.create.mockReset();
+        repo.save.mockReset();
+        repo.findOne.mockReset();
+        repo.find.mockReset();
+        repo.delete.mockReset();
+        repo.count.mockReset();
+        svcRepo.count.mockReset();
+        logs.create.mockReset();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CategoriesService,
+                { provide: getRepositoryToken(Category), useValue: repo },
+                { provide: getRepositoryToken(Service), useValue: svcRepo },
+                { provide: LogsService, useValue: logs },
+            ],
+        }).compile();
+        service = module.get(CategoriesService);
+    });
+
+    it('creates category', async () => {
+        repo.findOne.mockResolvedValue(undefined);
+        repo.create.mockImplementation((d: any) => d);
+        repo.save.mockImplementation((d: any) => ({ id: 1, ...d }));
+        const result = await service.create({ name: 'n' });
+        expect(result.id).toBe(1);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.CreateCategory,
+            JSON.stringify({ id: 1, name: 'n' }),
+        );
+    });
+
+    it('throws on duplicate name', async () => {
+        repo.findOne.mockResolvedValue({ id: 2 });
+        await expect(service.create({ name: 'n' })).rejects.toBeDefined();
+    });
+
+    it('updates category', async () => {
+        repo.findOne.mockResolvedValueOnce({ id: 1, name: 'a' });
+        repo.save.mockImplementation((d: any) => d);
+        const res = await service.update(1, { name: 'b' });
+        expect(res!.name).toBe('b');
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.UpdateCategory,
+            JSON.stringify({ id: 1, name: 'b' }),
+        );
+    });
+
+    it('delete conflicts when services exist', async () => {
+        repo.findOne.mockResolvedValue({ id: 1 });
+        svcRepo.count.mockResolvedValue(1);
+        await expect(service.remove(1)).rejects.toBeDefined();
+    });
+});

--- a/backend/src/categories/categories.service.ts
+++ b/backend/src/categories/categories.service.ts
@@ -1,0 +1,83 @@
+import {
+    ConflictException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Category } from '../catalog/category.entity';
+import { Service as ServiceEntity } from '../catalog/service.entity';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+
+@Injectable()
+export class CategoriesService {
+    constructor(
+        @InjectRepository(Category)
+        private readonly repo: Repository<Category>,
+        @InjectRepository(ServiceEntity)
+        private readonly services: Repository<ServiceEntity>,
+        private readonly logs: LogsService,
+    ) {}
+
+    async create(dto: CreateCategoryDto) {
+        const exists = await this.repo.findOne({ where: { name: dto.name } });
+        if (exists) {
+            throw new ConflictException('Category name must be unique');
+        }
+        const entity = this.repo.create(dto);
+        const saved = await this.repo.save(entity);
+        await this.logs.create(
+            LogAction.CreateCategory,
+            JSON.stringify({ id: saved.id, ...dto }),
+        );
+        return saved;
+    }
+
+    findAll() {
+        return this.repo.find();
+    }
+
+    findOne(id: number) {
+        return this.repo.findOne({ where: { id } });
+    }
+
+    async update(id: number, dto: UpdateCategoryDto) {
+        const entity = await this.repo.findOne({ where: { id } });
+        if (!entity) return undefined;
+        if (dto.name && dto.name !== entity.name) {
+            const exists = await this.repo.findOne({
+                where: { name: dto.name },
+            });
+            if (exists && exists.id !== id) {
+                throw new ConflictException('Category name must be unique');
+            }
+        }
+        Object.assign(entity, dto);
+        const saved = await this.repo.save(entity);
+        await this.logs.create(
+            LogAction.UpdateCategory,
+            JSON.stringify({ id, ...dto }),
+        );
+        return saved;
+    }
+
+    async remove(id: number) {
+        const entity = await this.repo.findOne({ where: { id } });
+        if (!entity) throw new NotFoundException();
+        const count = await this.services.count({
+            where: { category: { id } },
+        });
+        if (count > 0) {
+            throw new ConflictException('Category has services');
+        }
+        await this.repo.delete(id);
+        await this.logs.create(
+            LogAction.DeleteCategory,
+            JSON.stringify({ id }),
+        );
+        return { deleted: true };
+    }
+}

--- a/backend/src/categories/dto/create-category.dto.ts
+++ b/backend/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, Length, IsOptional } from 'class-validator';
+
+export class CreateCategoryDto {
+    @IsString()
+    @Length(2, 50)
+    name: string;
+
+    @IsOptional()
+    @IsString()
+    description?: string;
+}

--- a/backend/src/categories/dto/update-category.dto.ts
+++ b/backend/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -16,4 +16,7 @@ export enum LogAction {
     CalendarAdd = 'CALENDAR_ADD',
     CalendarUpdate = 'CALENDAR_UPDATE',
     CalendarDelete = 'CALENDAR_DELETE',
+    CreateCategory = 'CREATE_CATEGORY',
+    UpdateCategory = 'UPDATE_CATEGORY',
+    DeleteCategory = 'DELETE_CATEGORY',
 }

--- a/backend/src/migrations/20250711192024-UpdateCategorySchema.ts
+++ b/backend/src/migrations/20250711192024-UpdateCategorySchema.ts
@@ -1,0 +1,98 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    TableColumn,
+    TableUnique,
+    TableForeignKey,
+} from 'typeorm';
+
+export class UpdateCategorySchema20250711192024 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'category',
+            new TableColumn({
+                name: 'description',
+                type: 'text',
+                isNullable: true,
+            }),
+        );
+        await queryRunner.addColumns('category', [
+            new TableColumn({
+                name: 'createdAt',
+                type: 'datetime',
+                default: 'CURRENT_TIMESTAMP',
+            }),
+            new TableColumn({
+                name: 'updatedAt',
+                type: 'datetime',
+                default: 'CURRENT_TIMESTAMP',
+                onUpdate: 'CURRENT_TIMESTAMP',
+            }),
+        ]);
+        await queryRunner.changeColumn(
+            'category',
+            'name',
+            new TableColumn({ name: 'name', type: 'varchar', length: '50' }),
+        );
+        await queryRunner.createUniqueConstraint(
+            'category',
+            new TableUnique({ columnNames: ['name'] }),
+        );
+        const table = await queryRunner.getTable('service');
+        if (table) {
+            const fk = table.foreignKeys.find((f) =>
+                f.columnNames.includes('categoryId'),
+            );
+            if (fk) await queryRunner.dropForeignKey('service', fk);
+            await queryRunner.changeColumn(
+                'service',
+                'categoryId',
+                new TableColumn({ name: 'categoryId', type: 'int' }),
+            );
+            await queryRunner.createForeignKey(
+                'service',
+                new TableForeignKey({
+                    columnNames: ['categoryId'],
+                    referencedTableName: 'category',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'RESTRICT',
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('service');
+        if (table) {
+            const fk = table.foreignKeys.find((f) =>
+                f.columnNames.includes('categoryId'),
+            );
+            if (fk) await queryRunner.dropForeignKey('service', fk);
+            await queryRunner.changeColumn(
+                'service',
+                'categoryId',
+                new TableColumn({
+                    name: 'categoryId',
+                    type: 'int',
+                    isNullable: true,
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'service',
+                new TableForeignKey({
+                    columnNames: ['categoryId'],
+                    referencedTableName: 'category',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+            );
+        }
+        await queryRunner.dropColumn('category', 'description');
+        await queryRunner.dropColumn('category', 'createdAt');
+        await queryRunner.dropColumn('category', 'updatedAt');
+        await queryRunner.dropUniqueConstraint(
+            'category',
+            new TableUnique({ columnNames: ['name'] }),
+        );
+    }
+}

--- a/backend/src/services/dto/create-service.dto.ts
+++ b/backend/src/services/dto/create-service.dto.ts
@@ -18,7 +18,6 @@ export class CreateServiceDto {
     @IsNumber()
     defaultCommissionPercent?: number | null;
 
-    @IsOptional()
     @IsInt()
-    categoryId?: number | null;
+    categoryId: number;
 }

--- a/backend/src/services/services.module.ts
+++ b/backend/src/services/services.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Service as ServiceEntity } from '../catalog/service.entity';
 import { Appointment } from '../appointments/appointment.entity';
+import { Category } from '../catalog/category.entity';
 import { ServicesService } from './services.service';
 import { ServicesController } from './services.controller';
 import { LogsModule } from '../logs/logs.module';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([ServiceEntity, Appointment]),
+        TypeOrmModule.forFeature([ServiceEntity, Appointment, Category]),
         LogsModule,
     ],
     controllers: [ServicesController],

--- a/backend/test/categories.e2e-spec.ts
+++ b/backend/test/categories.e2e-spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+import { Role } from '../src/users/role.enum';
+
+describe('CategoriesModule (e2e)', () => {
+    let app: INestApplication<App>;
+    let users: UsersService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+        users = moduleFixture.get(UsersService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('allows public listing', () => {
+        return request(app.getHttpServer()).get('/categories').expect(200);
+    });
+
+    it('admin can create and update', async () => {
+        await users.createUser('admin@cat.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@cat.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+        const create = await request(app.getHttpServer())
+            .post('/categories')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'hair' })
+            .expect(201);
+        await request(app.getHttpServer())
+            .put(`/categories/${create.body.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ description: 'desc' })
+            .expect(200);
+    });
+
+    it('rejects duplicate name', async () => {
+        await users.createUser('admin2@cat.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin2@cat.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+        await request(app.getHttpServer())
+            .post('/categories')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'makeup' })
+            .expect(201);
+        await request(app.getHttpServer())
+            .post('/categories')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'makeup' })
+            .expect(409);
+    });
+});


### PR DESCRIPTION
## Summary
- add timestamps and description to `Category` entity
- create Category DTOs, service, controller and module
- log category actions and extend log action enum
- enforce category existence when creating services
- add migration for new category schema
- include category e2e tests

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run test:cov`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688a85c0c3648329a6f5d1064e71c817