### PR TITLE
feat: log stock corrections conditionally

### DIFF
--- a/backend/src/products/products.service.spec.ts
+++ b/backend/src/products/products.service.spec.ts
@@ -117,12 +117,7 @@ describe('ProductsService', () => {
         expect(usage.createStockCorrection).not.toHaveBeenCalled();
         expect(logs.create).toHaveBeenCalledWith(
             LogAction.UpdateProductStock,
-            JSON.stringify({
-                id: 1,
-                amount: 5,
-                stock: 15,
-                usageType: UsageType.STOCK_CORRECTION,
-            }),
+            JSON.stringify({ id: 1, amount: 5, stock: 15 }),
         );
     });
 
@@ -195,20 +190,12 @@ describe('ProductsService', () => {
         expect(logs.create).toHaveBeenNthCalledWith(
             1,
             LogAction.BulkUpdateProductStock,
-            JSON.stringify({
-                id: 1,
-                stock: 5,
-                usageType: UsageType.STOCK_CORRECTION,
-            }),
+            JSON.stringify({ id: 1, stock: 5 }),
         );
         expect(logs.create).toHaveBeenNthCalledWith(
             2,
             LogAction.BulkUpdateProductStock,
-            JSON.stringify({
-                id: 2,
-                stock: 3,
-                usageType: UsageType.STOCK_CORRECTION,
-            }),
+            JSON.stringify({ id: 2, stock: 3 }),
         );
         expect(usage.createStockCorrection).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- log product stock corrections only when stock decreases
- apply same conditional logging to bulk stock updates
- extend tests for stock increase and decrease logging

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68908a59e26083298cf40079345d44cc