### PR TITLE
feat: use enum for notification channel

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -20,6 +20,7 @@ import { UpdateAppointmentParams } from './dto/update-appointment-params';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
 import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationChannel } from '../notifications/notification.entity';
 import { ClientWithPhone, EmployeeWithPhone } from './phone-interfaces';
 
 @Injectable()
@@ -99,7 +100,7 @@ export class AppointmentsService {
             void this.notifications.sendNotification(
                 (saved.employee as EmployeeWithPhone).phone!,
                 `Nowa rezerwacja ${saved.startTime.toLocaleString()}`,
-                'whatsapp',
+                NotificationChannel.Whatsapp,
             );
         }
         return saved;

--- a/backend/src/migrations/20250711192022-NotificationChannelEnum.ts
+++ b/backend/src/migrations/20250711192022-NotificationChannelEnum.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NotificationChannelEnum20250711192022 implements MigrationInterface {
+    name = 'NotificationChannelEnum20250711192022';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TYPE \"notification_type_enum\" AS ENUM('sms', 'whatsapp')",
+        );
+        await queryRunner.query(
+            "UPDATE \"notification\" SET \"type\"='whatsapp' WHERE \"type\" NOT IN ('sms','whatsapp')",
+        );
+        await queryRunner.query(
+            'ALTER TABLE "notification" ALTER COLUMN "type" TYPE "notification_type_enum" USING "type"::text::"notification_type_enum"',
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "notification" ALTER COLUMN "type" TYPE varchar',
+        );
+        await queryRunner.query('DROP TYPE "notification_type_enum"');
+    }
+}

--- a/backend/src/notifications/notification.entity.ts
+++ b/backend/src/notifications/notification.entity.ts
@@ -5,6 +5,11 @@ import {
     CreateDateColumn,
 } from 'typeorm';
 
+export enum NotificationChannel {
+    Sms = 'sms',
+    Whatsapp = 'whatsapp',
+}
+
 export enum NotificationStatus {
     Pending = 'pending',
     Sent = 'sent',
@@ -19,8 +24,8 @@ export class Notification {
     @Column()
     recipient: string;
 
-    @Column()
-    type: string;
+    @Column({ type: 'simple-enum', enum: NotificationChannel })
+    type: NotificationChannel;
 
     @Column('text')
     message: string;

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -5,7 +5,11 @@ import { Appointment, AppointmentStatus } from '../appointments/appointment.enti
 import { NotificationsService } from './notifications.service';
 import { SmsService } from './sms.service';
 import { WhatsappService } from './whatsapp.service';
-import { Notification, NotificationStatus } from './notification.entity';
+import {
+    Notification,
+    NotificationStatus,
+    NotificationChannel,
+} from './notification.entity';
 
 describe('NotificationsService', () => {
     let service: NotificationsService;
@@ -32,13 +36,17 @@ describe('NotificationsService', () => {
     });
 
     it('uses SMS adapter when type sms', async () => {
-        await service.sendNotification('1', 'msg', 'sms');
+        await service.sendNotification('1', 'msg', NotificationChannel.Sms);
         expect(sms.sendSms).toHaveBeenCalledWith('1', 'msg');
         expect(whatsapp.sendText).not.toHaveBeenCalled();
     });
 
     it('uses WhatsApp adapter when type whatsapp', async () => {
-        await service.sendNotification('1', 'msg', 'whatsapp');
+        await service.sendNotification(
+            '1',
+            'msg',
+            NotificationChannel.Whatsapp,
+        );
         expect(whatsapp.sendText).toHaveBeenCalledWith('1', 'msg');
         expect(sms.sendSms).not.toHaveBeenCalled();
     });
@@ -48,7 +56,7 @@ describe('NotificationsService', () => {
         const notif = (await service.sendNotification(
             '1',
             'msg',
-            'whatsapp',
+            NotificationChannel.Whatsapp,
         )) as Notification;
         expect(notif.status).toBe(NotificationStatus.Failed);
     });

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -8,9 +8,11 @@ import {
 } from '../appointments/appointment.entity';
 import { SmsService } from './sms.service';
 import { WhatsappService } from './whatsapp.service';
-import { Notification, NotificationStatus } from './notification.entity';
-
-export type NotificationType = 'sms' | 'whatsapp';
+import {
+    Notification,
+    NotificationStatus,
+    NotificationChannel,
+} from './notification.entity';
 
 @Injectable()
 export class NotificationsService {
@@ -27,7 +29,7 @@ export class NotificationsService {
     async sendNotification(
         to: string,
         message: string,
-        type: NotificationType,
+        type: NotificationChannel,
     ) {
         if (process.env.NOTIFICATIONS_ENABLED === 'false') {
             const fake = this.repo.create({
@@ -47,7 +49,7 @@ export class NotificationsService {
         });
         await this.repo.save(notif);
         try {
-            if (type === 'sms') {
+            if (type === NotificationChannel.Sms) {
                 await this.sms.sendSms(to, message);
             } else {
                 await this.whatsapp.sendText(to, message);
@@ -64,17 +66,29 @@ export class NotificationsService {
 
     sendAppointmentConfirmation(to: string, when: Date) {
         const text = `Twoja wizyta została umówiona na ${when.toLocaleString()}`;
-        return this.sendNotification(to, text, 'whatsapp');
+        return this.sendNotification(
+            to,
+            text,
+            NotificationChannel.Whatsapp,
+        );
     }
 
     sendAppointmentReminder(to: string, when: Date) {
         const text = `Przypomnienie: wizyta ${when.toLocaleString()}`;
-        return this.sendNotification(to, text, 'whatsapp');
+        return this.sendNotification(
+            to,
+            text,
+            NotificationChannel.Whatsapp,
+        );
     }
 
     sendThankYou(to: string) {
         const text = 'Dziękujemy za wizytę!';
-        return this.sendNotification(to, text, 'whatsapp');
+        return this.sendNotification(
+            to,
+            text,
+            NotificationChannel.Whatsapp,
+        );
     }
 
     @Cron('0 7 * * *')

--- a/backend/test/dashboard.e2e-spec.ts
+++ b/backend/test/dashboard.e2e-spec.ts
@@ -7,6 +7,7 @@ import { UsersService } from './../src/users/users.service';
 import { AppointmentsService } from './../src/appointments/appointments.service';
 import { ReviewsService } from './../src/reviews/reviews.service';
 import { NotificationsService } from './../src/notifications/notifications.service';
+import { NotificationChannel } from './../src/notifications/notification.entity';
 import { Role } from './../src/users/role.enum';
 import { EmployeeCommission } from './../src/commissions/employee-commission.entity';
 import { Repository } from 'typeorm';
@@ -84,7 +85,7 @@ describe('Dashboard (e2e)', () => {
         await notifications.sendNotification(
             client.phone as string,
             'hi',
-            'whatsapp',
+            NotificationChannel.Whatsapp,
         );
         const res = await request(app.getHttpServer())
             .get('/dashboard')


### PR DESCRIPTION
## Summary
- add NotificationChannel enum for sms and whatsapp
- persist notification channel as simple-enum
- adjust services, tests, and migrations to use the enum

## Testing
- `npm test`
- `npm run test:e2e` *(fails: SQLITE_BUSY: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_6891c458f8288329a91313b16b21a11c