### PR TITLE
chore: ignore non-next directories

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,0 +1,3 @@
+design/
+public/assets/js/
+cypress/


### PR DESCRIPTION
## Summary
- skip non-Next.js folders from lint by adding `.eslintignore`

## Testing
- `npm run lint`
- `npx eslint public/assets/js/app.js`
- `npx eslint cypress/e2e/appointments.cy.ts`


------
https://chatgpt.com/codex/tasks/task_e_6894928178888329937845f7a072341c