### PR TITLE
Add product validation rules

### DIFF
--- a/backend/src/products/dto/create-product.dto.ts
+++ b/backend/src/products/dto/create-product.dto.ts
@@ -1,18 +1,31 @@
-import { IsString, IsNumber, IsInt, IsOptional, Min } from 'class-validator';
+import {
+    IsString,
+    IsNumber,
+    IsInt,
+    IsOptional,
+    Min,
+    Length,
+} from 'class-validator';
 
 export class CreateProductDto {
     @IsString()
+    @Length(2, 80)
     name: string;
 
     @IsOptional()
     @IsString()
     brand?: string;
 
-    @IsNumber()
-    @Min(0)
+    @IsNumber({ maxDecimalPlaces: 2 })
+    @Min(1.01)
     unitPrice: number;
 
     @IsInt()
     @Min(0)
     stock: number;
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    lowStockThreshold = 5;
 }

--- a/backend/src/products/dto/update-product.dto.ts
+++ b/backend/src/products/dto/update-product.dto.ts
@@ -1,4 +1,36 @@
 import { PartialType } from '@nestjs/mapped-types';
+import {
+    IsInt,
+    IsNumber,
+    IsOptional,
+    IsString,
+    Min,
+    Length,
+} from 'class-validator';
 import { CreateProductDto } from './create-product.dto';
 
-export class UpdateProductDto extends PartialType(CreateProductDto) {}
+export class UpdateProductDto extends PartialType(CreateProductDto) {
+    @IsOptional()
+    @IsString()
+    @Length(2, 80)
+    name?: string;
+
+    @IsOptional()
+    @IsString()
+    brand?: string | null;
+
+    @IsOptional()
+    @IsNumber({ maxDecimalPlaces: 2 })
+    @Min(1.01)
+    unitPrice?: number;
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    stock?: number;
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    lowStockThreshold?: number;
+}


### PR DESCRIPTION
## Summary
- enforce product name and unit price validation
- expose lowStockThreshold defaults and validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688beb7406788329ad6eed8f7eae5101