### PR TITLE
feat: add appointment retrieval by id with authorization

### DIFF
--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -467,4 +467,32 @@ describe('AppointmentsService', () => {
             commission: { amount: 10, percent: 10 },
         });
     });
+
+    describe('findOneForUser', () => {
+        it('returns appointment for owning client', async () => {
+            const appt: any = { id: 1, client: { id: 1 }, employee: { id: 2 } };
+            repo.findOne.mockResolvedValueOnce(appt);
+            await expect(
+                service.findOneForUser(1, 1, Role.Client),
+            ).resolves.toBe(appt);
+        });
+
+        it('throws when accessing another user\'s appointment', async () => {
+            repo.findOne.mockResolvedValueOnce({
+                id: 1,
+                client: { id: 2 },
+                employee: { id: 3 },
+            });
+            await expect(
+                service.findOneForUser(1, 1, Role.Client),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+        });
+
+        it('returns undefined when appointment not found', async () => {
+            repo.findOne.mockResolvedValueOnce(undefined);
+            await expect(
+                service.findOneForUser(1, 1, Role.Client),
+            ).resolves.toBeUndefined();
+        });
+    });
 });

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -120,6 +120,24 @@ export class AppointmentsService {
         return this.repo.findOne({ where: { id } });
     }
 
+    async findOneForUser(
+        id: number,
+        userId: number,
+        role: Role | EmployeeRole,
+    ) {
+        const appt = await this.repo.findOne({ where: { id } });
+        if (!appt) {
+            return undefined;
+        }
+        if (
+            (role === Role.Client && appt.client.id !== userId) ||
+            (role === Role.Employee && appt.employee.id !== userId)
+        ) {
+            throw new ForbiddenException();
+        }
+        return appt;
+    }
+
     async update(id: number, dto: UpdateAppointmentParams) {
         const appt = await this.repo.findOne({ where: { id } });
         if (!appt) {

--- a/backend/src/appointments/client-appointments.controller.spec.ts
+++ b/backend/src/appointments/client-appointments.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ClientAppointmentsController } from './client-appointments.controller';
+import { AppointmentsService } from './appointments.service';
+import { Role } from '../users/role.enum';
+
+describe('ClientAppointmentsController', () => {
+    let controller: ClientAppointmentsController;
+    let service: { findOneForUser: jest.Mock };
+
+    beforeEach(async () => {
+        service = { findOneForUser: jest.fn() };
+
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [ClientAppointmentsController],
+            providers: [{ provide: AppointmentsService, useValue: service }],
+        }).compile();
+
+        controller = module.get(ClientAppointmentsController);
+    });
+
+    it('get returns appointment or throws', async () => {
+        service.findOneForUser.mockResolvedValueOnce({ id: 1 });
+        await expect(
+            controller.get('1', { user: { id: 1, role: Role.Client } } as any),
+        ).resolves.toEqual({ id: 1 });
+
+        service.findOneForUser.mockResolvedValueOnce(undefined);
+        await expect(
+            controller.get('2', { user: { id: 1, role: Role.Client } } as any),
+        ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('get propagates forbidden errors', async () => {
+        service.findOneForUser.mockRejectedValueOnce(new ForbiddenException());
+        await expect(
+            controller.get('1', { user: { id: 2, role: Role.Client } } as any),
+        ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+});

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -8,6 +8,7 @@ import {
     Post,
     Request,
     UseGuards,
+    NotFoundException,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -42,6 +43,20 @@ export class ClientAppointmentsController {
     @ApiResponse({ status: 200 })
     list(@Request() req) {
         return this.service.findClientAppointments(Number(req.user.id));
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Get appointment for logged in client' })
+    async get(@Param('id') id: string, @Request() req: AuthRequest) {
+        const appt = await this.service.findOneForUser(
+            Number(id),
+            req.user.id,
+            req.user.role,
+        );
+        if (!appt) {
+            throw new NotFoundException();
+        }
+        return appt;
     }
 
     @Post()

--- a/backend/src/appointments/employee-appointments.controller.spec.ts
+++ b/backend/src/appointments/employee-appointments.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { EmployeeAppointmentsController } from './employee-appointments.controller';
+import { AppointmentsService } from './appointments.service';
+import { Role } from '../users/role.enum';
+
+describe('EmployeeAppointmentsController', () => {
+    let controller: EmployeeAppointmentsController;
+    let service: { findOneForUser: jest.Mock };
+
+    beforeEach(async () => {
+        service = { findOneForUser: jest.fn() };
+
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [EmployeeAppointmentsController],
+            providers: [{ provide: AppointmentsService, useValue: service }],
+        }).compile();
+
+        controller = module.get(EmployeeAppointmentsController);
+    });
+
+    it('get returns appointment or throws', async () => {
+        service.findOneForUser.mockResolvedValueOnce({ id: 1 });
+        await expect(
+            controller.get('1', { user: { id: 1, role: Role.Employee } } as any),
+        ).resolves.toEqual({ id: 1 });
+
+        service.findOneForUser.mockResolvedValueOnce(undefined);
+        await expect(
+            controller.get('2', { user: { id: 1, role: Role.Employee } } as any),
+        ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('get propagates forbidden errors', async () => {
+        service.findOneForUser.mockRejectedValueOnce(new ForbiddenException());
+        await expect(
+            controller.get('1', { user: { id: 2, role: Role.Employee } } as any),
+        ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+});

--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -42,6 +42,20 @@ export class EmployeeAppointmentsController {
         return this.service.findEmployeeAppointments(Number(req.user.id));
     }
 
+    @Get(':id')
+    @ApiOperation({ summary: 'Get appointment assigned to employee' })
+    async get(@Param('id') id: string, @Request() req: AuthRequest) {
+        const appt = await this.service.findOneForUser(
+            Number(id),
+            req.user.id,
+            req.user.role,
+        );
+        if (!appt) {
+            throw new NotFoundException();
+        }
+        return appt;
+    }
+
     @Patch(':id')
     @ApiOperation({ summary: 'Update appointment by employee' })
     update(


### PR DESCRIPTION
## Summary
- add appointment retrieval endpoints for clients and employees with user ownership checks
- implement `findOneForUser` in appointment service to enforce authorization
- add unit tests for service and controller handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb905d0ec8329b7d295cbf7cbc5e9