### PR TITLE
Fix missing service update

### DIFF
--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -55,7 +55,7 @@ export class ServicesService {
     async update(id: number, dto: UpdateServiceDto) {
         const entity = await this.repo.findOne({ where: { id } });
         if (!entity) {
-            return undefined;
+            throw new NotFoundException();
         }
         if (dto.categoryId !== undefined) {
             entity.category = dto.categoryId

--- a/backend/test/services.e2e-spec.ts
+++ b/backend/test/services.e2e-spec.ts
@@ -135,4 +135,21 @@ describe('ServicesModule (e2e)', () => {
             .set('Authorization', `Bearer ${token}`)
             .expect(400);
     });
+
+    it('returns 404 when updating nonexistent service', async () => {
+        await users.createUser('svcupd@test.com', 'secret', 'Admin', Role.Admin);
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'svcupd@test.com', password: 'secret' })
+            .expect(201);
+
+        const token = (login.body as { access_token: string }).access_token;
+
+        await request(app.getHttpServer())
+            .patch('/services/9999')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'bad' })
+            .expect(404);
+    });
 });


### PR DESCRIPTION
## Summary
- throw `NotFoundException` from `ServicesService.update` when service doesn't exist
- test update of nonexistent service returns 404

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_688b69dcdf3c8329a880b4874fed9225