### PR TITLE
Prevent deleting products with usage records

### DIFF
--- a/backend/src/products/products.module.ts
+++ b/backend/src/products/products.module.ts
@@ -8,10 +8,11 @@ import { Product } from '../catalog/product.entity';
 import { Sale } from '../sales/sale.entity';
 import { LogsModule } from '../logs/logs.module';
 import { ProductUsageModule } from '../product-usage/product-usage.module';
+import { ProductUsage } from '../product-usage/product-usage.entity';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([Product, Sale]),
+        TypeOrmModule.forFeature([Product, Sale, ProductUsage]),
         LogsModule,
         ProductUsageModule,
     ],


### PR DESCRIPTION
## Summary
- inject `ProductUsage` repository into `ProductsService`
- block product deletion when usage records exist
- register `ProductUsage` entity in `ProductsModule`
- expand unit tests for usage-based deletion conflicts

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc7e854f4832988e12daac2326889