### PR TITLE
Prevent admin creation of client accounts

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -7,6 +7,7 @@ import {
     Delete,
     Param,
     Patch,
+    BadRequestException,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -46,6 +47,11 @@ export class UsersController {
             privacyConsent,
             marketingConsent,
         } = createUserDto;
+        if (!role || role === Role.Client) {
+            throw new BadRequestException(
+                'Admins cannot create client accounts',
+            );
+        }
         return this.usersService.createUser(
             email,
             password,

--- a/backend/test/roles.e2e-spec.ts
+++ b/backend/test/roles.e2e-spec.ts
@@ -51,7 +51,7 @@ describe('RolesGuard (e2e)', () => {
             .expect(403);
     });
 
-    it('allows admin user to create a new user', async () => {
+    it('rejects admin user creating a client account', async () => {
         await usersService.createUser(
             'admin@test.com',
             'secret',
@@ -72,7 +72,37 @@ describe('RolesGuard (e2e)', () => {
             .send({
                 email: 'client2@test.com',
                 password: 'secret',
-                name: 'Client2',
+                firstName: 'Client2',
+                lastName: 'User',
+                role: Role.Client,
+            })
+            .expect(400);
+    });
+
+    it('allows admin user to create an employee', async () => {
+        await usersService.createUser(
+            'admin2@test.com',
+            'secret',
+            'Admin',
+            Role.Admin,
+        );
+
+        const login = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'admin2@test.com', password: 'secret' })
+            .expect(201);
+
+        const { access_token: token } = login.body as { access_token: string };
+
+        await request(app.getHttpServer())
+            .post('/users')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                email: 'employee@test.com',
+                password: 'secret',
+                firstName: 'Employee',
+                lastName: 'User',
+                role: Role.Employee,
             })
             .expect(201);
     });


### PR DESCRIPTION
## Summary
- Reject attempts to create client accounts via `POST /users`
- Add tests confirming admins cannot create clients but can create employees

## Testing
- `npm test`
- `npm run test:e2e` *(fails: DataTypeNotSupportedError for timestamptz with sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_688f77bd438083299a3aacd33bb84a87