### PR TITLE
Add product timestamps and stock threshold

### DIFF
--- a/backend/src/catalog/product.entity.ts
+++ b/backend/src/catalog/product.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, Check } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    Check,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
 
 @Check('CHK_product_unit_price', '"unitPrice" >= 0')
 @Check('CHK_product_stock', '"stock" >= 0')
@@ -7,7 +14,7 @@ export class Product {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({ unique: true })
     name: string;
 
     @Column({ nullable: true })
@@ -18,4 +25,20 @@ export class Product {
 
     @Column('int')
     stock: number;
+
+    @Column('int', { default: 5 })
+    lowStockThreshold: number;
+
+    @CreateDateColumn({
+        type: 'datetime',
+        default: () => 'CURRENT_TIMESTAMP',
+    })
+    createdAt: Date;
+
+    @UpdateDateColumn({
+        type: 'datetime',
+        default: () => 'CURRENT_TIMESTAMP',
+        onUpdate: 'CURRENT_TIMESTAMP',
+    })
+    updatedAt: Date;
 }

--- a/backend/src/migrations/20250711192027-UpdateProductSchema.ts
+++ b/backend/src/migrations/20250711192027-UpdateProductSchema.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableUnique } from 'typeorm';
+
+export class UpdateProductSchema20250711192027 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumns('product', [
+            new TableColumn({
+                name: 'lowStockThreshold',
+                type: 'int',
+                default: '5',
+            }),
+            new TableColumn({
+                name: 'createdAt',
+                type: 'datetime',
+                default: 'CURRENT_TIMESTAMP',
+            }),
+            new TableColumn({
+                name: 'updatedAt',
+                type: 'datetime',
+                default: 'CURRENT_TIMESTAMP',
+                onUpdate: 'CURRENT_TIMESTAMP',
+            }),
+        ]);
+        await queryRunner.createUniqueConstraint(
+            'product',
+            new TableUnique({ columnNames: ['name'] }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropUniqueConstraint(
+            'product',
+            new TableUnique({ columnNames: ['name'] }),
+        );
+        await queryRunner.dropColumn('product', 'lowStockThreshold');
+        await queryRunner.dropColumn('product', 'createdAt');
+        await queryRunner.dropColumn('product', 'updatedAt');
+    }
+}


### PR DESCRIPTION
## Summary
- make product names unique
- add timestamps and stock threshold fields to products
- create migration to update product table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bd8df58ac8329a16ccb6f56513f8a