### PR TITLE
refactor: centralize appointment notification helpers

### DIFF
--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -80,4 +80,30 @@ describe('NotificationsService', () => {
         await service.followUpCron();
         expect(whatsapp.sendText).toHaveBeenCalled();
     });
+
+    it('sendAppointmentConfirmation sends WhatsApp message', async () => {
+        const when = new Date('2025-01-01T10:00:00Z');
+        await service.sendAppointmentConfirmation('123', when);
+        expect(whatsapp.sendText).toHaveBeenCalledWith(
+            '123',
+            `Twoja wizyta została umówiona na ${when.toLocaleString()}`,
+        );
+    });
+
+    it('sendAppointmentReminder sends WhatsApp message', async () => {
+        const when = new Date('2025-01-02T15:00:00Z');
+        await service.sendAppointmentReminder('456', when);
+        expect(whatsapp.sendText).toHaveBeenCalledWith(
+            '456',
+            `Przypomnienie: wizyta ${when.toLocaleString()}`,
+        );
+    });
+
+    it('sendThankYou sends WhatsApp message', async () => {
+        await service.sendThankYou('789');
+        expect(whatsapp.sendText).toHaveBeenCalledWith(
+            '789',
+            'Dziękujemy za wizytę!',
+        );
+    });
 });

--- a/backend/src/notifications/whatsapp.service.ts
+++ b/backend/src/notifications/whatsapp.service.ts
@@ -109,18 +109,4 @@ export class WhatsappService {
         }
     }
 
-    async sendAppointmentConfirmation(to: string, when: Date) {
-        const text = `Twoja wizyta została umówiona na ${when.toLocaleString()}`;
-        return this.sendText(to, text);
-    }
-
-    async sendAppointmentReminder(to: string, when: Date) {
-        const text = `Przypomnienie: wizyta ${when.toLocaleString()}`;
-        return this.sendText(to, text);
-    }
-
-    async sendThankYou(to: string) {
-        const text = 'Dziękujemy za wizytę!';
-        return this.sendText(to, text);
-    }
 }


### PR DESCRIPTION
## Summary
- centralize appointment-specific notification helpers in `NotificationsService`
- drop redundant appointment helpers from `WhatsappService`
- add unit tests for appointment notification helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891c169c73083298ede78b453fadc05