### PR TITLE
refactor: type-safe global polyfills

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -4,13 +4,40 @@ import { TextEncoder, TextDecoder } from 'util';
 import { ReadableStream, WritableStream, TransformStream } from 'web-streams-polyfill';
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
 
+declare global {
+  interface BroadcastChannel {
+    name: string;
+    postMessage(): void;
+    close(): void;
+    addEventListener(): void;
+    removeEventListener(): void;
+  }
+
+  interface GlobalThis {
+    TextEncoder: typeof import('util').TextEncoder;
+    TextDecoder: typeof import('util').TextDecoder;
+    ReadableStream: typeof import('web-streams-polyfill').ReadableStream;
+    WritableStream: typeof import('web-streams-polyfill').WritableStream;
+    TransformStream: typeof import('web-streams-polyfill').TransformStream;
+    BroadcastChannel: {
+      new (name: string): BroadcastChannel;
+    };
+    matchMedia: (query: string) => {
+      media: string;
+      matches: boolean;
+      addEventListener: () => void;
+      removeEventListener: () => void;
+    };
+  }
+}
+
 // polyfill for msw/node
-(global as any).TextEncoder = TextEncoder;
-(global as any).TextDecoder = TextDecoder;
-(global as any).ReadableStream = ReadableStream;
-(global as any).WritableStream = WritableStream;
-(global as any).TransformStream = TransformStream;
-(global as any).BroadcastChannel = class {
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+global.ReadableStream = ReadableStream;
+global.WritableStream = WritableStream;
+global.TransformStream = TransformStream;
+global.BroadcastChannel = class {
   constructor(public name: string) {}
   postMessage() {}
   close() {}
@@ -19,7 +46,7 @@ process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
 };
 
 // polyfill window.matchMedia used by react-hot-toast
-(global as any).matchMedia = (query: string) => ({
+global.matchMedia = (query: string) => ({
   media: query,
   matches: false,
   addEventListener: () => {},


### PR DESCRIPTION
## Summary
- add typed `declare global` definitions for encoder/stream polyfills and matchMedia
- replace `global as any` casts with type-safe assignments in test setup

## Testing
- `npx eslint jest.setup.ts`
- `npm test`
- `npm run lint` *(fails: Promise-returning function provided to attribute where a void return was expected)*

------
https://chatgpt.com/codex/tasks/task_e_6894a68b188883298f108147988da6cf