### PR TITLE
feat: document product usage endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -112,6 +112,17 @@ $ npm run lint
 $ npm run lint:fix
 ```
 
+## Product stock and usage
+
+- `PATCH /products/admin/bulk-stock` updates the stock for multiple products in
+  one request. The body should contain an `entries` array with product IDs and
+  their new stock levels.
+- `POST /appointments/:id/product-usage` registers product consumption for an
+  appointment. Send an array of `{ "productId": number, "quantity": number }`
+  objects. Employees may only log usage for their own appointments.
+- `GET /products/:id/usage-history` returns the usage records for a given
+  product. This endpoint is restricted to administrators.
+
 ## WebSocket chat
 
 After connecting with a JWT token, emit `joinRoom` with an `appointmentId` to

--- a/backend/src/product-usage/appointment-product-usage.controller.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.ts
@@ -14,9 +14,16 @@ import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
 import { ProductUsageService } from './product-usage.service';
 import { AppointmentsService } from '../appointments/appointments.service';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiBody,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 import { EmployeeRole } from '../employees/employee-role.enum';
 import { Request as ExpressRequest } from 'express';
+import { ProductUsageEntryDto } from './dto/product-usage-entry.dto';
 
 interface AuthRequest extends ExpressRequest {
     user: { id: number; role: Role | EmployeeRole };
@@ -35,9 +42,13 @@ export class AppointmentProductUsageController {
     @Post(':id/product-usage')
     @Roles(Role.Admin, Role.Employee)
     @ApiOperation({ summary: 'Register product usage for appointment' })
+    @ApiResponse({ status: 201 })
+    @ApiResponse({ status: 404 })
+    @ApiResponse({ status: 409 })
+    @ApiBody({ type: [ProductUsageEntryDto] })
     async create(
         @Param('id') id: string,
-        @Body() body: { productId: number; quantity: number }[],
+        @Body() body: ProductUsageEntryDto[],
         @Request() req: AuthRequest,
     ) {
         const appt = await this.appointments.findOne(Number(id));

--- a/backend/src/product-usage/dto/product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/product-usage-entry.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+
+export class ProductUsageEntryDto {
+    @ApiProperty()
+    @IsInt()
+    productId: number;
+
+    @ApiProperty({ minimum: 1 })
+    @IsInt()
+    @Min(1)
+    quantity: number;
+}

--- a/backend/src/product-usage/product-usage.controller.ts
+++ b/backend/src/product-usage/product-usage.controller.ts
@@ -4,7 +4,12 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
 import { ProductUsageService } from './product-usage.service';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 
 @ApiTags('Product Usage')
 @ApiBearerAuth()
@@ -16,6 +21,7 @@ export class ProductUsageController {
     @Get(':id/usage-history')
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'List usage history for product' })
+    @ApiResponse({ status: 200 })
     list(@Param('id') id: string) {
         return this.usage.findForProduct(Number(id));
     }

--- a/backend/src/products/admin/admin.controller.ts
+++ b/backend/src/products/admin/admin.controller.ts
@@ -13,6 +13,7 @@ import {
     ApiOperation,
     ApiResponse,
     ApiBearerAuth,
+    ApiBody,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { RolesGuard } from '../../auth/roles.guard';
@@ -21,6 +22,7 @@ import { Role } from '../../users/role.enum';
 import { ProductsService } from '../products.service';
 import { CreateProductDto } from '../dto/create-product.dto';
 import { UpdateProductDto } from '../dto/update-product.dto';
+import { BulkUpdateStockDto } from '../dto/bulk-update-stock.dto';
 
 @ApiTags('Products')
 @ApiBearerAuth()
@@ -47,9 +49,8 @@ export class AdminController {
     @Patch('bulk-stock')
     @ApiOperation({ summary: 'Bulk update product stock' })
     @ApiResponse({ status: 200 })
-    bulkUpdateStock(
-        @Body() body: { entries: { id: number; stock: number }[] },
-    ) {
+    @ApiBody({ type: BulkUpdateStockDto })
+    bulkUpdateStock(@Body() body: BulkUpdateStockDto) {
         return this.service.bulkUpdateStock(body.entries);
     }
 

--- a/backend/src/products/dto/bulk-update-stock.dto.ts
+++ b/backend/src/products/dto/bulk-update-stock.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, Min, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class BulkStockEntryDto {
+    @ApiProperty()
+    @IsInt()
+    id: number;
+
+    @ApiProperty({ minimum: 0 })
+    @IsInt()
+    @Min(0)
+    stock: number;
+}
+
+export class BulkUpdateStockDto {
+    @ApiProperty({ type: [BulkStockEntryDto] })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => BulkStockEntryDto)
+    entries: BulkStockEntryDto[];
+}

--- a/backend/test/product-usage.e2e-spec.ts
+++ b/backend/test/product-usage.e2e-spec.ts
@@ -92,6 +92,17 @@ describe('ProductUsage (e2e)', () => {
             .set('Authorization', `Bearer ${adminToken}`)
             .expect(200);
         expect(history.body.length).toBe(1);
+
+        const logs = await request(app.getHttpServer())
+            .get('/logs')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .query({ action: 'PRODUCT_USED' })
+            .expect(200);
+        expect(
+            logs.body.some((l: any) =>
+                l.description.includes(`"productId":${product.id}`),
+            ),
+        ).toBe(true);
     });
 
     it('rejects usage with insufficient stock', async () => {

--- a/backend/test/products.e2e-spec.ts
+++ b/backend/test/products.e2e-spec.ts
@@ -237,6 +237,13 @@ describe('ProductsModule (e2e)', () => {
             .get(`/products/${p1.body.id}`)
             .expect(200);
         expect(res.body.stock).toBe(5);
+
+        const logs = await request(app.getHttpServer())
+            .get('/logs')
+            .set('Authorization', `Bearer ${token}`)
+            .query({ action: 'BULK_UPDATE_PRODUCT_STOCK' })
+            .expect(200);
+        expect(logs.body.length).toBe(2);
     });
 
     it('rejects bulk update with negative stock', async () => {


### PR DESCRIPTION
## Summary
- document bulk stock updates and product usage endpoints with Swagger
- cover product usage and bulk stock flows with tests
- add readme notes for updating stock and usage history

## Testing
- `npm test`
- `DATABASE_URL=sqlite::memory: npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_688ddcedec8083299464c76210bfbe5a