### PR TITLE
Refactor employee name fields

### DIFF
--- a/backend/src/employees/dto/employee.dto.ts
+++ b/backend/src/employees/dto/employee.dto.ts
@@ -13,7 +13,17 @@ export class EmployeeDto {
 
     @ApiProperty()
     @Expose()
-    name: string;
+    firstName: string;
+
+    @ApiProperty()
+    @Expose()
+    lastName: string;
+
+    @ApiProperty()
+    @Expose()
+    get fullName(): string {
+        return `${this.firstName} ${this.lastName}`.trim();
+    }
 
     @ApiProperty({ nullable: true })
     @Expose()

--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -18,11 +18,9 @@ export class EmployeesService {
     ) {}
 
     private toDto(user: User): EmployeeDto {
-        return plainToInstance(
-            EmployeeDto,
-            { ...user, name: `${user.firstName} ${user.lastName}` },
-            { excludeExtraneousValues: true },
-        );
+        return plainToInstance(EmployeeDto, user, {
+            excludeExtraneousValues: true,
+        });
     }
 
     async findAll(): Promise<EmployeeDto[]> {

--- a/backend/test/employees.e2e-spec.ts
+++ b/backend/test/employees.e2e-spec.ts
@@ -53,7 +53,9 @@ describe('EmployeesController (e2e)', () => {
             expect(e).not.toHaveProperty('password');
             expect(e).not.toHaveProperty('refreshToken');
             expect(e).toHaveProperty('email');
-            expect(e).toHaveProperty('name');
+            expect(e).toHaveProperty('firstName');
+            expect(e).toHaveProperty('lastName');
+            expect(e).toHaveProperty('fullName');
             expect(e).toHaveProperty('phone');
             expect([Role.Employee, Role.Admin]).toContain(e.role);
         });

--- a/frontend/src/__tests__/employeeApi.test.tsx
+++ b/frontend/src/__tests__/employeeApi.test.tsx
@@ -15,14 +15,21 @@ const toast = require('react-hot-toast').toast;
 
 describe('useEmployeeApi', () => {
   it('shows success toast on create', async () => {
-    const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
+    const apiFetch = jest
+      .fn()
+      .mockResolvedValue({
+        id: 1,
+        firstName: 'A',
+        lastName: 'B',
+        fullName: 'A B',
+      });
     mockedUseAuth.mockReturnValue({ apiFetch } as any);
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
     const { result } = renderHook(() => useEmployeeApi(), { wrapper });
     await act(async () => {
-      await result.current.create({ name: 'A' });
+      await result.current.create({ firstName: 'A', lastName: 'B' });
     });
     expect(toast.success).toHaveBeenCalled();
   });
@@ -36,7 +43,7 @@ describe('useEmployeeApi', () => {
     const { result } = renderHook(() => useEmployeeApi(), { wrapper });
     await expect(
       act(async () => {
-        await result.current.create({ name: 'A' });
+        await result.current.create({ firstName: 'A', lastName: 'B' });
       })
     ).rejects.toThrow();
     expect(toast.error).toHaveBeenCalled();

--- a/frontend/src/__tests__/employeeForm.test.tsx
+++ b/frontend/src/__tests__/employeeForm.test.tsx
@@ -13,8 +13,15 @@ describe('EmployeeForm', () => {
   it('submits valid data', async () => {
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(<EmployeeForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'A' } });
+    fireEvent.change(screen.getByPlaceholderText('First name'), {
+      target: { value: 'A' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Last name'), {
+      target: { value: 'B' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'A' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ firstName: 'A', lastName: 'B' })
+    );
   });
 });

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -6,7 +6,7 @@ export function useEmployeeApi() {
   const { apiFetch } = useAuth();
   const toast = useToast();
 
-  const create = async (data: { name: string }) => {
+  const create = async (data: { firstName: string; lastName: string }) => {
     try {
       const res = await apiFetch<Employee>('/employees', {
         method: 'POST',
@@ -21,7 +21,7 @@ export function useEmployeeApi() {
     }
   };
 
-  const update = async (id: number, data: { name: string }) => {
+  const update = async (id: number, data: { firstName: string; lastName: string }) => {
     try {
       const res = await apiFetch<Employee>(`/employees/${id}`, {
         method: 'PUT',

--- a/frontend/src/components/EmployeeForm.tsx
+++ b/frontend/src/components/EmployeeForm.tsx
@@ -3,23 +3,25 @@ import { z } from 'zod';
 import { Employee } from '@/types';
 
 const schema = z.object({
-  name: z.string().min(1, { message: 'Name is required' }),
+  firstName: z.string().min(1, { message: 'First name is required' }),
+  lastName: z.string().min(1, { message: 'Last name is required' }),
 });
 
 interface Props {
   initial?: Partial<Employee>;
-  onSubmit: (data: { name: string }) => Promise<void>;
+  onSubmit: (data: { firstName: string; lastName: string }) => Promise<void>;
   onCancel: () => void;
 }
 
 export default function EmployeeForm({ initial, onSubmit, onCancel }: Props) {
-  const [name, setName] = useState(initial?.name ?? '');
+  const [firstName, setFirstName] = useState(initial?.firstName ?? '');
+  const [lastName, setLastName] = useState(initial?.lastName ?? '');
   const [error, setError] = useState('');
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     try {
-      const data = schema.parse({ name });
+      const data = schema.parse({ firstName, lastName });
       await onSubmit(data);
     } catch (err: any) {
       if (err.errors) setError(err.errors[0].message);
@@ -30,10 +32,16 @@ export default function EmployeeForm({ initial, onSubmit, onCancel }: Props) {
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
+        value={firstName}
+        onChange={(e) => setFirstName(e.target.value)}
         className="border p-1 w-full"
-        placeholder="Name"
+        placeholder="First name"
+      />
+      <input
+        value={lastName}
+        onChange={(e) => setLastName(e.target.value)}
+        className="border p-1 w-full"
+        placeholder="Last name"
       />
       {error && (
         <p role="alert" className="text-red-600 text-sm">

--- a/frontend/src/pages/employees/index.tsx
+++ b/frontend/src/pages/employees/index.tsx
@@ -19,16 +19,16 @@ export default function EmployeesPage() {
 
   const columns: Column<Employee>[] = [
     { header: 'ID', accessor: 'id' },
-    { header: 'Name', accessor: 'name' },
+    { header: 'Name', accessor: 'fullName' },
   ];
 
-  const handleCreate = async (values: { name: string }) => {
+  const handleCreate = async (values: { firstName: string; lastName: string }) => {
     const created = await api.create(values);
     setRows((c) => [...c, created]);
     setOpenForm(false);
   };
 
-  const handleUpdate = async (values: { name: string }) => {
+  const handleUpdate = async (values: { firstName: string; lastName: string }) => {
     if (!editing) return;
     const updated = await api.update(editing.id, values);
     setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
@@ -37,7 +37,7 @@ export default function EmployeesPage() {
   };
 
   const handleDelete = async (row: Employee) => {
-    if (!confirm(`Delete ${row.name}?`)) return;
+    if (!confirm(`Delete ${row.fullName}?`)) return;
     await api.remove(row.id);
     setRows((c) => c.filter((cl) => cl.id !== row.id));
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,7 +19,9 @@ export interface Service {
 
 export interface Employee {
     id: number;
-    name: string;
+    firstName: string;
+    lastName: string;
+    fullName: string;
 }
 
 export interface Product {


### PR DESCRIPTION
## Summary\n- Split employee `name` into `firstName` and `lastName` with computed `fullName`\n- Map user entities to new fields and update frontend types, API calls, and UI\n- Align tests with updated employee DTO and components\n\n## Testing\n- `npm test` (backend)\n- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_688f97d2ec708329b13e10a75be6e0ca