### PR TITLE
Add service timestamps migration

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -30,10 +30,17 @@ export class Service {
     @Column({ type: 'float', nullable: true })
     defaultCommissionPercent: number | null;
 
-    @CreateDateColumn()
+    @CreateDateColumn({
+        type: 'datetime',
+        default: () => 'CURRENT_TIMESTAMP',
+    })
     createdAt: Date;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({
+        type: 'datetime',
+        default: () => 'CURRENT_TIMESTAMP',
+        onUpdate: 'CURRENT_TIMESTAMP',
+    })
     updatedAt: Date;
 
     @ManyToOne(() => Category, (category) => category.services, {

--- a/backend/src/migrations/20250711192026-AddServiceTimestamps.ts
+++ b/backend/src/migrations/20250711192026-AddServiceTimestamps.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddServiceTimestamps20250711192026 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('service');
+        if (!table) return;
+        if (!table.columns.find((c) => c.name === 'createdAt')) {
+            await queryRunner.addColumn(
+                'service',
+                new TableColumn({
+                    name: 'createdAt',
+                    type: 'datetime',
+                    default: 'CURRENT_TIMESTAMP',
+                }),
+            );
+        }
+        if (!table.columns.find((c) => c.name === 'updatedAt')) {
+            await queryRunner.addColumn(
+                'service',
+                new TableColumn({
+                    name: 'updatedAt',
+                    type: 'datetime',
+                    default: 'CURRENT_TIMESTAMP',
+                    onUpdate: 'CURRENT_TIMESTAMP',
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('service');
+        if (!table) return;
+        if (table.columns.find((c) => c.name === 'updatedAt')) {
+            await queryRunner.dropColumn('service', 'updatedAt');
+        }
+        if (table.columns.find((c) => c.name === 'createdAt')) {
+            await queryRunner.dropColumn('service', 'createdAt');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create a follow-up migration for timestamps on `service`
- set timestamp defaults in `Service` entity

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b786f5ec88329aabf48121e20af44