### PR TITLE
Ensure seeded passwords are hashed

### DIFF
--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -9,6 +9,11 @@ import { Repository } from 'typeorm';
 import { Appointment } from '../appointments/appointment.entity';
 import { LogsService } from '../logs/logs.service';
 
+/**
+ * Reminder: when seeding users in tests or scripts, ensure passwords are
+ * hashed using bcrypt. UsersService.createUser applies a 10 round hash and the
+ * test below guards against storing plaintext values.
+ */
 describe('UsersService', () => {
     let service: UsersService;
     let repo: {

--- a/frontend/design/laravel-frontend/database/seeders/AdminUserSeeder.php
+++ b/frontend/design/laravel-frontend/database/seeders/AdminUserSeeder.php
@@ -1,6 +1,8 @@
 <?php
 
 // database/seeders/AdminUserSeeder.php
+// Always hash seeded passwords. Hash::make uses bcrypt; explicitly set rounds
+// so future updates don't accidentally store plaintext values.
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
@@ -9,15 +11,16 @@ use Illuminate\Support\Facades\Hash;
 
 class AdminUserSeeder extends Seeder
 {
-	public function run()
-	{
-		User::updateOrCreate(
-			['email' => 'admin@salon-bw.pl'],
-			[
-				'name' => 'Admin',
-				'password' => Hash::make('SuperSecureHasło!123'),
-				'role' => 'admin',
-			]
-		);
-	}
+        public function run()
+        {
+                User::updateOrCreate(
+                        ['email' => 'admin@salon-bw.pl'],
+                        [
+                                'name' => 'Admin',
+                                // Hash password with bcrypt using 10 rounds
+                                'password' => Hash::make('SuperSecureHasło!123', ['rounds' => 10]),
+                                'role' => 'admin',
+                        ]
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- Hash seeded admin password with bcrypt and document hashing requirements
- Add reminder comment in UsersService tests about bcrypt seeding

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689115fb10988329aad2210131352874