### PR TITLE
feat: expand user profile schema

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -53,7 +53,8 @@ export class AuthController {
             user: {
                 id: user.id,
                 email: user.email,
-                fullName: user.name,
+                firstName: user.firstName,
+                lastName: user.lastName,
                 role: user.role,
             },
         };

--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -43,9 +43,10 @@ describe('AuthService.registerClient', () => {
         const dto: RegisterClientDto = {
             email: 'a@test.com',
             password: 'Secret123!',
-            fullName: 'Alice',
+            firstName: 'Alice',
+            lastName: 'Liddell',
             phone: '+48123123132',
-            consentRODO: true,
+            privacyConsent: true,
         } as RegisterClientDto;
         users.findByEmail.mockResolvedValue(null);
         users.createUser.mockResolvedValue({

--- a/backend/src/auth/dto/register-client.dto.ts
+++ b/backend/src/auth/dto/register-client.dto.ts
@@ -13,8 +13,13 @@ import { ApiProperty } from '@nestjs/swagger';
 export class RegisterClientDto {
     @ApiProperty()
     @IsString()
-    @MinLength(3)
-    fullName: string;
+    @MinLength(2)
+    firstName: string;
+
+    @ApiProperty()
+    @IsString()
+    @MinLength(2)
+    lastName: string;
 
     @ApiProperty()
     @IsEmail()
@@ -32,10 +37,10 @@ export class RegisterClientDto {
     @ApiProperty()
     @IsBoolean()
     @Equals(true)
-    consentRODO: boolean;
+    privacyConsent: boolean;
 
     @ApiProperty({ required: false })
     @IsBoolean()
     @IsOptional()
-    consentMarketing?: boolean;
+    marketingConsent?: boolean;
 }

--- a/backend/src/auth/dto/social-login.dto.ts
+++ b/backend/src/auth/dto/social-login.dto.ts
@@ -15,5 +15,5 @@ export class SocialLoginDto {
     @ApiProperty({ required: false })
     @IsBoolean()
     @IsOptional()
-    consentMarketing?: boolean;
+    marketingConsent?: boolean;
 }

--- a/backend/src/calendar/calendar.service.spec.ts
+++ b/backend/src/calendar/calendar.service.spec.ts
@@ -33,7 +33,7 @@ describe('CalendarService', () => {
             id: 1,
             startTime: new Date('2024-01-01T10:00:00Z'),
             service: { name: 'cut', duration: 60 },
-            client: { name: 'c' },
+            client: { firstName: 'c', lastName: 'd' },
         });
         const scope = nock('https://www.googleapis.com')
             .post('/calendar/v3/calendars/primary/events')
@@ -48,7 +48,7 @@ describe('CalendarService', () => {
             id: 1,
             startTime: new Date('2024-01-01T10:00:00Z'),
             service: { name: 'cut', duration: 60 },
-            client: { name: 'c' },
+            client: { firstName: 'c', lastName: 'd' },
         });
         const result = await service.add(1, 'ics');
         expect(result?.ics).toContain('BEGIN:VCALENDAR');

--- a/backend/src/calendar/calendar.service.ts
+++ b/backend/src/calendar/calendar.service.ts
@@ -29,7 +29,11 @@ export class CalendarService {
             new Date(appt.startTime.getTime() + appt.service.duration * 60000);
         return {
             title: appt.service.name,
-            description: `Wizyta z ${appt.client?.name ?? ''}`,
+            description: `Wizyta z ${
+                appt.client
+                    ? `${appt.client.firstName} ${appt.client.lastName}`.trim()
+                    : ''
+            }`,
             startTime: appt.startTime,
             endTime: end,
         };

--- a/backend/src/customers/customer.entity.ts
+++ b/backend/src/customers/customer.entity.ts
@@ -2,7 +2,7 @@ import { Entity, Index } from 'typeorm';
 import { User } from '../users/user.entity';
 
 // Customer accounts share the same table as regular users
-// but are typed separately for clarity.
+// (with first and last name fields) but are typed separately for clarity.
 @Index(['email'], { unique: true })
 @Entity('user')
 export class Customer extends User {}

--- a/backend/src/customers/dto/customer.dto.ts
+++ b/backend/src/customers/dto/customer.dto.ts
@@ -13,7 +13,11 @@ export class CustomerDto {
 
     @ApiProperty()
     @Expose()
-    name: string;
+    firstName: string;
+
+    @ApiProperty()
+    @Expose()
+    lastName: string;
 
     @ApiProperty({ nullable: true })
     @Expose()
@@ -22,4 +26,24 @@ export class CustomerDto {
     @ApiProperty({ enum: Role })
     @Expose()
     role: Role;
+
+    @ApiProperty()
+    @Expose()
+    privacyConsent: boolean;
+
+    @ApiProperty()
+    @Expose()
+    marketingConsent: boolean;
+
+    @ApiProperty()
+    @Expose()
+    createdAt: Date;
+
+    @ApiProperty()
+    @Expose()
+    updatedAt: Date;
+
+    @ApiProperty()
+    @Expose()
+    isActive: boolean;
 }

--- a/backend/src/dashboard/dashboard.service.ts
+++ b/backend/src/dashboard/dashboard.service.ts
@@ -74,7 +74,10 @@ export class DashboardService {
         role: Role | EmployeeRole,
     ): Promise<DashboardSummary> {
         const user = await this.users.findOne({ where: { id: userId } });
-        const base = { fullName: user?.name ?? '', email: user?.email ?? '' };
+        const base = {
+            fullName: `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim(),
+            email: user?.email ?? '',
+        };
         const now = new Date();
         const startOfDay = new Date(
             now.getFullYear(),

--- a/backend/src/invoices/invoices.service.spec.ts
+++ b/backend/src/invoices/invoices.service.spec.ts
@@ -39,7 +39,7 @@ describe('InvoicesService', () => {
     it('generates invoice', async () => {
         appts.findOne.mockResolvedValue({
             id: 1,
-            client: { name: 'c' },
+            client: { firstName: 'c', lastName: 'd' },
             service: { name: 's', price: 10 },
         });
         axiosMock.post.mockResolvedValue({
@@ -61,7 +61,7 @@ describe('InvoicesService', () => {
     it('logs on failure', async () => {
         appts.findOne.mockResolvedValue({
             id: 1,
-            client: { name: 'c' },
+            client: { firstName: 'c', lastName: 'd' },
             service: { name: 's', price: 10 },
         });
         axiosMock.post.mockRejectedValue(new Error('fail'));

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -28,7 +28,9 @@ export class InvoicesService {
             const res = await axios.post(
                 `${process.env.INVOICE_API_URL}/invoices`,
                 {
-                    client: { name: appt.client.name },
+                    client: {
+                        name: `${appt.client.firstName} ${appt.client.lastName}`,
+                    },
                     items: [
                         {
                             name: appt.service.name,

--- a/backend/src/migrations/20250711192002-CreateUsersTable.ts
+++ b/backend/src/migrations/20250711192002-CreateUsersTable.ts
@@ -21,14 +21,35 @@ export class CreateUsersTable20250711192002 implements MigrationInterface {
                     {
                         name: 'password',
                         type: 'varchar',
+                        isNullable: true,
                     },
                     {
-                        name: 'name',
+                        name: 'firstName',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'lastName',
                         type: 'varchar',
                     },
                     {
                         name: 'role',
                         type: 'varchar',
+                    },
+                    {
+                        name: 'isActive',
+                        type: 'boolean',
+                        default: true,
+                    },
+                    {
+                        name: 'createdAt',
+                        type: 'timestamptz',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                    {
+                        name: 'updatedAt',
+                        type: 'timestamptz',
+                        default: 'CURRENT_TIMESTAMP',
+                        onUpdate: 'CURRENT_TIMESTAMP',
                     },
                 ],
             }),

--- a/backend/src/migrations/20250711192023-AddConsentsToUser.ts
+++ b/backend/src/migrations/20250711192023-AddConsentsToUser.ts
@@ -4,13 +4,13 @@ export class AddConsentsToUser20250711192023 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.addColumns('user', [
             new TableColumn({
-                name: 'consentRODO',
+                name: 'privacyConsent',
                 type: 'boolean',
                 isNullable: false,
                 default: false,
             }),
             new TableColumn({
-                name: 'consentMarketing',
+                name: 'marketingConsent',
                 type: 'boolean',
                 isNullable: false,
                 default: false,
@@ -19,7 +19,7 @@ export class AddConsentsToUser20250711192023 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.dropColumn('user', 'consentRODO');
-        await queryRunner.dropColumn('user', 'consentMarketing');
+        await queryRunner.dropColumn('user', 'privacyConsent');
+        await queryRunner.dropColumn('user', 'marketingConsent');
     }
 }

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -5,6 +5,7 @@ import {
     IsString,
     IsNotEmpty,
     MinLength,
+    IsBoolean,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Role } from '../role.enum';
@@ -21,7 +22,26 @@ export class CreateUserDto {
 
     @ApiProperty()
     @IsString()
-    name: string;
+    firstName: string;
+
+    @ApiProperty()
+    @IsString()
+    lastName: string;
+
+    @ApiProperty({ required: false })
+    @IsString()
+    @IsOptional()
+    phone?: string;
+
+    @ApiProperty({ required: false })
+    @IsBoolean()
+    @IsOptional()
+    privacyConsent?: boolean;
+
+    @ApiProperty({ required: false })
+    @IsBoolean()
+    @IsOptional()
+    marketingConsent?: boolean;
 
     @ApiProperty({ enum: Role, required: false })
     @IsEnum(Role)

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
 import { Role } from './role.enum';
 import { EmployeeRole } from '../employees/employee-role.enum';
 
@@ -14,22 +20,34 @@ export class User {
     password: string | null; // hashed, null for social accounts
 
     @Column()
-    name: string;
+    firstName: string;
+
+    @Column()
+    lastName: string;
 
     @Column({ type: 'varchar', nullable: true })
     phone: string | null;
 
     @Column({ type: 'boolean', default: false })
-    consentRODO: boolean;
+    privacyConsent: boolean;
 
     @Column({ type: 'boolean', default: false })
-    consentMarketing: boolean;
+    marketingConsent: boolean;
 
     @Column({ type: 'simple-enum', enum: Role })
     role: Role | EmployeeRole;
 
     @Column({ type: 'varchar', nullable: true })
     refreshToken: string | null;
+
+    @CreateDateColumn({ type: 'timestamptz' })
+    createdAt: Date;
+
+    @UpdateDateColumn({ type: 'timestamptz' })
+    updatedAt: Date;
+
+    @Column({ type: 'boolean', default: true })
+    isActive: boolean;
 
     @Column({ type: 'float', nullable: true })
     commissionBase: number | null;

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -36,8 +36,26 @@ export class UsersController {
     @ApiOperation({ summary: 'Create a new user (admin only)' })
     @ApiResponse({ status: 201, description: 'User created' })
     create(@Body() createUserDto: CreateUserDto) {
-        const { email, password, name, role } = createUserDto;
-        return this.usersService.createUser(email, password, name, role);
+        const {
+            email,
+            password,
+            firstName,
+            lastName,
+            role,
+            phone,
+            privacyConsent,
+            marketingConsent,
+        } = createUserDto;
+        return this.usersService.createUser(
+            email,
+            password,
+            firstName,
+            lastName,
+            role,
+            phone,
+            privacyConsent,
+            marketingConsent,
+        );
     }
 
     @Get('profile')

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -54,13 +54,20 @@ describe('UsersService', () => {
         const created = {
             email: 'a@test.com',
             password: 'hashed',
-            name: 'A',
+            firstName: 'A',
+            lastName: 'Test',
             role: Role.Client,
         } as User;
         repo.create.mockReturnValue(created);
         repo.save.mockResolvedValue(created);
 
-        await service.createUser('a@test.com', plain, 'A', Role.Client);
+        await service.createUser(
+            'a@test.com',
+            plain,
+            'A',
+            'Test',
+            Role.Client,
+        );
 
         const passed: string = repo.create.mock.calls[0][0].password as string;
         expect(await bcrypt.compare(plain, passed)).toBe(true);
@@ -71,7 +78,13 @@ describe('UsersService', () => {
         repo.findOne.mockResolvedValue({ id: 2 } as User);
 
         await expect(
-            service.createUser('a@test.com', 'secret', 'Alice', Role.Client),
+            service.createUser(
+                'a@test.com',
+                'secret',
+                'Alice',
+                'Smith',
+                Role.Client,
+            ),
         ).rejects.toBeInstanceOf(BadRequestException);
         expect(repo.save).not.toHaveBeenCalled();
     });
@@ -81,12 +94,16 @@ describe('UsersService', () => {
             id: 1,
             email: 'old@test.com',
             password: 'p',
-            name: 'Old',
+            firstName: 'Old',
+            lastName: 'Name',
         } as User;
         repo.findOne.mockResolvedValue(user);
         repo.save.mockResolvedValue(user);
 
-        await service.updateCustomer(1, { password: 'new', name: 'New' });
+        await service.updateCustomer(1, {
+            password: 'new',
+            firstName: 'New',
+        });
 
         const passed: string = repo.save.mock.calls[0][0].password as string;
         expect(await bcrypt.compare('new', passed)).toBe(true);
@@ -96,7 +113,7 @@ describe('UsersService', () => {
     it('updateCustomer returns undefined when user missing', async () => {
         repo.findOne.mockResolvedValue(undefined);
         await expect(
-            service.updateCustomer(2, { name: 'x' }),
+            service.updateCustomer(2, { firstName: 'x' }),
         ).resolves.toBeUndefined();
     });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -31,11 +31,12 @@ export class UsersService {
     async createUser(
         email: string,
         password: string,
-        name: string,
+        firstName: string,
+        lastName: string,
         role: Role = Role.Client,
         phone?: string | null,
-        consentRODO?: boolean,
-        consentMarketing?: boolean,
+        privacyConsent?: boolean,
+        marketingConsent?: boolean,
     ) {
         const existing = await this.findByEmail(email);
         if (existing) {
@@ -45,22 +46,24 @@ export class UsersService {
         const user = this.usersRepository.create({
             email,
             password: hashed,
-            name,
+            firstName,
+            lastName,
             role,
             phone: phone ?? null,
-            consentRODO: consentRODO ?? false,
-            consentMarketing: consentMarketing ?? false,
+            privacyConsent: privacyConsent ?? false,
+            marketingConsent: marketingConsent ?? false,
         });
         return this.usersRepository.save(user);
     }
 
     async createSocialUser(
         email: string,
-        name: string,
+        firstName: string,
+        lastName: string,
         role: Role = Role.Client,
         phone?: string | null,
-        consentRODO = true,
-        consentMarketing = false,
+        privacyConsent = true,
+        marketingConsent = false,
     ) {
         const existing = await this.findByEmail(email);
         if (existing) {
@@ -69,11 +72,12 @@ export class UsersService {
         const user = this.usersRepository.create({
             email,
             password: null,
-            name,
+            firstName,
+            lastName,
             role,
             phone: phone ?? null,
-            consentRODO,
-            consentMarketing,
+            privacyConsent,
+            marketingConsent,
         });
         return this.usersRepository.save(user);
     }
@@ -101,8 +105,20 @@ export class UsersService {
         if (dto.password) {
             user.password = await bcrypt.hash(dto.password, 10);
         }
-        if (dto.name !== undefined) {
-            user.name = dto.name;
+        if (dto.firstName !== undefined) {
+            user.firstName = dto.firstName;
+        }
+        if (dto.lastName !== undefined) {
+            user.lastName = dto.lastName;
+        }
+        if (dto.phone !== undefined) {
+            user.phone = dto.phone;
+        }
+        if (dto.privacyConsent !== undefined) {
+            user.privacyConsent = dto.privacyConsent;
+        }
+        if (dto.marketingConsent !== undefined) {
+            user.marketingConsent = dto.marketingConsent;
         }
         return this.usersRepository.save(user);
     }


### PR DESCRIPTION
## Summary
- split user `name` into `firstName` and `lastName`
- track consent, timestamps, and active status for users
- adapt auth/users logic and DTOs to new profile fields

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f65a38a9483299205be2f0d774327