### PR TITLE
feat: lock product for usage

### DIFF
--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -37,8 +37,10 @@ export class ProductUsageService {
                 if (quantity <= 0) {
                     throw new BadRequestException('quantity must be > 0');
                 }
+                // Acquire a pessimistic write lock to avoid concurrent stock modifications
                 const product = await manager.findOne(Product, {
                     where: { id: productId },
+                    lock: { mode: 'pessimistic_write' },
                 });
                 if (!product) {
                     throw new NotFoundException(


### PR DESCRIPTION
## Summary
- lock product rows when registering usage to prevent concurrent stock updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68909cff2ec883299653948ff91d9172