### PR TITLE
feat: filter product usage by type

### DIFF
--- a/backend/src/product-usage/product-usage.controller.ts
+++ b/backend/src/product-usage/product-usage.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -9,7 +9,9 @@ import {
     ApiOperation,
     ApiResponse,
     ApiTags,
+    ApiQuery,
 } from '@nestjs/swagger';
+import { UsageType } from './usage-type.enum';
 
 @ApiTags('Product Usage')
 @ApiBearerAuth()
@@ -22,7 +24,11 @@ export class ProductUsageController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'List usage history for product' })
     @ApiResponse({ status: 200 })
-    list(@Param('id') id: string) {
-        return this.usage.findForProduct(Number(id));
+    @ApiQuery({ name: 'usageType', required: false, enum: UsageType })
+    list(
+        @Param('id') id: string,
+        @Query('usageType') usageType?: UsageType,
+    ) {
+        return this.usage.findForProduct(Number(id), usageType);
     }
 }

--- a/backend/src/product-usage/product-usage.service.spec.ts
+++ b/backend/src/product-usage/product-usage.service.spec.ts
@@ -14,12 +14,13 @@ import { UsageType } from './usage-type.enum';
 
 describe('ProductUsageService', () => {
     let service: ProductUsageService;
-    const repo = { manager: { transaction: jest.fn() } } as any;
+    const repo = { manager: { transaction: jest.fn() }, find: jest.fn() } as any;
     const products = { findOne: jest.fn(), save: jest.fn() } as any;
     const logs = { create: jest.fn() } as any;
 
     beforeEach(async () => {
         repo.manager.transaction.mockReset();
+        repo.find.mockReset();
         products.findOne.mockReset();
         products.save.mockReset();
         logs.create.mockReset();
@@ -98,5 +99,14 @@ describe('ProductUsageService', () => {
                 { productId: 1, quantity: 1, usageType: UsageType.INTERNAL },
             ]),
         ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('filters by usage type when provided', async () => {
+        repo.find.mockResolvedValue([]);
+        await service.findForProduct(1, UsageType.SALE);
+        expect(repo.find).toHaveBeenCalledWith({
+            where: { product: { id: 1 }, usageType: UsageType.SALE },
+            order: { timestamp: 'DESC' },
+        });
     });
 });

--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -129,9 +129,13 @@ export class ProductUsageService {
         return usage;
     }
 
-    findForProduct(productId: number) {
+    findForProduct(productId: number, usageType?: UsageType) {
+        const where: any = { product: { id: productId } };
+        if (usageType) {
+            where.usageType = usageType;
+        }
         return this.repo.find({
-            where: { product: { id: productId } },
+            where,
             order: { timestamp: 'DESC' },
         });
     }


### PR DESCRIPTION
## Summary
- allow optional usageType query to filter product usage history
- add service filtering and swagger docs
- test usageType filtering for product usage

## Testing
- `npm test`
- `npm run test:e2e` *(fails: DataTypeNotSupportedError: Data type "timestamptz" in "Service.createdAt" is not supported by "sqlite" database)*

------
https://chatgpt.com/codex/tasks/task_e_688e0375a57483299b6766c557294535