### PR TITLE
chore: use timestamptz for timestamps

### DIFF
--- a/backend/src/catalog/product.entity.ts
+++ b/backend/src/catalog/product.entity.ts
@@ -30,13 +30,13 @@ export class Product {
     lowStockThreshold: number;
 
     @CreateDateColumn({
-        type: 'datetime',
+        type: 'timestamptz',
         default: () => 'CURRENT_TIMESTAMP',
     })
     createdAt: Date;
 
     @UpdateDateColumn({
-        type: 'datetime',
+        type: 'timestamptz',
         default: () => 'CURRENT_TIMESTAMP',
         onUpdate: 'CURRENT_TIMESTAMP',
     })

--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -31,13 +31,13 @@ export class Service {
     defaultCommissionPercent: number | null;
 
     @CreateDateColumn({
-        type: 'datetime',
+        type: 'timestamptz',
         default: () => 'CURRENT_TIMESTAMP',
     })
     createdAt: Date;
 
     @UpdateDateColumn({
-        type: 'datetime',
+        type: 'timestamptz',
         default: () => 'CURRENT_TIMESTAMP',
         onUpdate: 'CURRENT_TIMESTAMP',
     })

--- a/backend/src/migrations/20250711192024-UpdateCategorySchema.ts
+++ b/backend/src/migrations/20250711192024-UpdateCategorySchema.ts
@@ -19,12 +19,12 @@ export class UpdateCategorySchema20250711192024 implements MigrationInterface {
         await queryRunner.addColumns('category', [
             new TableColumn({
                 name: 'createdAt',
-                type: 'datetime',
+                type: 'timestamptz',
                 default: 'CURRENT_TIMESTAMP',
             }),
             new TableColumn({
                 name: 'updatedAt',
-                type: 'datetime',
+                type: 'timestamptz',
                 default: 'CURRENT_TIMESTAMP',
                 onUpdate: 'CURRENT_TIMESTAMP',
             }),

--- a/backend/src/migrations/20250711192025-UpdateServiceSchema.ts
+++ b/backend/src/migrations/20250711192025-UpdateServiceSchema.ts
@@ -1,16 +1,21 @@
-import { MigrationInterface, QueryRunner, TableColumn, TableUnique } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    TableColumn,
+    TableUnique,
+} from 'typeorm';
 
 export class UpdateServiceSchema20250711192025 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.addColumns('service', [
             new TableColumn({
                 name: 'createdAt',
-                type: 'datetime',
+                type: 'timestamptz',
                 default: 'CURRENT_TIMESTAMP',
             }),
             new TableColumn({
                 name: 'updatedAt',
-                type: 'datetime',
+                type: 'timestamptz',
                 default: 'CURRENT_TIMESTAMP',
                 onUpdate: 'CURRENT_TIMESTAMP',
             }),

--- a/backend/src/migrations/20250711192026-AddServiceTimestamps.ts
+++ b/backend/src/migrations/20250711192026-AddServiceTimestamps.ts
@@ -9,7 +9,7 @@ export class AddServiceTimestamps20250711192026 implements MigrationInterface {
                 'service',
                 new TableColumn({
                     name: 'createdAt',
-                    type: 'datetime',
+                    type: 'timestamptz',
                     default: 'CURRENT_TIMESTAMP',
                 }),
             );
@@ -19,7 +19,7 @@ export class AddServiceTimestamps20250711192026 implements MigrationInterface {
                 'service',
                 new TableColumn({
                     name: 'updatedAt',
-                    type: 'datetime',
+                    type: 'timestamptz',
                     default: 'CURRENT_TIMESTAMP',
                     onUpdate: 'CURRENT_TIMESTAMP',
                 }),

--- a/backend/src/migrations/20250711192027-UpdateProductSchema.ts
+++ b/backend/src/migrations/20250711192027-UpdateProductSchema.ts
@@ -1,4 +1,9 @@
-import { MigrationInterface, QueryRunner, TableColumn, TableUnique } from 'typeorm';
+import {
+    MigrationInterface,
+    QueryRunner,
+    TableColumn,
+    TableUnique,
+} from 'typeorm';
 
 export class UpdateProductSchema20250711192027 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
@@ -10,12 +15,12 @@ export class UpdateProductSchema20250711192027 implements MigrationInterface {
             }),
             new TableColumn({
                 name: 'createdAt',
-                type: 'datetime',
+                type: 'timestamptz',
                 default: 'CURRENT_TIMESTAMP',
             }),
             new TableColumn({
                 name: 'updatedAt',
-                type: 'datetime',
+                type: 'timestamptz',
                 default: 'CURRENT_TIMESTAMP',
                 onUpdate: 'CURRENT_TIMESTAMP',
             }),


### PR DESCRIPTION
## Summary
- use timestamptz for catalog entity timestamps
- update migrations to match timestamptz columns

## Testing
- `npm run lint`
- `npm test`
- `npm start` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_688de613f4d48329baf9a2dd59a45a60