### PR TITLE
feat: expose review APIs under appointments and employees

### DIFF
--- a/backend/src/appointments/appointment-reviews.controller.ts
+++ b/backend/src/appointments/appointment-reviews.controller.ts
@@ -1,0 +1,48 @@
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    ParseIntPipe,
+    Post,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
+import { ReviewsService } from '../reviews/reviews.service';
+import { CreateAppointmentReviewDto } from './dto/create-appointment-review.dto';
+
+@ApiTags('Appointments')
+@ApiBearerAuth()
+@Controller('appointments')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AppointmentReviewsController {
+    constructor(private readonly reviews: ReviewsService) {}
+
+    @Post(':id/review')
+    @Roles(Role.Client)
+    @ApiOperation({ summary: 'Create review for appointment' })
+    @ApiResponse({ status: 201 })
+    create(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: CreateAppointmentReviewDto,
+        @Request() req,
+    ) {
+        return this.reviews.create(
+            { ...dto, appointmentId: id },
+            req.user.id,
+        );
+    }
+
+    @Get(':id/review')
+    @Roles(Role.Client)
+    @ApiOperation({ summary: 'Get review for appointment' })
+    @ApiResponse({ status: 200 })
+    find(@Param('id', ParseIntPipe) id: number) {
+        return this.reviews.findByAppointment(id);
+    }
+}

--- a/backend/src/appointments/appointments.module.ts
+++ b/backend/src/appointments/appointments.module.ts
@@ -6,10 +6,12 @@ import { ClientAppointmentsController } from './client-appointments.controller';
 import { EmployeeAppointmentsController } from './employee-appointments.controller';
 import { AdminAppointmentsController } from './admin-appointments.controller';
 import { MeAppointmentsController } from './me-appointments.controller';
+import { AppointmentReviewsController } from './appointment-reviews.controller';
 import { FormulasModule } from '../formulas/formulas.module';
 import { CommissionsModule } from '../commissions/commissions.module';
 import { LogsModule } from '../logs/logs.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { ReviewsModule } from '../reviews/reviews.module';
 
 @Module({
     imports: [
@@ -18,6 +20,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         CommissionsModule,
         LogsModule,
         NotificationsModule,
+        ReviewsModule,
     ],
 
     controllers: [
@@ -25,6 +28,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         EmployeeAppointmentsController,
         AdminAppointmentsController,
         MeAppointmentsController,
+        AppointmentReviewsController,
     ],
     providers: [AppointmentsService],
     exports: [AppointmentsService],

--- a/backend/src/appointments/dto/create-appointment-review.dto.ts
+++ b/backend/src/appointments/dto/create-appointment-review.dto.ts
@@ -1,0 +1,13 @@
+import { IsInt, IsOptional, IsString, Max, Min, MaxLength } from 'class-validator';
+
+export class CreateAppointmentReviewDto {
+    @IsInt()
+    @Min(1)
+    @Max(5)
+    rating: number;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(500)
+    comment?: string;
+}

--- a/backend/src/employees/employee-reviews.controller.ts
+++ b/backend/src/employees/employee-reviews.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ReviewsService } from '../reviews/reviews.service';
+
+@ApiTags('Employees')
+@Controller('employees')
+export class EmployeeReviewsController {
+    constructor(private readonly reviews: ReviewsService) {}
+
+    @Get(':id/reviews')
+    @ApiOperation({ summary: 'List reviews for employee' })
+    @ApiQuery({ name: 'page', required: false })
+    @ApiQuery({ name: 'limit', required: false })
+    @ApiQuery({ name: 'rating', required: false })
+    @ApiResponse({ status: 200 })
+    list(
+        @Param('id', ParseIntPipe) id: number,
+        @Query('page') page = '1',
+        @Query('limit') limit = '10',
+        @Query('rating') rating?: string,
+    ) {
+        return this.reviews.findEmployeeReviews(
+            id,
+            Number(page),
+            Number(limit),
+            rating ? Number(rating) : undefined,
+        );
+    }
+}

--- a/backend/src/employees/employees.module.ts
+++ b/backend/src/employees/employees.module.ts
@@ -4,10 +4,12 @@ import { User } from '../users/user.entity';
 import { EmployeesService } from './employees.service';
 import { EmployeesController } from './employees.controller';
 import { LogsModule } from '../logs/logs.module';
+import { EmployeeReviewsController } from './employee-reviews.controller';
+import { ReviewsModule } from '../reviews/reviews.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([User]), LogsModule],
-    controllers: [EmployeesController],
+    imports: [TypeOrmModule.forFeature([User]), LogsModule, ReviewsModule],
+    controllers: [EmployeesController, EmployeeReviewsController],
     providers: [EmployeesService],
     exports: [TypeOrmModule, EmployeesService],
 })

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -1,43 +1,23 @@
-import {
-    Body,
-    Controller,
-    Delete,
-    Get,
-    Param,
-    Patch,
-    Post,
-    Request,
-} from '@nestjs/common';
+import { Controller, Delete, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../users/role.enum';
 import { ReviewsService } from './reviews.service';
-import { CreateReviewDto } from './dto/create-review.dto';
-import { UpdateReviewDto } from './dto/update-review.dto';
 
+@ApiTags('Reviews')
+@ApiBearerAuth()
 @Controller('reviews')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
 export class ReviewsController {
     constructor(private readonly service: ReviewsService) {}
 
-    @Get()
-    list() {
-        return this.service.findAll();
-    }
-
-    @Get(':id')
-    get(@Param('id') id: number) {
-        return this.service.findOne(Number(id));
-    }
-
-    @Post()
-    create(@Body() dto: CreateReviewDto, @Request() req) {
-        return this.service.create(dto, req.user.id);
-    }
-
-    @Patch(':id')
-    update(@Param('id') id: number, @Body() dto: UpdateReviewDto) {
-        return this.service.update(Number(id), dto);
-    }
-
     @Delete(':id')
-    remove(@Param('id') id: number) {
-        return this.service.remove(Number(id));
+    @ApiOperation({ summary: 'Delete review' })
+    @ApiResponse({ status: 200 })
+    remove(@Param('id', ParseIntPipe) id: number) {
+        return this.service.remove(id);
     }
 }

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -61,6 +61,30 @@ export class ReviewsService {
         return this.repo.save(review);
     }
 
+    findByAppointment(appointmentId: number) {
+        return this.repo.findOne({
+            where: { appointment: { id: appointmentId } },
+        });
+    }
+
+    async findEmployeeReviews(
+        employeeId: number,
+        page = 1,
+        limit = 10,
+        rating?: number,
+    ) {
+        const [data, total] = await this.repo.findAndCount({
+            where: {
+                employee: { id: employeeId },
+                ...(rating ? { rating } : {}),
+            },
+            order: { createdAt: 'DESC' },
+            skip: (page - 1) * limit,
+            take: limit,
+        });
+        return { data, total, page, limit };
+    }
+
     findAll() {
         return this.repo.find();
     }

--- a/backend/test/reviews.e2e-spec.ts
+++ b/backend/test/reviews.e2e-spec.ts
@@ -65,15 +65,15 @@ describe('ReviewsModule (e2e)', () => {
         const { access_token: token } = login.body as { access_token: string };
 
         await request(app.getHttpServer())
-            .post('/reviews')
+            .post(`/appointments/${appointment.id}/review`)
             .set('Authorization', `Bearer ${token}`)
-            .send({ appointmentId: appointment.id, rating: 5 })
+            .send({ rating: 5 })
             .expect(201);
 
         await request(app.getHttpServer())
-            .post('/reviews')
+            .post(`/appointments/${appointment.id}/review`)
             .set('Authorization', `Bearer ${token}`)
-            .send({ appointmentId: appointment.id, rating: 4 })
+            .send({ rating: 4 })
             .expect(400);
     });
 });


### PR DESCRIPTION
## Summary
- add client review endpoints under `/appointments/:id/review`
- list employee reviews with optional filters and pagination
- restrict review deletion to admin only

## Testing
- `npm run lint`
- `npm test`
- `DATABASE_URL=sqlite::memory: npm run test:e2e` *(fails: SQLITE_BUSY database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_689202d259b083299d8b2d26f4892a9d