### PR TITLE
feat: validate appointment owner for reviews

### DIFF
--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -6,6 +6,7 @@ import {
     Param,
     Patch,
     Post,
+    Request,
 } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
@@ -26,8 +27,8 @@ export class ReviewsController {
     }
 
     @Post()
-    create(@Body() dto: CreateReviewDto) {
-        return this.service.create(dto);
+    create(@Body() dto: CreateReviewDto, @Request() req) {
+        return this.service.create(dto, req.user.id);
     }
 
     @Patch(':id')


### PR DESCRIPTION
## Summary
- ensure only completed appointments can be reviewed
- check client owns appointment before creating review
- store review author and employee relations using ids

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689200e7eab8832992558828cd37e15e