### PR TITLE
Track appointment creator in logs

### DIFF
--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -47,13 +47,14 @@ export class AdminAppointmentsController {
     @Post()
     @ApiOperation({ summary: 'Create appointment' })
     @ApiResponse({ status: 201 })
-    create(@Body() dto: CreateAppointmentDto) {
+    create(@Body() dto: CreateAppointmentDto, @Request() req: AuthRequest) {
         return this.service.create(
             dto.clientId,
             dto.employeeId,
             dto.serviceId,
             dto.startTime,
             dto.notes,
+            req.user.id,
         );
     }
 

--- a/backend/src/appointments/appointments.service.spec.ts
+++ b/backend/src/appointments/appointments.service.spec.ts
@@ -94,6 +94,8 @@ describe('AppointmentsService', () => {
             2,
             3,
             '2100-07-01T10:00:00.000Z',
+            undefined,
+            7,
         );
 
         expect(repo.create).toHaveBeenCalledWith({
@@ -113,7 +115,7 @@ describe('AppointmentsService', () => {
                 serviceId: 3,
                 startTime: '2100-07-01T10:00:00.000Z',
             }),
-            1,
+            7,
         );
         expect(notifications.sendAppointmentConfirmation).toHaveBeenCalled();
         expect(result).toBe(created);
@@ -139,6 +141,7 @@ describe('AppointmentsService', () => {
             3,
             '2100-07-01T10:00:00.000Z',
             'bring tools',
+            7,
         );
 
         expect(repo.create).toHaveBeenCalledWith({

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -43,6 +43,7 @@ export class AppointmentsService {
         serviceId: number,
         startTime: string,
         notes?: string,
+        createdBy?: number,
     ): Promise<Appointment> {
         const start = new Date(startTime);
         if (start < new Date()) {
@@ -86,7 +87,7 @@ export class AppointmentsService {
         await this.logs.create(
             LogAction.CreateAppointment,
             JSON.stringify({ clientId, employeeId, serviceId, startTime }),
-            clientId,
+            createdBy ?? clientId,
         );
         if ((saved.client as ClientWithPhone)?.phone) {
             void this.notifications.sendAppointmentConfirmation(

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -72,6 +72,7 @@ export class ClientAppointmentsController {
             dto.serviceId,
             dto.startTime,
             dto.notes,
+            req.user.id,
         );
     }
 


### PR DESCRIPTION
## Summary
- allow AppointmentsService.create to accept a `createdBy` user ID and use it for log entries
- propagate request user ID from client and admin appointment controllers
- adjust tests for new optional parameter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fbac538188329a465446e55e0a481