### PR TITLE
test: verify product usage types

### DIFF
--- a/backend/src/product-usage/product-usage.service.spec.ts
+++ b/backend/src/product-usage/product-usage.service.spec.ts
@@ -50,6 +50,15 @@ describe('ProductUsageService', () => {
         ]);
         expect(res).toHaveLength(1);
         expect(manager.save).toHaveBeenCalledTimes(2);
+        expect(manager.create).toHaveBeenCalledWith(
+            ProductUsage,
+            expect.objectContaining({ usageType: UsageType.INTERNAL }),
+        );
+        expect(manager.save).toHaveBeenCalledWith(
+            ProductUsage,
+            expect.objectContaining({ usageType: UsageType.INTERNAL }),
+        );
+        expect(res[0].usageType).toBe(UsageType.INTERNAL);
         expect(logs.create).toHaveBeenCalledWith(
             LogAction.ProductUsed,
             expect.any(String),

--- a/backend/test/product-usage.e2e-spec.ts
+++ b/backend/test/product-usage.e2e-spec.ts
@@ -92,6 +92,7 @@ describe('ProductUsage (e2e)', () => {
             .set('Authorization', `Bearer ${adminToken}`)
             .expect(200);
         expect(history.body.length).toBe(1);
+        expect(history.body[0].usageType).toBe('INTERNAL');
 
         const logs = await request(app.getHttpServer())
             .get('/logs')
@@ -141,6 +142,64 @@ describe('ProductUsage (e2e)', () => {
             .set('Authorization', `Bearer ${empToken}`)
             .send([{ productId: product.id, quantity: 5 }])
             .expect(409);
+    });
+
+    it('allows overriding usageType', async () => {
+        const admin = await users.createUser(
+            'admino@pu.com',
+            'secret',
+            'AO',
+            Role.Admin,
+        );
+        const employee = await users.createUser(
+            'empo@pu.com',
+            'secret',
+            'EO',
+            Role.Employee,
+        );
+        const client = await users.createUser(
+            'cliento@pu.com',
+            'secret',
+            'CO',
+            Role.Client,
+        );
+
+        const product = await products.create({
+            name: 'wax',
+            unitPrice: 5,
+            stock: 2,
+        } as any);
+        const appt = await appointments.create(
+            client.id,
+            employee.id,
+            1,
+            new Date(Date.now() + 3600000).toISOString(),
+        );
+
+        const empLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'empo@pu.com', password: 'secret' })
+            .expect(201);
+        const empToken = empLogin.body.access_token as string;
+
+        await request(app.getHttpServer())
+            .post(`/appointments/${appt.id}/product-usage`)
+            .set('Authorization', `Bearer ${empToken}`)
+            .send([{ productId: product.id, quantity: 1, usageType: 'SALE' }])
+            .expect(201);
+
+        const adminLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admino@pu.com', password: 'secret' })
+            .expect(201);
+        const adminToken = adminLogin.body.access_token as string;
+
+        const history = await request(app.getHttpServer())
+            .get(`/products/${product.id}/usage-history`)
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(200);
+        expect(history.body.length).toBe(1);
+        expect(history.body[0].usageType).toBe('SALE');
     });
 
     it('filters usage history by usageType', async () => {

--- a/backend/test/products.e2e-spec.ts
+++ b/backend/test/products.e2e-spec.ts
@@ -253,6 +253,13 @@ describe('ProductsModule (e2e)', () => {
         expect(usedLogs.body.length).toBe(1);
         const payload = JSON.parse(usedLogs.body[0].data);
         expect(payload.usageType).toBe('STOCK_CORRECTION');
+
+        const usageHistory = await request(app.getHttpServer())
+            .get(`/products/${p1.body.id}/usage-history`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+        expect(usageHistory.body.length).toBe(1);
+        expect(usageHistory.body[0].usageType).toBe('STOCK_CORRECTION');
     });
 
     it('rejects bulk update with negative stock', async () => {


### PR DESCRIPTION
## Summary
- ensure product usage service persists usage type and logs it
- test default and override usage types on product usage API
- validate stock correction usage records during bulk stock updates

## Testing
- `npm test`
- `npm run test:e2e` *(fails: DataTypeNotSupportedError: Data type "timestamptz" in "Service.createdAt" is not supported by "sqlite" database)*

------
https://chatgpt.com/codex/tasks/task_e_688e09f8fc208329ab2532169fa4225c