### PR TITLE
feat: add cancellation cutoff

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,9 @@ JWT_SECRET=your-jwt-secret
 # Secret used to sign JWT refresh tokens
 JWT_REFRESH_SECRET=your-refresh-secret
 
+# Minutes before start when cancellation is disallowed for non-admins
+CANCEL_CUTOFF_MINUTES=60
+
 # WhatsApp Cloud API credentials
 WHATSAPP_TOKEN=your-whatsapp-token
 WHATSAPP_PHONE_ID=your-whatsapp-phone-id


### PR DESCRIPTION
## Summary
- make cancellation cutoff configurable
- prevent non-admins from canceling close to start time
- document cutoff env var and test cancellation rules

## Testing
- `npm test src/appointments/appointments.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_688fb74e80fc832982eb26919e7f688a