### PR TITLE
Add service lookup endpoint

### DIFF
--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -7,6 +7,7 @@ import {
     Patch,
     Post,
     UseGuards,
+    NotFoundException,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -36,6 +37,19 @@ export class ServicesController {
     @ApiResponse({ status: 200 })
     list() {
         return this.service.findAll();
+    }
+
+    @Public()
+    @Get(':id')
+    @ApiOperation({ summary: 'Get service by id' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
+    async get(@Param('id') id: number) {
+        const svc = await this.service.findOne(Number(id));
+        if (!svc) {
+            throw new NotFoundException();
+        }
+        return svc;
     }
 
     @Post()


### PR DESCRIPTION
## Summary
- expose `GET /services/:id` endpoint
- handle not found with `NotFoundException`
- document endpoint via Swagger

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a8b6b73b8832983e35b8494742ca9