### PR TITLE
feat: audit profile and consent updates

### DIFF
--- a/backend/src/customers/customers.module.ts
+++ b/backend/src/customers/customers.module.ts
@@ -4,9 +4,10 @@ import { Customer } from './customer.entity';
 import { CustomersController } from './customers.controller';
 import { CustomersService } from './customers.service';
 import { UsersModule } from '../users/users.module';
+import { LogsModule } from '../logs/logs.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Customer]), UsersModule],
+    imports: [TypeOrmModule.forFeature([Customer]), UsersModule, LogsModule],
     controllers: [CustomersController],
     providers: [CustomersService],
     exports: [TypeOrmModule, CustomersService],

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -26,5 +26,7 @@ export enum LogAction {
     BulkUpdateProductStock = 'BULK_UPDATE_PRODUCT_STOCK',
     ProductUsed = 'PRODUCT_USED',
     DeleteProduct = 'DELETE_PRODUCT',
+    ProfileUpdate = 'PROFILE_UPDATE',
+    MarketingConsentChange = 'MARKETING_CONSENT_CHANGE',
     CustomerDelete = 'CUSTOMER_DELETE',
 }


### PR DESCRIPTION
## Summary
- log profile and marketing consent updates for users and customers
- add audit actions for profile updates and consent changes
- verify profile and consent logging in e2e tests

## Testing
- `npm test`
- `npm run test:e2e -- test/logs.e2e-spec.ts` *(fails: DataTypeNotSupportedError: Data type "timestamptz" in "Service.createdAt" is not supported by "sqlite" database)*

------
https://chatgpt.com/codex/tasks/task_e_688f89031cd883298562083e4e316ed7