### PR TITLE
Use ConfigService for JWT secrets

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
@@ -14,9 +15,19 @@ import { LogsModule } from '../logs/logs.module';
     imports: [
         UsersModule,
         LogsModule,
-        JwtModule.register({
-            secret: process.env.JWT_SECRET ?? 'secret',
-            signOptions: { expiresIn: '1h' },
+        ConfigModule,
+        JwtModule.registerAsync({
+            inject: [ConfigService],
+            useFactory: (config: ConfigService) => {
+                const secret = config.get<string>('JWT_SECRET');
+                if (!secret) {
+                    throw new Error('JWT_SECRET is not defined');
+                }
+                return {
+                    secret,
+                    signOptions: { expiresIn: '1h' },
+                };
+            },
         }),
     ],
     providers: [

--- a/backend/src/auth/auth.service.register.spec.ts
+++ b/backend/src/auth/auth.service.register.spec.ts
@@ -7,6 +7,7 @@ import { Role } from '../users/role.enum';
 import { RegisterClientDto } from './dto/register-client.dto';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
+import { ConfigService } from '@nestjs/config';
 
 describe('AuthService.registerClient', () => {
     let service: AuthService;
@@ -17,6 +18,7 @@ describe('AuthService.registerClient', () => {
     };
     let jwt: { signAsync: jest.Mock };
     let logs: { create: jest.Mock };
+    let config: { get: jest.Mock };
 
     beforeEach(async () => {
         users = {
@@ -26,6 +28,11 @@ describe('AuthService.registerClient', () => {
         };
         jwt = { signAsync: jest.fn() };
         logs = { create: jest.fn() };
+        config = {
+            get: jest.fn((key: string) =>
+                key === 'JWT_REFRESH_SECRET' ? 'refresh-secret' : undefined,
+            ),
+        };
 
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -33,6 +40,7 @@ describe('AuthService.registerClient', () => {
                 { provide: UsersService, useValue: users },
                 { provide: JwtService, useValue: jwt },
                 { provide: LogsService, useValue: logs },
+                { provide: ConfigService, useValue: config },
             ],
         }).compile();
 

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { UsersService } from '../users/users.service';
 import { Role } from '../users/role.enum';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
+import { ConfigService } from '@nestjs/config';
 
 describe('AuthService', () => {
     let service: AuthService;
@@ -17,6 +18,7 @@ describe('AuthService', () => {
     };
     let jwt: { signAsync: jest.Mock; verifyAsync: jest.Mock };
     let logs: { create: jest.Mock };
+    let config: { get: jest.Mock };
 
     beforeEach(async () => {
         users = {
@@ -26,6 +28,11 @@ describe('AuthService', () => {
         };
         jwt = { signAsync: jest.fn(), verifyAsync: jest.fn() };
         logs = { create: jest.fn() };
+        config = {
+            get: jest.fn((key: string) =>
+                key === 'JWT_REFRESH_SECRET' ? 'refresh-secret' : undefined,
+            ),
+        };
 
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -33,6 +40,7 @@ describe('AuthService', () => {
                 { provide: UsersService, useValue: users },
                 { provide: JwtService, useValue: jwt },
                 { provide: LogsService, useValue: logs },
+                { provide: ConfigService, useValue: config },
             ],
         }).compile();
 


### PR DESCRIPTION
## Summary
- configure JWT module via ConfigService and fail fast when `JWT_SECRET` is missing
- inject ConfigService into AuthService to supply `JWT_REFRESH_SECRET`
- update unit tests to mock ConfigService for token secrets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910c3b52608329a742f355e23f07d6