### PR TITLE
feat: add appointment filters

### DIFF
--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -8,12 +8,14 @@ import {
     Post,
     UseGuards,
     Request,
+    Query,
 } from '@nestjs/common';
 import {
     ApiTags,
     ApiOperation,
     ApiResponse,
     ApiBearerAuth,
+    ApiQuery,
 } from '@nestjs/swagger';
 import { AppointmentsService } from './appointments.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -24,6 +26,7 @@ import { EmployeeRole } from '../employees/employee-role.enum';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 import { Request as ExpressRequest } from 'express';
+import { AppointmentStatus } from './appointment.entity';
 
 interface AuthRequest extends ExpressRequest {
     user: { id: number; role: Role | EmployeeRole };
@@ -40,8 +43,22 @@ export class AdminAppointmentsController {
     @Get()
     @ApiOperation({ summary: 'List all appointments' })
     @ApiResponse({ status: 200 })
-    list() {
-        return this.service.findAll();
+    @ApiQuery({ name: 'employeeId', required: false })
+    @ApiQuery({ name: 'startDate', required: false })
+    @ApiQuery({ name: 'endDate', required: false })
+    @ApiQuery({ name: 'status', enum: AppointmentStatus, required: false })
+    list(
+        @Query('employeeId') employeeId?: string,
+        @Query('startDate') startDate?: string,
+        @Query('endDate') endDate?: string,
+        @Query('status') status?: AppointmentStatus,
+    ) {
+        return this.service.findAll({
+            employeeId: employeeId ? Number(employeeId) : undefined,
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status,
+        });
     }
 
     @Post()

--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -113,8 +113,40 @@ export class AppointmentsService {
         return this.repo.find({ where: { employee: { id: employeeId } } });
     }
 
-    findAll() {
-        return this.repo.find();
+    findAll(filters?: {
+        employeeId?: number;
+        startDate?: Date;
+        endDate?: Date;
+        status?: AppointmentStatus;
+    }) {
+        const qb = this.repo
+            .createQueryBuilder('appointment')
+            .leftJoinAndSelect('appointment.client', 'client')
+            .leftJoinAndSelect('appointment.employee', 'employee')
+            .leftJoinAndSelect('appointment.service', 'service');
+
+        if (filters?.employeeId) {
+            qb.andWhere('appointment.employeeId = :employeeId', {
+                employeeId: filters.employeeId,
+            });
+        }
+        if (filters?.startDate) {
+            qb.andWhere('appointment.startTime >= :start', {
+                start: filters.startDate,
+            });
+        }
+        if (filters?.endDate) {
+            qb.andWhere('appointment.startTime <= :end', {
+                end: filters.endDate,
+            });
+        }
+        if (filters?.status) {
+            qb.andWhere('appointment.status = :status', {
+                status: filters.status,
+            });
+        }
+
+        return qb.getMany();
     }
 
     findOne(id: number) {


### PR DESCRIPTION
## Summary
- allow filtering appointments by employee, date range, and status
- wire admin appointments list to query parameters
- test appointment filtering logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbc2ff6388329aed08455b5202e03