### PR TITLE
Add product service tests and expand e2e coverage

### DIFF
--- a/backend/src/products/public/public.controller.ts
+++ b/backend/src/products/public/public.controller.ts
@@ -33,6 +33,14 @@ export class PublicController {
         return this.service.findAll();
     }
 
+    @Get('low-stock')
+    @Roles(Role.Admin)
+    @ApiOperation({ summary: 'List low stock products' })
+    @ApiResponse({ status: 200 })
+    listLowStock() {
+        return this.service.findLowStock();
+    }
+
     @Public()
     @Get(':id')
     @ApiOperation({ summary: 'Get product by id' })
@@ -44,13 +52,5 @@ export class PublicController {
             throw new NotFoundException();
         }
         return prod;
-    }
-
-    @Get('low-stock')
-    @Roles(Role.Admin)
-    @ApiOperation({ summary: 'List low stock products' })
-    @ApiResponse({ status: 200 })
-    listLowStock() {
-        return this.service.findLowStock();
     }
 }

--- a/backend/test/products.e2e-spec.ts
+++ b/backend/test/products.e2e-spec.ts
@@ -81,4 +81,125 @@ describe('ProductsModule (e2e)', () => {
             .send({ stock: -2 })
             .expect(400);
     });
+
+    it('admin can CRUD products and list low stock', async () => {
+        await users.createUser('crud@prod.com', 'secret', 'Admin', Role.Admin);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'crud@prod.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        const create = await request(app.getHttpServer())
+            .post('/products/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                name: 'shampoo',
+                unitPrice: 10,
+                stock: 5,
+                lowStockThreshold: 4,
+            })
+            .expect(201);
+        const id = create.body.id as number;
+
+        const list = await request(app.getHttpServer())
+            .get('/products')
+            .expect(200);
+        expect(list.body.some((p: any) => p.id === id)).toBe(true);
+
+        await request(app.getHttpServer())
+            .patch(`/products/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ brand: 'best' })
+            .expect(200);
+
+        await request(app.getHttpServer())
+            .patch(`/products/admin/${id}/stock`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ amount: -3 })
+            .expect(200);
+
+        const low = await request(app.getHttpServer())
+            .get('/products/low-stock')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+        expect(low.body.some((p: any) => p.id === id)).toBe(true);
+
+        await request(app.getHttpServer())
+            .delete(`/products/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+
+        await request(app.getHttpServer()).get(`/products/${id}`).expect(404);
+    });
+
+    it('enforces authorization', async () => {
+        await users.createUser('client@prod.com', 'secret', 'C', Role.Client);
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'client@prod.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .post('/products/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'x', unitPrice: 1, stock: 1 })
+            .expect(403);
+
+        await request(app.getHttpServer())
+            .get('/products/low-stock')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(403);
+    });
+
+    it('cannot delete product with sales', async () => {
+        const admin = await users.createUser(
+            'saleadmin@prod.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const employee = await users.createUser(
+            'saleemp@prod.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const client = await users.createUser(
+            'saleclient@prod.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'saleadmin@prod.com', password: 'secret' })
+            .expect(201);
+        const token = login.body.access_token as string;
+
+        const prod = await request(app.getHttpServer())
+            .post('/products/admin')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ name: 'nails', unitPrice: 5, stock: 5 })
+            .expect(201);
+        const id = prod.body.id;
+
+        await request(app.getHttpServer())
+            .post('/sales')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                productId: id,
+                quantity: 1,
+            })
+            .expect(201);
+
+        await request(app.getHttpServer())
+            .delete(`/products/admin/${id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(409);
+    });
 });


### PR DESCRIPTION
## Summary
- cover remaining branches in `ProductsService`
- fix low stock route in `PublicController`
- expand product e2e tests with CRUD flow, auth checks and deletion rules

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run test:e2e`
- `npm --prefix backend run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_688ca88f29408329ba5887305d4a8aa5