### PR TITLE
Group services by category on services page

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,6 +15,14 @@ export interface Appointment {
 export interface Service {
     id: number;
     name: string;
+    duration: number;
+    price: number;
+    category?: Category | null;
+}
+
+export interface Category {
+    id: number;
+    name: string;
 }
 
 export interface Employee {


### PR DESCRIPTION
## Summary
- group service list by category and show duration/price
- extend Service type with duration, price and category fields

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68946af23fd48329bc183d8237101a51