### PR TITLE
Document usageType defaults and log stock changes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -114,14 +114,26 @@ $ npm run lint:fix
 
 ## Product stock and usage
 
+The `usageType` enum documents why stock changes:
+
+- `SALE` – product sold to a customer
+- `INTERNAL` – internal consumption
+- `STOCK_CORRECTION` – manual adjustment or correction
+
 - `PATCH /products/admin/bulk-stock` updates the stock for multiple products in
   one request. The body should contain an `entries` array with product IDs and
-  their new stock levels.
+  their new stock levels. Each change is logged with `usageType` `STOCK_CORRECTION`.
+- `PATCH /products/admin/:id/stock` adjusts the stock for a single product. Send
+  `{ "amount": number }` to increment or decrement the current value. Logged as
+  `usageType` `STOCK_CORRECTION`.
 - `POST /appointments/:id/product-usage` registers product consumption for an
-  appointment. Send an array of `{ "productId": number, "quantity": number }`
-  objects. Employees may only log usage for their own appointments.
+  appointment. Send an array of `{ "productId": number, "quantity": number,
+  "usageType"?: "SALE" | "INTERNAL" | "STOCK_CORRECTION" }` objects. The
+  `usageType` defaults to `INTERNAL` when omitted. Employees may only log usage
+  for their own appointments.
 - `GET /products/:id/usage-history` returns the usage records for a given
-  product. This endpoint is restricted to administrators.
+  product and accepts an optional `usageType` query parameter to filter results.
+  This endpoint is restricted to administrators.
 
 ## WebSocket chat
 

--- a/backend/src/product-usage/appointment-product-usage.controller.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.ts
@@ -42,11 +42,18 @@ export class AppointmentProductUsageController {
 
     @Post(':id/product-usage')
     @Roles(Role.Admin, Role.Employee)
-    @ApiOperation({ summary: 'Register product usage for appointment' })
+    @ApiOperation({
+        summary: 'Register product usage for appointment',
+        description:
+            'Records consumption of products. The usageType defaults to INTERNAL when not provided.',
+    })
     @ApiResponse({ status: 201 })
     @ApiResponse({ status: 404 })
     @ApiResponse({ status: 409 })
-    @ApiBody({ type: [ProductUsageEntryDto] })
+    @ApiBody({
+        type: [ProductUsageEntryDto],
+        description: 'Each entry may specify a usageType; defaults to INTERNAL.',
+    })
     async create(
         @Param('id') id: string,
         @Body() body: ProductUsageEntryDto[],

--- a/backend/src/product-usage/dto/product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/product-usage-entry.dto.ts
@@ -13,6 +13,10 @@ export class ProductUsageEntryDto {
     quantity: number;
 
     @IsEnum(UsageType)
-    @ApiProperty({ enum: UsageType, required: false })
+    @ApiProperty({
+        enum: UsageType,
+        required: false,
+        description: 'Usage classification. Defaults to INTERNAL when omitted.',
+    })
     usageType?: UsageType;
 }

--- a/backend/src/product-usage/product-usage.controller.ts
+++ b/backend/src/product-usage/product-usage.controller.ts
@@ -24,7 +24,12 @@ export class ProductUsageController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'List usage history for product' })
     @ApiResponse({ status: 200 })
-    @ApiQuery({ name: 'usageType', required: false, enum: UsageType })
+    @ApiQuery({
+        name: 'usageType',
+        required: false,
+        enum: UsageType,
+        description: 'Filter by usage type. Returns all records when omitted.',
+    })
     list(
         @Param('id') id: string,
         @Query('usageType') usageType?: UsageType,

--- a/backend/src/product-usage/product-usage.entity.ts
+++ b/backend/src/product-usage/product-usage.entity.ts
@@ -9,6 +9,7 @@ import { Appointment } from '../appointments/appointment.entity';
 import { Product } from '../catalog/product.entity';
 import { User } from '../users/user.entity';
 import { UsageType } from './usage-type.enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
 export class ProductUsage {
@@ -29,6 +30,7 @@ export class ProductUsage {
     quantity: number;
 
     @Column({ type: 'enum', enum: UsageType, default: UsageType.INTERNAL })
+    @ApiProperty({ enum: UsageType, default: UsageType.INTERNAL })
     usageType: UsageType;
 
     @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })

--- a/backend/src/products/admin/admin.controller.ts
+++ b/backend/src/products/admin/admin.controller.ts
@@ -53,9 +53,16 @@ export class AdminController {
     }
 
     @Patch('bulk-stock')
-    @ApiOperation({ summary: 'Bulk update product stock' })
+    @ApiOperation({
+        summary: 'Bulk update product stock',
+        description:
+            'Adjusts stock levels for multiple products. Each change is logged with usageType STOCK_CORRECTION.',
+    })
     @ApiResponse({ status: 200 })
-    @ApiBody({ type: BulkUpdateStockDto })
+    @ApiBody({
+        type: BulkUpdateStockDto,
+        description: 'Stock levels to apply. Logged as usageType STOCK_CORRECTION.',
+    })
     bulkUpdateStock(
         @Body() body: BulkUpdateStockDto,
         @Request() req: AuthRequest,
@@ -71,8 +78,23 @@ export class AdminController {
     }
 
     @Patch(':id/stock')
-    @ApiOperation({ summary: 'Adjust product stock' })
+    @ApiOperation({
+        summary: 'Adjust product stock',
+        description: 'Increments or decrements stock. Logged with usageType STOCK_CORRECTION.',
+    })
     @ApiResponse({ status: 200 })
+    @ApiBody({
+        schema: {
+            type: 'object',
+            properties: {
+                amount: {
+                    type: 'integer',
+                    description:
+                        'Change in stock (positive or negative). Logged as usageType STOCK_CORRECTION.',
+                },
+            },
+        },
+    })
     updateStock(@Param('id') id: number, @Body('amount') amount: number) {
         return this.service.updateStock(Number(id), Number(amount));
     }

--- a/backend/src/products/dto/bulk-update-stock.dto.ts
+++ b/backend/src/products/dto/bulk-update-stock.dto.ts
@@ -7,14 +7,22 @@ export class BulkStockEntryDto {
     @IsInt()
     id: number;
 
-    @ApiProperty({ minimum: 0 })
+    @ApiProperty({
+        minimum: 0,
+        description:
+            'New stock level. Adjustments are logged with usageType STOCK_CORRECTION.',
+    })
     @IsInt()
     @Min(0)
     stock: number;
 }
 
 export class BulkUpdateStockDto {
-    @ApiProperty({ type: [BulkStockEntryDto] })
+    @ApiProperty({
+        type: [BulkStockEntryDto],
+        description:
+            'Array of stock updates. Each change is logged with usageType STOCK_CORRECTION.',
+    })
     @IsArray()
     @ValidateNested({ each: true })
     @Type(() => BulkStockEntryDto)

--- a/backend/src/products/products.service.spec.ts
+++ b/backend/src/products/products.service.spec.ts
@@ -11,6 +11,7 @@ import {
     NotFoundException,
 } from '@nestjs/common';
 import { ProductUsageService } from '../product-usage/product-usage.service';
+import { UsageType } from '../product-usage/usage-type.enum';
 
 describe('ProductsService', () => {
     let service: ProductsService;
@@ -82,7 +83,12 @@ describe('ProductsService', () => {
         expect(res!.stock).toBe(1);
         expect(logs.create).toHaveBeenCalledWith(
             LogAction.UpdateProductStock,
-            JSON.stringify({ id: 1, amount: -1, stock: 1 }),
+            JSON.stringify({
+                id: 1,
+                amount: -1,
+                stock: 1,
+                usageType: UsageType.STOCK_CORRECTION,
+            }),
         );
     });
 
@@ -153,12 +159,20 @@ describe('ProductsService', () => {
         expect(logs.create).toHaveBeenNthCalledWith(
             1,
             LogAction.BulkUpdateProductStock,
-            JSON.stringify({ id: 1, stock: 5 }),
+            JSON.stringify({
+                id: 1,
+                stock: 5,
+                usageType: UsageType.STOCK_CORRECTION,
+            }),
         );
         expect(logs.create).toHaveBeenNthCalledWith(
             2,
             LogAction.BulkUpdateProductStock,
-            JSON.stringify({ id: 2, stock: 3 }),
+            JSON.stringify({
+                id: 2,
+                stock: 3,
+                usageType: UsageType.STOCK_CORRECTION,
+            }),
         );
         expect(usage.createStockCorrection).not.toHaveBeenCalled();
     });
@@ -183,7 +197,11 @@ describe('ProductsService', () => {
         );
         expect(logs.create).toHaveBeenCalledWith(
             LogAction.BulkUpdateProductStock,
-            JSON.stringify({ id: 1, stock: 3 }),
+            JSON.stringify({
+                id: 1,
+                stock: 3,
+                usageType: UsageType.STOCK_CORRECTION,
+            }),
         );
     });
 

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -13,6 +13,7 @@ import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
 import { Sale } from '../sales/sale.entity';
 import { ProductUsageService } from '../product-usage/product-usage.service';
+import { UsageType } from '../product-usage/usage-type.enum';
 
 @Injectable()
 export class ProductsService {
@@ -74,7 +75,12 @@ export class ProductsService {
         const saved = await this.repo.save(product);
         await this.logs.create(
             LogAction.UpdateProductStock,
-            JSON.stringify({ id, amount, stock: saved.stock }),
+            JSON.stringify({
+                id,
+                amount,
+                stock: saved.stock,
+                usageType: UsageType.STOCK_CORRECTION,
+            }),
         );
         return saved;
     }
@@ -112,7 +118,11 @@ export class ProductsService {
             for (const prod of updated) {
                 await this.logs.create(
                     LogAction.BulkUpdateProductStock,
-                    JSON.stringify({ id: prod.id, stock: prod.stock }),
+                    JSON.stringify({
+                        id: prod.id,
+                        stock: prod.stock,
+                        usageType: UsageType.STOCK_CORRECTION,
+                    }),
                 );
             }
             return updated;


### PR DESCRIPTION
## Summary
- document usageType enum and default behaviors in Swagger and README
- include usageType in stock change logging
- ensure tests check for usageType in stock logs

## Testing
- `npm test`
- `npm run test:e2e -- test/health.e2e-spec.ts` *(fails: DataTypeNotSupportedError for timestamptz with sqlite)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e8aab42108329ad44eaaa3ab3c447