### PR TITLE
feat: add product usage type enum

### DIFF
--- a/backend/src/migrations/20250711192030-AddUsageTypeToProductUsage.ts
+++ b/backend/src/migrations/20250711192030-AddUsageTypeToProductUsage.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddUsageTypeToProductUsage20250711192030
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'product_usage',
+            new TableColumn({
+                name: 'usageType',
+                type: 'varchar',
+                enum: ['SALE', 'INTERNAL', 'STOCK_CORRECTION'],
+                isNullable: false,
+                default: `'INTERNAL'`,
+            }),
+        );
+        await queryRunner.changeColumn(
+            'product_usage',
+            'appointmentId',
+            new TableColumn({
+                name: 'appointmentId',
+                type: 'int',
+                isNullable: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.changeColumn(
+            'product_usage',
+            'appointmentId',
+            new TableColumn({
+                name: 'appointmentId',
+                type: 'int',
+                isNullable: false,
+            }),
+        );
+        await queryRunner.dropColumn('product_usage', 'usageType');
+    }
+}

--- a/backend/src/product-usage/product-usage.entity.ts
+++ b/backend/src/product-usage/product-usage.entity.ts
@@ -8,20 +8,28 @@ import {
 import { Appointment } from '../appointments/appointment.entity';
 import { Product } from '../catalog/product.entity';
 import { User } from '../users/user.entity';
+import { UsageType } from './usage-type.enum';
 
 @Entity()
 export class ProductUsage {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => Appointment, { eager: true, onDelete: 'RESTRICT' })
-    appointment: Appointment;
+    @ManyToOne(() => Appointment, {
+        eager: true,
+        onDelete: 'RESTRICT',
+        nullable: true,
+    })
+    appointment: Appointment | null;
 
     @ManyToOne(() => Product, { eager: true, onDelete: 'RESTRICT' })
     product: Product;
 
     @Column('int')
     quantity: number;
+
+    @Column({ type: 'enum', enum: UsageType, default: UsageType.INTERNAL })
+    usageType: UsageType;
 
     @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
     usedByEmployee: User;

--- a/backend/src/product-usage/product-usage.module.ts
+++ b/backend/src/product-usage/product-usage.module.ts
@@ -19,3 +19,5 @@ import { AppointmentsModule } from '../appointments/appointments.module';
     exports: [TypeOrmModule, ProductUsageService],
 })
 export class ProductUsageModule {}
+
+export { UsageType } from './usage-type.enum';

--- a/backend/src/product-usage/usage-type.enum.ts
+++ b/backend/src/product-usage/usage-type.enum.ts
@@ -1,0 +1,5 @@
+export enum UsageType {
+    SALE = 'SALE',
+    INTERNAL = 'INTERNAL',
+    STOCK_CORRECTION = 'STOCK_CORRECTION',
+}


### PR DESCRIPTION
## Summary
- add UsageType enum for product usage categorization
- track usage type on ProductUsage and allow missing appointment
- expose UsageType via ProductUsageModule and migration for schema changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688df7b6d9708329ac60ea369633a1dd