### PR TITLE
Validate product usage does not accept sales entries

### DIFF
--- a/backend/src/product-usage/appointment-product-usage.controller.spec.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.spec.ts
@@ -55,6 +55,25 @@ describe('AppointmentProductUsageController', () => {
         expect(res).toEqual({ sales: ['sale'], usage: ['usage'] });
     });
 
+    it('routes sale-only entries through sales service', async () => {
+        appointments.findOne.mockResolvedValue({
+            id: 1,
+            client: { id: 2 },
+            employee: { id: 3 },
+        });
+        sales.create.mockResolvedValue('sale');
+
+        const res = await controller.create(
+            '1',
+            [{ productId: 1, quantity: 1, usageType: UsageType.SALE }],
+            { user: { id: 3, role: Role.Employee } } as any,
+        );
+
+        expect(sales.create).toHaveBeenCalledWith(2, 3, 1, 1);
+        expect(usage.registerUsage).not.toHaveBeenCalled();
+        expect(res).toEqual({ sales: ['sale'], usage: [] });
+    });
+
     it('rejects sale entries without client', async () => {
         appointments.findOne.mockResolvedValue({
             id: 1,

--- a/backend/src/product-usage/product-usage.service.spec.ts
+++ b/backend/src/product-usage/product-usage.service.spec.ts
@@ -110,6 +110,18 @@ describe('ProductUsageService', () => {
         ).rejects.toBeInstanceOf(NotFoundException);
     });
 
+    it('rejects sale entries', async () => {
+        const manager = { findOne: jest.fn(), save: jest.fn() } as any;
+        repo.manager.transaction.mockImplementation(async (cb: any) =>
+            cb(manager),
+        );
+        await expect(
+            service.registerUsage(1, 2, [
+                { productId: 1, quantity: 1, usageType: UsageType.SALE },
+            ]),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
     it('prevents concurrent stock modifications', async () => {
         const product = { id: 1, stock: 1 };
         const manager = {

--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -34,6 +34,11 @@ export class ProductUsageService {
         return this.repo.manager.transaction(async (manager) => {
             const records: ProductUsage[] = [];
             for (const { productId, quantity, usageType } of entries) {
+                if (usageType === UsageType.SALE) {
+                    throw new BadRequestException(
+                        'sale entries must be registered via SalesService',
+                    );
+                }
                 if (quantity <= 0) {
                     throw new BadRequestException('quantity must be > 0');
                 }


### PR DESCRIPTION
## Summary
- reject UsageType.SALE in ProductUsageService.registerUsage and require SalesService for sales
- add tests ensuring sale entries are routed through SalesService and rejected by registerUsage

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c3a08120832993f7df60063b55a0