### PR TITLE
docs: document swagger response types

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,6 +1,6 @@
 import { ApiErrorResponses } from './common/decorators/api-error-responses.decorator';
 import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
 import { Public } from './auth/public.decorator';
 import { AppService } from './app.service';
 
@@ -12,7 +12,13 @@ export class AppController {
     @Get()
     @Public()
     @ApiOperation({ summary: 'Get greeting message' })
-    @ApiResponse({ status: 200 })
+    @ApiOkResponse({
+        description: 'Greeting returned by the service',
+        schema: {
+            type: 'string',
+            example: 'Hello World!',
+        },
+    })
     @ApiErrorResponses()
     getHello(): string {
         return this.appService.getHello();

--- a/backend/src/auth/dto/social-login-response.dto.ts
+++ b/backend/src/auth/dto/social-login-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AuthTokensDto } from './auth-tokens.dto';
+
+class SocialUserDto {
+    @ApiProperty({ example: 1 })
+    id: number;
+
+    @ApiProperty({ example: 'user@example.com' })
+    email: string;
+
+    @ApiProperty({ example: 'Jane' })
+    firstName: string;
+
+    @ApiProperty({ example: 'Doe' })
+    lastName: string;
+
+    @ApiProperty({ example: 'client' })
+    role: string;
+}
+
+export class SocialLoginResponseDto extends AuthTokensDto {
+    @ApiProperty({ description: 'Authenticated user information', type: SocialUserDto })
+    user: SocialUserDto;
+}
+

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,6 +1,6 @@
 import { ApiErrorResponses } from './common/decorators/api-error-responses.decorator';
 import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
 import { Public } from './auth/public.decorator';
 
 @ApiTags('Health')
@@ -9,9 +9,14 @@ export class HealthController {
     @Get()
     @Public()
     @ApiOperation({ summary: 'Health check' })
-    @ApiResponse({ status: 200 })
+    @ApiOkResponse({
+        description: 'Service is up and running',
+        schema: {
+            example: { status: 'ok' },
+        },
+    })
     @ApiErrorResponses()
-    getHealth() {
+    getHealth(): { status: string } {
         return { status: 'ok' };
     }
 }

--- a/backend/src/messages/message.entity.ts
+++ b/backend/src/messages/message.entity.ts
@@ -6,21 +6,31 @@ import {
     CreateDateColumn,
 } from 'typeorm';
 import { User } from '../users/user.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
 export class Message {
     @PrimaryGeneratedColumn()
+    @ApiProperty({ example: 1 })
     id: number;
 
     @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
+    @ApiProperty({ type: () => User })
     sender: User;
 
     @ManyToOne(() => User, { eager: true, onDelete: 'RESTRICT' })
+    @ApiProperty({ type: () => User })
     recipient: User;
 
     @Column()
+    @ApiProperty({ example: 'Hello there!' })
     content: string;
 
     @CreateDateColumn()
+    @ApiProperty({
+        type: String,
+        format: 'date-time',
+        example: '2024-01-01T12:00:00.000Z',
+    })
     sentAt: Date;
 }

--- a/backend/src/messages/messages.controller.ts
+++ b/backend/src/messages/messages.controller.ts
@@ -7,13 +7,20 @@ import {
     Request,
     UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiTags,
+    ApiOkResponse,
+    ApiCreatedResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../users/role.enum';
 import { MessagesService } from './messages.service';
 import { CreateMessageDto } from './dto/create-message.dto';
+import { Message } from './message.entity';
 
 @ApiTags('Messages')
 @ApiBearerAuth()
@@ -25,17 +32,27 @@ export class MessagesController {
 
     @Get()
     @ApiOperation({ summary: 'List messages for user' })
-    @ApiResponse({ status: 200 })
+    @ApiOkResponse({
+        description: 'Messages for the authenticated user',
+        type: Message,
+        isArray: true,
+    })
     @ApiErrorResponses()
-    list(@Request() req) {
+    list(@Request() req): Promise<Message[]> {
         return this.service.findForUser(Number(req.user.id));
     }
 
     @Post()
     @ApiOperation({ summary: 'Create message' })
-    @ApiResponse({ status: 201 })
+    @ApiCreatedResponse({
+        description: 'Message successfully created',
+        type: Message,
+    })
     @ApiErrorResponses()
-    create(@Request() req, @Body() dto: CreateMessageDto) {
+    create(
+        @Request() req,
+        @Body() dto: CreateMessageDto,
+    ): Promise<Message> {
         return this.service.create(
             Number(req.user.id),
             dto.recipientId,


### PR DESCRIPTION
## Summary
- detail message list/create responses and annotate entity fields
- clarify auth controller responses and add social login response dto
- provide descriptive examples for health and app endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68939cb1a2dc8329937a8a2c063d1af2