### PR TITLE
feat: skip disabled notifications

### DIFF
--- a/backend/src/migrations/20250711192033-AddNotificationStatusSkipped.ts
+++ b/backend/src/migrations/20250711192033-AddNotificationStatusSkipped.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotificationStatusSkipped20250711192033 implements MigrationInterface {
+    name = 'AddNotificationStatusSkipped20250711192033';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TYPE \"notification_status_enum\" AS ENUM('pending', 'sent', 'failed', 'skipped')",
+        );
+        await queryRunner.query(
+            "UPDATE \"notification\" SET \"status\"='sent' WHERE \"status\" NOT IN ('pending','sent','failed','skipped')",
+        );
+        await queryRunner.query(
+            'ALTER TABLE "notification" ALTER COLUMN "status" TYPE "notification_status_enum" USING "status"::text::"'
+            + 'notification_status_enum"',
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "notification" ALTER COLUMN "status" TYPE varchar',
+        );
+        await queryRunner.query('DROP TYPE "notification_status_enum"');
+    }
+}

--- a/backend/src/notifications/notification.entity.ts
+++ b/backend/src/notifications/notification.entity.ts
@@ -10,6 +10,7 @@ export enum NotificationStatus {
     Pending = 'pending',
     Sent = 'sent',
     Failed = 'failed',
+    Skipped = 'skipped',
 }
 
 @Entity()

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -21,7 +21,10 @@ describe('NotificationsService', () => {
     beforeEach(async () => {
         sms = { sendSms: jest.fn() };
         whatsapp = { sendText: jest.fn() };
-        repo = { create: jest.fn((x) => x), save: jest.fn() } as any;
+        repo = {
+            create: jest.fn((x) => x),
+            save: jest.fn(async (x) => x),
+        } as any;
         appts = { find: jest.fn() };
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -59,6 +62,17 @@ describe('NotificationsService', () => {
             NotificationChannel.Whatsapp,
         )) as Notification;
         expect(notif.status).toBe(NotificationStatus.Failed);
+    });
+
+    it('records skipped status when notifications are disabled', async () => {
+        process.env.NOTIFICATIONS_ENABLED = 'false';
+        const notif = (await service.sendNotification(
+            '1',
+            'msg',
+            NotificationChannel.Sms,
+        )) as Notification;
+        expect(notif.status).toBe(NotificationStatus.Skipped);
+        delete process.env.NOTIFICATIONS_ENABLED;
     });
 
     it('reminderCron dispatches reminders concurrently', async () => {

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -36,7 +36,7 @@ export class NotificationsService {
                 recipient: to,
                 type,
                 message,
-                status: NotificationStatus.Sent,
+                status: NotificationStatus.Skipped,
                 sentAt: new Date(),
             });
             return this.repo.save(fake);


### PR DESCRIPTION
## Summary
- mark disabled notifications as `skipped`
- record skipped notifications in database via new `notification_status_enum` migration
- test notification service behavior when notifications are disabled

## Testing
- `npm test`
- `npm run test:e2e` *(fails: SQLITE_BUSY: database is locked; Nest can't resolve dependencies of the JWT module)*

------
https://chatgpt.com/codex/tasks/task_e_6891ded865788329bd1c569f8d382a02