### PR TITLE
feat(swagger): expose public endpoints without bearer auth

### DIFF
--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -26,7 +26,6 @@ import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 
 @ApiTags('Categories')
-@ApiBearerAuth()
 @Controller('categories')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class CategoriesController {
@@ -52,6 +51,7 @@ export class CategoriesController {
 
     @Post()
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Create category' })
     create(@Body() dto: CreateCategoryDto) {
         return this.service.create(dto);
@@ -59,6 +59,7 @@ export class CategoriesController {
 
     @Put(':id')
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Update category' })
     update(@Param('id') id: number, @Body() dto: UpdateCategoryDto) {
         return this.service.update(Number(id), dto);
@@ -66,6 +67,7 @@ export class CategoriesController {
 
     @Delete(':id')
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Delete category' })
     remove(@Param('id') id: number) {
         return this.service.remove(Number(id));

--- a/backend/src/products/public/public.controller.ts
+++ b/backend/src/products/public/public.controller.ts
@@ -20,7 +20,6 @@ import { Role } from '../../users/role.enum';
 import { ProductsService } from '../products.service';
 
 @ApiTags('Products')
-@ApiBearerAuth()
 @Controller('products')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class PublicController {
@@ -37,6 +36,7 @@ export class PublicController {
 
     @Get('low-stock')
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'List low stock products' })
     @ApiResponse({ status: 200 })
     @ApiErrorResponses()

--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -26,7 +26,6 @@ import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
 
 @ApiTags('Services')
-@ApiBearerAuth()
 @Controller('services')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class ServicesController {
@@ -58,6 +57,7 @@ export class ServicesController {
 
     @Post()
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Create service' })
     @ApiResponse({ status: 201 })
     @ApiErrorResponses()
@@ -67,6 +67,7 @@ export class ServicesController {
 
     @Patch(':id')
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Update service' })
     update(@Param('id') id: number, @Body() dto: UpdateServiceDto) {
         return this.service.update(Number(id), dto);
@@ -74,6 +75,7 @@ export class ServicesController {
 
     @Delete(':id')
     @Roles(Role.Admin)
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Delete service' })
     remove(@Param('id') id: number) {
         return this.service.remove(Number(id));


### PR DESCRIPTION
## Summary
- restrict @ApiBearerAuth to protected routes in services, categories, and products controllers
- ensure public endpoints are not marked as requiring JWT in swagger

## Testing
- `npm test`
- `npm run swagger:generate`

------
https://chatgpt.com/codex/tasks/task_e_6893873ae9ac8329ba1f56c439a11832