### PR TITLE
Add timestamps and unique service constraint

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -1,6 +1,15 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+    UpdateDateColumn,
+    Index,
+} from 'typeorm';
 import { Category } from './category.entity';
 
+@Index(['category', 'name'], { unique: true })
 @Entity()
 export class Service {
     @PrimaryGeneratedColumn()
@@ -20,6 +29,12 @@ export class Service {
 
     @Column({ type: 'float', nullable: true })
     defaultCommissionPercent: number | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
 
     @ManyToOne(() => Category, (category) => category.services, {
         eager: true,

--- a/backend/src/migrations/20250711192025-UpdateServiceSchema.ts
+++ b/backend/src/migrations/20250711192025-UpdateServiceSchema.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableUnique } from 'typeorm';
+
+export class UpdateServiceSchema20250711192025 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumns('service', [
+            new TableColumn({
+                name: 'createdAt',
+                type: 'datetime',
+                default: 'CURRENT_TIMESTAMP',
+            }),
+            new TableColumn({
+                name: 'updatedAt',
+                type: 'datetime',
+                default: 'CURRENT_TIMESTAMP',
+                onUpdate: 'CURRENT_TIMESTAMP',
+            }),
+        ]);
+        await queryRunner.createUniqueConstraint(
+            'service',
+            new TableUnique({ columnNames: ['categoryId', 'name'] }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropUniqueConstraint(
+            'service',
+            new TableUnique({ columnNames: ['categoryId', 'name'] }),
+        );
+        await queryRunner.dropColumn('service', 'createdAt');
+        await queryRunner.dropColumn('service', 'updatedAt');
+    }
+}


### PR DESCRIPTION
## Summary
- add `createdAt` and `updatedAt` fields to `Service` entity
- enforce unique service names per category
- add migration updating the schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b4a83a59483299975f1291b4c947c