### PR TITLE
feat: expand customer management

### DIFF
--- a/backend/src/common/validators/is-eu-phone-number.ts
+++ b/backend/src/common/validators/is-eu-phone-number.ts
@@ -6,7 +6,7 @@ const EU_COUNTRIES = [
 ];
 
 export function IsEuPhoneNumber(validationOptions?: ValidationOptions) {
-    return function (object: Object, propertyName: string) {
+    return function (object: object, propertyName: string) {
         registerDecorator({
             name: 'isEuPhoneNumber',
             target: object.constructor,

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -1,35 +1,122 @@
 import {
+    Body,
     Controller,
     Get,
     Param,
     NotFoundException,
     UseGuards,
     ParseIntPipe,
+    Request,
+    Put,
+    Patch,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiTags,
+    ApiOperation,
+    ApiResponse,
+} from '@nestjs/swagger';
 import { CustomersService } from './customers.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
 import { EmployeeRole } from '../employees/employee-role.enum';
+import { UsersService } from '../users/users.service';
+import { UpdateCustomerDto } from '../users/dto/update-customer.dto';
+import { UpdateMarketingConsentDto } from './dto/update-marketing-consent.dto';
 
 @ApiTags('Customers')
 @ApiBearerAuth()
 @Controller('customers')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
 export class CustomersController {
-    constructor(private readonly service: CustomersService) {}
+    constructor(
+        private readonly service: CustomersService,
+        private readonly users: UsersService,
+    ) {}
 
     @Get()
+    @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
+    @ApiOperation({ summary: 'List customers' })
+    @ApiResponse({ status: 200 })
     async list() {
         return this.service.findAll();
     }
 
+    @Get('me')
+    @Roles(Role.Client)
+    @ApiOperation({ summary: 'Get own customer profile' })
+    @ApiResponse({ status: 200 })
+    async getMe(@Request() req) {
+        const customer = await this.service.findOne(req.user.id);
+        if (!customer) {
+            throw new NotFoundException();
+        }
+        return customer;
+    }
+
+    @Put('me')
+    @Roles(Role.Client)
+    @ApiOperation({ summary: 'Update own customer profile' })
+    @ApiResponse({ status: 200 })
+    async updateMe(@Request() req, @Body() dto: UpdateCustomerDto) {
+        await this.users.updateCustomer(req.user.id, dto);
+        const updated = await this.service.findOne(req.user.id);
+        if (!updated) {
+            throw new NotFoundException();
+        }
+        return updated;
+    }
+
     @Get(':id')
+    @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
+    @ApiOperation({ summary: 'Get customer by id' })
+    @ApiResponse({ status: 200 })
     async get(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.findOne(id);
+        if (!customer) {
+            throw new NotFoundException();
+        }
+        return customer;
+    }
+
+    @Patch(':id/activate')
+    @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
+    @ApiOperation({ summary: 'Activate customer account' })
+    @ApiResponse({ status: 200 })
+    async activate(@Param('id', ParseIntPipe) id: number) {
+        const customer = await this.service.setActive(id, true);
+        if (!customer) {
+            throw new NotFoundException();
+        }
+        return customer;
+    }
+
+    @Patch(':id/deactivate')
+    @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
+    @ApiOperation({ summary: 'Deactivate customer account' })
+    @ApiResponse({ status: 200 })
+    async deactivate(@Param('id', ParseIntPipe) id: number) {
+        const customer = await this.service.setActive(id, false);
+        if (!customer) {
+            throw new NotFoundException();
+        }
+        return customer;
+    }
+
+    @Patch(':id/marketing-consent')
+    @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
+    @ApiOperation({ summary: 'Update customer marketing consent' })
+    @ApiResponse({ status: 200 })
+    async updateMarketingConsent(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: UpdateMarketingConsentDto,
+    ) {
+        const customer = await this.service.updateMarketingConsent(
+            id,
+            dto.marketingConsent,
+        );
         if (!customer) {
             throw new NotFoundException();
         }

--- a/backend/src/customers/customers.module.ts
+++ b/backend/src/customers/customers.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Customer } from './customer.entity';
 import { CustomersController } from './customers.controller';
 import { CustomersService } from './customers.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Customer])],
+    imports: [TypeOrmModule.forFeature([Customer]), UsersModule],
     controllers: [CustomersController],
     providers: [CustomersService],
     exports: [TypeOrmModule, CustomersService],

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -31,4 +31,34 @@ export class CustomersService {
             excludeExtraneousValues: true,
         });
     }
+
+    async setActive(
+        id: number,
+        isActive: boolean,
+    ): Promise<CustomerDto | undefined> {
+        const customer = await this.repo.findOne({
+            where: { id, role: Role.Client },
+        });
+        if (!customer) return undefined;
+        customer.isActive = isActive;
+        const saved = await this.repo.save(customer);
+        return plainToInstance(CustomerDto, saved, {
+            excludeExtraneousValues: true,
+        });
+    }
+
+    async updateMarketingConsent(
+        id: number,
+        marketingConsent: boolean,
+    ): Promise<CustomerDto | undefined> {
+        const customer = await this.repo.findOne({
+            where: { id, role: Role.Client },
+        });
+        if (!customer) return undefined;
+        customer.marketingConsent = marketingConsent;
+        const saved = await this.repo.save(customer);
+        return plainToInstance(CustomerDto, saved, {
+            excludeExtraneousValues: true,
+        });
+    }
 }

--- a/backend/src/customers/dto/update-marketing-consent.dto.ts
+++ b/backend/src/customers/dto/update-marketing-consent.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class UpdateMarketingConsentDto {
+    @ApiProperty()
+    @IsBoolean()
+    marketingConsent: boolean;
+}


### PR DESCRIPTION
## Summary
- add customer self-service profile endpoints
- add admin endpoints to activate, deactivate and toggle marketing consent
- wire user module into customers and document new routes in Swagger

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f729476088329a7f6559cca5c0eb2