### PR TITLE
Log product usage for sales

### DIFF
--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -102,6 +102,33 @@ export class ProductUsageService {
         return usage;
     }
 
+    async createSale(
+        productId: number,
+        quantity: number,
+        stock: number,
+        employeeId: number,
+    ) {
+        const usage = this.repo.create({
+            appointment: null,
+            product: { id: productId } as any,
+            quantity,
+            usageType: UsageType.SALE,
+            usedByEmployee: { id: employeeId } as any,
+        });
+        await this.repo.save(usage);
+        await this.logs.create(
+            LogAction.ProductUsed,
+            JSON.stringify({
+                productId,
+                quantity,
+                usageType: UsageType.SALE,
+                stock,
+            }),
+            employeeId,
+        );
+        return usage;
+    }
+
     findForProduct(productId: number) {
         return this.repo.find({
             where: { product: { id: productId } },

--- a/backend/src/sales/sales.module.ts
+++ b/backend/src/sales/sales.module.ts
@@ -6,11 +6,13 @@ import { SalesController } from './sales.controller';
 import { Product } from '../catalog/product.entity';
 import { CommissionRecord } from '../commissions/commission-record.entity';
 import { CommissionsModule } from '../commissions/commissions.module';
+import { ProductUsageModule } from '../product-usage/product-usage.module';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([Sale, Product, CommissionRecord]),
         CommissionsModule,
+        ProductUsageModule,
     ],
     controllers: [SalesController],
     providers: [SalesService],

--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SalesService } from './sales.service';
+import { Sale } from './sale.entity';
+import { Product } from '../catalog/product.entity';
+import { CommissionRecord } from '../commissions/commission-record.entity';
+import { CommissionsService } from '../commissions/commissions.service';
+import { ProductUsageService } from '../product-usage/product-usage.service';
+
+describe('SalesService', () => {
+    let service: SalesService;
+    const repo = { create: jest.fn(), save: jest.fn() } as any;
+    const products = { findOne: jest.fn(), save: jest.fn() } as any;
+    const commissions = { create: jest.fn(), save: jest.fn() } as any;
+    const commissionService = { getPercentForProduct: jest.fn() } as any;
+    const usage = { createSale: jest.fn() } as any;
+
+    beforeEach(async () => {
+        repo.create.mockReset();
+        repo.save.mockReset();
+        products.findOne.mockReset();
+        products.save.mockReset();
+        commissions.create.mockReset();
+        commissions.save.mockReset();
+        commissionService.getPercentForProduct.mockReset();
+        usage.createSale.mockReset();
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SalesService,
+                { provide: getRepositoryToken(Sale), useValue: repo },
+                { provide: getRepositoryToken(Product), useValue: products },
+                {
+                    provide: getRepositoryToken(CommissionRecord),
+                    useValue: commissions,
+                },
+                { provide: CommissionsService, useValue: commissionService },
+                { provide: ProductUsageService, useValue: usage },
+            ],
+        }).compile();
+
+        service = module.get(SalesService);
+    });
+
+    it('creates sale and records product usage', async () => {
+        products.findOne.mockResolvedValue({
+            id: 1,
+            stock: 5,
+            unitPrice: 10,
+        });
+        repo.create.mockImplementation((d: any) => d);
+        repo.save.mockImplementation((d: any) => ({ id: 1, ...d }));
+        commissionService.getPercentForProduct.mockResolvedValue(0);
+
+        const sale = await service.create(1, 2, 1, 2);
+
+        expect(sale.id).toBe(1);
+        expect(products.save).toHaveBeenCalledWith({
+            id: 1,
+            stock: 3,
+            unitPrice: 10,
+        });
+        expect(usage.createSale).toHaveBeenCalledWith(1, 2, 3, 2);
+    });
+});
+

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -5,6 +5,7 @@ import { Sale } from './sale.entity';
 import { Product } from '../catalog/product.entity';
 import { CommissionRecord } from '../commissions/commission-record.entity';
 import { CommissionsService } from '../commissions/commissions.service';
+import { ProductUsageService } from '../product-usage/product-usage.service';
 
 @Injectable()
 export class SalesService {
@@ -16,6 +17,7 @@ export class SalesService {
         @InjectRepository(CommissionRecord)
         private readonly commissions: Repository<CommissionRecord>,
         private readonly commissionService: CommissionsService,
+        private readonly usage: ProductUsageService,
     ) {}
 
     async create(
@@ -38,6 +40,12 @@ export class SalesService {
         }
         product.stock -= quantity;
         await this.products.save(product);
+        await this.usage.createSale(
+            productId,
+            quantity,
+            product.stock,
+            employeeId,
+        );
 
         const sale = this.repo.create({
             client: { id: clientId } as any,

--- a/backend/test/sales.e2e-spec.ts
+++ b/backend/test/sales.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { Role } from './../src/users/role.enum';
+import { ProductsService } from './../src/products/products.service';
+
+describe('Sales (e2e)', () => {
+    let app: INestApplication<App>;
+    let users: UsersService;
+    let products: ProductsService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+
+        users = moduleFixture.get(UsersService);
+        products = moduleFixture.get(ProductsService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('creates product usage on sale', async () => {
+        const admin = await users.createUser(
+            'admin@sales.com',
+            'secret',
+            'A',
+            Role.Admin,
+        );
+        const employee = await users.createUser(
+            'emp@sales.com',
+            'secret',
+            'E',
+            Role.Employee,
+        );
+        const client = await users.createUser(
+            'client@sales.com',
+            'secret',
+            'C',
+            Role.Client,
+        );
+
+        const product = await products.create({
+            name: 'gel',
+            unitPrice: 5,
+            stock: 3,
+        } as any);
+
+        const adminLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin@sales.com', password: 'secret' })
+            .expect(201);
+        const token = adminLogin.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .post('/sales')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                clientId: client.id,
+                employeeId: employee.id,
+                productId: product.id,
+                quantity: 2,
+            })
+            .expect(201);
+
+        const prod = await products.findOne(product.id);
+        expect(prod!.stock).toBe(1);
+
+        const history = await request(app.getHttpServer())
+            .get(`/products/${product.id}/usage-history`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+        expect(history.body.length).toBe(1);
+        expect(history.body[0].usageType).toBe('SALE');
+        expect(history.body[0].quantity).toBe(2);
+
+        const logs = await request(app.getHttpServer())
+            .get('/logs')
+            .set('Authorization', `Bearer ${token}`)
+            .query({ action: 'PRODUCT_USED' })
+            .expect(200);
+        expect(
+            logs.body.some((l: any) =>
+                l.description.includes(`"usageType":"SALE"`) &&
+                l.description.includes(`"productId":${product.id}`),
+            ),
+        ).toBe(true);
+    });
+});
+


### PR DESCRIPTION
## Summary
- record product usage and log sale after stock reduction
- expose createSale helper on ProductUsageService
- test usage creation for sales

## Testing
- `npm test`
- `npm run test:e2e -- test/sales.e2e-spec.ts` *(fails: DataTypeNotSupportedError: Data type "timestamptz" in "Service.createdAt" is not supported by "sqlite" database)*

------
https://chatgpt.com/codex/tasks/task_e_688e019256ac832988c59f522b866247