### PR TITLE
Add product usage tracking

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { CommissionsModule } from './commissions/commissions.module';
 import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
 import { SalesModule } from './sales/sales.module';
+import { ProductUsageModule } from './product-usage/product-usage.module';
 import { LogsModule } from './logs/logs.module';
 import { CommunicationsModule } from './communications/communications.module';
 import { ReviewsModule } from './reviews/reviews.module';
@@ -62,6 +63,7 @@ import { CategoriesModule } from './categories/categories.module';
         CommissionsModule,
         ServicesModule,
         ProductsModule,
+        ProductUsageModule,
         SalesModule,
         ReviewsModule,
         ChatMessagesModule,

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -25,4 +25,5 @@ export enum LogAction {
     UpdateProductStock = 'UPDATE_PRODUCT_STOCK',
     BulkUpdateProductStock = 'BULK_UPDATE_PRODUCT_STOCK',
     DeleteProduct = 'DELETE_PRODUCT',
+    ProductUsed = 'PRODUCT_USED',
 }

--- a/backend/src/migrations/20250711192028-CreateProductUsageTable.ts
+++ b/backend/src/migrations/20250711192028-CreateProductUsageTable.ts
@@ -1,0 +1,56 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+} from 'typeorm';
+
+export class CreateProductUsageTable20250711192028
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'product_usage',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    { name: 'appointmentId', type: 'int' },
+                    { name: 'productId', type: 'int' },
+                    { name: 'quantity', type: 'int' },
+                    { name: 'usedByEmployeeId', type: 'int' },
+                    { name: 'timestamp', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+        );
+        await queryRunner.createForeignKeys('product_usage', [
+            new TableForeignKey({
+                columnNames: ['appointmentId'],
+                referencedTableName: 'appointment',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+            new TableForeignKey({
+                columnNames: ['productId'],
+                referencedTableName: 'product',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+            new TableForeignKey({
+                columnNames: ['usedByEmployeeId'],
+                referencedTableName: 'user',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('product_usage');
+    }
+}

--- a/backend/src/product-usage/appointment-product-usage.controller.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.ts
@@ -1,0 +1,52 @@
+import {
+    Body,
+    Controller,
+    Param,
+    Post,
+    Request,
+    UseGuards,
+    NotFoundException,
+    ForbiddenException,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { ProductUsageService } from './product-usage.service';
+import { AppointmentsService } from '../appointments/appointments.service';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { EmployeeRole } from '../employees/employee-role.enum';
+import { Request as ExpressRequest } from 'express';
+
+interface AuthRequest extends ExpressRequest {
+    user: { id: number; role: Role | EmployeeRole };
+}
+
+@ApiTags('Product Usage')
+@ApiBearerAuth()
+@Controller('appointments')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AppointmentProductUsageController {
+    constructor(
+        private readonly usage: ProductUsageService,
+        private readonly appointments: AppointmentsService,
+    ) {}
+
+    @Post(':id/product-usage')
+    @Roles(Role.Admin, Role.Employee)
+    @ApiOperation({ summary: 'Register product usage for appointment' })
+    async create(
+        @Param('id') id: string,
+        @Body() body: { productId: number; quantity: number }[],
+        @Request() req: AuthRequest,
+    ) {
+        const appt = await this.appointments.findOne(Number(id));
+        if (!appt) {
+            throw new NotFoundException();
+        }
+        if (req.user.role !== Role.Admin && appt.employee.id !== req.user.id) {
+            throw new ForbiddenException();
+        }
+        return this.usage.registerUsage(Number(id), req.user.id, body);
+    }
+}

--- a/backend/src/product-usage/product-usage.controller.ts
+++ b/backend/src/product-usage/product-usage.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { ProductUsageService } from './product-usage.service';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Product Usage')
+@ApiBearerAuth()
+@Controller('products')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ProductUsageController {
+    constructor(private readonly usage: ProductUsageService) {}
+
+    @Get(':id/usage-history')
+    @Roles(Role.Admin)
+    @ApiOperation({ summary: 'List usage history for product' })
+    list(@Param('id') id: string) {
+        return this.usage.findForProduct(Number(id));
+    }
+}

--- a/backend/src/product-usage/product-usage.entity.ts
+++ b/backend/src/product-usage/product-usage.entity.ts
@@ -1,0 +1,31 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
+import { Appointment } from '../appointments/appointment.entity';
+import { Product } from '../catalog/product.entity';
+import { User } from '../users/user.entity';
+
+@Entity()
+export class ProductUsage {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Appointment, { eager: true, onDelete: 'RESTRICT' })
+    appointment: Appointment;
+
+    @ManyToOne(() => Product, { eager: true, onDelete: 'RESTRICT' })
+    product: Product;
+
+    @Column('int')
+    quantity: number;
+
+    @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
+    usedByEmployee: User;
+
+    @CreateDateColumn()
+    timestamp: Date;
+}

--- a/backend/src/product-usage/product-usage.module.ts
+++ b/backend/src/product-usage/product-usage.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProductUsage } from './product-usage.entity';
+import { Product } from '../catalog/product.entity';
+import { LogsModule } from '../logs/logs.module';
+import { ProductUsageService } from './product-usage.service';
+import { AppointmentProductUsageController } from './appointment-product-usage.controller';
+import { ProductUsageController } from './product-usage.controller';
+import { AppointmentsModule } from '../appointments/appointments.module';
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([ProductUsage, Product]),
+        LogsModule,
+        AppointmentsModule,
+    ],
+    controllers: [AppointmentProductUsageController, ProductUsageController],
+    providers: [ProductUsageService],
+    exports: [TypeOrmModule, ProductUsageService],
+})
+export class ProductUsageModule {}

--- a/backend/src/product-usage/product-usage.service.spec.ts
+++ b/backend/src/product-usage/product-usage.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ProductUsageService } from './product-usage.service';
+import { ProductUsage } from './product-usage.entity';
+import { Product } from '../catalog/product.entity';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+import { ConflictException } from '@nestjs/common';
+
+describe('ProductUsageService', () => {
+    let service: ProductUsageService;
+    const repo = { manager: { transaction: jest.fn() } } as any;
+    const products = { findOne: jest.fn(), save: jest.fn() } as any;
+    const logs = { create: jest.fn() } as any;
+
+    beforeEach(async () => {
+        repo.manager.transaction.mockReset();
+        products.findOne.mockReset();
+        products.save.mockReset();
+        logs.create.mockReset();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ProductUsageService,
+                { provide: getRepositoryToken(ProductUsage), useValue: repo },
+                { provide: getRepositoryToken(Product), useValue: products },
+                { provide: LogsService, useValue: logs },
+            ],
+        }).compile();
+        service = module.get(ProductUsageService);
+    });
+
+    it('registers usage and decrements stock', async () => {
+        const manager = {
+            findOne: jest.fn().mockResolvedValue({ id: 1, stock: 2 }),
+            save: jest.fn().mockImplementation((_: any, d: any) => d),
+            create: jest.fn((_: any, d: any) => d),
+        } as any;
+        repo.manager.transaction.mockImplementation(async (cb: any) =>
+            cb(manager),
+        );
+
+        const res = await service.registerUsage(1, 2, [
+            { productId: 1, quantity: 1 },
+        ]);
+        expect(res).toHaveLength(1);
+        expect(manager.save).toHaveBeenCalledTimes(2);
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.ProductUsed,
+            expect.any(String),
+            2,
+        );
+    });
+
+    it('throws on insufficient stock', async () => {
+        const manager = {
+            findOne: jest.fn().mockResolvedValue({ id: 1, stock: 0 }),
+            save: jest.fn(),
+        } as any;
+        repo.manager.transaction.mockImplementation(async (cb: any) =>
+            cb(manager),
+        );
+        await expect(
+            service.registerUsage(1, 2, [{ productId: 1, quantity: 1 }]),
+        ).rejects.toBeInstanceOf(ConflictException);
+    });
+});

--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -1,0 +1,76 @@
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProductUsage } from './product-usage.entity';
+import { Product } from '../catalog/product.entity';
+import { LogsService } from '../logs/logs.service';
+import { LogAction } from '../logs/action.enum';
+
+@Injectable()
+export class ProductUsageService {
+    constructor(
+        @InjectRepository(ProductUsage)
+        private readonly repo: Repository<ProductUsage>,
+        @InjectRepository(Product)
+        private readonly products: Repository<Product>,
+        private readonly logs: LogsService,
+    ) {}
+
+    async registerUsage(
+        appointmentId: number,
+        employeeId: number,
+        entries: { productId: number; quantity: number }[],
+    ) {
+        return this.repo.manager.transaction(async (manager) => {
+            const records: ProductUsage[] = [];
+            for (const { productId, quantity } of entries) {
+                if (quantity <= 0) {
+                    throw new BadRequestException('quantity must be > 0');
+                }
+                const product = await manager.findOne(Product, {
+                    where: { id: productId },
+                });
+                if (!product) {
+                    throw new NotFoundException(
+                        `Product ${productId} not found`,
+                    );
+                }
+                if (product.stock < quantity) {
+                    throw new ConflictException('insufficient stock');
+                }
+                product.stock -= quantity;
+                await manager.save(Product, product);
+                const usage = manager.create(ProductUsage, {
+                    appointment: { id: appointmentId } as any,
+                    product: { id: productId } as any,
+                    quantity,
+                    usedByEmployee: { id: employeeId } as any,
+                });
+                records.push(await manager.save(ProductUsage, usage));
+                await this.logs.create(
+                    LogAction.ProductUsed,
+                    JSON.stringify({
+                        appointmentId,
+                        productId,
+                        quantity,
+                        stock: product.stock,
+                    }),
+                    employeeId,
+                );
+            }
+            return records;
+        });
+    }
+
+    findForProduct(productId: number) {
+        return this.repo.find({
+            where: { product: { id: productId } },
+            order: { timestamp: 'DESC' },
+        });
+    }
+}

--- a/backend/test/product-usage.e2e-spec.ts
+++ b/backend/test/product-usage.e2e-spec.ts
@@ -1,0 +1,134 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+import { AppointmentsService } from './../src/appointments/appointments.service';
+import { ProductsService } from './../src/products/products.service';
+
+describe('ProductUsage (e2e)', () => {
+    let app: INestApplication<App>;
+    let users: UsersService;
+    let appointments: AppointmentsService;
+    let products: ProductsService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+
+        users = moduleFixture.get(UsersService);
+        appointments = moduleFixture.get(AppointmentsService);
+        products = moduleFixture.get(ProductsService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('employee can register product usage', async () => {
+        const admin = await users.createUser(
+            'admin@pu.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const employee = await users.createUser(
+            'emp@pu.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const client = await users.createUser(
+            'client@pu.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+
+        const product = await products.create({
+            name: 'gel',
+            unitPrice: 5,
+            stock: 3,
+        } as any);
+        const appt = await appointments.create(
+            client.id,
+            employee.id,
+            1,
+            new Date(Date.now() + 3600000).toISOString(),
+        );
+
+        const empLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'emp@pu.com', password: 'secret' })
+            .expect(201);
+        const empToken = empLogin.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .post(`/appointments/${appt.id}/product-usage`)
+            .set('Authorization', `Bearer ${empToken}`)
+            .send([{ productId: product.id, quantity: 2 }])
+            .expect(201);
+
+        const prod = await products.findOne(product.id);
+        expect(prod!.stock).toBe(1);
+
+        const adminLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@pu.com', password: 'secret' })
+            .expect(201);
+        const adminToken = adminLogin.body.access_token as string;
+
+        const history = await request(app.getHttpServer())
+            .get(`/products/${product.id}/usage-history`)
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(200);
+        expect(history.body.length).toBe(1);
+    });
+
+    it('rejects usage with insufficient stock', async () => {
+        const employee = await users.createUser(
+            'emp2@pu.com',
+            'secret',
+            'E2',
+            Role.Employee,
+        );
+        const client = await users.createUser(
+            'client2@pu.com',
+            'secret',
+            'C2',
+            Role.Client,
+        );
+        const product = await products.create({
+            name: 'oil',
+            unitPrice: 5,
+            stock: 1,
+        } as any);
+        const appt = await appointments.create(
+            client.id,
+            employee.id,
+            1,
+            new Date(Date.now() + 7200000).toISOString(),
+        );
+
+        const empLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'emp2@pu.com', password: 'secret' })
+            .expect(201);
+        const empToken = empLogin.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .post(`/appointments/${appt.id}/product-usage`)
+            .set('Authorization', `Bearer ${empToken}`)
+            .send([{ productId: product.id, quantity: 5 }])
+            .expect(409);
+    });
+});


### PR DESCRIPTION
## Summary
- track appointment product usage in `ProductUsage` entity
- log usage via new `PRODUCT_USED` action
- expose POST `/appointments/:id/product-usage`
- add usage history endpoint under `/products/:id/usage-history`
- wire new `ProductUsageModule` and provide unit/e2e tests

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_688d0e42a2e88329a288b407adb98d85