### PR TITLE
feat: add financial summary report

### DIFF
--- a/backend/src/reports/reports.module.ts
+++ b/backend/src/reports/reports.module.ts
@@ -1,8 +1,21 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ReportsController } from './reports.controller';
 import { ReportsService } from './reports.service';
+import { Appointment } from '../appointments/appointment.entity';
+import { Sale } from '../sales/sale.entity';
+import { CommissionRecord } from '../commissions/commission-record.entity';
+import { User } from '../users/user.entity';
 
 @Module({
+    imports: [
+        TypeOrmModule.forFeature([
+            Appointment,
+            Sale,
+            CommissionRecord,
+            User,
+        ]),
+    ],
     controllers: [ReportsController],
     providers: [ReportsService],
 })

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -1,9 +1,32 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import {
+    Appointment,
+    PaymentStatus,
+} from '../appointments/appointment.entity';
+import { Sale } from '../sales/sale.entity';
+import { CommissionRecord } from '../commissions/commission-record.entity';
+import { User } from '../users/user.entity';
+import { Role } from '../users/role.enum';
 
 @Injectable()
 export class ReportsService {
+    constructor(
+        @InjectRepository(Appointment)
+        private readonly appointments: Repository<Appointment>,
+        @InjectRepository(Sale)
+        private readonly sales: Repository<Sale>,
+        @InjectRepository(CommissionRecord)
+        private readonly commissions: Repository<CommissionRecord>,
+        @InjectRepository(User)
+        private readonly users: Repository<User>,
+    ) {}
+
     getFinancial(from?: string, to?: string) {
-        return { from, to };
+        const start = from ? new Date(from) : undefined;
+        const end = to ? new Date(to) : undefined;
+        return this.getFinancialSummary(start, end);
     }
 
     getEmployeeReport(id: number, from?: string, to?: string) {
@@ -24,5 +47,153 @@ export class ReportsService {
 
     export(type: string) {
         return { type };
+    }
+
+    async getFinancialSummary(from?: Date, to?: Date) {
+        const now = new Date();
+        const start = from ?? new Date(now.getFullYear(), now.getMonth(), 1);
+        const end =
+            to ?? new Date(start.getFullYear(), start.getMonth() + 1, 1);
+
+        const serviceResult = await this.appointments
+            .createQueryBuilder('a')
+            .leftJoin('a.service', 's')
+            .select('SUM(s.price)', 'sum')
+            .where('a.paymentStatus = :status', {
+                status: PaymentStatus.Paid,
+            })
+            .andWhere('a.startTime >= :start AND a.startTime < :end', {
+                start,
+                end,
+            })
+            .getRawOne();
+        const serviceRevenue = Number(serviceResult?.sum ?? 0);
+
+        const productResult = await this.sales
+            .createQueryBuilder('sale')
+            .leftJoin('sale.product', 'p')
+            .select('SUM(p.unitPrice * sale.quantity)', 'sum')
+            .where('sale.soldAt >= :start AND sale.soldAt < :end', {
+                start,
+                end,
+            })
+            .getRawOne();
+        const productRevenue = Number(productResult?.sum ?? 0);
+
+        const servicePerEmployee = await this.appointments
+            .createQueryBuilder('a')
+            .leftJoin('a.service', 's')
+            .select('a.employeeId', 'employeeId')
+            .addSelect('SUM(s.price)', 'serviceRevenue')
+            .where('a.paymentStatus = :status', {
+                status: PaymentStatus.Paid,
+            })
+            .andWhere('a.startTime >= :start AND a.startTime < :end', {
+                start,
+                end,
+            })
+            .groupBy('a.employeeId')
+            .getRawMany();
+
+        const salesPerEmployee = await this.sales
+            .createQueryBuilder('sale')
+            .leftJoin('sale.product', 'p')
+            .select('sale.employeeId', 'employeeId')
+            .addSelect('SUM(p.unitPrice * sale.quantity)', 'productRevenue')
+            .where('sale.soldAt >= :start AND sale.soldAt < :end', {
+                start,
+                end,
+            })
+            .groupBy('sale.employeeId')
+            .getRawMany();
+
+        const revenueMap = new Map<
+            number,
+            { serviceRevenue: number; productRevenue: number }
+        >();
+        for (const row of servicePerEmployee) {
+            const id = Number(row.employeeId);
+            revenueMap.set(id, {
+                serviceRevenue: Number(row.serviceRevenue ?? 0),
+                productRevenue: 0,
+            });
+        }
+        for (const row of salesPerEmployee) {
+            const id = Number(row.employeeId);
+            const existing =
+                revenueMap.get(id) || {
+                    serviceRevenue: 0,
+                    productRevenue: 0,
+                };
+            existing.productRevenue = Number(row.productRevenue ?? 0);
+            revenueMap.set(id, existing);
+        }
+        const revenuePerEmployee = Array.from(revenueMap.entries()).map(
+            ([employeeId, r]) => ({
+                employeeId,
+                serviceRevenue: r.serviceRevenue,
+                productRevenue: r.productRevenue,
+                totalRevenue: r.serviceRevenue + r.productRevenue,
+            }),
+        );
+
+        const commissionResult = await this.commissions
+            .createQueryBuilder('c')
+            .select('SUM(c.amount)', 'sum')
+            .where('c.createdAt >= :start AND c.createdAt < :end', {
+                start,
+                end,
+            })
+            .getRawOne();
+        const commissionTotal = Number(commissionResult?.sum ?? 0);
+
+        const commissionPerEmployeeRaw = await this.commissions
+            .createQueryBuilder('c')
+            .select('c.employeeId', 'employeeId')
+            .addSelect('SUM(c.amount)', 'amount')
+            .where('c.createdAt >= :start AND c.createdAt < :end', {
+                start,
+                end,
+            })
+            .groupBy('c.employeeId')
+            .getRawMany();
+        const commissionPerEmployee = commissionPerEmployeeRaw.map((r) => ({
+            employeeId: Number(r.employeeId),
+            amount: Number(r.amount),
+        }));
+
+        const serviceCount = await this.appointments.count({
+            where: {
+                paymentStatus: PaymentStatus.Paid,
+                startTime: Between(start, end),
+            },
+        });
+
+        const newClients = await this.users.count({
+            where: {
+                role: Role.Client,
+                createdAt: Between(start, end),
+            },
+        });
+
+        const salesCount = await this.sales.count({
+            where: { soldAt: Between(start, end) },
+        });
+        const averageBasketSize =
+            salesCount > 0 ? productRevenue / salesCount : 0;
+
+        return {
+            from: start,
+            to: end,
+            serviceRevenue,
+            productRevenue,
+            totalRevenue: serviceRevenue + productRevenue,
+            revenuePerEmployee,
+            commissionTotal,
+            commissionPerEmployee,
+            serviceCount,
+            newClients,
+            averageBasketSize,
+        };
     }
 }

--- a/backend/test/reports.financial-summary.integration-spec.ts
+++ b/backend/test/reports.financial-summary.integration-spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { ReportsService } from '../src/reports/reports.service';
+import { DataSource, Repository } from 'typeorm';
+import { Appointment, PaymentStatus } from '../src/appointments/appointment.entity';
+import { Sale } from '../src/sales/sale.entity';
+import { CommissionRecord } from '../src/commissions/commission-record.entity';
+import { User } from '../src/users/user.entity';
+import { Role } from '../src/users/role.enum';
+import { Service as CatalogService } from '../src/catalog/service.entity';
+import { Product } from '../src/catalog/product.entity';
+
+describe('ReportsService.getFinancialSummary (integration)', () => {
+    let moduleRef: TestingModule;
+    let reports: ReportsService;
+    let dataSource: DataSource;
+    let users: Repository<User>;
+    let appointments: Repository<Appointment>;
+    let sales: Repository<Sale>;
+    let products: Repository<Product>;
+    let commissions: Repository<CommissionRecord>;
+    let services: Repository<CatalogService>;
+
+    beforeEach(async () => {
+        moduleRef = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        reports = moduleRef.get(ReportsService);
+        dataSource = moduleRef.get(DataSource);
+        users = dataSource.getRepository(User);
+        appointments = dataSource.getRepository(Appointment);
+        sales = dataSource.getRepository(Sale);
+        products = dataSource.getRepository(Product);
+        commissions = dataSource.getRepository(CommissionRecord);
+        services = dataSource.getRepository(CatalogService);
+    });
+
+    afterEach(async () => {
+        await moduleRef.close();
+    });
+
+    it('calculates financial summary for current month', async () => {
+        const employee = await users.save({
+            email: 'emp@report.com',
+            password: 'secret',
+            firstName: 'Emp',
+            lastName: 'Report',
+            role: Role.Employee,
+        });
+        const client = await users.save({
+            email: 'client@report.com',
+            password: 'secret',
+            firstName: 'Cli',
+            lastName: 'Ent',
+            role: Role.Client,
+        });
+        const service = await services.findOne({ where: { name: 'cut' } });
+        await appointments.save({
+            client: { id: client.id } as any,
+            employee: { id: employee.id } as any,
+            service: { id: service!.id } as any,
+            startTime: new Date(),
+            paymentStatus: PaymentStatus.Paid,
+        });
+        const product = await products.save({
+            name: 'gel',
+            unitPrice: 20,
+            stock: 10,
+        });
+        await sales.save({
+            client: { id: client.id } as any,
+            employee: { id: employee.id } as any,
+            product: { id: product.id } as any,
+            quantity: 2,
+            soldAt: new Date(),
+        });
+        await commissions.save({
+            employee: { id: employee.id } as any,
+            appointment: null,
+            product: { id: product.id } as any,
+            amount: 5,
+            percent: 10,
+        });
+
+        const summary = await reports.getFinancialSummary();
+        expect(summary.serviceRevenue).toBeCloseTo(10);
+        expect(summary.productRevenue).toBeCloseTo(40);
+        expect(summary.totalRevenue).toBeCloseTo(50);
+        expect(summary.revenuePerEmployee).toEqual([
+            {
+                employeeId: employee.id,
+                serviceRevenue: 10,
+                productRevenue: 40,
+                totalRevenue: 50,
+            },
+        ]);
+        expect(summary.commissionTotal).toBeCloseTo(5);
+        expect(summary.serviceCount).toBe(1);
+        expect(summary.newClients).toBe(1);
+        expect(summary.averageBasketSize).toBeCloseTo(40);
+    });
+});
+


### PR DESCRIPTION
## Summary
- add financial summary reporting with revenue, commissions, counts and default month range
- wire reports module for required repositories
- cover financial summary with integration test

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Nest can't resolve dependencies of the JWT_MODULE_OPTIONS)*


------
https://chatgpt.com/codex/tasks/task_e_68921aa6316883298d6bfc9945c3f06f