### PR TITLE
feat(appointments): capture notes on creation

### DIFF
--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -53,6 +53,7 @@ export class AdminAppointmentsController {
             dto.employeeId,
             dto.serviceId,
             dto.startTime,
+            dto.notes,
         );
     }
 

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -118,6 +118,40 @@ describe('AppointmentsService', () => {
         expect(result).toBe(created);
     });
 
+    it('create persists notes when provided', async () => {
+        const created: any = {
+            id: 1,
+            client: { phone: '111' },
+            employee: { phone: '222' },
+            startTime: new Date('2100-07-01T10:00:00.000Z'),
+            endTime: new Date('2100-07-01T10:30:00.000Z'),
+            notes: 'bring tools',
+        };
+        repo.create.mockReturnValue(created);
+        repo.save.mockResolvedValue(created);
+        repo.manager.findOne.mockResolvedValue({ id: 3, duration: 30 });
+        repo.find.mockResolvedValue([]);
+
+        const result = await service.create(
+            1,
+            2,
+            3,
+            '2100-07-01T10:00:00.000Z',
+            'bring tools',
+        );
+
+        expect(repo.create).toHaveBeenCalledWith({
+            client: { id: 1 },
+            employee: { id: 2 },
+            service: { id: 3 },
+            startTime: new Date('2100-07-01T10:00:00.000Z'),
+            endTime: new Date('2100-07-01T10:30:00.000Z'),
+            status: AppointmentStatus.Scheduled,
+            notes: 'bring tools',
+        });
+        expect(result.notes).toBe('bring tools');
+    });
+
     it('create rejects overlapping appointment for employee', async () => {
         repo.manager.findOne.mockResolvedValue({ id: 3, duration: 30 });
         repo.find.mockResolvedValue([

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -39,6 +39,7 @@ export class AppointmentsService {
         employeeId: number,
         serviceId: number,
         startTime: string,
+        notes?: string,
     ): Promise<Appointment> {
         const start = new Date(startTime);
         if (start < new Date()) {
@@ -76,6 +77,7 @@ export class AppointmentsService {
             startTime: start,
             endTime,
             status: AppointmentStatus.Scheduled,
+            notes,
         });
         const saved = await this.repo.save(appointment);
         await this.logs.create(

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -56,6 +56,7 @@ export class ClientAppointmentsController {
             dto.employeeId,
             dto.serviceId,
             dto.startTime,
+            dto.notes,
         );
     }
 

--- a/backend/src/appointments/dto/create-appointment.dto.ts
+++ b/backend/src/appointments/dto/create-appointment.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsDateString } from 'class-validator';
+import { IsInt, IsDateString, IsString, IsOptional } from 'class-validator';
 
 export class CreateAppointmentDto {
     @IsInt()
@@ -12,4 +12,8 @@ export class CreateAppointmentDto {
 
     @IsDateString()
     startTime: string;
+
+    @IsOptional()
+    @IsString()
+    notes?: string;
 }


### PR DESCRIPTION
## Summary
- allow appointments to include optional notes during creation
- propagate notes from controllers to service and persist them
- test note persistence in appointment creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb5d29f888329a7e6826b4888d793