### PR TITLE
feat: expand employee management

### DIFF
--- a/backend/src/employees/dto/create-employee.dto.ts
+++ b/backend/src/employees/dto/create-employee.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    IsEmail,
+    IsEnum,
+    IsMobilePhone,
+    IsOptional,
+    IsString,
+} from 'class-validator';
+import { Role } from '../../users/role.enum';
+
+export class CreateEmployeeDto {
+    @ApiProperty()
+    @IsEmail()
+    email: string;
+
+    @ApiProperty()
+    @IsString()
+    firstName: string;
+
+    @ApiProperty()
+    @IsString()
+    lastName: string;
+
+    @ApiPropertyOptional()
+    @IsMobilePhone()
+    @IsOptional()
+    phone?: string;
+
+    @ApiPropertyOptional({ enum: Role })
+    @IsEnum(Role)
+    @IsOptional()
+    role?: Role;
+}

--- a/backend/src/employees/dto/update-employee-commission.dto.ts
+++ b/backend/src/employees/dto/update-employee-commission.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class UpdateEmployeeCommissionDto {
+    @ApiProperty()
+    @IsNumber()
+    commissionBase: number;
+}

--- a/backend/src/employees/dto/update-employee.dto.ts
+++ b/backend/src/employees/dto/update-employee.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    IsEmail,
+    IsEnum,
+    IsMobilePhone,
+    IsOptional,
+    IsString,
+} from 'class-validator';
+import { Role } from '../../users/role.enum';
+
+export class UpdateEmployeeDto {
+    @ApiPropertyOptional()
+    @IsEmail()
+    @IsOptional()
+    email?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    firstName?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    lastName?: string;
+
+    @ApiPropertyOptional()
+    @IsMobilePhone()
+    @IsOptional()
+    phone?: string;
+
+    @ApiPropertyOptional({ enum: Role })
+    @IsEnum(Role)
+    @IsOptional()
+    role?: Role;
+}

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -1,17 +1,30 @@
 import {
+    Body,
     Controller,
+    Delete,
     Get,
     Param,
-    NotFoundException,
     ParseIntPipe,
+    NotFoundException,
+    Patch,
+    Post,
+    Put,
     UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 import { EmployeesService } from './employees.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { UpdateEmployeeCommissionDto } from './dto/update-employee-commission.dto';
 
 @ApiTags('Employees')
 @ApiBearerAuth()
@@ -22,16 +35,97 @@ export class EmployeesController {
     constructor(private readonly service: EmployeesService) {}
 
     @Get()
+    @ApiOperation({ summary: 'List employees' })
+    @ApiResponse({ status: 200 })
     list() {
         return this.service.findAll();
     }
 
     @Get(':id')
+    @ApiOperation({ summary: 'Get employee by id' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
     async get(@Param('id', ParseIntPipe) id: number) {
         const employee = await this.service.findOne(id);
         if (!employee) {
             throw new NotFoundException();
         }
         return employee;
+    }
+
+    @Post()
+    @ApiOperation({ summary: 'Create employee' })
+    @ApiResponse({ status: 201 })
+    create(@Body() dto: CreateEmployeeDto) {
+        return this.service.create(dto);
+    }
+
+    @Put(':id')
+    @ApiOperation({ summary: 'Update employee profile' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
+    async update(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: UpdateEmployeeDto,
+    ) {
+        const employee = await this.service.update(id, dto);
+        if (!employee) {
+            throw new NotFoundException();
+        }
+        return employee;
+    }
+
+    @Patch(':id/activate')
+    @ApiOperation({ summary: 'Activate employee account' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
+    async activate(@Param('id', ParseIntPipe) id: number) {
+        const employee = await this.service.setActive(id, true);
+        if (!employee) {
+            throw new NotFoundException();
+        }
+        return employee;
+    }
+
+    @Patch(':id/deactivate')
+    @ApiOperation({ summary: 'Deactivate employee account' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
+    async deactivate(@Param('id', ParseIntPipe) id: number) {
+        const employee = await this.service.setActive(id, false);
+        if (!employee) {
+            throw new NotFoundException();
+        }
+        return employee;
+    }
+
+    @Patch(':id/commission')
+    @ApiOperation({ summary: 'Update employee commission base' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
+    async updateCommission(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: UpdateEmployeeCommissionDto,
+    ) {
+        const employee = await this.service.setCommissionBase(
+            id,
+            dto.commissionBase,
+        );
+        if (!employee) {
+            throw new NotFoundException();
+        }
+        return employee;
+    }
+
+    @Delete(':id')
+    @ApiOperation({ summary: 'Soft delete employee' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 404 })
+    async remove(@Param('id', ParseIntPipe) id: number) {
+        const removed = await this.service.remove(id);
+        if (!removed) {
+            throw new NotFoundException();
+        }
+        return { success: true };
     }
 }

--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
 import { User } from '../users/user.entity';
 import { Role } from '../users/role.enum';
 import { EmployeeDto } from './dto/employee.dto';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import * as bcrypt from 'bcrypt';
+import { randomBytes } from 'crypto';
 
 @Injectable()
 export class EmployeesService {
@@ -13,13 +17,19 @@ export class EmployeesService {
         private readonly repo: Repository<User>,
     ) {}
 
+    private toDto(user: User): EmployeeDto {
+        return plainToInstance(
+            EmployeeDto,
+            { ...user, name: `${user.firstName} ${user.lastName}` },
+            { excludeExtraneousValues: true },
+        );
+    }
+
     async findAll(): Promise<EmployeeDto[]> {
         const employees = await this.repo.find({
             where: [{ role: Role.Employee }, { role: Role.Admin }],
         });
-        return plainToInstance(EmployeeDto, employees, {
-            excludeExtraneousValues: true,
-        });
+        return employees.map((e) => this.toDto(e));
     }
 
     async findOne(id: number): Promise<EmployeeDto | undefined> {
@@ -30,8 +40,109 @@ export class EmployeesService {
             ],
         });
         if (!employee) return undefined;
-        return plainToInstance(EmployeeDto, employee, {
-            excludeExtraneousValues: true,
+        return this.toDto(employee);
+    }
+
+    async create(
+        dto: CreateEmployeeDto,
+    ): Promise<{ employee: EmployeeDto; password: string }> {
+        const existing = await this.repo.findOne({
+            where: { email: dto.email },
         });
+        if (existing) {
+            throw new BadRequestException('Email already registered');
+        }
+        const password = randomBytes(8).toString('hex');
+        const hashed = await bcrypt.hash(password, 10);
+        const user = this.repo.create({
+            email: dto.email,
+            password: hashed,
+            firstName: dto.firstName,
+            lastName: dto.lastName,
+            phone: dto.phone ?? null,
+            role: dto.role ?? Role.Employee,
+        });
+        const saved = await this.repo.save(user);
+        return { employee: this.toDto(saved), password };
+    }
+
+    async update(
+        id: number,
+        dto: UpdateEmployeeDto,
+    ): Promise<EmployeeDto | undefined> {
+        const employee = await this.repo.findOne({
+            where: [
+                { id, role: Role.Employee },
+                { id, role: Role.Admin },
+            ],
+        });
+        if (!employee) return undefined;
+        if (dto.email && dto.email !== employee.email) {
+            const existing = await this.repo.findOne({
+                where: { email: dto.email },
+            });
+            if (existing && existing.id !== id) {
+                throw new BadRequestException('Email already registered');
+            }
+            employee.email = dto.email;
+        }
+        if (dto.firstName !== undefined) {
+            employee.firstName = dto.firstName;
+        }
+        if (dto.lastName !== undefined) {
+            employee.lastName = dto.lastName;
+        }
+        if (dto.phone !== undefined) {
+            employee.phone = dto.phone;
+        }
+        if (dto.role !== undefined) {
+            employee.role = dto.role;
+        }
+        const saved = await this.repo.save(employee);
+        return this.toDto(saved);
+    }
+
+    async setActive(
+        id: number,
+        isActive: boolean,
+    ): Promise<EmployeeDto | undefined> {
+        const employee = await this.repo.findOne({
+            where: [
+                { id, role: Role.Employee },
+                { id, role: Role.Admin },
+            ],
+        });
+        if (!employee) return undefined;
+        employee.isActive = isActive;
+        const saved = await this.repo.save(employee);
+        return this.toDto(saved);
+    }
+
+    async setCommissionBase(
+        id: number,
+        commissionBase: number,
+    ): Promise<EmployeeDto | undefined> {
+        const employee = await this.repo.findOne({
+            where: [
+                { id, role: Role.Employee },
+                { id, role: Role.Admin },
+            ],
+        });
+        if (!employee) return undefined;
+        employee.commissionBase = commissionBase;
+        const saved = await this.repo.save(employee);
+        return this.toDto(saved);
+    }
+
+    async remove(id: number): Promise<boolean> {
+        const employee = await this.repo.findOne({
+            where: [
+                { id, role: Role.Employee },
+                { id, role: Role.Admin },
+            ],
+        });
+        if (!employee) return false;
+        await this.repo.softDelete(id);
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- add admin-only employee management endpoints for creation, updates, activation, commission changes and soft deletion
- extend service to generate random passwords, update profiles, toggle activation, adjust commission and soft delete
- create DTOs for employee creation, profile updates and commission changes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f92f1bafc8329b6becf152d24d837