### PR TITLE
Add usage type to product usage entries

### DIFF
--- a/backend/src/product-usage/appointment-product-usage.controller.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.ts
@@ -24,6 +24,7 @@ import {
 import { EmployeeRole } from '../employees/employee-role.enum';
 import { Request as ExpressRequest } from 'express';
 import { ProductUsageEntryDto } from './dto/product-usage-entry.dto';
+import { UsageType } from './usage-type.enum';
 
 interface AuthRequest extends ExpressRequest {
     user: { id: number; role: Role | EmployeeRole };
@@ -58,6 +59,10 @@ export class AppointmentProductUsageController {
         if (req.user.role !== Role.Admin && appt.employee.id !== req.user.id) {
             throw new ForbiddenException();
         }
-        return this.usage.registerUsage(Number(id), req.user.id, body);
+        const entries = body.map((entry) => ({
+            ...entry,
+            usageType: entry.usageType ?? UsageType.INTERNAL,
+        }));
+        return this.usage.registerUsage(Number(id), req.user.id, entries);
     }
 }

--- a/backend/src/product-usage/dto/product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/product-usage-entry.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, Min } from 'class-validator';
+import { IsEnum, IsInt, Min } from 'class-validator';
+import { UsageType } from '../usage-type.enum';
 
 export class ProductUsageEntryDto {
     @ApiProperty()
@@ -10,4 +11,8 @@ export class ProductUsageEntryDto {
     @IsInt()
     @Min(1)
     quantity: number;
+
+    @IsEnum(UsageType)
+    @ApiProperty({ enum: UsageType, required: false })
+    usageType?: UsageType;
 }

--- a/backend/src/product-usage/product-usage.service.spec.ts
+++ b/backend/src/product-usage/product-usage.service.spec.ts
@@ -10,6 +10,7 @@ import {
     ConflictException,
     NotFoundException,
 } from '@nestjs/common';
+import { UsageType } from './usage-type.enum';
 
 describe('ProductUsageService', () => {
     let service: ProductUsageService;
@@ -44,7 +45,7 @@ describe('ProductUsageService', () => {
         );
 
         const res = await service.registerUsage(1, 2, [
-            { productId: 1, quantity: 1 },
+            { productId: 1, quantity: 1, usageType: UsageType.INTERNAL },
         ]);
         expect(res).toHaveLength(1);
         expect(manager.save).toHaveBeenCalledTimes(2);
@@ -53,6 +54,8 @@ describe('ProductUsageService', () => {
             expect.any(String),
             2,
         );
+        const payload = JSON.parse(logs.create.mock.calls[0][1]);
+        expect(payload.usageType).toBe(UsageType.INTERNAL);
     });
 
     it('throws on insufficient stock', async () => {
@@ -64,7 +67,9 @@ describe('ProductUsageService', () => {
             cb(manager),
         );
         await expect(
-            service.registerUsage(1, 2, [{ productId: 1, quantity: 1 }]),
+            service.registerUsage(1, 2, [
+                { productId: 1, quantity: 1, usageType: UsageType.INTERNAL },
+            ]),
         ).rejects.toBeInstanceOf(ConflictException);
     });
 
@@ -74,7 +79,9 @@ describe('ProductUsageService', () => {
             cb(manager),
         );
         await expect(
-            service.registerUsage(1, 2, [{ productId: 1, quantity: 0 }]),
+            service.registerUsage(1, 2, [
+                { productId: 1, quantity: 0, usageType: UsageType.INTERNAL },
+            ]),
         ).rejects.toBeInstanceOf(BadRequestException);
     });
 
@@ -87,7 +94,9 @@ describe('ProductUsageService', () => {
             cb(manager),
         );
         await expect(
-            service.registerUsage(1, 2, [{ productId: 1, quantity: 1 }]),
+            service.registerUsage(1, 2, [
+                { productId: 1, quantity: 1, usageType: UsageType.INTERNAL },
+            ]),
         ).rejects.toBeInstanceOf(NotFoundException);
     });
 });

--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -10,6 +10,7 @@ import { ProductUsage } from './product-usage.entity';
 import { Product } from '../catalog/product.entity';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
+import { UsageType } from './usage-type.enum';
 
 @Injectable()
 export class ProductUsageService {
@@ -24,11 +25,15 @@ export class ProductUsageService {
     async registerUsage(
         appointmentId: number,
         employeeId: number,
-        entries: { productId: number; quantity: number }[],
+        entries: {
+            productId: number;
+            quantity: number;
+            usageType: UsageType;
+        }[],
     ) {
         return this.repo.manager.transaction(async (manager) => {
             const records: ProductUsage[] = [];
-            for (const { productId, quantity } of entries) {
+            for (const { productId, quantity, usageType } of entries) {
                 if (quantity <= 0) {
                     throw new BadRequestException('quantity must be > 0');
                 }
@@ -49,6 +54,7 @@ export class ProductUsageService {
                     appointment: { id: appointmentId } as any,
                     product: { id: productId } as any,
                     quantity,
+                    usageType,
                     usedByEmployee: { id: employeeId } as any,
                 });
                 records.push(await manager.save(ProductUsage, usage));
@@ -58,6 +64,7 @@ export class ProductUsageService {
                         appointmentId,
                         productId,
                         quantity,
+                        usageType,
                         stock: product.stock,
                     }),
                     employeeId,


### PR DESCRIPTION
## Summary
- allow product usage entries to include optional `usageType` with enum validation and Swagger docs
- default appointment product usage to INTERNAL when `usageType` omitted
- track `usageType` when registering product usage and in audit logs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688df9e406b48329a2a4cb6e3186fcec