### PR TITLE
Add validation constraints for service DTOs

### DIFF
--- a/backend/src/services/dto/create-service.dto.ts
+++ b/backend/src/services/dto/create-service.dto.ts
@@ -1,7 +1,8 @@
-import { IsInt, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsNumber, IsOptional, IsString, Length, Max, Min } from 'class-validator';
 
 export class CreateServiceDto {
     @IsString()
+    @Length(2, 80)
     name: string;
 
     @IsOptional()
@@ -9,9 +10,13 @@ export class CreateServiceDto {
     description?: string;
 
     @IsInt()
+    @Min(10)
+    @Max(480)
     duration: number;
 
-    @IsNumber()
+    @IsNumber({ maxDecimalPlaces: 2 })
+    @Min(1)
+    @Max(10000)
     price: number;
 
     @IsOptional()

--- a/backend/src/services/dto/update-service.dto.ts
+++ b/backend/src/services/dto/update-service.dto.ts
@@ -1,8 +1,9 @@
-import { IsInt, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsNumber, IsOptional, IsString, Length, Max, Min } from 'class-validator';
 
 export class UpdateServiceDto {
     @IsOptional()
     @IsString()
+    @Length(2, 80)
     name?: string;
 
     @IsOptional()
@@ -11,10 +12,14 @@ export class UpdateServiceDto {
 
     @IsOptional()
     @IsInt()
+    @Min(10)
+    @Max(480)
     duration?: number;
 
     @IsOptional()
-    @IsNumber()
+    @IsNumber({ maxDecimalPlaces: 2 })
+    @Min(1)
+    @Max(10000)
     price?: number;
 
     @IsOptional()


### PR DESCRIPTION
## Summary
- enforce length and range checks on service names, prices and durations
- keep categoryId typed as an integer

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b4eac8e508329b03fd13b53c9c262