### PR TITLE
docs: add swagger metadata to dto properties

### DIFF
--- a/backend/src/appointments/dto/create-appointment-review.dto.ts
+++ b/backend/src/appointments/dto/create-appointment-review.dto.ts
@@ -1,11 +1,25 @@
 import { IsInt, IsOptional, IsString, Max, Min, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateAppointmentReviewDto {
+    @ApiProperty({
+        description: 'Rating given to the appointment from 1 (worst) to 5 (best)',
+        type: Number,
+        minimum: 1,
+        maximum: 5,
+        example: 5,
+    })
     @IsInt()
     @Min(1)
     @Max(5)
     rating: number;
 
+    @ApiPropertyOptional({
+        description: 'Optional review comment',
+        type: String,
+        example: 'Great service and friendly staff',
+        maxLength: 500,
+    })
     @IsOptional()
     @IsString()
     @MaxLength(500)

--- a/backend/src/appointments/dto/create-appointment.dto.ts
+++ b/backend/src/appointments/dto/create-appointment.dto.ts
@@ -1,18 +1,44 @@
 import { IsInt, IsDateString, IsString, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateAppointmentDto {
+    @ApiProperty({
+        description: 'Unique identifier of the client',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     clientId: number;
 
+    @ApiProperty({
+        description: 'Employee assigned to the appointment',
+        type: Number,
+        example: 2,
+    })
     @IsInt()
     employeeId: number;
 
+    @ApiProperty({
+        description: 'Service to be performed during the appointment',
+        type: Number,
+        example: 3,
+    })
     @IsInt()
     serviceId: number;
 
+    @ApiProperty({
+        description: 'Start time in ISO 8601 format',
+        type: String,
+        example: '2024-01-01T09:00:00Z',
+    })
     @IsDateString()
     startTime: string;
 
+    @ApiPropertyOptional({
+        description: 'Additional notes for the appointment',
+        type: String,
+        example: 'Customer requests a window seat',
+    })
     @IsOptional()
     @IsString()
     notes?: string;

--- a/backend/src/appointments/dto/update-appointment.dto.ts
+++ b/backend/src/appointments/dto/update-appointment.dto.ts
@@ -1,30 +1,66 @@
 import { IsOptional, IsDateString, IsEnum, IsInt } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { AppointmentStatus } from '../appointment.entity';
 
 export class UpdateAppointmentDto {
+    @ApiPropertyOptional({
+        description: 'Updated employee assigned to the appointment',
+        type: Number,
+        example: 3,
+    })
     @IsOptional()
     @IsInt()
     employeeId?: number;
 
+    @ApiPropertyOptional({
+        description: 'Updated start time in ISO 8601 format',
+        type: String,
+        example: '2024-01-01T10:00:00Z',
+    })
     @IsOptional()
     @IsDateString()
     startTime?: string;
 
+    @ApiPropertyOptional({
+        description: 'Updated end time in ISO 8601 format',
+        type: String,
+        example: '2024-01-01T11:00:00Z',
+    })
     @IsOptional()
     @IsDateString()
     endTime?: string;
 
+    @ApiPropertyOptional({
+        description: 'Updated service identifier',
+        type: Number,
+        example: 4,
+    })
     @IsOptional()
     @IsInt()
     serviceId?: number;
 
+    @ApiPropertyOptional({
+        description: 'Updated notes for the appointment',
+        type: String,
+        example: 'Customer requested a different stylist',
+    })
     @IsOptional()
     notes?: string;
 
+    @ApiPropertyOptional({
+        description: 'Current status of the appointment',
+        enum: AppointmentStatus,
+        example: AppointmentStatus.Cancelled,
+    })
     @IsOptional()
     @IsEnum(AppointmentStatus)
     status?: AppointmentStatus;
 
+    @ApiPropertyOptional({
+        description: 'Formula details used during the appointment',
+        type: String,
+        example: 'Foil highlight mix',
+    })
     @IsOptional()
     formulaDescription?: string;
 }

--- a/backend/src/auth/dto/auth-tokens.dto.ts
+++ b/backend/src/auth/dto/auth-tokens.dto.ts
@@ -1,9 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class AuthTokensDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'JWT access token',
+        type: String,
+        example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    })
     access_token: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'JWT refresh token',
+        type: String,
+        example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    })
     refresh_token: string;
 }

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,10 +1,22 @@
 import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+    @ApiProperty({
+        description: 'Email address used for login',
+        type: String,
+        example: 'user@example.com',
+    })
     @IsEmail()
     @IsNotEmpty()
     email: string;
 
+    @ApiProperty({
+        description: 'Account password',
+        type: String,
+        minLength: 6,
+        example: 'Secret123',
+    })
     @MinLength(6)
     password: string;
 }

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,6 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RefreshTokenDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Refresh token issued during authentication',
+        type: String,
+        example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    })
     refresh_token: string;
 }

--- a/backend/src/auth/dto/register-client.dto.ts
+++ b/backend/src/auth/dto/register-client.dto.ts
@@ -12,35 +12,66 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsEuPhoneNumber } from '../../common/validators/is-eu-phone-number';
 
 export class RegisterClientDto {
-    @ApiProperty({ example: 'Jan' })
+    @ApiProperty({
+        description: 'First name of the client',
+        type: String,
+        minLength: 2,
+        example: 'Jan',
+    })
     @IsString()
     @MinLength(2)
     firstName: string;
 
-    @ApiProperty({ example: 'Kowalski' })
+    @ApiProperty({
+        description: 'Last name of the client',
+        type: String,
+        minLength: 2,
+        example: 'Kowalski',
+    })
     @IsString()
     @MinLength(2)
     lastName: string;
 
-    @ApiProperty({ example: 'jan@example.com' })
+    @ApiProperty({
+        description: 'Client email address',
+        type: String,
+        example: 'jan@example.com',
+    })
     @IsEmail()
     @IsNotEmpty()
     email: string;
 
-    @ApiProperty({ example: '+48123123123' })
+    @ApiProperty({
+        description: 'Contact phone number in EU format',
+        type: String,
+        example: '+48123123123',
+    })
     @IsEuPhoneNumber()
     phone: string;
 
-    @ApiProperty({ example: 'Secret123!' })
+    @ApiProperty({
+        description: 'Account password',
+        type: String,
+        example: 'Secret123!'
+    })
     @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)
     password: string;
 
-    @ApiProperty({ example: true })
+    @ApiProperty({
+        description: 'Confirmation of privacy policy acceptance',
+        type: Boolean,
+        example: true,
+    })
     @IsBoolean()
     @Equals(true)
     privacyConsent: boolean;
 
-    @ApiProperty({ required: false, example: false })
+    @ApiProperty({
+        description: 'Marketing consent flag',
+        type: Boolean,
+        required: false,
+        example: false,
+    })
     @IsBoolean()
     @IsOptional()
     marketingConsent?: boolean;

--- a/backend/src/auth/dto/social-login.dto.ts
+++ b/backend/src/auth/dto/social-login.dto.ts
@@ -2,17 +2,30 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class SocialLoginDto {
-    @ApiProperty({ enum: ['google', 'facebook', 'apple'] })
+    @ApiProperty({
+        description: 'Social provider used for authentication',
+        enum: ['google', 'facebook', 'apple'],
+        example: 'google',
+    })
     @IsString()
     @IsIn(['google', 'facebook', 'apple'])
     provider: 'google' | 'facebook' | 'apple';
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Token issued by the social provider',
+        type: String,
+        example: 'ya29.a0AfH6SMA...',
+    })
     @IsString()
     @IsNotEmpty()
     token: string;
 
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        description: 'Marketing consent provided during social login',
+        required: false,
+        type: Boolean,
+        example: true,
+    })
     @IsBoolean()
     @IsOptional()
     marketingConsent?: boolean;

--- a/backend/src/categories/dto/create-category.dto.ts
+++ b/backend/src/categories/dto/create-category.dto.ts
@@ -1,10 +1,23 @@
 import { IsString, Length, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateCategoryDto {
+    @ApiProperty({
+        description: 'Category name',
+        type: String,
+        minLength: 2,
+        maxLength: 50,
+        example: 'Hair Care',
+    })
     @IsString()
     @Length(2, 50)
     name: string;
 
+    @ApiPropertyOptional({
+        description: 'Optional category description',
+        type: String,
+        example: 'Products for maintaining healthy hair',
+    })
     @IsOptional()
     @IsString()
     description?: string;

--- a/backend/src/communications/dto/create-communication.dto.ts
+++ b/backend/src/communications/dto/create-communication.dto.ts
@@ -1,12 +1,28 @@
 import { IsInt, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateCommunicationDto {
+    @ApiProperty({
+        description: 'Identifier of the customer receiving the communication',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     customerId: number;
 
+    @ApiProperty({
+        description: 'Medium used for the communication',
+        type: String,
+        example: 'email',
+    })
     @IsString()
     medium: string;
 
+    @ApiProperty({
+        description: 'Content of the communication message',
+        type: String,
+        example: 'Thank you for your visit!'
+    })
     @IsString()
     content: string;
 }

--- a/backend/src/customers/dto/customer.dto.ts
+++ b/backend/src/customers/dto/customer.dto.ts
@@ -3,47 +3,92 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Role } from '../../users/role.enum';
 
 export class CustomerDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Unique identifier of the customer',
+        type: Number,
+        example: 1,
+    })
     @Expose()
     id: number;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Customer email address',
+        type: String,
+        example: 'jan@example.com',
+    })
     @Expose()
     email: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'First name of the customer',
+        type: String,
+        example: 'Jan',
+    })
     @Expose()
     firstName: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Last name of the customer',
+        type: String,
+        example: 'Kowalski',
+    })
     @Expose()
     lastName: string;
 
-    @ApiProperty({ nullable: true })
+    @ApiProperty({
+        description: 'Contact phone number',
+        type: String,
+        nullable: true,
+        example: '+48123123123',
+    })
     @Expose()
     phone: string | null;
 
-    @ApiProperty({ enum: Role })
+    @ApiProperty({
+        description: 'Role assigned to the customer',
+        enum: Role,
+        example: Role.Client,
+    })
     @Expose()
     role: Role;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Whether the customer accepted the privacy policy',
+        type: Boolean,
+        example: true,
+    })
     @Expose()
     privacyConsent: boolean;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Whether the customer consents to marketing messages',
+        type: Boolean,
+        example: false,
+    })
     @Expose()
     marketingConsent: boolean;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Timestamp when the customer was created',
+        type: String,
+        example: '2024-01-01T00:00:00.000Z',
+    })
     @Expose()
     createdAt: Date;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Timestamp of the last update',
+        type: String,
+        example: '2024-01-02T00:00:00.000Z',
+    })
     @Expose()
     updatedAt: Date;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Indicates if the customer account is active',
+        type: Boolean,
+        example: true,
+    })
     @Expose()
     isActive: boolean;
 }

--- a/backend/src/customers/dto/update-marketing-consent.dto.ts
+++ b/backend/src/customers/dto/update-marketing-consent.dto.ts
@@ -2,7 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean } from 'class-validator';
 
 export class UpdateMarketingConsentDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Indicates if the customer consents to receive marketing communications',
+        type: Boolean,
+        example: true,
+    })
     @IsBoolean()
     marketingConsent: boolean;
 }

--- a/backend/src/employees/dto/create-employee-response.dto.ts
+++ b/backend/src/employees/dto/create-employee-response.dto.ts
@@ -2,9 +2,16 @@ import { ApiProperty } from '@nestjs/swagger';
 import { EmployeeDto } from './employee.dto';
 
 export class CreateEmployeeResponseDto {
-    @ApiProperty({ type: () => EmployeeDto })
+    @ApiProperty({
+        description: 'Created employee details',
+        type: () => EmployeeDto,
+    })
     employee: EmployeeDto;
 
-    @ApiProperty({ description: 'Plaintext password, returned only once.' })
+    @ApiProperty({
+        description: 'Plaintext password, returned only once.',
+        type: String,
+        example: 'TempPass123!',
+    })
     password: string;
 }

--- a/backend/src/employees/dto/create-employee.dto.ts
+++ b/backend/src/employees/dto/create-employee.dto.ts
@@ -10,28 +10,52 @@ import {
 import { Role } from '../../users/role.enum';
 
 export class CreateEmployeeDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Employee email address',
+        type: String,
+        example: 'employee@example.com',
+    })
     @IsEmail()
     email: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'First name of the employee',
+        type: String,
+        example: 'Jane',
+    })
     @IsString()
     firstName: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Last name of the employee',
+        type: String,
+        example: 'Doe',
+    })
     @IsString()
     lastName: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Base commission percentage for the employee',
+        type: Number,
+        example: 20,
+    })
     @IsNumber()
     commissionBase: number;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Contact phone number',
+        type: String,
+        example: '+48123123123',
+    })
     @IsMobilePhone()
     @IsOptional()
     phone?: string;
 
-    @ApiPropertyOptional({ enum: Role })
+    @ApiPropertyOptional({
+        enum: Role,
+        description: 'Role assigned to the employee',
+        example: Role.Employee,
+    })
     @IsEnum(Role)
     @IsOptional()
     role?: Role;

--- a/backend/src/employees/dto/employee.dto.ts
+++ b/backend/src/employees/dto/employee.dto.ts
@@ -3,37 +3,70 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Role } from '../../users/role.enum';
 
 export class EmployeeDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Unique identifier of the employee',
+        type: Number,
+        example: 1,
+    })
     @Expose()
     id: number;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Employee email address',
+        type: String,
+        example: 'employee@example.com',
+    })
     @Expose()
     email: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'First name of the employee',
+        type: String,
+        example: 'Jane',
+    })
     @Expose()
     firstName: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Last name of the employee',
+        type: String,
+        example: 'Doe',
+    })
     @Expose()
     lastName: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Full name of the employee',
+        type: String,
+        example: 'Jane Doe',
+    })
     @Expose()
     get fullName(): string {
         return `${this.firstName} ${this.lastName}`.trim();
     }
 
-    @ApiProperty({ nullable: true })
+    @ApiProperty({
+        description: 'Contact phone number',
+        type: String,
+        nullable: true,
+        example: '+48123123123',
+    })
     @Expose()
     phone: string | null;
 
-    @ApiProperty({ enum: Role })
+    @ApiProperty({
+        description: 'Role of the employee',
+        enum: Role,
+        example: Role.Employee,
+    })
     @Expose()
     role: Role;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Base commission percentage',
+        type: Number,
+        example: 20,
+    })
     @Expose()
     commissionBase: number;
 }

--- a/backend/src/employees/dto/update-employee-commission.dto.ts
+++ b/backend/src/employees/dto/update-employee-commission.dto.ts
@@ -2,7 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, Max, Min } from 'class-validator';
 
 export class UpdateEmployeeCommissionDto {
-    @ApiProperty({ minimum: 0, maximum: 100, description: 'Commission percentage' })
+    @ApiProperty({
+        description: 'Commission percentage for the employee',
+        type: Number,
+        minimum: 0,
+        maximum: 100,
+        example: 15,
+    })
     @IsNumber()
     @Min(0)
     @Max(100)

--- a/backend/src/employees/dto/update-employee-profile.dto.ts
+++ b/backend/src/employees/dto/update-employee-profile.dto.ts
@@ -8,27 +8,47 @@ import {
 } from 'class-validator';
 
 export class UpdateEmployeeProfileDto {
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated email address',
+        type: String,
+        example: 'employee.new@example.com',
+    })
     @IsEmail()
     @IsOptional()
     email?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated first name',
+        type: String,
+        example: 'Eva',
+    })
     @IsString()
     @IsOptional()
     firstName?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated last name',
+        type: String,
+        example: 'Kowalska',
+    })
     @IsString()
     @IsOptional()
     lastName?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated phone number',
+        type: String,
+        example: '+48123456789',
+    })
     @IsMobilePhone('pl-PL')
     @IsOptional()
     phone?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'New account password',
+        type: String,
+        example: 'NewPass123!'
+    })
     @IsString()
     @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)
     @IsOptional()

--- a/backend/src/employees/dto/update-employee.dto.ts
+++ b/backend/src/employees/dto/update-employee.dto.ts
@@ -9,27 +9,47 @@ import {
 import { Role } from '../../users/role.enum';
 
 export class UpdateEmployeeDto {
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated email address',
+        type: String,
+        example: 'employee.new@example.com',
+    })
     @IsEmail()
     @IsOptional()
     email?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated first name',
+        type: String,
+        example: 'Eve',
+    })
     @IsString()
     @IsOptional()
     firstName?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated last name',
+        type: String,
+        example: 'Smith',
+    })
     @IsString()
     @IsOptional()
     lastName?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated phone number',
+        type: String,
+        example: '+48123456789',
+    })
     @IsMobilePhone()
     @IsOptional()
     phone?: string;
 
-    @ApiPropertyOptional({ enum: Role })
+    @ApiPropertyOptional({
+        enum: Role,
+        description: 'Updated role of the employee',
+        example: Role.Admin,
+    })
     @IsEnum(Role)
     @IsOptional()
     role?: Role;

--- a/backend/src/formulas/dto/create-appointment-formula.dto.ts
+++ b/backend/src/formulas/dto/create-appointment-formula.dto.ts
@@ -1,6 +1,12 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateAppointmentFormulaDto {
+    @ApiProperty({
+        description: 'Description of the formula used during the appointment',
+        type: String,
+        example: '2 parts developer to 1 part color',
+    })
     @IsString()
     description: string;
 }

--- a/backend/src/formulas/dto/create-formula.dto.ts
+++ b/backend/src/formulas/dto/create-formula.dto.ts
@@ -1,12 +1,28 @@
 import { IsInt, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateFormulaDto {
+    @ApiProperty({
+        description: 'Identifier of the client for whom the formula is created',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     clientId: number;
 
+    @ApiProperty({
+        description: 'Description of the formula',
+        type: String,
+        example: 'Custom hair color mix',
+    })
     @IsString()
     description: string;
 
+    @ApiPropertyOptional({
+        description: 'Associated appointment identifier',
+        type: Number,
+        example: 10,
+    })
     @IsOptional()
     @IsInt()
     appointmentId?: number;

--- a/backend/src/messages/dto/create-message.dto.ts
+++ b/backend/src/messages/dto/create-message.dto.ts
@@ -1,9 +1,20 @@
 import { IsInt, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateMessageDto {
+    @ApiProperty({
+        description: 'Identifier of the message recipient',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     recipientId: number;
 
+    @ApiProperty({
+        description: 'Message content',
+        type: String,
+        example: 'Your order is ready for pickup.',
+    })
     @IsString()
     content: string;
 }

--- a/backend/src/product-usage/dto/appointment-product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/appointment-product-usage-entry.dto.ts
@@ -6,11 +6,20 @@ const allowedUsageTypes = [UsageType.INTERNAL, UsageType.STOCK_CORRECTION] as co
 export type AppointmentUsageType = (typeof allowedUsageTypes)[number];
 
 export class AppointmentProductUsageEntryDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Identifier of the product used',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     productId: number;
 
-    @ApiProperty({ minimum: 1 })
+    @ApiProperty({
+        description: 'Quantity of product used',
+        type: Number,
+        minimum: 1,
+        example: 2,
+    })
     @IsInt()
     @Min(1)
     quantity: number;
@@ -20,6 +29,7 @@ export class AppointmentProductUsageEntryDto {
         enum: allowedUsageTypes,
         required: false,
         description: 'Usage classification. Allowed values: INTERNAL or STOCK_CORRECTION. Defaults to INTERNAL when omitted.',
+        example: UsageType.INTERNAL,
     })
     usageType?: AppointmentUsageType;
 }

--- a/backend/src/product-usage/dto/product-usage-entry.dto.ts
+++ b/backend/src/product-usage/dto/product-usage-entry.dto.ts
@@ -3,12 +3,22 @@ import { IsEnum, IsInt, Min } from 'class-validator';
 import { UsageType } from '../usage-type.enum';
 
 export class ProductUsageEntryDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Identifier of the product used',
+        type: Number,
+        minimum: 1,
+        example: 1,
+    })
     @IsInt()
     @Min(1)
     productId: number;
 
-    @ApiProperty({ minimum: 1 })
+    @ApiProperty({
+        description: 'Quantity of product used',
+        type: Number,
+        minimum: 1,
+        example: 2,
+    })
     @IsInt()
     @Min(1)
     quantity: number;
@@ -18,6 +28,7 @@ export class ProductUsageEntryDto {
         enum: UsageType,
         required: false,
         description: 'Usage classification. Defaults to INTERNAL when omitted.',
+        example: UsageType.INTERNAL,
     })
     usageType?: UsageType;
 }

--- a/backend/src/products/dto/bulk-update-stock.dto.ts
+++ b/backend/src/products/dto/bulk-update-stock.dto.ts
@@ -3,7 +3,11 @@ import { IsArray, IsInt, Min, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class BulkStockEntryDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Product identifier',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     id: number;
 
@@ -11,6 +15,8 @@ export class BulkStockEntryDto {
         minimum: 0,
         description:
             'New stock level. Adjustments are logged with usageType STOCK_CORRECTION.',
+        type: Number,
+        example: 20,
     })
     @IsInt()
     @Min(0)
@@ -22,6 +28,7 @@ export class BulkUpdateStockDto {
         type: [BulkStockEntryDto],
         description:
             'Array of stock updates. Each change is logged with usageType STOCK_CORRECTION.',
+        example: [{ id: 1, stock: 20 }],
     })
     @IsArray()
     @ValidateNested({ each: true })

--- a/backend/src/products/dto/create-product.dto.ts
+++ b/backend/src/products/dto/create-product.dto.ts
@@ -6,24 +6,55 @@ import {
     Min,
     Length,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateProductDto {
+    @ApiProperty({
+        description: 'Product name',
+        type: String,
+        minLength: 2,
+        maxLength: 80,
+        example: 'Shampoo',
+    })
     @IsString()
     @Length(2, 80)
     name: string;
 
+    @ApiPropertyOptional({
+        description: 'Product brand',
+        type: String,
+        example: 'Acme',
+    })
     @IsOptional()
     @IsString()
     brand?: string;
 
+    @ApiProperty({
+        description: 'Price per unit',
+        type: Number,
+        minimum: 1.01,
+        example: 19.99,
+    })
     @IsNumber({ maxDecimalPlaces: 2 })
     @Min(1.01)
     unitPrice: number;
 
+    @ApiProperty({
+        description: 'Number of items currently in stock',
+        type: Number,
+        minimum: 0,
+        example: 100,
+    })
     @IsInt()
     @Min(0)
     stock: number;
 
+    @ApiPropertyOptional({
+        description: 'Threshold below which stock is considered low',
+        type: Number,
+        minimum: 0,
+        example: 5,
+    })
     @IsOptional()
     @IsInt()
     @Min(0)

--- a/backend/src/products/dto/update-product.dto.ts
+++ b/backend/src/products/dto/update-product.dto.ts
@@ -7,30 +7,60 @@ import {
     Min,
     Length,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { CreateProductDto } from './create-product.dto';
 
 export class UpdateProductDto extends PartialType(
     OmitType(CreateProductDto, ['brand'] as const),
 ) {
+    @ApiPropertyOptional({
+        description: 'Updated product name',
+        type: String,
+        example: 'Conditioner',
+    })
     @IsOptional()
     @IsString()
     @Length(2, 80)
     name?: string;
 
+    @ApiPropertyOptional({
+        description: 'Updated product brand',
+        type: String,
+        example: 'Acme',
+        nullable: true,
+    })
     @IsOptional()
     @IsString()
     brand?: string | null;
 
+    @ApiPropertyOptional({
+        description: 'Updated unit price',
+        type: Number,
+        minimum: 1.01,
+        example: 15.99,
+    })
     @IsOptional()
     @IsNumber({ maxDecimalPlaces: 2 })
     @Min(1.01)
     unitPrice?: number;
 
+    @ApiPropertyOptional({
+        description: 'Updated stock level',
+        type: Number,
+        minimum: 0,
+        example: 50,
+    })
     @IsOptional()
     @IsInt()
     @Min(0)
     stock?: number;
 
+    @ApiPropertyOptional({
+        description: 'Updated low stock threshold',
+        type: Number,
+        minimum: 0,
+        example: 10,
+    })
     @IsOptional()
     @IsInt()
     @Min(0)

--- a/backend/src/reviews/dto/create-review.dto.ts
+++ b/backend/src/reviews/dto/create-review.dto.ts
@@ -1,14 +1,33 @@
 import { IsInt, IsOptional, IsString, Max, Min, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateReviewDto {
+    @ApiProperty({
+        description: 'Identifier of the reviewed appointment',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     appointmentId: number;
 
+    @ApiProperty({
+        description: 'Rating from 1 (worst) to 5 (best)',
+        type: Number,
+        minimum: 1,
+        maximum: 5,
+        example: 5,
+    })
     @IsInt()
     @Min(1)
     @Max(5)
     rating: number;
 
+    @ApiPropertyOptional({
+        description: 'Optional review comment',
+        type: String,
+        maxLength: 500,
+        example: 'Excellent service',
+    })
     @IsOptional()
     @IsString()
     @MaxLength(500)

--- a/backend/src/sales/dto/create-sale.dto.ts
+++ b/backend/src/sales/dto/create-sale.dto.ts
@@ -1,19 +1,46 @@
 import { IsInt, Min, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateSaleDto {
+    @ApiProperty({
+        description: 'Identifier of the purchasing client',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     clientId: number;
 
+    @ApiProperty({
+        description: 'Identifier of the employee processing the sale',
+        type: Number,
+        example: 2,
+    })
     @IsInt()
     employeeId: number;
 
+    @ApiProperty({
+        description: 'Identifier of the product sold',
+        type: Number,
+        example: 3,
+    })
     @IsInt()
     productId: number;
 
+    @ApiProperty({
+        description: 'Quantity of product sold',
+        type: Number,
+        minimum: 1,
+        example: 2,
+    })
     @IsInt()
     @Min(1)
     quantity: number;
 
+    @ApiPropertyOptional({
+        description: 'Optional related appointment identifier',
+        type: Number,
+        example: 10,
+    })
     @IsInt()
     @IsOptional()
     appointmentId?: number;

--- a/backend/src/services/dto/create-service.dto.ts
+++ b/backend/src/services/dto/create-service.dto.ts
@@ -1,28 +1,66 @@
 import { IsInt, IsNumber, IsOptional, IsString, Length, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateServiceDto {
+    @ApiProperty({
+        description: 'Service name',
+        type: String,
+        minLength: 2,
+        maxLength: 80,
+        example: 'Haircut',
+    })
     @IsString()
     @Length(2, 80)
     name: string;
 
+    @ApiPropertyOptional({
+        description: 'Detailed description of the service',
+        type: String,
+        example: 'Includes wash and style',
+    })
     @IsOptional()
     @IsString()
     description?: string;
 
+    @ApiProperty({
+        description: 'Duration of the service in minutes',
+        type: Number,
+        minimum: 10,
+        maximum: 480,
+        example: 60,
+    })
     @IsInt()
     @Min(10)
     @Max(480)
     duration: number;
 
+    @ApiProperty({
+        description: 'Price of the service',
+        type: Number,
+        minimum: 1,
+        maximum: 10000,
+        example: 49.99,
+    })
     @IsNumber({ maxDecimalPlaces: 2 })
     @Min(1)
     @Max(10000)
     price: number;
 
+    @ApiPropertyOptional({
+        description: 'Default commission percentage for the service',
+        type: Number,
+        example: 10,
+        nullable: true,
+    })
     @IsOptional()
     @IsNumber()
     defaultCommissionPercent?: number | null;
 
+    @ApiProperty({
+        description: 'Category identifier to which the service belongs',
+        type: Number,
+        example: 1,
+    })
     @IsInt()
     categoryId: number;
 }

--- a/backend/src/services/dto/update-service.dto.ts
+++ b/backend/src/services/dto/update-service.dto.ts
@@ -1,31 +1,69 @@
 import { IsInt, IsNumber, IsOptional, IsString, Length, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateServiceDto {
+    @ApiPropertyOptional({
+        description: 'Updated service name',
+        type: String,
+        example: 'Deluxe Haircut',
+    })
     @IsOptional()
     @IsString()
     @Length(2, 80)
     name?: string;
 
+    @ApiPropertyOptional({
+        description: 'Updated service description',
+        type: String,
+        example: 'Includes wash, cut and style',
+        nullable: true,
+    })
     @IsOptional()
     @IsString()
     description?: string | null;
 
+    @ApiPropertyOptional({
+        description: 'Updated duration in minutes',
+        type: Number,
+        minimum: 10,
+        maximum: 480,
+        example: 90,
+    })
     @IsOptional()
     @IsInt()
     @Min(10)
     @Max(480)
     duration?: number;
 
+    @ApiPropertyOptional({
+        description: 'Updated service price',
+        type: Number,
+        minimum: 1,
+        maximum: 10000,
+        example: 59.99,
+    })
     @IsOptional()
     @IsNumber({ maxDecimalPlaces: 2 })
     @Min(1)
     @Max(10000)
     price?: number;
 
+    @ApiPropertyOptional({
+        description: 'Updated default commission percentage',
+        type: Number,
+        example: 12,
+        nullable: true,
+    })
     @IsOptional()
     @IsNumber()
     defaultCommissionPercent?: number | null;
 
+    @ApiPropertyOptional({
+        description: 'Updated category identifier',
+        type: Number,
+        example: 2,
+        nullable: true,
+    })
     @IsOptional()
     @IsInt()
     categoryId?: number | null;

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -11,39 +11,76 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Role } from '../role.enum';
 
 export class CreateUserDto {
-    @ApiProperty()
+    @ApiProperty({
+        description: 'User email address',
+        type: String,
+        example: 'user@example.com',
+    })
     @IsEmail()
     @IsNotEmpty()
     email: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Account password',
+        type: String,
+        minLength: 6,
+        example: 'Secret123',
+    })
     @MinLength(6)
     password: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'First name of the user',
+        type: String,
+        example: 'Jan',
+    })
     @IsString()
     firstName: string;
 
-    @ApiProperty()
+    @ApiProperty({
+        description: 'Last name of the user',
+        type: String,
+        example: 'Kowalski',
+    })
     @IsString()
     lastName: string;
 
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        description: 'Optional contact phone number',
+        type: String,
+        required: false,
+        example: '+48123123123',
+    })
     @IsString()
     @IsOptional()
     phone?: string;
 
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        description: 'Whether the user accepted the privacy policy',
+        type: Boolean,
+        required: false,
+        example: true,
+    })
     @IsBoolean()
     @IsOptional()
     privacyConsent?: boolean;
 
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        description: 'Whether the user consents to marketing messages',
+        type: Boolean,
+        required: false,
+        example: false,
+    })
     @IsBoolean()
     @IsOptional()
     marketingConsent?: boolean;
 
-    @ApiProperty({ enum: Role, required: false })
+    @ApiProperty({
+        description: 'Role assigned to the user',
+        enum: Role,
+        required: false,
+        example: Role.Client,
+    })
     @IsEnum(Role)
     @IsOptional()
     role?: Role;

--- a/backend/src/users/dto/update-customer.dto.ts
+++ b/backend/src/users/dto/update-customer.dto.ts
@@ -8,27 +8,47 @@ import {
 } from 'class-validator';
 
 export class UpdateCustomerDto {
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated email address',
+        type: String,
+        example: 'new@example.com',
+    })
     @IsEmail()
     @IsOptional()
     email?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated first name',
+        type: String,
+        example: 'Anna',
+    })
     @IsString()
     @IsOptional()
     firstName?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated last name',
+        type: String,
+        example: 'Nowak',
+    })
     @IsString()
     @IsOptional()
     lastName?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated phone number',
+        type: String,
+        example: '+48123456789',
+    })
     @IsMobilePhone()
     @IsOptional()
     phone?: string;
 
-    @ApiPropertyOptional()
+    @ApiPropertyOptional({
+        description: 'Updated marketing consent',
+        type: Boolean,
+        example: true,
+    })
     @IsBoolean()
     @IsOptional()
     marketingConsent?: boolean;


### PR DESCRIPTION
## Summary
- document appointment creation and update request DTOs for Swagger
- add descriptive `@ApiProperty` metadata across customer, product, and other DTOs
- include examples, types and required flags for accurate API docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68933ae9ec9c8329aecf776b0acbcd55