### PR TITLE
refactor: narrow API hook error types

### DIFF
--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -20,8 +20,8 @@ export function useAppointmentsApi() {
       });
       toast.success('Appointment created');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -35,8 +35,8 @@ export function useAppointmentsApi() {
       });
       toast.success('Appointment updated');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -15,8 +15,8 @@ export function useClientApi() {
       });
       toast.success('Client created');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -30,8 +30,8 @@ export function useClientApi() {
       });
       toast.success('Client updated');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -40,8 +40,8 @@ export function useClientApi() {
     try {
       await apiFetch<void>(`/clients/${id}`, { method: 'DELETE' });
       toast.success('Client deleted');
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -15,8 +15,8 @@ export function useEmployeeApi() {
       });
       toast.success('Employee created');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -30,8 +30,8 @@ export function useEmployeeApi() {
       });
       toast.success('Employee updated');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -40,8 +40,8 @@ export function useEmployeeApi() {
     try {
       await apiFetch<void>(`/employees/${id}`, { method: 'DELETE' });
       toast.success('Employee deleted');
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -20,8 +20,8 @@ export function useProductApi() {
             });
             toast.success('Product created');
             return res;
-        } catch (err: any) {
-            toast.error(err.message || 'Error');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
             throw err;
         }
     };
@@ -43,8 +43,8 @@ export function useProductApi() {
             });
             toast.success('Product updated');
             return res;
-        } catch (err: any) {
-            toast.error(err.message || 'Error');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
             throw err;
         }
     };
@@ -58,8 +58,8 @@ export function useProductApi() {
             });
             toast.success('Stock updated');
             return res;
-        } catch (err: any) {
-            toast.error(err.message || 'Error');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
             throw err;
         }
     };
@@ -68,8 +68,8 @@ export function useProductApi() {
         try {
             await apiFetch<void>(`/products/admin/${id}`, { method: 'DELETE' });
             toast.success('Product deleted');
-        } catch (err: any) {
-            toast.error(err.message || 'Error');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
             throw err;
         }
     };

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -21,8 +21,8 @@ export function useReviewApi() {
       );
       toast.success('Review created');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -32,8 +32,8 @@ export function useReviewApi() {
       return await apiFetch<Review>(
         `/appointments/${appointmentId}/review`,
       );
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -51,8 +51,8 @@ export function useReviewApi() {
       return await apiFetch<{ data: Review[]; total: number; page: number; limit: number }>(
         `/employees/${employeeId}/reviews${qs ? `?${qs}` : ''}`,
       );
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -66,8 +66,8 @@ export function useReviewApi() {
       });
       toast.success('Review updated');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -76,8 +76,8 @@ export function useReviewApi() {
     try {
       await apiFetch<void>(`/reviews/${id}`, { method: 'DELETE' });
       toast.success('Review deleted');
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -15,8 +15,8 @@ export function useServiceApi() {
       });
       toast.success('Service created');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -30,8 +30,8 @@ export function useServiceApi() {
       });
       toast.success('Service updated');
       return res;
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };
@@ -40,8 +40,8 @@ export function useServiceApi() {
     try {
       await apiFetch<void>(`/services/${id}`, { method: 'DELETE' });
       toast.success('Service deleted');
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
       throw err;
     }
   };


### PR DESCRIPTION
## Summary
- replace `err: any` with `err: unknown` in API hooks
- guard error messages via `instanceof Error`

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a48f7dc08329817892c1170eabcb