### PR TITLE
Escape unescaped entities in frontend pages

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -136,7 +136,7 @@ export default function HomePage() {
                 <section className="p-4 space-y-4 text-center">
                     <h2 className="text-xl font-bold">Testimonials</h2>
                     <p className="italic max-w-md mx-auto">
-                        "{testimonials[testimonialIndex].text}"
+                        &quot;{testimonials[testimonialIndex].text}&quot;
                     </p>
                     <p className="mt-2 font-semibold">
                         - {testimonials[testimonialIndex].name}

--- a/frontend/src/pages/policy.tsx
+++ b/frontend/src/pages/policy.tsx
@@ -12,7 +12,7 @@ export default function PolicyPage() {
       </Head>
       <div className="p-4 space-y-4 max-w-md">
         <h1 className="text-2xl font-bold">Policy</h1>
-        <p>Placeholder for the salon's policy information.</p>
+        <p>Placeholder for the salon&apos;s policy information.</p>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- Escape testimonial quotes with HTML entities
- Escape apostrophe in policy placeholder text

## Testing
- `npx eslint src/pages/index.tsx src/pages/policy.tsx && echo "lint passed"`


------
https://chatgpt.com/codex/tasks/task_e_6894949299b483299d09d4e81f89bada