### PR TITLE
chore: enable strict lint rules

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -23,15 +23,16 @@ export default tseslint.config(
     },
     {
         rules: {
-            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-explicit-any': 'error',
             '@typescript-eslint/no-floating-promises': 'warn',
             '@typescript-eslint/no-unsafe-argument': 'warn',
-            '@typescript-eslint/no-unused-vars': 'off',
+            '@typescript-eslint/no-unused-vars': 'error',
             '@typescript-eslint/no-empty-interface': 'off',
             '@typescript-eslint/no-empty-function': 'off',
             '@typescript-eslint/no-empty-object-type': 'off',
             '@typescript-eslint/no-require-imports': 'off',
-            '@typescript-eslint/no-misused-promises': 'off',
+            '@typescript-eslint/no-misused-promises': 'error',
+            'no-unused-vars': 'error',
         },
     },
 );


### PR DESCRIPTION
## Summary
- enable strict TypeScript lint rules for no-explicit-any, no-unused-vars, and no-misused-promises

## Testing
- `npm run lint` *(fails: reports many instances of explicit any, unused vars, and misused Promises)*


------
https://chatgpt.com/codex/tasks/task_e_689480111dd48329ba5e4d73ed81608d