### PR TITLE
Refine error handling and async event callbacks

### DIFF
--- a/backend/src/calendar/calendar.service.ts
+++ b/backend/src/calendar/calendar.service.ts
@@ -93,10 +93,11 @@ export class CalendarService {
                 JSON.stringify({ id, provider: 'ics' }),
             );
             return { ics: value };
-        } catch (e: any) {
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
             await this.logs.create(
                 LogAction.CalendarAdd,
-                JSON.stringify({ id, provider, error: e.message }),
+                JSON.stringify({ id, provider, error: message }),
             );
             throw e;
         }
@@ -119,10 +120,11 @@ export class CalendarService {
                 LogAction.CalendarUpdate,
                 JSON.stringify({ id, provider }),
             );
-        } catch (e: any) {
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
             await this.logs.create(
                 LogAction.CalendarUpdate,
-                JSON.stringify({ id, provider, error: e.message }),
+                JSON.stringify({ id, provider, error: message }),
             );
             throw e;
         }
@@ -139,10 +141,11 @@ export class CalendarService {
                 LogAction.CalendarDelete,
                 JSON.stringify({ provider, eventId }),
             );
-        } catch (e: any) {
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
             await this.logs.create(
                 LogAction.CalendarDelete,
-                JSON.stringify({ provider, eventId, error: e.message }),
+                JSON.stringify({ provider, eventId, error: message }),
             );
             throw e;
         }

--- a/backend/src/calendar/google-calendar.adapter.ts
+++ b/backend/src/calendar/google-calendar.adapter.ts
@@ -12,8 +12,14 @@ export class GoogleCalendarAdapter {
                 },
             );
             return res.data;
-        } catch (err: any) {
-            throw new Error(`Google API error: ${err.response?.status}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(`Google API error: ${err.response?.status}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('Google API error');
         }
     }
 
@@ -28,8 +34,14 @@ export class GoogleCalendarAdapter {
                 },
             );
             return res.data;
-        } catch (err: any) {
-            throw new Error(`Google API error: ${err.response?.status}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(`Google API error: ${err.response?.status}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('Google API error');
         }
     }
 
@@ -42,8 +54,14 @@ export class GoogleCalendarAdapter {
                     proxy: false,
                 },
             );
-        } catch (err: any) {
-            throw new Error(`Google API error: ${err.response?.status}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(`Google API error: ${err.response?.status}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('Google API error');
         }
     }
 }

--- a/backend/src/calendar/outlook-calendar.adapter.ts
+++ b/backend/src/calendar/outlook-calendar.adapter.ts
@@ -12,8 +12,14 @@ export class OutlookCalendarAdapter {
                 },
             );
             return res.data;
-        } catch (err: any) {
-            throw new Error(`Outlook API error: ${err.response?.status}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(`Outlook API error: ${err.response?.status}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('Outlook API error');
         }
     }
 
@@ -28,8 +34,14 @@ export class OutlookCalendarAdapter {
                 },
             );
             return res.data;
-        } catch (err: any) {
-            throw new Error(`Outlook API error: ${err.response?.status}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(`Outlook API error: ${err.response?.status}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('Outlook API error');
         }
     }
 
@@ -42,8 +54,14 @@ export class OutlookCalendarAdapter {
                     proxy: false,
                 },
             );
-        } catch (err: any) {
-            throw new Error(`Outlook API error: ${err.response?.status}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                throw new Error(`Outlook API error: ${err.response?.status}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('Outlook API error');
         }
     }
 }

--- a/backend/src/emails/emails.service.ts
+++ b/backend/src/emails/emails.service.ts
@@ -74,10 +74,11 @@ export class EmailsService {
                 });
                 log.status = EmailStatus.Sent;
             }
-        } catch (err: any) {
+        } catch (err: unknown) {
             log.status = EmailStatus.Failed;
-            log.error = err.message;
-            this.logger.error(`Email send failed: ${err.message}`);
+            const message = err instanceof Error ? err.message : 'Unknown error';
+            log.error = message;
+            this.logger.error(`Email send failed: ${message}`);
         }
         return this.logs.save(log);
     }

--- a/backend/src/notifications/whatsapp.service.ts
+++ b/backend/src/notifications/whatsapp.service.ts
@@ -53,10 +53,16 @@ export class WhatsappService {
                 },
             );
             return res.data;
-        } catch (err: any) {
-            const status = err.response?.status;
-            const body = err.response?.data;
-            throw new Error(`WhatsApp API error: ${status} ${body}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                const status = err.response?.status;
+                const body = err.response?.data;
+                throw new Error(`WhatsApp API error: ${status} ${body}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('WhatsApp API error');
         }
     }
 
@@ -102,10 +108,16 @@ export class WhatsappService {
                 },
             );
             return res.data;
-        } catch (err: any) {
-            const status = err.response?.status;
-            const body = err.response?.data;
-            throw new Error(`WhatsApp API error: ${status} ${body}`);
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                const status = err.response?.status;
+                const body = err.response?.data;
+                throw new Error(`WhatsApp API error: ${status} ${body}`);
+            }
+            if (err instanceof Error) {
+                throw err;
+            }
+            throw new Error('WhatsApp API error');
         }
     }
 

--- a/frontend/src/components/AppointmentForm.tsx
+++ b/frontend/src/components/AppointmentForm.tsx
@@ -20,14 +20,24 @@ export default function AppointmentForm({ clients, services, initial, onSubmit, 
     setError('');
     try {
       await onSubmit({ clientId: Number(clientId), serviceId: Number(serviceId), startTime });
-    } catch (err: any) {
-      if (err.status === 409) setError('Conflict');
-      else setError(err.message || 'Error');
+    } catch (err: unknown) {
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'status' in err &&
+        (err as { status?: number }).status === 409
+      ) {
+        setError('Conflict');
+      } else if (err instanceof Error) {
+        setError(err.message || 'Error');
+      } else {
+        setError('Error');
+      }
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <select value={clientId} onChange={(e) => setClientId(Number(e.target.value))} className="border p-1 w-full">
         {clients.map((c) => (
           <option key={c.id} value={c.id}>

--- a/frontend/src/components/ClientForm.tsx
+++ b/frontend/src/components/ClientForm.tsx
@@ -21,14 +21,14 @@ export default function ClientForm({ initial, onSubmit, onCancel }: Props) {
     try {
       const data = schema.parse({ name });
       await onSubmit(data);
-    } catch (err: any) {
-      if (err.errors) setError(err.errors[0].message);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
       else setError('Error');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <input
         value={name}
         onChange={(e) => setName(e.target.value)}

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -47,13 +47,13 @@ export default function ContactForm() {
       if (!res.ok) throw new Error('Failed');
       toast.success('Message sent');
       setForm({ name: '', email: '', message: '' });
-    } catch (err: any) {
-      toast.error(err.message || 'Error');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Error');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <input
         name="name"
         value={form.name}

--- a/frontend/src/components/EmployeeForm.tsx
+++ b/frontend/src/components/EmployeeForm.tsx
@@ -23,14 +23,14 @@ export default function EmployeeForm({ initial, onSubmit, onCancel }: Props) {
     try {
       const data = schema.parse({ firstName, lastName });
       await onSubmit(data);
-    } catch (err: any) {
-      if (err.errors) setError(err.errors[0].message);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
       else setError('Error');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <input
         value={firstName}
         onChange={(e) => setFirstName(e.target.value)}

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -34,14 +34,14 @@ export default function ProductForm({ initial, onSubmit, onCancel }: Props) {
     try {
       const data = schema.parse(form);
       await onSubmit(data);
-    } catch (err: any) {
-      if (err.errors) setError(err.errors[0].message);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
       else setError('Error');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <input name="name" value={form.name} onChange={handleChange} className="border p-1 w-full" placeholder="Name" />
       <input name="brand" value={form.brand} onChange={handleChange} className="border p-1 w-full" placeholder="Brand" />
       <input name="unitPrice" value={form.unitPrice} onChange={handleChange} className="border p-1 w-full" placeholder="Price" />

--- a/frontend/src/components/ReviewForm.tsx
+++ b/frontend/src/components/ReviewForm.tsx
@@ -32,14 +32,14 @@ export default function ReviewForm({ initial, onSubmit, onCancel }: Props) {
     try {
       const data = schema.parse(form);
       await onSubmit(data);
-    } catch (err: any) {
-      if (err.errors) setError(err.errors[0].message);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
       else setError('Error');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <input
         name="appointmentId"
         value={form.appointmentId}

--- a/frontend/src/components/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm.tsx
@@ -21,14 +21,14 @@ export default function ServiceForm({ initial, onSubmit, onCancel }: Props) {
     try {
       const data = schema.parse({ name });
       await onSubmit(data);
-    } catch (err: any) {
-      if (err.errors) setError(err.errors[0].message);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
       else setError('Error');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
       <input
         value={name}
         onChange={(e) => setName(e.target.value)}

--- a/frontend/src/components/StockForm.tsx
+++ b/frontend/src/components/StockForm.tsx
@@ -18,13 +18,13 @@ export default function StockForm({ onSubmit, onCancel }: Props) {
         }
         try {
             await onSubmit(num);
-        } catch (err: any) {
-            setError(err.message || 'Error');
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Error');
         }
     };
 
     return (
-        <form onSubmit={handleSubmit} className="space-y-2">
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
             <input
                 type="number"
                 value={amount}

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -21,10 +21,10 @@ export default function LoginPage() {
       const creds = schema.parse({ email, password });
       await login(creds.email, creds.password);
       router.push('/dashboard');
-    } catch (err: any) {
-      if (err.errors) {
-        setError(err.errors[0].message);
-      } else if (err.message) {
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) {
+        setError(err.issues[0]?.message ?? 'Login failed');
+      } else if (err instanceof Error) {
         setError(err.message);
       } else {
         setError('Login failed');
@@ -33,7 +33,7 @@ export default function LoginPage() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={(e) => void handleSubmit(e)}>
       <input
         placeholder="email"
         value={email}

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -22,13 +22,13 @@ export default function RegisterPage() {
       );
       if (!res.ok) throw new Error('Registration failed');
       router.push('/auth/login');
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Registration failed');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2 p-4">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2 p-4">
       <h1 className="text-2xl font-bold">Register</h1>
       <input
         className="border p-1 w-full"

--- a/frontend/src/pages/clients/index.tsx
+++ b/frontend/src/pages/clients/index.tsx
@@ -75,7 +75,7 @@ export default function ClientsPage() {
                 </button>
                 <button
                   className="border px-2 py-1"
-                  onClick={() => handleDelete(c)}
+                  onClick={() => void handleDelete(c)}
                 >
                   Delete
                 </button>

--- a/frontend/src/pages/dashboard/services/index.tsx
+++ b/frontend/src/pages/dashboard/services/index.tsx
@@ -70,7 +70,7 @@ export default function ServicesPage() {
                 >
                   Edit
                 </button>
-                <button className="border px-2 py-1" onClick={() => handleDelete(r)}>
+                <button className="border px-2 py-1" onClick={() => void handleDelete(r)}>
                   Delete
                 </button>
               </span>

--- a/frontend/src/pages/employees/index.tsx
+++ b/frontend/src/pages/employees/index.tsx
@@ -72,7 +72,7 @@ export default function EmployeesPage() {
                 >
                   Edit
                 </button>
-                <button className="border px-2 py-1" onClick={() => handleDelete(r)}>
+                <button className="border px-2 py-1" onClick={() => void handleDelete(r)}>
                   Delete
                 </button>
               </span>

--- a/frontend/src/pages/products/index.tsx
+++ b/frontend/src/pages/products/index.tsx
@@ -106,7 +106,7 @@ export default function ProductsPage() {
                                 </button>
                                 <button
                                     className="border px-2 py-1"
-                                    onClick={() => handleDelete(r)}
+                                    onClick={() => void handleDelete(r)}
                                 >
                                     Delete
                                 </button>

--- a/frontend/src/pages/reviews/index.tsx
+++ b/frontend/src/pages/reviews/index.tsx
@@ -114,7 +114,7 @@ export default function ReviewsPage() {
                 >
                   Edit
                 </button>
-                <button className="border px-2 py-1" onClick={() => handleDelete(r)}>
+                <button className="border px-2 py-1" onClick={() => void handleDelete(r)}>
                   Delete
                 </button>
               </span>


### PR DESCRIPTION
## Summary
- Replace `any` error catches with `unknown` and narrow using Axios and Error checks
- Prefix async JSX handlers with `void` and wrap component event callbacks to satisfy `no-misused-promises`
- Normalize Zod error handling across forms and pages

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6894b1f29bcc832988be8f3356a217dd