### PR TITLE
Use ParseIntPipe for appointment product usage ID

### DIFF
--- a/backend/src/product-usage/appointment-product-usage.controller.spec.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.spec.ts
@@ -33,7 +33,7 @@ describe('AppointmentProductUsageController', () => {
         usage.registerUsage.mockResolvedValue(['usage']);
 
         const res = await controller.create(
-            '1',
+            1,
             [
                 { productId: 1, quantity: 1 },
                 { productId: 2, quantity: 2, usageType: UsageType.STOCK_CORRECTION },

--- a/backend/src/product-usage/appointment-product-usage.controller.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.ts
@@ -3,6 +3,7 @@ import {
     Controller,
     Param,
     Post,
+    ParseIntPipe,
     Request,
     UseGuards,
     NotFoundException,
@@ -56,11 +57,11 @@ export class AppointmentProductUsageController {
             'Each entry may specify a usageType; allowed values: INTERNAL or STOCK_CORRECTION. Defaults to INTERNAL.',
     })
     async create(
-        @Param('id') id: string,
+        @Param('id', ParseIntPipe) id: number,
         @Body() body: AppointmentProductUsageEntryDto[],
         @Request() req: AuthRequest,
     ) {
-        const appt = await this.appointments.findOne(Number(id));
+        const appt = await this.appointments.findOne(id);
         if (!appt) {
             throw new NotFoundException();
         }
@@ -74,7 +75,7 @@ export class AppointmentProductUsageController {
 
         const usageRecords = entries.length
             ? await this.usage.registerUsage(
-                  Number(id),
+                  id,
                   req.user.id,
                   entries,
               )


### PR DESCRIPTION
## Summary
- parse numeric appointment ID with `ParseIntPipe` in product usage controller
- adjust controller test to pass numeric ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890da3386088329bd02daa6df880cf0