### PR TITLE
docs: document error responses

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from './common/decorators/api-error-responses.decorator';
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from './auth/public.decorator';
@@ -12,6 +13,7 @@ export class AppController {
     @Public()
     @ApiOperation({ summary: 'Get greeting message' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     getHello(): string {
         return this.appService.getHello();
     }

--- a/backend/src/appointments/admin-appointments.controller.ts
+++ b/backend/src/appointments/admin-appointments.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -43,6 +44,7 @@ export class AdminAppointmentsController {
     @Get()
     @ApiOperation({ summary: 'List all appointments' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({ name: 'employeeId', required: false })
     @ApiQuery({ name: 'startDate', required: false })
     @ApiQuery({ name: 'endDate', required: false })
@@ -64,6 +66,7 @@ export class AdminAppointmentsController {
     @Post()
     @ApiOperation({ summary: 'Create appointment' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Body() dto: CreateAppointmentDto, @Request() req: AuthRequest) {
         return this.service.create(
             dto.clientId,
@@ -78,6 +81,7 @@ export class AdminAppointmentsController {
     @Patch(':id')
     @ApiOperation({ summary: 'Update appointment' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     update(@Param('id') id: string, @Body() dto: UpdateAppointmentDto) {
         return this.service.update(Number(id), dto);
     }

--- a/backend/src/appointments/appointment-reviews.controller.ts
+++ b/backend/src/appointments/appointment-reviews.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -27,6 +28,7 @@ export class AppointmentReviewsController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Create review for appointment' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: CreateAppointmentReviewDto,
@@ -42,6 +44,7 @@ export class AppointmentReviewsController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Get review for appointment' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     find(@Param('id', ParseIntPipe) id: number) {
         return this.reviews.findByAppointment(id);
     }

--- a/backend/src/appointments/client-appointments.controller.ts
+++ b/backend/src/appointments/client-appointments.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -41,6 +42,7 @@ export class ClientAppointmentsController {
     @Get()
     @ApiOperation({ summary: 'List appointments for logged in client' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list(@Request() req) {
         return this.service.findClientAppointments(Number(req.user.id));
     }
@@ -62,6 +64,7 @@ export class ClientAppointmentsController {
     @Post()
     @ApiOperation({ summary: 'Create new appointment for client' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(
         @Request() req: AuthRequest,
         @Body() dto: Omit<CreateAppointmentDto, 'clientId'>,

--- a/backend/src/appointments/employee-appointments.controller.ts
+++ b/backend/src/appointments/employee-appointments.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -38,6 +39,7 @@ export class EmployeeAppointmentsController {
     @Get()
     @ApiOperation({ summary: 'List appointments assigned to employee' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list(@Request() req) {
         return this.service.findEmployeeAppointments(Number(req.user.id));
     }

--- a/backend/src/appointments/me-appointments.controller.ts
+++ b/backend/src/appointments/me-appointments.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Controller,
     Get,
@@ -33,6 +34,7 @@ export class MeAppointmentsController {
     @Get('me')
     @ApiOperation({ summary: 'List appointments for current user' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list(@Request() req: AuthRequest) {
         const { id, role } = req.user;
         if (role === Role.Client) {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
 import {
     ApiTags,
@@ -30,6 +31,7 @@ export class AuthController {
     @UseGuards(LocalAuthGuard)
     @ApiOperation({ summary: 'Login with email and password' })
     @ApiResponse({ status: 201, description: 'JWT access and refresh tokens' })
+    @ApiErrorResponses()
     login(@Request() req: AuthRequest): Promise<AuthTokensDto> {
         return this.authService.generateTokens(req.user.id, req.user.role);
     }
@@ -38,6 +40,7 @@ export class AuthController {
     @Public()
     @ApiOperation({ summary: 'Register a new client account' })
     @ApiResponse({ status: 201, description: 'JWT access and refresh tokens' })
+    @ApiErrorResponses()
     register(@Body() registerDto: RegisterClientDto): Promise<AuthTokensDto> {
         return this.authService.registerClient(registerDto);
     }
@@ -46,6 +49,7 @@ export class AuthController {
     @Public()
     @ApiOperation({ summary: 'Login or register using social provider token' })
     @ApiResponse({ status: 201, description: 'JWT tokens and user data' })
+    @ApiErrorResponses()
     async socialLogin(@Body() dto: SocialLoginDto, @Request() req): Promise<any> {
         const { tokens, user, isNew } = await this.authService.socialLogin(dto);
         const result = {
@@ -67,6 +71,7 @@ export class AuthController {
     @Public()
     @ApiOperation({ summary: 'Refresh expired access token' })
     @ApiResponse({ status: 201, description: 'New access and refresh tokens' })
+    @ApiErrorResponses()
     refresh(@Body() dto: RefreshTokenDto): Promise<AuthTokensDto> {
         return this.authService.refresh(dto.refresh_token);
     }

--- a/backend/src/calendar/calendar.controller.ts
+++ b/backend/src/calendar/calendar.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Param, Query, Headers } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
@@ -12,6 +13,7 @@ export class CalendarController {
     @Public()
     @ApiOperation({ summary: 'Add event to calendar' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async add(
         @Param('id') id: number,
         @Query('provider') provider = 'ics',

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,

--- a/backend/src/chat-messages/appointment-chat.controller.ts
+++ b/backend/src/chat-messages/appointment-chat.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Controller,
     Get,
@@ -28,6 +29,7 @@ export class AppointmentChatController {
     @Roles(Role.Client, Role.Employee)
     @ApiOperation({ summary: 'List chat messages for appointment' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async list(@Param('id') id: number, @Request() req) {
         const appt = await this.appointments.findOne(Number(id));
         if (!appt) {

--- a/backend/src/commissions/commissions.controller.ts
+++ b/backend/src/commissions/commissions.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Request, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CommissionsService } from './commissions.service';
@@ -17,6 +18,7 @@ export class CommissionsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'List all commissions' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     listAll() {
         return this.service.listAll();
     }
@@ -25,6 +27,7 @@ export class CommissionsController {
     @Roles(Role.Employee)
     @ApiOperation({ summary: 'List commissions for employee' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     listOwn(@Request() req) {
         return this.service.listForEmployee(Number(req.user.id));
     }

--- a/backend/src/common/decorators/api-error-responses.decorator.ts
+++ b/backend/src/common/decorators/api-error-responses.decorator.ts
@@ -1,0 +1,29 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+    ApiBadRequestResponse,
+    ApiUnauthorizedResponse,
+    ApiForbiddenResponse,
+    ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import { ErrorResponseDto } from '../dto/error-response.dto';
+
+export function ApiErrorResponses() {
+    return applyDecorators(
+        ApiBadRequestResponse({
+            description: 'Invalid request',
+            type: ErrorResponseDto,
+        }),
+        ApiUnauthorizedResponse({
+            description: 'Unauthorized',
+            type: ErrorResponseDto,
+        }),
+        ApiForbiddenResponse({
+            description: 'Forbidden',
+            type: ErrorResponseDto,
+        }),
+        ApiNotFoundResponse({
+            description: 'Not found',
+            type: ErrorResponseDto,
+        }),
+    );
+}

--- a/backend/src/common/dto/error-response.dto.ts
+++ b/backend/src/common/dto/error-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ErrorResponseDto {
+    @ApiProperty({ example: 400 })
+    statusCode!: number;
+
+    @ApiProperty({ example: 'Invalid request' })
+    message!: string | string[];
+
+    @ApiProperty({ example: 'Bad Request' })
+    error!: string;
+}

--- a/backend/src/communications/communications.controller.ts
+++ b/backend/src/communications/communications.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -18,6 +19,7 @@ export class CommunicationsController {
     @Roles(Role.Employee, Role.Admin)
     @ApiOperation({ summary: 'List communications for customer' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list(@Param('customerId') customerId: number) {
         return this.service.findForCustomer(Number(customerId));
     }
@@ -26,6 +28,7 @@ export class CommunicationsController {
     @Roles(Role.Employee, Role.Admin)
     @ApiOperation({ summary: 'Create communication' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Body() dto: CreateCommunicationDto) {
         return this.service.create(dto.customerId, dto.medium, dto.content);
     }

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -37,9 +38,13 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'List customers' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     async list() {
         return this.service.findAll();
     }
@@ -48,10 +53,15 @@ export class CustomersController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Get own customer profile' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404, description: 'Not Found' })
+    @ApiErrorResponses()
     async getMe(@Request() req) {
         const customer = await this.service.findOne(req.user.id);
         if (!customer) {
@@ -64,9 +74,13 @@ export class CustomersController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Update own customer profile' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     async updateMe(@Request() req, @Body() dto: UpdateCustomerDto) {
         return this.service.updateProfile(req.user.id, dto);
     }
@@ -75,10 +89,15 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Get customer by id' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404, description: 'Not Found' })
+    @ApiErrorResponses()
     async get(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.findOne(id);
         if (!customer) {
@@ -91,10 +110,15 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Activate customer account' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404, description: 'Not Found' })
+    @ApiErrorResponses()
     async activate(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.setActive(id, true);
         if (!customer) {
@@ -107,10 +131,15 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Deactivate customer account' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404, description: 'Not Found' })
+    @ApiErrorResponses()
     async deactivate(@Param('id', ParseIntPipe) id: number) {
         const customer = await this.service.setActive(id, false);
         if (!customer) {
@@ -123,10 +152,15 @@ export class CustomersController {
     @Roles(Role.Admin, EmployeeRole.RECEPTIONIST)
     @ApiOperation({ summary: 'Update customer marketing consent' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404, description: 'Not Found' })
+    @ApiErrorResponses()
     async updateMarketingConsent(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: UpdateMarketingConsentDto,
@@ -145,9 +179,13 @@ export class CustomersController {
     @Roles(Role.Client)
     @ApiOperation({ summary: 'Request account deletion' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 400, description: 'Bad Request' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiErrorResponses()
     @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiErrorResponses()
     async removeMe(@Request() req) {
         await this.service.forgetMe(req.user.id);
         return { success: true };

--- a/backend/src/dashboard/dashboard.controller.ts
+++ b/backend/src/dashboard/dashboard.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Request, UseGuards } from '@nestjs/common';
 import {
     ApiTags,
@@ -25,6 +26,7 @@ export class DashboardController {
     @Get()
     @ApiOperation({ summary: 'Get dashboard summary for logged user' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     getDashboard(@Request() req: AuthRequest) {
         return this.service.getSummary(req.user.id, req.user.role);
     }

--- a/backend/src/emails/emails.controller.ts
+++ b/backend/src/emails/emails.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     BadRequestException,
     Body,
@@ -19,6 +20,7 @@ export class EmailsController {
     @Public()
     @ApiOperation({ summary: 'List emails' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }
@@ -27,6 +29,7 @@ export class EmailsController {
     @Public()
     @ApiOperation({ summary: 'Send email' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     send(@Body() body: EmailPayload) {
         return this.service.sendEmail(body);
     }
@@ -35,6 +38,7 @@ export class EmailsController {
     @Public()
     @ApiOperation({ summary: 'Send bulk emails' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     sendBulk(@Body() body: { emails: EmailPayload[] }) {
         return this.service.sendBulk(body.emails);
     }
@@ -43,6 +47,7 @@ export class EmailsController {
     @Public()
     @ApiOperation({ summary: 'Opt out email' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     optOut(@Body() body: { token?: string; email?: string }) {
         const tokenOrEmail = body.token || body.email;
         if (!tokenOrEmail) {
@@ -55,6 +60,7 @@ export class EmailsController {
     @Public()
     @ApiOperation({ summary: 'Unsubscribe email' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     unsubscribe(@Param('token') token: string) {
         return this.service.optOut(token);
     }

--- a/backend/src/employees/employee-reviews.controller.ts
+++ b/backend/src/employees/employee-reviews.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ReviewsService } from '../reviews/reviews.service';
@@ -13,6 +14,7 @@ export class EmployeeReviewsController {
     @ApiQuery({ name: 'limit', required: false })
     @ApiQuery({ name: 'rating', required: false })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list(
         @Param('id', ParseIntPipe) id: number,
         @Query('page') page = '1',

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -45,6 +46,7 @@ export class EmployeesController {
     @Get()
     @ApiOperation({ summary: 'List employees' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }
@@ -53,6 +55,7 @@ export class EmployeesController {
     @Roles(Role.Employee)
     @ApiOperation({ summary: 'Get own employee profile' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async getMe(@Request() req: AuthRequest) {
         const employee = await this.service.findMe(req.user.id);
         if (!employee) {
@@ -65,6 +68,7 @@ export class EmployeesController {
     @Roles(Role.Employee)
     @ApiOperation({ summary: 'Update own employee profile' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async updateMe(
         @Request() req: AuthRequest,
         @Body() dto: UpdateEmployeeProfileDto,
@@ -75,7 +79,9 @@ export class EmployeesController {
     @Get(':id')
     @ApiOperation({ summary: 'Get employee by id' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async get(@Param('id', ParseIntPipe) id: number) {
         const employee = await this.service.findOne(id);
         if (!employee) {
@@ -92,6 +98,7 @@ export class EmployeesController {
             'Employee created. The plaintext password is returned only in this response.',
         type: CreateEmployeeResponseDto,
     })
+    @ApiErrorResponses()
     create(
         @Body() dto: CreateEmployeeDto,
         @Request() req: AuthRequest,
@@ -102,7 +109,9 @@ export class EmployeesController {
     @Put(':id')
     @ApiOperation({ summary: 'Update employee profile' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async update(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: UpdateEmployeeDto,
@@ -118,7 +127,9 @@ export class EmployeesController {
     @Patch(':id/activate')
     @ApiOperation({ summary: 'Activate employee account' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async activate(
         @Param('id', ParseIntPipe) id: number,
         @Request() req: AuthRequest,
@@ -133,7 +144,9 @@ export class EmployeesController {
     @Patch(':id/deactivate')
     @ApiOperation({ summary: 'Deactivate employee account' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async deactivate(
         @Param('id', ParseIntPipe) id: number,
         @Request() req: AuthRequest,
@@ -149,7 +162,9 @@ export class EmployeesController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Update employee commission percentage' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async updateCommission(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: UpdateEmployeeCommissionDto,
@@ -169,7 +184,9 @@ export class EmployeesController {
     @Delete(':id')
     @ApiOperation({ summary: 'Soft delete employee' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async remove(
         @Param('id', ParseIntPipe) id: number,
         @Request() req: AuthRequest,

--- a/backend/src/formulas/appointment-formulas.controller.ts
+++ b/backend/src/formulas/appointment-formulas.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -30,6 +31,7 @@ export class AppointmentFormulasController {
     @Roles(Role.Employee, Role.Admin)
     @ApiOperation({ summary: 'Create formula for appointment' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     async create(
         @Param('id') id: number,
         @Body() dto: CreateAppointmentFormulaDto,

--- a/backend/src/formulas/clients-formulas.controller.ts
+++ b/backend/src/formulas/clients-formulas.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Controller,
     Get,
@@ -24,6 +25,7 @@ export class ClientsFormulasController {
     @Roles(Role.Client, Role.Employee)
     @ApiOperation({ summary: 'List formulas for client' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async list(@Param('id') id: number, @Request() req) {
         if (req.user.role === Role.Client && req.user.id !== Number(id)) {
             throw new ForbiddenException();

--- a/backend/src/formulas/formulas.controller.ts
+++ b/backend/src/formulas/formulas.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -26,6 +27,7 @@ export class FormulasController {
     @Roles(Role.Client, Role.Employee)
     @ApiOperation({ summary: 'List formulas for current user' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     listOwn(@Request() req) {
         return this.service.findForUser(Number(req.user.id));
     }
@@ -34,6 +36,7 @@ export class FormulasController {
     @Roles(Role.Employee)
     @ApiOperation({ summary: 'List formulas for client' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     listForClient(@Param('clientId') clientId: string) {
         return this.service.findForUser(Number(clientId));
     }
@@ -42,6 +45,7 @@ export class FormulasController {
     @Roles(Role.Employee)
     @ApiOperation({ summary: 'Create formula' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Body() dto: CreateFormulaDto) {
         return this.service.create(
             dto.clientId,

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from './common/decorators/api-error-responses.decorator';
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from './auth/public.decorator';
@@ -9,6 +10,7 @@ export class HealthController {
     @Public()
     @ApiOperation({ summary: 'Health check' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     getHealth() {
         return { status: 'ok' };
     }

--- a/backend/src/integrations/gallery.controller.ts
+++ b/backend/src/integrations/gallery.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
@@ -12,6 +13,7 @@ export class GalleryController {
     @Public()
     @ApiOperation({ summary: 'Get gallery posts' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     getGallery(@Query('count') count = '9') {
         const num = parseInt(count, 10) || 9;
         return this.instagram.fetchLatestPosts(num);

--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -17,6 +18,7 @@ export class InvoicesController {
     @Get()
     @ApiOperation({ summary: 'List invoices' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }
@@ -24,6 +26,7 @@ export class InvoicesController {
     @Post('generate/:reservationId')
     @ApiOperation({ summary: 'Generate invoice for reservation' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     generate(@Param('reservationId') id: number) {
         return this.service.generate(Number(id));
     }
@@ -31,6 +34,7 @@ export class InvoicesController {
     @Get(':id/pdf')
     @ApiOperation({ summary: 'Get invoice PDF' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     getPdf(@Param('id') id: number) {
         return this.service.getPdf(Number(id));
     }

--- a/backend/src/logs/logs.controller.ts
+++ b/backend/src/logs/logs.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';

--- a/backend/src/messages/messages.controller.ts
+++ b/backend/src/messages/messages.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -25,6 +26,7 @@ export class MessagesController {
     @Get()
     @ApiOperation({ summary: 'List messages for user' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list(@Request() req) {
         return this.service.findForUser(Number(req.user.id));
     }
@@ -32,6 +34,7 @@ export class MessagesController {
     @Post()
     @ApiOperation({ summary: 'Create message' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Request() req, @Body() dto: CreateMessageDto) {
         return this.service.create(
             Number(req.user.id),

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
@@ -12,6 +13,7 @@ export class NotificationsController {
     @Public()
     @ApiOperation({ summary: 'List notifications' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Body, Controller, Post, Req, Headers } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { PaymentsService } from './payments.service';
@@ -10,6 +11,7 @@ export class PaymentsController {
     @Post('create-session')
     @ApiOperation({ summary: 'Create Stripe checkout session' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     async create(@Body('appointmentId') appointmentId: number) {
         const url = await this.payments.createCheckoutSession(appointmentId);
         return { url };
@@ -18,6 +20,7 @@ export class PaymentsController {
     @Post('webhook')
     @ApiOperation({ summary: 'Stripe webhook endpoint' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async webhook(@Req() req: any, @Headers('stripe-signature') sig: string) {
         const buf = req.rawBody as Buffer;
         await this.payments.handleWebhook(buf, sig);

--- a/backend/src/product-usage/appointment-product-usage.controller.ts
+++ b/backend/src/product-usage/appointment-product-usage.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -49,8 +50,11 @@ export class AppointmentProductUsageController {
             'Records consumption of products. The usageType defaults to INTERNAL when not provided.',
     })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 409 })
+    @ApiErrorResponses()
     @ApiBody({
         type: [AppointmentProductUsageEntryDto],
         description:

--- a/backend/src/product-usage/product-usage.controller.ts
+++ b/backend/src/product-usage/product-usage.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -24,6 +25,7 @@ export class ProductUsageController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'List usage history for product' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({
         name: 'usageType',
         required: false,

--- a/backend/src/products/admin/admin.controller.ts
+++ b/backend/src/products/admin/admin.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -41,6 +42,7 @@ export class AdminController {
     @Get()
     @ApiOperation({ summary: 'List all products' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }
@@ -48,6 +50,7 @@ export class AdminController {
     @Post()
     @ApiOperation({ summary: 'Create product' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Body() dto: CreateProductDto) {
         return this.service.create(dto);
     }
@@ -59,6 +62,7 @@ export class AdminController {
             'Adjusts stock levels for multiple products. Each change is logged with usageType STOCK_CORRECTION.',
     })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiBody({
         type: BulkUpdateStockDto,
         description: 'Stock levels to apply. Logged as usageType STOCK_CORRECTION.',
@@ -73,6 +77,7 @@ export class AdminController {
     @Patch(':id')
     @ApiOperation({ summary: 'Update product' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     update(@Param('id') id: number, @Body() dto: UpdateProductDto) {
         return this.service.update(Number(id), dto);
     }
@@ -83,6 +88,7 @@ export class AdminController {
         description: 'Increments or decrements stock. Logged with usageType STOCK_CORRECTION.',
     })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiBody({
         schema: {
             type: 'object',
@@ -110,6 +116,7 @@ export class AdminController {
     @Delete(':id')
     @ApiOperation({ summary: 'Delete product' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     remove(@Param('id') id: number) {
         return this.service.remove(Number(id));
     }

--- a/backend/src/products/employee/employee.controller.ts
+++ b/backend/src/products/employee/employee.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../../common/decorators/api-error-responses.decorator';
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
@@ -17,6 +18,7 @@ export class EmployeeController {
     @Get()
     @ApiOperation({ summary: 'List products for employee' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }

--- a/backend/src/products/public/public.controller.ts
+++ b/backend/src/products/public/public.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../../common/decorators/api-error-responses.decorator';
 import {
     Controller,
     Get,
@@ -29,6 +30,7 @@ export class PublicController {
     @Get()
     @ApiOperation({ summary: 'List all products' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }
@@ -37,6 +39,7 @@ export class PublicController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'List low stock products' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     listLowStock() {
         return this.service.findLowStock();
     }
@@ -45,7 +48,9 @@ export class PublicController {
     @Get(':id')
     @ApiOperation({ summary: 'Get product by id' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async get(@Param('id') id: number) {
         const prod = await this.service.findOne(Number(id));
         if (!prod) {

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Controller,
     Get,
@@ -34,6 +35,7 @@ export class ReportsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Get financial report' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({
         name: 'from',
         required: false,
@@ -58,6 +60,7 @@ export class ReportsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Get employee report' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({
         name: 'from',
         required: false,
@@ -83,6 +86,7 @@ export class ReportsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Get top services' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({
         name: 'limit',
         required: false,
@@ -107,6 +111,7 @@ export class ReportsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Get top products' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({
         name: 'limit',
         required: false,
@@ -131,6 +136,7 @@ export class ReportsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Get new customers report' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiQuery({
         name: 'from',
         required: false,
@@ -155,6 +161,7 @@ export class ReportsController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Export report' })
     @ApiResponse({ status: 200, description: 'CSV export' })
+    @ApiErrorResponses()
     @ApiParam({
         name: 'type',
         enum: ['financial', 'services', 'products', 'customers'],

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Controller, Delete, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -17,6 +18,7 @@ export class ReviewsController {
     @Delete(':id')
     @ApiOperation({ summary: 'Delete review' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     remove(@Param('id', ParseIntPipe) id: number) {
         return this.service.remove(id);
     }

--- a/backend/src/sales/sales.controller.ts
+++ b/backend/src/sales/sales.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -18,6 +19,7 @@ export class SalesController {
     @Roles(Role.Admin, Role.Employee)
     @ApiOperation({ summary: 'Create sale' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Body() dto: CreateSaleDto) {
         return this.service.create(
             dto.clientId,

--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -35,6 +36,7 @@ export class ServicesController {
     @Get()
     @ApiOperation({ summary: 'List all services' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     list() {
         return this.service.findAll();
     }
@@ -43,7 +45,9 @@ export class ServicesController {
     @Get(':id')
     @ApiOperation({ summary: 'Get service by id' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     @ApiResponse({ status: 404 })
+    @ApiErrorResponses()
     async get(@Param('id') id: number) {
         const svc = await this.service.findOne(Number(id));
         if (!svc) {
@@ -56,6 +60,7 @@ export class ServicesController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Create service' })
     @ApiResponse({ status: 201 })
+    @ApiErrorResponses()
     create(@Body() dto: CreateServiceDto) {
         return this.service.create(dto);
     }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,3 +1,4 @@
+import { ApiErrorResponses } from '../common/decorators/api-error-responses.decorator';
 import {
     Body,
     Controller,
@@ -36,6 +37,7 @@ export class UsersController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Create a new user (admin only)' })
     @ApiResponse({ status: 201, description: 'User created' })
+    @ApiErrorResponses()
     create(@Body() createUserDto: CreateUserDto) {
         const {
             email,
@@ -67,6 +69,7 @@ export class UsersController {
     @Get('profile')
     @ApiOperation({ summary: 'Get current user profile' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     async getProfile(@Request() req) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const user = await this.usersService.findOne(req.user.id);
@@ -81,6 +84,7 @@ export class UsersController {
     @Roles(EmployeeRole.RECEPTIONIST, EmployeeRole.ADMIN, Role.Admin)
     @ApiOperation({ summary: 'Update customer data' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     updateCustomer(@Param('id') id: string, @Body() dto: UpdateCustomerDto) {
          
         return this.usersService.updateCustomer(Number(id), dto);
@@ -90,6 +94,7 @@ export class UsersController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Delete customer' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     removeCustomer(
         @Param('id') id: string,
         @Request() req: AuthRequest,
@@ -102,6 +107,7 @@ export class UsersController {
     @Roles(Role.Admin)
     @ApiOperation({ summary: 'Delete employee' })
     @ApiResponse({ status: 200 })
+    @ApiErrorResponses()
     removeEmployee(
         @Param('id') id: string,
         @Request() req: AuthRequest,


### PR DESCRIPTION
## Summary
- add `ErrorResponseDto` and `ApiErrorResponses` helper decorator
- document common error responses across all controllers

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68938401e2c083298ad62bb8502762d2