### PR TITLE
Restrict appointment product usage types

### DIFF
--- a/backend/src/product-usage/appointment-product-usage.controller.spec.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.spec.ts
@@ -2,91 +2,49 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AppointmentProductUsageController } from './appointment-product-usage.controller';
 import { ProductUsageService } from './product-usage.service';
 import { AppointmentsService } from '../appointments/appointments.service';
-import { SalesService } from '../sales/sales.service';
 import { Role } from '../users/role.enum';
 import { UsageType } from './usage-type.enum';
-import { BadRequestException } from '@nestjs/common';
 
 describe('AppointmentProductUsageController', () => {
     let controller: AppointmentProductUsageController;
     let usage: { registerUsage: jest.Mock };
     let appointments: { findOne: jest.Mock };
-    let sales: { create: jest.Mock };
 
     beforeEach(async () => {
         usage = { registerUsage: jest.fn() } as any;
         appointments = { findOne: jest.fn() } as any;
-        sales = { create: jest.fn() } as any;
 
         const module: TestingModule = await Test.createTestingModule({
             controllers: [AppointmentProductUsageController],
             providers: [
                 { provide: ProductUsageService, useValue: usage },
                 { provide: AppointmentsService, useValue: appointments },
-                { provide: SalesService, useValue: sales },
             ],
         }).compile();
 
         controller = module.get(AppointmentProductUsageController);
     });
 
-    it('splits sale and usage entries', async () => {
+    it('registers usage entries with default INTERNAL type', async () => {
         appointments.findOne.mockResolvedValue({
             id: 1,
-            client: { id: 2 },
             employee: { id: 3 },
         });
         usage.registerUsage.mockResolvedValue(['usage']);
-        sales.create.mockResolvedValue('sale');
 
         const res = await controller.create(
             '1',
             [
                 { productId: 1, quantity: 1 },
-                { productId: 2, quantity: 2, usageType: UsageType.SALE },
+                { productId: 2, quantity: 2, usageType: UsageType.STOCK_CORRECTION },
             ],
             { user: { id: 3, role: Role.Employee } } as any,
         );
 
-        expect(sales.create).toHaveBeenCalledWith(2, 3, 2, 2);
         expect(usage.registerUsage).toHaveBeenCalledWith(1, 3, [
             { productId: 1, quantity: 1, usageType: UsageType.INTERNAL },
+            { productId: 2, quantity: 2, usageType: UsageType.STOCK_CORRECTION },
         ]);
-        expect(res).toEqual({ sales: ['sale'], usage: ['usage'] });
-    });
-
-    it('routes sale-only entries through sales service', async () => {
-        appointments.findOne.mockResolvedValue({
-            id: 1,
-            client: { id: 2 },
-            employee: { id: 3 },
-        });
-        sales.create.mockResolvedValue('sale');
-
-        const res = await controller.create(
-            '1',
-            [{ productId: 1, quantity: 1, usageType: UsageType.SALE }],
-            { user: { id: 3, role: Role.Employee } } as any,
-        );
-
-        expect(sales.create).toHaveBeenCalledWith(2, 3, 1, 1);
-        expect(usage.registerUsage).not.toHaveBeenCalled();
-        expect(res).toEqual({ sales: ['sale'], usage: [] });
-    });
-
-    it('rejects sale entries without client', async () => {
-        appointments.findOne.mockResolvedValue({
-            id: 1,
-            client: null,
-            employee: { id: 3 },
-        });
-        await expect(
-            controller.create(
-                '1',
-                [{ productId: 1, quantity: 1, usageType: UsageType.SALE }],
-                { user: { id: 3, role: Role.Employee } } as any,
-            ),
-        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(res).toEqual({ usage: ['usage'] });
     });
 });
-

--- a/backend/src/product-usage/dto/appointment-product-usage-entry.dto.spec.ts
+++ b/backend/src/product-usage/dto/appointment-product-usage-entry.dto.spec.ts
@@ -1,0 +1,32 @@
+import { validate } from 'class-validator';
+import { AppointmentProductUsageEntryDto } from './appointment-product-usage-entry.dto';
+import { UsageType } from '../usage-type.enum';
+
+describe('AppointmentProductUsageEntryDto', () => {
+    it('rejects SALE usageType', async () => {
+        const dto = new AppointmentProductUsageEntryDto();
+        dto.productId = 1;
+        dto.quantity = 1;
+        dto.usageType = UsageType.SALE as any;
+        const errors = await validate(dto);
+        expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('accepts INTERNAL usageType', async () => {
+        const dto = new AppointmentProductUsageEntryDto();
+        dto.productId = 1;
+        dto.quantity = 1;
+        dto.usageType = UsageType.INTERNAL;
+        const errors = await validate(dto);
+        expect(errors).toHaveLength(0);
+    });
+
+    it('accepts STOCK_CORRECTION usageType', async () => {
+        const dto = new AppointmentProductUsageEntryDto();
+        dto.productId = 1;
+        dto.quantity = 1;
+        dto.usageType = UsageType.STOCK_CORRECTION;
+        const errors = await validate(dto);
+        expect(errors).toHaveLength(0);
+    });
+});

--- a/backend/src/product-usage/dto/appointment-product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/appointment-product-usage-entry.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsInt, Min } from 'class-validator';
+import { UsageType } from '../usage-type.enum';
+
+const allowedUsageTypes = [UsageType.INTERNAL, UsageType.STOCK_CORRECTION] as const;
+export type AppointmentUsageType = (typeof allowedUsageTypes)[number];
+
+export class AppointmentProductUsageEntryDto {
+    @ApiProperty()
+    @IsInt()
+    productId: number;
+
+    @ApiProperty({ minimum: 1 })
+    @IsInt()
+    @Min(1)
+    quantity: number;
+
+    @IsEnum(allowedUsageTypes)
+    @ApiProperty({
+        enum: allowedUsageTypes,
+        required: false,
+        description: 'Usage classification. Allowed values: INTERNAL or STOCK_CORRECTION. Defaults to INTERNAL when omitted.',
+    })
+    usageType?: AppointmentUsageType;
+}
+
+export { allowedUsageTypes as appointmentUsageTypes };

--- a/backend/src/product-usage/product-usage.module.ts
+++ b/backend/src/product-usage/product-usage.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProductUsage } from './product-usage.entity';
 import { Product } from '../catalog/product.entity';
@@ -7,14 +7,12 @@ import { ProductUsageService } from './product-usage.service';
 import { AppointmentProductUsageController } from './appointment-product-usage.controller';
 import { ProductUsageController } from './product-usage.controller';
 import { AppointmentsModule } from '../appointments/appointments.module';
-import { SalesModule } from '../sales/sales.module';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([ProductUsage, Product]),
         LogsModule,
         AppointmentsModule,
-        forwardRef(() => SalesModule),
     ],
     controllers: [AppointmentProductUsageController, ProductUsageController],
     providers: [ProductUsageService],


### PR DESCRIPTION
## Summary
- limit appointment product usage type to INTERNAL or STOCK_CORRECTION
- remove sale handling from appointment product usage controller
- cover new DTO with validation and e2e tests

## Testing
- `npm test`
- `npm run test:e2e -- test/product-usage.e2e-spec.ts` *(fails: LockNotSupportedOnGivenDriverError)*

------
https://chatgpt.com/codex/tasks/task_e_6890cf2db7908329b4c9fd90c505a70e