### PR TITLE
Add log for service creation

### DIFF
--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -1,5 +1,6 @@
 export enum LogAction {
     CreateAppointment = 'CREATE_APPOINTMENT',
+    CreateService = 'CREATE_SERVICE',
     UpdateService = 'UPDATE_SERVICE',
     LoginFail = 'LOGIN_FAIL',
     LoginSuccess = 'LOGIN_SUCCESS',

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -38,7 +38,7 @@ export class ServicesService {
         });
         const saved = await this.repo.save(entity);
         await this.logs.create(
-            LogAction.UpdateService,
+            LogAction.CreateService,
             JSON.stringify({ id: saved.id, ...dto }),
         );
         return saved;


### PR DESCRIPTION
## Summary
- extend `LogAction` with `CreateService`
- record `CreateService` when a new service is created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b553494ac8329a991c9ba9dc86842