### PR TITLE
feat: allow customers to update profile

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -22,7 +22,6 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
 import { EmployeeRole } from '../employees/employee-role.enum';
-import { UsersService } from '../users/users.service';
 import { UpdateCustomerDto } from '../users/dto/update-customer.dto';
 import { UpdateMarketingConsentDto } from './dto/update-marketing-consent.dto';
 
@@ -31,10 +30,7 @@ import { UpdateMarketingConsentDto } from './dto/update-marketing-consent.dto';
 @Controller('customers')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class CustomersController {
-    constructor(
-        private readonly service: CustomersService,
-        private readonly users: UsersService,
-    ) {}
+    constructor(private readonly service: CustomersService) {}
 
     @Get()
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
@@ -61,12 +57,7 @@ export class CustomersController {
     @ApiOperation({ summary: 'Update own customer profile' })
     @ApiResponse({ status: 200 })
     async updateMe(@Request() req, @Body() dto: UpdateCustomerDto) {
-        await this.users.updateCustomer(req.user.id, dto);
-        const updated = await this.service.findOne(req.user.id);
-        if (!updated) {
-            throw new NotFoundException();
-        }
-        return updated;
+        return this.service.updateProfile(req.user.id, dto);
     }
 
     @Get(':id')

--- a/backend/src/users/dto/update-customer.dto.ts
+++ b/backend/src/users/dto/update-customer.dto.ts
@@ -1,4 +1,35 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from './create-user.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    IsEmail,
+    IsString,
+    IsOptional,
+    IsBoolean,
+    IsMobilePhone,
+} from 'class-validator';
 
-export class UpdateCustomerDto extends PartialType(CreateUserDto) {}
+export class UpdateCustomerDto {
+    @ApiPropertyOptional()
+    @IsEmail()
+    @IsOptional()
+    email?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    firstName?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    lastName?: string;
+
+    @ApiPropertyOptional()
+    @IsMobilePhone('any')
+    @IsOptional()
+    phone?: string;
+
+    @ApiPropertyOptional()
+    @IsBoolean()
+    @IsOptional()
+    marketingConsent?: boolean;
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -142,9 +142,6 @@ export class UsersService {
             }
             user.email = dto.email;
         }
-        if (dto.password) {
-            user.password = await bcrypt.hash(dto.password, 10);
-        }
         if (dto.firstName !== undefined) {
             user.firstName = dto.firstName;
         }
@@ -153,9 +150,6 @@ export class UsersService {
         }
         if (dto.phone !== undefined) {
             user.phone = dto.phone;
-        }
-        if (dto.privacyConsent !== undefined) {
-            user.privacyConsent = dto.privacyConsent;
         }
         if (dto.marketingConsent !== undefined) {
             user.marketingConsent = dto.marketingConsent;


### PR DESCRIPTION
## Summary
- restrict user updates to non-sensitive fields and validate phone numbers
- add service for clients to edit their own profile via PUT /customers/me
- cover profile update behavior and email uniqueness in tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7e1d74f48329836cd33ec1465b87