### PR TITLE
refactor: extract notification channel enum

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -20,7 +20,7 @@ import { UpdateAppointmentParams } from './dto/update-appointment-params';
 import { LogsService } from '../logs/logs.service';
 import { LogAction } from '../logs/action.enum';
 import { NotificationsService } from '../notifications/notifications.service';
-import { NotificationChannel } from '../notifications/notification.entity';
+import { NotificationChannel } from '../notifications/notification-channel.enum';
 import { ClientWithPhone, EmployeeWithPhone } from './phone-interfaces';
 
 @Injectable()

--- a/backend/src/notifications/notification-channel.enum.ts
+++ b/backend/src/notifications/notification-channel.enum.ts
@@ -1,0 +1,4 @@
+export enum NotificationChannel {
+    Sms = 'sms',
+    Whatsapp = 'whatsapp',
+}

--- a/backend/src/notifications/notification.entity.ts
+++ b/backend/src/notifications/notification.entity.ts
@@ -4,11 +4,7 @@ import {
     Column,
     CreateDateColumn,
 } from 'typeorm';
-
-export enum NotificationChannel {
-    Sms = 'sms',
-    Whatsapp = 'whatsapp',
-}
+import { NotificationChannel } from './notification-channel.enum';
 
 export enum NotificationStatus {
     Pending = 'pending',

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -8,8 +8,8 @@ import { WhatsappService } from './whatsapp.service';
 import {
     Notification,
     NotificationStatus,
-    NotificationChannel,
 } from './notification.entity';
+import { NotificationChannel } from './notification-channel.enum';
 
 describe('NotificationsService', () => {
     let service: NotificationsService;

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -11,8 +11,8 @@ import { WhatsappService } from './whatsapp.service';
 import {
     Notification,
     NotificationStatus,
-    NotificationChannel,
 } from './notification.entity';
+import { NotificationChannel } from './notification-channel.enum';
 
 @Injectable()
 export class NotificationsService {

--- a/backend/test/dashboard.e2e-spec.ts
+++ b/backend/test/dashboard.e2e-spec.ts
@@ -7,7 +7,7 @@ import { UsersService } from './../src/users/users.service';
 import { AppointmentsService } from './../src/appointments/appointments.service';
 import { ReviewsService } from './../src/reviews/reviews.service';
 import { NotificationsService } from './../src/notifications/notifications.service';
-import { NotificationChannel } from './../src/notifications/notification.entity';
+import { NotificationChannel } from './../src/notifications/notification-channel.enum';
 import { Role } from './../src/users/role.enum';
 import { EmployeeCommission } from './../src/commissions/employee-commission.entity';
 import { Repository } from 'typeorm';


### PR DESCRIPTION
## Summary
- centralize notification channel enum definition
- use enum across notification entity, services, tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891cdcadf44832985be3072de13e408