### PR TITLE
Add bulk stock update for products

### DIFF
--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -23,5 +23,6 @@ export enum LogAction {
     CreateProduct = 'CREATE_PRODUCT',
     UpdateProduct = 'UPDATE_PRODUCT',
     UpdateProductStock = 'UPDATE_PRODUCT_STOCK',
+    BulkUpdateProductStock = 'BULK_UPDATE_PRODUCT_STOCK',
     DeleteProduct = 'DELETE_PRODUCT',
 }

--- a/backend/src/products/admin/admin.controller.ts
+++ b/backend/src/products/admin/admin.controller.ts
@@ -44,6 +44,15 @@ export class AdminController {
         return this.service.create(dto);
     }
 
+    @Patch('bulk-stock')
+    @ApiOperation({ summary: 'Bulk update product stock' })
+    @ApiResponse({ status: 200 })
+    bulkUpdateStock(
+        @Body() body: { entries: { id: number; stock: number }[] },
+    ) {
+        return this.service.bulkUpdateStock(body.entries);
+    }
+
     @Patch(':id')
     @ApiOperation({ summary: 'Update product' })
     @ApiResponse({ status: 200 })


### PR DESCRIPTION
## Summary
- support bulk stock updates in ProductsService
- log `BULK_UPDATE_PRODUCT_STOCK` action
- expose admin endpoint `PATCH /products/admin/bulk-stock`
- test bulk stock update behaviour

## Testing
- `npm run lint`
- `npm run test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_688ce610372083298f02a24ded96127c