### PR TITLE
chore: remove test notifications endpoint

### DIFF
--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,9 +1,6 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { Public } from '../auth/public.decorator';
-import {
-    NotificationsService,
-    NotificationType,
-} from './notifications.service';
+import { NotificationsService } from './notifications.service';
 
 @Controller('notifications')
 export class NotificationsController {
@@ -13,13 +10,5 @@ export class NotificationsController {
     @Public()
     list() {
         return this.service.findAll();
-    }
-
-    @Post('test')
-    @Public()
-    test(
-        @Body() body: { to: string; message: string; type: NotificationType },
-    ) {
-        return this.service.sendNotification(body.to, body.message, body.type);
     }
 }

--- a/backend/test/notifications.e2e-spec.ts
+++ b/backend/test/notifications.e2e-spec.ts
@@ -25,15 +25,11 @@ describe('Notifications (e2e)', () => {
         delete process.env.NOTIFICATIONS_ENABLED;
     });
 
-    it('creates log entry when sending test notification', async () => {
-        await request(app.getHttpServer())
-            .post('/notifications/test')
-            .send({ to: '+111', message: 'hi', type: 'sms' })
-            .expect(201);
-
+    it('returns list of notifications', async () => {
         const res = await request(app.getHttpServer())
             .get('/notifications')
             .expect(200);
-        expect(res.body.length).toBeGreaterThanOrEqual(1);
+
+        expect(Array.isArray(res.body)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- remove public /notifications/test endpoint
- update notifications e2e test to verify notification listing

## Testing
- `npm test`
- `npm run test:e2e -- test/notifications.e2e-spec.ts` *(fails: Nest can't resolve dependencies of the JWT module and SQLITE_BUSY: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_689133feff08832986f76dd31599e82e