### PR TITLE
Add booking link to public navigation

### DIFF
--- a/frontend/src/components/PublicNav.tsx
+++ b/frontend/src/components/PublicNav.tsx
@@ -9,6 +9,7 @@ export default function PublicNav() {
       <Link href="/gallery">Gallery</Link>
       <Link href="/faq">FAQ</Link>
       <Link href="/contact">Contact</Link>
+      <Link href="/appointments">Book Now</Link>
       <Link href="/auth/login">Login</Link>
       <Link href="/auth/register">Register</Link>
       <Link href="/policy">Policy</Link>


### PR DESCRIPTION
## Summary
- add Book Now link to appointments in public navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893c7d3dc108329846add40bbf36291