### PR TITLE
feat: track appointment no-shows

### DIFF
--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -69,8 +69,17 @@ export class AdminAppointmentsController {
         @Param('id') id: string,
         @Request() req: AuthRequest,
     ) {
-         
+
         return this.service.cancel(Number(id), req.user.id, req.user.role);
+    }
+
+    @Patch(':id/no-show')
+    @ApiOperation({ summary: 'Mark appointment as no-show' })
+    noShow(
+        @Param('id') id: string,
+        @Request() req: AuthRequest,
+    ) {
+        return this.service.noShow(Number(id), req.user.id, req.user.role);
     }
 
     @Patch(':id/complete')

--- a/backend/src/appointments/appointment.entity.ts
+++ b/backend/src/appointments/appointment.entity.ts
@@ -15,6 +15,7 @@ export enum AppointmentStatus {
     Scheduled = 'scheduled',
     Completed = 'completed',
     Cancelled = 'cancelled',
+    NO_SHOW = 'no_show',
 }
 
 export enum PaymentStatus {

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -344,6 +344,40 @@ describe('AppointmentsService', () => {
         );
     });
 
+    it('noShow updates status when authorized', async () => {
+        const appt: any = {
+            id: 3,
+            status: AppointmentStatus.Scheduled,
+            client: { id: 2 },
+            employee: { id: 4 },
+        };
+        repo.findOne.mockResolvedValue(appt);
+        repo.save.mockResolvedValue(appt);
+
+        await service.noShow(3, 4, Role.Employee);
+        expect(appt.status).toBe(AppointmentStatus.NO_SHOW);
+        expect(repo.save).toHaveBeenCalledWith(appt);
+    });
+
+    it('noShow logs action', async () => {
+        const appt: any = {
+            id: 4,
+            status: AppointmentStatus.Scheduled,
+            client: { id: 2 },
+            employee: { id: 5 },
+        };
+        repo.findOne.mockResolvedValue(appt);
+        repo.save.mockResolvedValue(appt);
+
+        await service.noShow(4, 5, Role.Employee);
+
+        expect(logs.create).toHaveBeenCalledWith(
+            LogAction.NoShowAppointment,
+            JSON.stringify({ appointmentId: 4, userId: 5 }),
+            5,
+        );
+    });
+
     it('complete saves status and commission', async () => {
         const appt: any = {
             id: 2,

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -315,6 +315,27 @@ export class AppointmentsService {
         return this.applyUpdates(appt, dto);
     }
 
+    async noShow(id: number, userId: number, role: Role | EmployeeRole) {
+        const appt = await this.repo.findOne({ where: { id } });
+        if (!appt) {
+            return undefined;
+        }
+        if (
+            role !== Role.Admin &&
+            (role !== Role.Employee || appt.employee.id !== userId)
+        ) {
+            throw new ForbiddenException();
+        }
+        appt.status = AppointmentStatus.NO_SHOW;
+        const saved = await this.repo.save(appt);
+        await this.logs.create(
+            LogAction.NoShowAppointment,
+            JSON.stringify({ appointmentId: id, userId }),
+            userId,
+        );
+        return saved;
+    }
+
     async cancel(id: number, userId: number, role: Role | EmployeeRole) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {

--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -71,6 +71,20 @@ export class EmployeeAppointmentsController {
         return result;
     }
 
+    @Patch(':id/no-show')
+    @ApiOperation({ summary: 'Mark appointment as no-show by employee' })
+    async noShow(@Param('id') id: string, @Request() req: AuthRequest) {
+        const result = await this.service.noShow(
+            Number(id),
+            req.user.id,
+            req.user.role,
+        );
+        if (result === undefined) {
+            throw new NotFoundException();
+        }
+        return result;
+    }
+
     @Patch(':id/complete')
     @ApiOperation({ summary: 'Mark appointment completed by employee' })
     async complete(@Param('id') id: string, @Request() req: AuthRequest) {

--- a/backend/src/logs/action.enum.ts
+++ b/backend/src/logs/action.enum.ts
@@ -7,6 +7,7 @@ export enum LogAction {
     RegisterSuccess = 'REGISTER_SUCCESS',
     ForbiddenAccess = 'FORBIDDEN_ACCESS',
     CancelAppointment = 'CANCEL_APPOINTMENT',
+    NoShowAppointment = 'NO_SHOW_APPOINTMENT',
     CompleteAppointment = 'COMPLETE_APPOINTMENT',
     DeleteAppointment = 'DELETE_APPOINTMENT',
     DeleteService = 'DELETE_SERVICE',


### PR DESCRIPTION
## Summary
- add NO_SHOW appointment status and related log action
- allow admins and employees to mark appointments as no-show
- test no-show flow in appointments service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb360e6f0832994b1a3d3624026c3