### PR TITLE
docs: add error responses to customers controller

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -37,6 +37,9 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'List customers' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
     async list() {
         return this.service.findAll();
     }
@@ -45,6 +48,10 @@ export class CustomersController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Get own customer profile' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Not Found' })
     async getMe(@Request() req) {
         const customer = await this.service.findOne(req.user.id);
         if (!customer) {
@@ -57,6 +64,9 @@ export class CustomersController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Update own customer profile' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
     async updateMe(@Request() req, @Body() dto: UpdateCustomerDto) {
         return this.service.updateProfile(req.user.id, dto);
     }
@@ -65,6 +75,10 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Get customer by id' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Not Found' })
     async get(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.findOne(id);
         if (!customer) {
@@ -77,6 +91,10 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Activate customer account' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Not Found' })
     async activate(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.setActive(id, true);
         if (!customer) {
@@ -89,6 +107,10 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Deactivate customer account' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Not Found' })
     async deactivate(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.setActive(id, false);
         if (!customer) {
@@ -101,6 +123,10 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Update customer marketing consent' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Not Found' })
     async updateMarketingConsent(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: UpdateMarketingConsentDto,
@@ -119,6 +145,9 @@ export class CustomersController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Request account deletion' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
     async removeMe(@Request() req) {
         await this.service.forgetMe(req.user.id);
         return { success: true };


### PR DESCRIPTION
## Summary
- document common error responses for customer endpoints

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893402d96808329bb304b8e4b346b22