### PR TITLE
feat: generate passwords server side

### DIFF
--- a/backend/src/common/password.util.ts
+++ b/backend/src/common/password.util.ts
@@ -1,0 +1,12 @@
+import { randomBytes } from 'crypto';
+
+const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=+';
+
+export function generateStrongPassword(length = 12): string {
+    const bytes = randomBytes(length);
+    let password = '';
+    for (let i = 0; i < length; i++) {
+        password += CHARSET[bytes[i] % CHARSET.length];
+    }
+    return password;
+}

--- a/backend/src/employees/dto/create-employee-response.dto.ts
+++ b/backend/src/employees/dto/create-employee-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EmployeeDto } from './employee.dto';
+
+export class CreateEmployeeResponseDto {
+    @ApiProperty({ type: () => EmployeeDto })
+    employee: EmployeeDto;
+
+    @ApiProperty({ description: 'Plaintext password, returned only once.' })
+    password: string;
+}

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -25,6 +25,7 @@ import { Role } from '../users/role.enum';
 import { CreateEmployeeDto } from './dto/create-employee.dto';
 import { UpdateEmployeeDto } from './dto/update-employee.dto';
 import { UpdateEmployeeCommissionDto } from './dto/update-employee-commission.dto';
+import { CreateEmployeeResponseDto } from './dto/create-employee-response.dto';
 
 @ApiTags('Employees')
 @ApiBearerAuth()
@@ -55,8 +56,13 @@ export class EmployeesController {
 
     @Post()
     @ApiOperation({ summary: 'Create employee' })
-    @ApiResponse({ status: 201 })
-    create(@Body() dto: CreateEmployeeDto) {
+    @ApiResponse({
+        status: 201,
+        description:
+            'Employee created. The plaintext password is returned only in this response.',
+        type: CreateEmployeeResponseDto,
+    })
+    create(@Body() dto: CreateEmployeeDto): Promise<CreateEmployeeResponseDto> {
         return this.service.create(dto);
     }
 

--- a/backend/src/employees/employees.service.ts
+++ b/backend/src/employees/employees.service.ts
@@ -7,8 +7,9 @@ import { Role } from '../users/role.enum';
 import { EmployeeDto } from './dto/employee.dto';
 import { CreateEmployeeDto } from './dto/create-employee.dto';
 import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { CreateEmployeeResponseDto } from './dto/create-employee-response.dto';
 import * as bcrypt from 'bcrypt';
-import { randomBytes } from 'crypto';
+import { generateStrongPassword } from '../common/password.util';
 
 @Injectable()
 export class EmployeesService {
@@ -43,14 +44,14 @@ export class EmployeesService {
 
     async create(
         dto: CreateEmployeeDto,
-    ): Promise<{ employee: EmployeeDto; password: string }> {
+    ): Promise<CreateEmployeeResponseDto> {
         const existing = await this.repo.findOne({
             where: { email: dto.email },
         });
         if (existing) {
             throw new BadRequestException('Email already registered');
         }
-        const password = randomBytes(8).toString('hex');
+        const password = generateStrongPassword();
         const hashed = await bcrypt.hash(password, 10);
         const user = this.repo.create({
             email: dto.email,


### PR DESCRIPTION
## Summary
- add utility to generate strong random passwords
- create employee passwords server side and return plaintext once
- document one-time password response in swagger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f9ac11928832999b5b6a9d69db967