### PR TITLE
feat: track bulk stock usage

### DIFF
--- a/backend/src/products/admin/admin.controller.ts
+++ b/backend/src/products/admin/admin.controller.ts
@@ -7,6 +7,7 @@ import {
     Post,
     Param,
     UseGuards,
+    Request,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -23,6 +24,11 @@ import { ProductsService } from '../products.service';
 import { CreateProductDto } from '../dto/create-product.dto';
 import { UpdateProductDto } from '../dto/update-product.dto';
 import { BulkUpdateStockDto } from '../dto/bulk-update-stock.dto';
+import { Request as ExpressRequest } from 'express';
+
+interface AuthRequest extends ExpressRequest {
+    user: { id: number };
+}
 
 @ApiTags('Products')
 @ApiBearerAuth()
@@ -50,8 +56,11 @@ export class AdminController {
     @ApiOperation({ summary: 'Bulk update product stock' })
     @ApiResponse({ status: 200 })
     @ApiBody({ type: BulkUpdateStockDto })
-    bulkUpdateStock(@Body() body: BulkUpdateStockDto) {
-        return this.service.bulkUpdateStock(body.entries);
+    bulkUpdateStock(
+        @Body() body: BulkUpdateStockDto,
+        @Request() req: AuthRequest,
+    ) {
+        return this.service.bulkUpdateStock(body.entries, req.user.id);
     }
 
     @Patch(':id')

--- a/backend/src/products/products.module.ts
+++ b/backend/src/products/products.module.ts
@@ -7,9 +7,14 @@ import { ProductsService } from './products.service';
 import { Product } from '../catalog/product.entity';
 import { Sale } from '../sales/sale.entity';
 import { LogsModule } from '../logs/logs.module';
+import { ProductUsageModule } from '../product-usage/product-usage.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Product, Sale]), LogsModule],
+    imports: [
+        TypeOrmModule.forFeature([Product, Sale]),
+        LogsModule,
+        ProductUsageModule,
+    ],
     controllers: [AdminController, EmployeeController, PublicController],
     providers: [ProductsService],
     exports: [TypeOrmModule, ProductsService],

--- a/backend/test/products.e2e-spec.ts
+++ b/backend/test/products.e2e-spec.ts
@@ -214,7 +214,7 @@ describe('ProductsModule (e2e)', () => {
         const p1 = await request(app.getHttpServer())
             .post('/products/admin')
             .set('Authorization', `Bearer ${token}`)
-            .send({ name: 'p1', unitPrice: 2, stock: 1 })
+            .send({ name: 'p1', unitPrice: 2, stock: 5 })
             .expect(201);
         const p2 = await request(app.getHttpServer())
             .post('/products/admin')
@@ -227,7 +227,7 @@ describe('ProductsModule (e2e)', () => {
             .set('Authorization', `Bearer ${token}`)
             .send({
                 entries: [
-                    { id: p1.body.id, stock: 5 },
+                    { id: p1.body.id, stock: 3 },
                     { id: p2.body.id, stock: 4 },
                 ],
             })
@@ -236,7 +236,7 @@ describe('ProductsModule (e2e)', () => {
         const res = await request(app.getHttpServer())
             .get(`/products/${p1.body.id}`)
             .expect(200);
-        expect(res.body.stock).toBe(5);
+        expect(res.body.stock).toBe(3);
 
         const logs = await request(app.getHttpServer())
             .get('/logs')
@@ -244,6 +244,15 @@ describe('ProductsModule (e2e)', () => {
             .query({ action: 'BULK_UPDATE_PRODUCT_STOCK' })
             .expect(200);
         expect(logs.body.length).toBe(2);
+
+        const usedLogs = await request(app.getHttpServer())
+            .get('/logs')
+            .set('Authorization', `Bearer ${token}`)
+            .query({ action: 'PRODUCT_USED' })
+            .expect(200);
+        expect(usedLogs.body.length).toBe(1);
+        const payload = JSON.parse(usedLogs.body[0].data);
+        expect(payload.usageType).toBe('STOCK_CORRECTION');
     });
 
     it('rejects bulk update with negative stock', async () => {


### PR DESCRIPTION
## Summary
- log stock corrections when product stock decreases in bulk update
- record stock usage with `UsageType.STOCK_CORRECTION`
- wire ProductUsageModule into products module

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Data type "timestamptz" is not supported by "sqlite" database)*

------
https://chatgpt.com/codex/tasks/task_e_688dfccf8d1c83299a87a5d88e905556