### PR TITLE
feat: validate product usage productId

### DIFF
--- a/backend/src/product-usage/dto/product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/product-usage-entry.dto.ts
@@ -5,6 +5,7 @@ import { UsageType } from '../usage-type.enum';
 export class ProductUsageEntryDto {
     @ApiProperty()
     @IsInt()
+    @Min(1)
     productId: number;
 
     @ApiProperty({ minimum: 1 })


### PR DESCRIPTION
## Summary
- ensure product usage entries require productId >= 1
- test 400 status when productId is 0

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d3b90328832991578edc9f284074