### PR TITLE
Ensure product usage logs include appointment ID

### DIFF
--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -99,6 +99,7 @@ export class ProductUsageService {
         await this.logs.create(
             LogAction.ProductUsed,
             JSON.stringify({
+                appointmentId: null,
                 productId,
                 quantity,
                 usageType: UsageType.STOCK_CORRECTION,
@@ -129,7 +130,7 @@ export class ProductUsageService {
         await this.logs.create(
             LogAction.ProductUsed,
             JSON.stringify({
-                appointmentId: appointmentId ?? undefined,
+                appointmentId: appointmentId ?? null,
                 productId,
                 quantity,
                 usageType: UsageType.SALE,

--- a/backend/test/product-usage.e2e-spec.ts
+++ b/backend/test/product-usage.e2e-spec.ts
@@ -100,9 +100,17 @@ describe('ProductUsage (e2e)', () => {
             .query({ action: 'PRODUCT_USED' })
             .expect(200);
         expect(
-            logs.body.some((l: any) =>
-                l.description.includes(`"productId":${product.id}`),
-            ),
+            logs.body.some((l: any) => {
+                const desc = JSON.parse(l.description);
+                return (
+                    'appointmentId' in desc &&
+                    'productId' in desc &&
+                    'usageType' in desc &&
+                    'quantity' in desc &&
+                    'stock' in desc &&
+                    desc.productId === product.id
+                );
+            }),
         ).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
- Include `appointmentId: null` in stock correction log payloads
- Always log `appointmentId`, `productId`, `usageType`, `quantity`, and `stock`
- Verify logs in e2e tests by parsing JSON descriptions

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689100f4d8cc8329b2d5430e62b0b1af