### PR TITLE
feat: add employee self profile endpoints

### DIFF
--- a/backend/src/employees/dto/update-employee-profile.dto.ts
+++ b/backend/src/employees/dto/update-employee-profile.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    IsEmail,
+    IsOptional,
+    IsString,
+    IsMobilePhone,
+    Matches,
+} from 'class-validator';
+
+export class UpdateEmployeeProfileDto {
+    @ApiPropertyOptional()
+    @IsEmail()
+    @IsOptional()
+    email?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    firstName?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    lastName?: string;
+
+    @ApiPropertyOptional()
+    @IsMobilePhone('pl-PL')
+    @IsOptional()
+    phone?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)
+    @IsOptional()
+    password?: string;
+}

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -27,6 +27,7 @@ import { CreateEmployeeDto } from './dto/create-employee.dto';
 import { UpdateEmployeeDto } from './dto/update-employee.dto';
 import { UpdateEmployeeCommissionDto } from './dto/update-employee-commission.dto';
 import { CreateEmployeeResponseDto } from './dto/create-employee-response.dto';
+import { UpdateEmployeeProfileDto } from './dto/update-employee-profile.dto';
 import { Request as ExpressRequest } from 'express';
 
 interface AuthRequest extends ExpressRequest {
@@ -46,6 +47,29 @@ export class EmployeesController {
     @ApiResponse({ status: 200 })
     list() {
         return this.service.findAll();
+    }
+
+    @Get('me')
+    @Roles(Role.Employee)
+    @ApiOperation({ summary: 'Get own employee profile' })
+    @ApiResponse({ status: 200 })
+    async getMe(@Request() req: AuthRequest) {
+        const employee = await this.service.findMe(req.user.id);
+        if (!employee) {
+            throw new NotFoundException();
+        }
+        return employee;
+    }
+
+    @Patch('me')
+    @Roles(Role.Employee)
+    @ApiOperation({ summary: 'Update own employee profile' })
+    @ApiResponse({ status: 200 })
+    async updateMe(
+        @Request() req: AuthRequest,
+        @Body() dto: UpdateEmployeeProfileDto,
+    ) {
+        return this.service.updateProfile(req.user.id, dto);
     }
 
     @Get(':id')


### PR DESCRIPTION
## Summary
- allow employees to view and update their own profile
- support updating employee first/last name, email, phone and password
- test employee self profile operations

## Testing
- `npm test`
- `npm run test:e2e -- test/employees.e2e-spec.ts`
- `npm run test:e2e` *(fails: ProductsModule admin can bulk update stock, EmployeesController self profile, Customer update, AuthController /auth/register rejects duplicates)*

------
https://chatgpt.com/codex/tasks/task_e_688fa270b2788329aed7f4df1f156705