### PR TITLE
UpdateProductDto uses OmitType

### DIFF
--- a/backend/src/products/dto/update-product.dto.ts
+++ b/backend/src/products/dto/update-product.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType, OmitType } from '@nestjs/mapped-types';
 import {
     IsInt,
     IsNumber,
@@ -9,7 +9,9 @@ import {
 } from 'class-validator';
 import { CreateProductDto } from './create-product.dto';
 
-export class UpdateProductDto extends PartialType(CreateProductDto) {
+export class UpdateProductDto extends PartialType(
+    OmitType(CreateProductDto, ['brand'] as const),
+) {
     @IsOptional()
     @IsString()
     @Length(2, 80)


### PR DESCRIPTION
## Summary
- refine UpdateProductDto to exclude `brand` from the inherited fields
- adjust imports to bring in `OmitType`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bf448b610832986f60e611417bce0