### PR TITLE
feat(auth): split name fields and add EU phone validation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,6 +30,7 @@
                 "ics": "^3.8.1",
                 "jsonwebtoken": "^9.0.2",
                 "jwk-to-pem": "^2.0.7",
+                "libphonenumber-js": "^1.12.10",
                 "mustache": "^4.2.0",
                 "passport": "^0.7.0",
                 "passport-jwt": "^4.0.1",
@@ -10467,9 +10468,9 @@
             }
         },
         "node_modules/libphonenumber-js": {
-            "version": "1.12.9",
-            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.9.tgz",
-            "integrity": "sha512-VWwAdNeJgN7jFOD+wN4qx83DTPMVPPAUyx9/TUkBXKLiNkuWWk6anV0439tgdtwaJDrEdqkvdN22iA6J4bUCZg==",
+            "version": "1.12.10",
+            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.10.tgz",
+            "integrity": "sha512-E91vHJD61jekHHR/RF/E83T/CMoaLXT7cwYA75T4gim4FZjnM6hbJjVIGg7chqlSqRsSvQ3izGmOjHy1SQzcGQ==",
             "license": "MIT"
         },
         "node_modules/lines-and-columns": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
         "ics": "^3.8.1",
         "jsonwebtoken": "^9.0.2",
         "jwk-to-pem": "^2.0.7",
+        "libphonenumber-js": "^1.12.10",
         "mustache": "^4.2.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",

--- a/backend/src/auth/dto/register-client.dto.ts
+++ b/backend/src/auth/dto/register-client.dto.ts
@@ -9,37 +9,38 @@ import {
     Equals,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEuPhoneNumber } from '../../common/validators/is-eu-phone-number';
 
 export class RegisterClientDto {
-    @ApiProperty()
+    @ApiProperty({ example: 'Jan' })
     @IsString()
     @MinLength(2)
     firstName: string;
 
-    @ApiProperty()
+    @ApiProperty({ example: 'Kowalski' })
     @IsString()
     @MinLength(2)
     lastName: string;
 
-    @ApiProperty()
+    @ApiProperty({ example: 'jan@example.com' })
     @IsEmail()
     @IsNotEmpty()
     email: string;
 
-    @ApiProperty()
-    @Matches(/^\+48\d{9}$/)
+    @ApiProperty({ example: '+48123123123' })
+    @IsEuPhoneNumber()
     phone: string;
 
-    @ApiProperty()
+    @ApiProperty({ example: 'Secret123!' })
     @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)
     password: string;
 
-    @ApiProperty()
+    @ApiProperty({ example: true })
     @IsBoolean()
     @Equals(true)
     privacyConsent: boolean;
 
-    @ApiProperty({ required: false })
+    @ApiProperty({ required: false, example: false })
     @IsBoolean()
     @IsOptional()
     marketingConsent?: boolean;

--- a/backend/src/common/validators/is-eu-phone-number.ts
+++ b/backend/src/common/validators/is-eu-phone-number.ts
@@ -1,0 +1,31 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+
+const EU_COUNTRIES = [
+    'AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE'
+];
+
+export function IsEuPhoneNumber(validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        registerDecorator({
+            name: 'isEuPhoneNumber',
+            target: object.constructor,
+            propertyName,
+            options: validationOptions,
+            validator: {
+                validate(value: any) {
+                    if (typeof value !== 'string') return false;
+                    const phoneNumber = parsePhoneNumberFromString(value);
+                    return (
+                        phoneNumber?.isValid() === true &&
+                        !!phoneNumber.country &&
+                        EU_COUNTRIES.includes(phoneNumber.country)
+                    );
+                },
+                defaultMessage() {
+                    return '$property must be a valid EU phone number';
+                },
+            },
+        });
+    };
+}

--- a/backend/test/appointments.e2e-spec.ts
+++ b/backend/test/appointments.e2e-spec.ts
@@ -41,9 +41,10 @@ describe('AppointmentsModule (e2e)', () => {
             .send({
                 email: 'client@test.com',
                 password: 'Secret123!',
-                fullName: 'Client',
+                firstName: 'Client',
+                lastName: 'User',
                 phone: '+48123123128',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
         const { access_token: token } = register.body as {
@@ -61,9 +62,10 @@ describe('AppointmentsModule (e2e)', () => {
             .send({
                 email: 'client2@test.com',
                 password: 'Secret123!',
-                fullName: 'Client',
+                firstName: 'Client',
+                lastName: 'User',
                 phone: '+48123123129',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
         const { access_token: token } = register.body as {

--- a/backend/test/login.e2e-spec.ts
+++ b/backend/test/login.e2e-spec.ts
@@ -29,9 +29,10 @@ describe('AuthController.login (e2e)', () => {
             .send({
                 email: 'test@test.com',
                 password: 'Secret123!',
-                fullName: 'Test',
+                firstName: 'Test',
+                lastName: 'User',
                 phone: '+48123123123',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 
@@ -51,9 +52,10 @@ describe('AuthController.login (e2e)', () => {
             .send({
                 email: 'test@test.com',
                 password: 'Secret123!',
-                fullName: 'Test',
+                firstName: 'Test',
+                lastName: 'User',
                 phone: '+48123123123',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 

--- a/backend/test/logs.e2e-spec.ts
+++ b/backend/test/logs.e2e-spec.ts
@@ -41,9 +41,10 @@ describe('LogsModule (e2e)', () => {
             .send({
                 email: 'client@logs.com',
                 password: 'Secret123!',
-                fullName: 'Client',
+                firstName: 'Client',
+                lastName: 'User',
                 phone: '+48123123131',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 

--- a/backend/test/profile.e2e-spec.ts
+++ b/backend/test/profile.e2e-spec.ts
@@ -33,9 +33,10 @@ describe('UsersController (e2e)', () => {
             .send({
                 email: 'test@test.com',
                 password: 'Secret123!',
-                fullName: 'Test',
+                firstName: 'Test',
+                lastName: 'User',
                 phone: '+48123123130',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 
@@ -49,7 +50,8 @@ describe('UsersController (e2e)', () => {
                 expect(res.body).toHaveProperty('id');
                 expect(res.body).toMatchObject({
                     email: 'test@test.com',
-                    name: 'Test',
+                    firstName: 'Test',
+                    lastName: 'User',
                     role: 'client',
                 });
             });
@@ -61,9 +63,10 @@ describe('UsersController (e2e)', () => {
             .send({
                 email: 'test@test.com',
                 password: 'Secret123!',
-                fullName: 'Test',
+                firstName: 'Test',
+                lastName: 'User',
                 phone: '+48123123130',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 

--- a/backend/test/register.e2e-spec.ts
+++ b/backend/test/register.e2e-spec.ts
@@ -29,9 +29,10 @@ describe('AuthController (e2e)', () => {
             .send({
                 email: 'test@test.com',
                 password: 'Secret123!',
-                fullName: 'Test',
+                firstName: 'Test',
+                lastName: 'User',
                 phone: '+48123123123',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201)
             .expect((res) => {
@@ -46,9 +47,10 @@ describe('AuthController (e2e)', () => {
             .send({
                 email: 'bad',
                 password: '123',
-                fullName: 'T',
+                firstName: 'T',
+                lastName: 'U',
                 phone: '123',
-                consentRODO: false,
+                privacyConsent: false,
             })
             .expect(400);
     });
@@ -59,9 +61,10 @@ describe('AuthController (e2e)', () => {
             .send({
                 email: 'dup@test.com',
                 password: 'Secret123!',
-                fullName: 'One',
+                firstName: 'One',
+                lastName: 'A',
                 phone: '+48123123124',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 
@@ -70,9 +73,10 @@ describe('AuthController (e2e)', () => {
             .send({
                 email: 'dup@test.com',
                 password: 'Other123!',
-                fullName: 'Two',
+                firstName: 'Two',
+                lastName: 'B',
                 phone: '+48123123125',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(400);
     });

--- a/backend/test/roles.e2e-spec.ts
+++ b/backend/test/roles.e2e-spec.ts
@@ -33,9 +33,10 @@ describe('RolesGuard (e2e)', () => {
             .send({
                 email: 'client@test.com',
                 password: 'Secret123!',
-                fullName: 'Client',
+                firstName: 'Client',
+                lastName: 'User',
                 phone: '+48123123126',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 

--- a/backend/test/services.e2e-spec.ts
+++ b/backend/test/services.e2e-spec.ts
@@ -34,9 +34,10 @@ describe('ServicesModule (e2e)', () => {
             .send({
                 email: 'client@services.com',
                 password: 'Secret123!',
-                fullName: 'Client',
+                firstName: 'Client',
+                lastName: 'User',
                 phone: '+48123123127',
-                consentRODO: true,
+                privacyConsent: true,
             })
             .expect(201);
 

--- a/backend/test/social-login.e2e-spec.ts
+++ b/backend/test/social-login.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('AuthController.socialLogin (e2e)', () => {
     it('registers new user via Google', async () => {
         const res = await request(app.getHttpServer())
             .post('/auth/social-login')
-            .send({ provider: 'google', token: 'good', consentMarketing: true })
+            .send({ provider: 'google', token: 'good', marketingConsent: true })
             .expect(201);
         expect(res.body).toHaveProperty('access_token');
         expect(res.body).toHaveProperty('refresh_token');
@@ -57,7 +57,7 @@ describe('AuthController.socialLogin (e2e)', () => {
     });
 
     it('logs in existing social user', async () => {
-        await users.createSocialUser('log@test.com', 'Existing');
+        await users.createSocialUser('log@test.com', 'Existing', 'User');
         await request(app.getHttpServer())
             .post('/auth/social-login')
             .send({ provider: 'google', token: 'exist' })


### PR DESCRIPTION
## Summary
- replace `fullName` with `firstName`/`lastName` in client registration DTO
- add EU phone number validation using `libphonenumber-js`
- rename RODO/marketing consents to `privacyConsent` and `marketingConsent`
- update registration tests for new fields and validation

## Testing
- `npm test`
- `npm run test:e2e` *(fails: DataTypeNotSupportedError: "timestamptz" not supported by sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_688f6a94be2c83298e625537caea3fb7