### PR TITLE
feat: link sales to appointments

### DIFF
--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -114,9 +114,12 @@ export class ProductUsageService {
         quantity: number,
         stock: number,
         employeeId: number,
+        appointmentId?: number,
     ) {
         const usage = this.repo.create({
-            appointment: null,
+            appointment: appointmentId
+                ? ({ id: appointmentId } as any)
+                : null,
             product: { id: productId } as any,
             quantity,
             usageType: UsageType.SALE,
@@ -126,6 +129,7 @@ export class ProductUsageService {
         await this.logs.create(
             LogAction.ProductUsed,
             JSON.stringify({
+                appointmentId: appointmentId ?? undefined,
                 productId,
                 quantity,
                 usageType: UsageType.SALE,

--- a/backend/src/sales/dto/create-sale.dto.ts
+++ b/backend/src/sales/dto/create-sale.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, Min } from 'class-validator';
+import { IsInt, Min, IsOptional } from 'class-validator';
 
 export class CreateSaleDto {
     @IsInt()
@@ -13,4 +13,8 @@ export class CreateSaleDto {
     @IsInt()
     @Min(1)
     quantity: number;
+
+    @IsInt()
+    @IsOptional()
+    appointmentId?: number;
 }

--- a/backend/src/sales/sales.controller.ts
+++ b/backend/src/sales/sales.controller.ts
@@ -19,6 +19,7 @@ export class SalesController {
             dto.employeeId,
             dto.productId,
             dto.quantity,
+            dto.appointmentId,
         );
     }
 }

--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -47,7 +47,7 @@ describe('SalesService', () => {
         );
         commissionService.getPercentForProduct.mockResolvedValue(0);
 
-        const sale = await service.create(1, 2, 1, 2);
+        const sale = await service.create(1, 2, 1, 2, 3);
 
         expect(manager.findOne).toHaveBeenCalledWith(Product, {
             where: { id: 1 },
@@ -58,7 +58,7 @@ describe('SalesService', () => {
             stock: 3,
             unitPrice: 10,
         });
-        expect(usage.createSale).toHaveBeenCalledWith(1, 2, 3, 2);
+        expect(usage.createSale).toHaveBeenCalledWith(1, 2, 3, 2, 3);
         expect(sale.id).toBe(1);
     });
 });

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -25,6 +25,7 @@ export class SalesService {
         employeeId: number,
         productId: number,
         quantity: number,
+        appointmentId?: number,
     ) {
         if (quantity <= 0) {
             throw new BadRequestException('quantity must be > 0');
@@ -78,6 +79,7 @@ export class SalesService {
             quantity,
             updatedStock,
             employeeId,
+            appointmentId,
         );
 
         return saved;


### PR DESCRIPTION
## Summary
- allow recording appointment ID for sales
- persist appointment linkage in product usage
- test sale product usage is associated with appointments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c6b525148329a994f31f51cb8059