### PR TITLE
Implement product stock management

### DIFF
--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -3,48 +3,76 @@ import { useToast } from '@/contexts/ToastContext';
 import { Product } from '@/types';
 
 export function useProductApi() {
-  const { apiFetch } = useAuth();
-  const toast = useToast();
+    const { apiFetch } = useAuth();
+    const toast = useToast();
 
-  const create = async (data: { name: string; unitPrice: number; stock: number; brand?: string }) => {
-    try {
-      const res = await apiFetch<Product>('/products/admin', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Product created');
-      return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
-      throw err;
-    }
-  };
+    const create = async (data: {
+        name: string;
+        unitPrice: number;
+        stock: number;
+        brand?: string;
+    }) => {
+        try {
+            const res = await apiFetch<Product>('/products/admin', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Product created');
+            return res;
+        } catch (err: any) {
+            toast.error(err.message || 'Error');
+            throw err;
+        }
+    };
 
-  const update = async (id: number, data: { name?: string; unitPrice?: number; stock?: number; brand?: string }) => {
-    try {
-      const res = await apiFetch<Product>(`/products/admin/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Product updated');
-      return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
-      throw err;
-    }
-  };
+    const update = async (
+        id: number,
+        data: {
+            name?: string;
+            unitPrice?: number;
+            stock?: number;
+            brand?: string;
+        },
+    ) => {
+        try {
+            const res = await apiFetch<Product>(`/products/admin/${id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Product updated');
+            return res;
+        } catch (err: any) {
+            toast.error(err.message || 'Error');
+            throw err;
+        }
+    };
 
-  const remove = async (id: number) => {
-    try {
-      await apiFetch<void>(`/products/admin/${id}`, { method: 'DELETE' });
-      toast.success('Product deleted');
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
-      throw err;
-    }
-  };
+    const updateStock = async (id: number, amount: number) => {
+        try {
+            const res = await apiFetch<Product>(`/products/admin/${id}/stock`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ amount }),
+            });
+            toast.success('Stock updated');
+            return res;
+        } catch (err: any) {
+            toast.error(err.message || 'Error');
+            throw err;
+        }
+    };
 
-  return { create, update, remove };
+    const remove = async (id: number) => {
+        try {
+            await apiFetch<void>(`/products/admin/${id}`, { method: 'DELETE' });
+            toast.success('Product deleted');
+        } catch (err: any) {
+            toast.error(err.message || 'Error');
+            throw err;
+        }
+    };
+
+    return { create, update, updateStock, remove };
 }

--- a/frontend/src/components/StockForm.tsx
+++ b/frontend/src/components/StockForm.tsx
@@ -1,0 +1,54 @@
+import { FormEvent, useState } from 'react';
+
+interface Props {
+    onSubmit: (amount: number) => Promise<void>;
+    onCancel: () => void;
+}
+
+export default function StockForm({ onSubmit, onCancel }: Props) {
+    const [amount, setAmount] = useState(0);
+    const [error, setError] = useState('');
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        const num = Number(amount);
+        if (Number.isNaN(num) || !Number.isFinite(num)) {
+            setError('Amount is required');
+            return;
+        }
+        try {
+            await onSubmit(num);
+        } catch (err: any) {
+            setError(err.message || 'Error');
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-2">
+            <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(Number(e.target.value))}
+                className="border p-1 w-full"
+                placeholder="Amount"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
+}

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -2,5 +2,5 @@ import { useList } from './useList';
 import { Product } from '@/types';
 
 export function useProducts() {
-  return useList<Product>('/products/admin');
+    return useList<Product>('/products');
 }

--- a/frontend/src/pages/products/index.tsx
+++ b/frontend/src/pages/products/index.tsx
@@ -4,101 +4,142 @@ import Layout from '@/components/Layout';
 import DataTable, { Column } from '@/components/DataTable';
 import Modal from '@/components/Modal';
 import ProductForm from '@/components/ProductForm';
+import StockForm from '@/components/StockForm';
 import { useProducts } from '@/hooks/useProducts';
 import { useProductApi } from '@/api/products';
 import { Product } from '@/types';
 
 export default function ProductsPage() {
-  const { data } = useProducts();
-  const api = useProductApi();
-  const [rows, setRows] = useState<Product[]>([]);
-  const [openForm, setOpenForm] = useState(false);
-  const [editing, setEditing] = useState<Product | null>(null);
+    const { data } = useProducts();
+    const api = useProductApi();
+    const [rows, setRows] = useState<Product[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [editing, setEditing] = useState<Product | null>(null);
+    const [stockProd, setStockProd] = useState<Product | null>(null);
 
-  if (data && rows.length === 0) setRows(data);
+    if (data && rows.length === 0) setRows(data);
 
-  const columns: Column<Product>[] = [
-    { header: 'ID', accessor: 'id' },
-    { header: 'Name', accessor: 'name' },
-    { header: 'Brand', accessor: 'brand' },
-    { header: 'Price', accessor: 'unitPrice' },
-    { header: 'Stock', accessor: 'stock' },
-  ];
+    const columns: Column<Product>[] = [
+        { header: 'ID', accessor: 'id' },
+        { header: 'Name', accessor: 'name' },
+        { header: 'Brand', accessor: 'brand' },
+        { header: 'Price', accessor: 'unitPrice' },
+        { header: 'Stock', accessor: 'stock' },
+    ];
 
-  const handleCreate = async (values: { name: string; unitPrice: number; stock: number; brand?: string }) => {
-    const created = await api.create(values);
-    setRows((c) => [...c, created]);
-    setOpenForm(false);
-  };
+    const handleCreate = async (values: {
+        name: string;
+        unitPrice: number;
+        stock: number;
+        brand?: string;
+    }) => {
+        const created = await api.create(values);
+        setRows((c) => [...c, created]);
+        setOpenForm(false);
+    };
 
-  const handleUpdate = async (values: { name: string; unitPrice: number; stock: number; brand?: string }) => {
-    if (!editing) return;
-    const updated = await api.update(editing.id, values);
-    setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
-    setEditing(null);
-    setOpenForm(false);
-  };
+    const handleUpdate = async (values: {
+        name: string;
+        unitPrice: number;
+        stock: number;
+        brand?: string;
+    }) => {
+        if (!editing) return;
+        const updated = await api.update(editing.id, values);
+        setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
+        setEditing(null);
+        setOpenForm(false);
+    };
 
-  const handleDelete = async (row: Product) => {
-    if (!confirm(`Delete ${row.name}?`)) return;
-    await api.remove(row.id);
-    setRows((c) => c.filter((cl) => cl.id !== row.id));
-  };
+    const handleStockUpdate = async (amount: number) => {
+        if (!stockProd) return;
+        const updated = await api.updateStock(stockProd.id, amount);
+        setRows((c) => c.map((cl) => (cl.id === stockProd.id ? updated : cl)));
+        setStockProd(null);
+    };
 
-  return (
-    <RouteGuard>
-      <Layout>
-        <div className="mb-2 flex justify-end">
-          <button
-            className="border px-2 py-1"
-            onClick={() => {
-              setEditing(null);
-              setOpenForm(true);
-            }}
-          >
-            Add Product
-          </button>
-        </div>
-        {rows && (
-          <DataTable
-            data={rows}
-            columns={columns}
-            initialSort="id"
-            renderActions={(r) => (
-              <span className="space-x-2">
-                <button
-                  className="border px-2 py-1"
-                  onClick={() => {
-                    setEditing(r);
-                    setOpenForm(true);
-                  }}
+    const handleDelete = async (row: Product) => {
+        if (!confirm(`Delete ${row.name}?`)) return;
+        try {
+            await api.remove(row.id);
+            setRows((c) => c.filter((cl) => cl.id !== row.id));
+        } catch {
+            // error toast handled in api
+        }
+    };
+
+    return (
+        <RouteGuard>
+            <Layout>
+                <div className="mb-2 flex justify-end">
+                    <button
+                        className="border px-2 py-1"
+                        onClick={() => {
+                            setEditing(null);
+                            setOpenForm(true);
+                        }}
+                    >
+                        Add Product
+                    </button>
+                </div>
+                {rows && (
+                    <DataTable
+                        data={rows}
+                        columns={columns}
+                        initialSort="id"
+                        renderActions={(r) => (
+                            <span className="space-x-2">
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => {
+                                        setEditing(r);
+                                        setOpenForm(true);
+                                    }}
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => setStockProd(r)}
+                                >
+                                    Stock
+                                </button>
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => handleDelete(r)}
+                                >
+                                    Delete
+                                </button>
+                            </span>
+                        )}
+                    />
+                )}
+                <Modal
+                    open={openForm || Boolean(editing)}
+                    onClose={() => {
+                        setOpenForm(false);
+                        setEditing(null);
+                    }}
                 >
-                  Edit
-                </button>
-                <button className="border px-2 py-1" onClick={() => handleDelete(r)}>
-                  Delete
-                </button>
-              </span>
-            )}
-          />
-        )}
-        <Modal
-          open={openForm || Boolean(editing)}
-          onClose={() => {
-            setOpenForm(false);
-            setEditing(null);
-          }}
-        >
-          <ProductForm
-            initial={editing ?? undefined}
-            onCancel={() => {
-              setOpenForm(false);
-              setEditing(null);
-            }}
-            onSubmit={editing ? handleUpdate : handleCreate}
-          />
-        </Modal>
-      </Layout>
-    </RouteGuard>
-  );
+                    <ProductForm
+                        initial={editing ?? undefined}
+                        onCancel={() => {
+                            setOpenForm(false);
+                            setEditing(null);
+                        }}
+                        onSubmit={editing ? handleUpdate : handleCreate}
+                    />
+                </Modal>
+                <Modal
+                    open={Boolean(stockProd)}
+                    onClose={() => setStockProd(null)}
+                >
+                    <StockForm
+                        onCancel={() => setStockProd(null)}
+                        onSubmit={handleStockUpdate}
+                    />
+                </Modal>
+            </Layout>
+        </RouteGuard>
+    );
 }


### PR DESCRIPTION
## Summary
- fetch products from public endpoint
- expose stock update endpoint in product API
- add `StockForm` for updating product stock
- update products admin page to adjust stock and handle delete errors

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688cbb4193548329a7587b355fdf4022