### PR TITLE
feat: add pagination to report lists

### DIFF
--- a/backend/src/reports/__tests__/reports.service.spec.ts
+++ b/backend/src/reports/__tests__/reports.service.spec.ts
@@ -255,36 +255,36 @@ describe('ReportsService', () => {
         expect(report.productSales).toBe(2);
     });
 
-    it('returns top services with limit', async () => {
+    it('returns top services with pagination', async () => {
         const { cut, color } = await seedSampleData();
-        const topOne = await service.getTopServices(1);
-        expect(topOne).toHaveLength(1);
-        expect(topOne[0]).toMatchObject({
+        const pageOne = await service.getTopServices(1, 1);
+        expect(pageOne).toHaveLength(1);
+        expect(pageOne[0]).toMatchObject({
             serviceId: cut.id,
             count: 2,
             revenue: 60,
         });
-        const topTwo = await service.getTopServices(2);
-        expect(topTwo).toHaveLength(2);
-        expect(topTwo[1]).toMatchObject({
+        const pageTwo = await service.getTopServices(1, 2);
+        expect(pageTwo).toHaveLength(1);
+        expect(pageTwo[0]).toMatchObject({
             serviceId: color.id,
             count: 1,
             revenue: 50,
         });
     });
 
-    it('returns top products with limit', async () => {
+    it('returns top products with pagination', async () => {
         const { shampoo, brush } = await seedSampleData();
-        const topOne = await service.getTopProducts(1);
-        expect(topOne).toHaveLength(1);
-        expect(topOne[0]).toMatchObject({
+        const pageOne = await service.getTopProducts(1, 1);
+        expect(pageOne).toHaveLength(1);
+        expect(pageOne[0]).toMatchObject({
             productId: shampoo.id,
             quantity: 4,
             revenue: 40,
         });
-        const topTwo = await service.getTopProducts(2);
-        expect(topTwo).toHaveLength(2);
-        expect(topTwo[1]).toMatchObject({
+        const pageTwo = await service.getTopProducts(1, 2);
+        expect(pageTwo).toHaveLength(1);
+        expect(pageTwo[0]).toMatchObject({
             productId: brush.id,
             quantity: 2,
             revenue: 30,
@@ -359,6 +359,13 @@ describe('ReportsService', () => {
         expect(fileName).toBe('financial.csv');
         expect(csv).toContain('serviceRevenue');
         expect(csv).toContain('110');
+    });
+
+    it('exports services data with pagination', async () => {
+        const { cut, color } = await seedSampleData();
+        const { csv } = await service.export('services', 1, 2);
+        expect(csv).toContain(color.name);
+        expect(csv).not.toContain(cut.name);
     });
 });
 

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -89,10 +89,17 @@ export class ReportsController {
         type: Number,
         description: 'Maximum number of services to return',
     })
+    @ApiQuery({
+        name: 'page',
+        required: false,
+        type: Number,
+        description: 'Page number (starting from 1)',
+    })
     topServices(
         @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+        @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     ) {
-        return this.service.getTopServices(limit);
+        return this.service.getTopServices(limit, page);
     }
 
     @Get('top-products')
@@ -106,10 +113,17 @@ export class ReportsController {
         type: Number,
         description: 'Maximum number of products to return',
     })
+    @ApiQuery({
+        name: 'page',
+        required: false,
+        type: Number,
+        description: 'Page number (starting from 1)',
+    })
     topProducts(
         @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+        @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     ) {
-        return this.service.getTopProducts(limit);
+        return this.service.getTopProducts(limit, page);
     }
 
     @Get('new-customers')
@@ -146,8 +160,25 @@ export class ReportsController {
         enum: ['financial', 'services', 'products', 'customers'],
         description: 'Type of report to export as CSV',
     })
-    async export(@Param('type') type: string, @Res() res: Response) {
-        const { fileName, csv } = await this.service.export(type);
+    @ApiQuery({
+        name: 'limit',
+        required: false,
+        type: Number,
+        description: 'Maximum number of records per page',
+    })
+    @ApiQuery({
+        name: 'page',
+        required: false,
+        type: Number,
+        description: 'Page number (starting from 1)',
+    })
+    async export(
+        @Param('type') type: string,
+        @Res() res: Response,
+        @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit: number,
+        @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    ) {
+        const { fileName, csv } = await this.service.export(type, limit, page);
         res.setHeader('Content-Type', 'text/csv');
         res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
         res.send(csv);


### PR DESCRIPTION
## Summary
- add optional limit/page to report list endpoints and exports
- paginate top service/product queries with skip/take
- document pagination params in Swagger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926eca0c308329804f678af66c3acd