### PR TITLE
Add policy and privacy pages

### DIFF
--- a/frontend/src/components/PublicNav.tsx
+++ b/frontend/src/components/PublicNav.tsx
@@ -11,6 +11,8 @@ export default function PublicNav() {
       <Link href="/contact">Contact</Link>
       <Link href="/auth/login">Login</Link>
       <Link href="/auth/register">Register</Link>
+      <Link href="/policy">Policy</Link>
+      <Link href="/privacy">Privacy</Link>
     </nav>
   );
 }

--- a/frontend/src/pages/policy.tsx
+++ b/frontend/src/pages/policy.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+export default function PolicyPage() {
+  return (
+    <>
+      <Head>
+        <title>Policy | Salon Black & White</title>
+        <meta
+          name="description"
+          content="Policies for using Salon Black & White."
+        />
+      </Head>
+      <div className="p-4 space-y-4 max-w-md">
+        <h1 className="text-2xl font-bold">Policy</h1>
+        <p>Placeholder for the salon's policy information.</p>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <Head>
+        <title>Privacy Policy | Salon Black & White</title>
+        <meta
+          name="description"
+          content="Privacy policy for Salon Black & White."
+        />
+      </Head>
+      <div className="p-4 space-y-4 max-w-md">
+        <h1 className="text-2xl font-bold">Privacy Policy</h1>
+        <p>Placeholder for the privacy policy content.</p>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add navigation links for policy and privacy pages
- add placeholder policy and privacy pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893c3fbd2248329bf0c300c2d284e90