### PR TITLE
feat: add appointment self endpoint

### DIFF
--- a/backend/src/appointments/appointments.module.ts
+++ b/backend/src/appointments/appointments.module.ts
@@ -5,6 +5,7 @@ import { AppointmentsService } from './appointments.service';
 import { ClientAppointmentsController } from './client-appointments.controller';
 import { EmployeeAppointmentsController } from './employee-appointments.controller';
 import { AdminAppointmentsController } from './admin-appointments.controller';
+import { MeAppointmentsController } from './me-appointments.controller';
 import { FormulasModule } from '../formulas/formulas.module';
 import { CommissionsModule } from '../commissions/commissions.module';
 import { LogsModule } from '../logs/logs.module';
@@ -24,6 +25,7 @@ import { ReminderService } from './reminder.service';
         ClientAppointmentsController,
         EmployeeAppointmentsController,
         AdminAppointmentsController,
+        MeAppointmentsController,
     ],
     providers: [AppointmentsService, ReminderService],
     exports: [AppointmentsService],

--- a/backend/src/appointments/me-appointments.controller.ts
+++ b/backend/src/appointments/me-appointments.controller.ts
@@ -1,0 +1,46 @@
+import {
+    Controller,
+    Get,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
+import {
+    ApiTags,
+    ApiOperation,
+    ApiResponse,
+    ApiBearerAuth,
+} from '@nestjs/swagger';
+import { AppointmentsService } from './appointments.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { Request as ExpressRequest } from 'express';
+import { EmployeeRole } from '../employees/employee-role.enum';
+
+interface AuthRequest extends ExpressRequest {
+    user: { id: number; role: Role | EmployeeRole };
+}
+
+@ApiTags('Appointments')
+@ApiBearerAuth()
+@Controller('appointments')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin, Role.Employee, Role.Client)
+export class MeAppointmentsController {
+    constructor(private readonly service: AppointmentsService) {}
+
+    @Get('me')
+    @ApiOperation({ summary: 'List appointments for current user' })
+    @ApiResponse({ status: 200 })
+    list(@Request() req: AuthRequest) {
+        const { id, role } = req.user;
+        if (role === Role.Client) {
+            return this.service.findClientAppointments(Number(id));
+        }
+        if (role === Role.Employee) {
+            return this.service.findEmployeeAppointments(Number(id));
+        }
+        return this.service.findAll();
+    }
+}

--- a/backend/test/appointments-me.e2e-spec.ts
+++ b/backend/test/appointments-me.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UsersService } from './../src/users/users.service';
+import { AppointmentsService } from './../src/appointments/appointments.service';
+import { Role } from './../src/users/role.enum';
+
+describe('Appointments /me endpoint (e2e)', () => {
+    let app: INestApplication<App>;
+    let users: UsersService;
+    let appointments: AppointmentsService;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+        await app.init();
+
+        users = moduleFixture.get(UsersService);
+        appointments = moduleFixture.get(AppointmentsService);
+    });
+
+    afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    it('returns appointments based on user role', async () => {
+        const client1 = await users.createUser(
+            'me-client1@test.com',
+            'secret',
+            'Client1',
+            Role.Client,
+        );
+        const client2 = await users.createUser(
+            'me-client2@test.com',
+            'secret',
+            'Client2',
+            Role.Client,
+        );
+        const emp1 = await users.createUser(
+            'me-emp1@test.com',
+            'secret',
+            'Emp1',
+            Role.Employee,
+        );
+        const emp2 = await users.createUser(
+            'me-emp2@test.com',
+            'secret',
+            'Emp2',
+            Role.Employee,
+        );
+        await users.createUser('me-admin@test.com', 'secret', 'Admin', Role.Admin);
+
+        const clientLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'me-client1@test.com', password: 'secret' })
+            .expect(201);
+        const clientToken = clientLogin.body.access_token as string;
+
+        const empLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'me-emp1@test.com', password: 'secret' })
+            .expect(201);
+        const empToken = empLogin.body.access_token as string;
+
+        const adminLogin = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send({ email: 'me-admin@test.com', password: 'secret' })
+            .expect(201);
+        const adminToken = adminLogin.body.access_token as string;
+
+        const start1 = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+        const start2 = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+        const appt1 = await appointments.create(client1.id, emp1.id, 1, start1);
+        await appointments.create(client2.id, emp2.id, 1, start2);
+
+        const clientRes = await request(app.getHttpServer())
+            .get('/appointments/me')
+            .set('Authorization', `Bearer ${clientToken}`)
+            .expect(200);
+        expect(Array.isArray(clientRes.body)).toBe(true);
+        expect(clientRes.body.length).toBe(1);
+        expect(clientRes.body[0].id).toBe(appt1.id);
+
+        const empRes = await request(app.getHttpServer())
+            .get('/appointments/me')
+            .set('Authorization', `Bearer ${empToken}`)
+            .expect(200);
+        expect(empRes.body.length).toBe(1);
+        expect(empRes.body[0].id).toBe(appt1.id);
+
+        const adminRes = await request(app.getHttpServer())
+            .get('/appointments/me')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(200);
+        expect(adminRes.body.length).toBe(2);
+    });
+});


### PR DESCRIPTION
## Summary
- allow authenticated users to fetch their own appointments via `/appointments/me`
- document new endpoint
- test role-based responses for clients, employees and admins

## Testing
- `npm test`
- `npm run test:e2e` *(fails: ProductsModule (e2e) › admin can bulk update stock, Customer update (e2e) › allows admin to update customer, AuthController (e2e) › /auth/register (POST) rejects duplicates)*
- `npm run test:e2e -- test/appointments-me.e2e-spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_688fbdb148108329b2a6c17aede10acb