### PR TITLE
feat: add CSV export for reports

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
                 "class-validator": "^0.14.2",
                 "googleapis": "^153.0.0",
                 "ics": "^3.8.1",
+                "json2csv": "^5.0.7",
                 "jsonwebtoken": "^9.0.2",
                 "jwk-to-pem": "^2.0.7",
                 "libphonenumber-js": "^1.12.10",
@@ -10336,6 +10337,34 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/json2csv": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+            "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^6.1.0",
+                "jsonparse": "^1.3.1",
+                "lodash.get": "^4.4.2"
+            },
+            "bin": {
+                "json2csv": "bin/json2csv.js"
+            },
+            "engines": {
+                "node": ">= 10",
+                "npm": ">= 6.13.0"
+            }
+        },
+        "node_modules/json2csv/node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10368,6 +10397,15 @@
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
+        },
+        "node_modules/jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "license": "MIT"
         },
         "node_modules/jsonwebtoken": {
             "version": "9.0.2",
@@ -10529,6 +10567,13 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
             "license": "MIT"
         },
         "node_modules/lodash.includes": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
         "class-validator": "^0.14.2",
         "googleapis": "^153.0.0",
         "ics": "^3.8.1",
+        "json2csv": "^5.0.7",
         "jsonwebtoken": "^9.0.2",
         "jwk-to-pem": "^2.0.7",
         "libphonenumber-js": "^1.12.10",

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -6,6 +6,7 @@ import {
     ParseIntPipe,
     UseGuards,
     DefaultValuePipe,
+    Res,
 } from '@nestjs/common';
 import {
     ApiBearerAuth,
@@ -18,6 +19,7 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
 import { ReportsService } from './reports.service';
+import { Response } from 'express';
 
 @ApiTags('Reports')
 @ApiBearerAuth()
@@ -88,8 +90,11 @@ export class ReportsController {
     @UseGuards(JwtAuthGuard, RolesGuard)
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Export report' })
-    @ApiResponse({ status: 200 })
-    export(@Param('type') type: string) {
-        return this.service.export(type);
+    @ApiResponse({ status: 200, description: 'CSV export' })
+    async export(@Param('type') type: string, @Res() res: Response) {
+        const { fileName, csv } = await this.service.export(type);
+        res.setHeader('Content-Type', 'text/csv');
+        res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+        res.send(csv);
     }
 }


### PR DESCRIPTION
## Summary
- add CSV export endpoint for reports
- implement report exporters for financial, services, products, and customers
- install json2csv for CSV generation

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68924d3c8c7883298fe939ff7c5d0083