### PR TITLE
Refine frontend tests by removing any casts

### DIFF
--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -21,7 +21,7 @@ describe('auth flow', () => {
   it('login fetches token and fetches clients then logout clears token', async () => {
     const wrapper = ({ children }: { children: React.ReactNode }) =>
       React.createElement(AuthProvider, null, children);
-    const { result, waitForNextUpdate } = renderHook(() => useAuth(), { wrapper });
+    const { result } = renderHook(() => useAuth(), { wrapper });
 
     await act(async () => {
       await result.current.login('a', 'b');

--- a/frontend/src/__tests__/clientApi.test.tsx
+++ b/frontend/src/__tests__/clientApi.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useClientApi } from '@/api/clients';
 import { useAuth } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
@@ -16,7 +17,7 @@ const toast = require('react-hot-toast').toast;
 describe('useClientApi', () => {
   it('shows success toast on create', async () => {
     const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
@@ -29,7 +30,7 @@ describe('useClientApi', () => {
 
   it('shows error toast on failure', async () => {
     const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );

--- a/frontend/src/__tests__/contactForm.test.tsx
+++ b/frontend/src/__tests__/contactForm.test.tsx
@@ -5,7 +5,7 @@ import { ToastProvider } from '@/contexts/ToastContext';
 
 describe('ContactForm', () => {
   beforeEach(() => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) }) as any;
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) }) as jest.MockedFunction<typeof fetch>;
   });
 
   it('posts form data', async () => {

--- a/frontend/src/__tests__/employeeApi.test.tsx
+++ b/frontend/src/__tests__/employeeApi.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useEmployeeApi } from '@/api/employees';
 import { useAuth } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
@@ -23,7 +24,7 @@ describe('useEmployeeApi', () => {
         lastName: 'B',
         fullName: 'A B',
       });
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
@@ -36,7 +37,7 @@ describe('useEmployeeApi', () => {
 
   it('shows error toast on failure', async () => {
     const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );

--- a/frontend/src/__tests__/login.test.tsx
+++ b/frontend/src/__tests__/login.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import LoginPage from '@/pages/auth/login';
 import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
 
 const push = jest.fn();
 jest.mock('next/router', () => ({ useRouter: () => ({ push, replace: jest.fn() }) }));
@@ -16,7 +17,7 @@ describe('LoginPage', () => {
 
   it('submits valid form', async () => {
     const login = jest.fn().mockResolvedValue(undefined);
-    mockedUseAuth.mockReturnValue({ login } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ login }));
     render(<LoginPage />);
     fireEvent.change(screen.getByPlaceholderText('email'), { target: { value: 'a@b.com' } });
     fireEvent.change(screen.getByPlaceholderText('password'), { target: { value: 'secret' } });
@@ -27,7 +28,7 @@ describe('LoginPage', () => {
 
   it('shows validation error', async () => {
     const login = jest.fn();
-    mockedUseAuth.mockReturnValue({ login } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ login }));
     render(<LoginPage />);
     fireEvent.change(screen.getByPlaceholderText('email'), { target: { value: 'bad' } });
     fireEvent.change(screen.getByPlaceholderText('password'), { target: { value: '' } });

--- a/frontend/src/__tests__/paymentsApi.test.tsx
+++ b/frontend/src/__tests__/paymentsApi.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
-import React from 'react';
 import { usePaymentsApi } from '@/api/payments';
 import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 
@@ -10,7 +10,7 @@ const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 describe('usePaymentsApi', () => {
   it('creates session and returns url', async () => {
     const apiFetch = jest.fn().mockResolvedValue({ url: 'u' });
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const { result } = renderHook(() => usePaymentsApi());
     let url: string | null = null;
     await act(async () => { url = await result.current.createSession(1); });

--- a/frontend/src/__tests__/productApi.test.tsx
+++ b/frontend/src/__tests__/productApi.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useProductApi } from '@/api/products';
 import { useAuth } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
@@ -16,7 +17,7 @@ const toast = require('react-hot-toast').toast;
 describe('useProductApi', () => {
   it('shows success toast on create', async () => {
     const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
@@ -29,7 +30,7 @@ describe('useProductApi', () => {
 
   it('shows error toast on failure', async () => {
     const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );

--- a/frontend/src/__tests__/receptionistAppointments.test.tsx
+++ b/frontend/src/__tests__/receptionistAppointments.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import AppointmentsPage from '@/pages/appointments';
 import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/hooks/useAppointments', () => ({ useAppointments: () => ({ data: [], loading: false, error: null }) }));
 jest.mock('@/hooks/useClients', () => ({ useClients: () => ({ data: [], loading: false }) }));
 jest.mock('@/hooks/useServices', () => ({ useServices: () => ({ data: [], loading: false }) }));
 jest.mock('@/api/appointments', () => ({ useAppointmentsApi: () => ({ create: jest.fn(), update: jest.fn() }) }));
+// eslint-disable-next-line react/display-name
 jest.mock('@fullcalendar/react', () => () => <div>calendar</div>);
 jest.mock('@fullcalendar/daygrid', () => ({}));
 jest.mock('@fullcalendar/timegrid', () => ({}));
@@ -16,7 +18,9 @@ const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('Receptionist appointments', () => {
   it('shows all employees message', () => {
-    mockedUseAuth.mockReturnValue({ role: 'receptionist', isAuthenticated: true } as any);
+    mockedUseAuth.mockReturnValue(
+      createAuthValue({ role: 'receptionist', isAuthenticated: true })
+    );
     render(<AppointmentsPage />);
     expect(
       screen.getByText(/Viewing appointments for all employees/i)

--- a/frontend/src/__tests__/receptionistNav.test.tsx
+++ b/frontend/src/__tests__/receptionistNav.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import DashboardNav from '@/components/DashboardNav';
 import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('DashboardNav receptionist', () => {
   it('shows receptionist links', () => {
-    mockedUseAuth.mockReturnValue({ logout: jest.fn(), role: 'receptionist' } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ role: 'receptionist' }));
     render(<DashboardNav />);
     expect(screen.getByText('Home')).toBeInTheDocument();
     expect(screen.getByText('Appointments')).toBeInTheDocument();

--- a/frontend/src/__tests__/reviewApi.test.tsx
+++ b/frontend/src/__tests__/reviewApi.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useReviewApi } from '@/api/reviews';
 import { useAuth } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
@@ -16,7 +17,7 @@ const toast = require('react-hot-toast').toast;
 describe('useReviewApi', () => {
   it('shows success toast on create', async () => {
     const apiFetch = jest.fn().mockResolvedValue({ id: 1, rating: 5 });
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
@@ -29,7 +30,7 @@ describe('useReviewApi', () => {
 
   it('shows error toast on failure', async () => {
     const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );

--- a/frontend/src/__tests__/routeGuard.test.tsx
+++ b/frontend/src/__tests__/routeGuard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import RouteGuard from '@/components/RouteGuard';
 import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
 
 const replace = jest.fn();
 jest.mock('next/router', () => ({ useRouter: () => ({ replace, push: jest.fn() }) }));
@@ -14,7 +15,7 @@ describe('RouteGuard', () => {
     replace.mockClear();
   });
   it('redirects when unauthenticated', () => {
-    mockedUseAuth.mockReturnValue({ isAuthenticated: false } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ isAuthenticated: false }));
     render(
       <RouteGuard>
         <div>Secret</div>
@@ -25,7 +26,9 @@ describe('RouteGuard', () => {
   });
 
   it('renders children when authenticated and role allowed', () => {
-    mockedUseAuth.mockReturnValue({ isAuthenticated: true, role: 'receptionist' } as any);
+    mockedUseAuth.mockReturnValue(
+      createAuthValue({ isAuthenticated: true, role: 'receptionist' })
+    );
     render(
       <RouteGuard roles={['receptionist']}>
         <div>Secret</div>
@@ -36,7 +39,9 @@ describe('RouteGuard', () => {
   });
 
   it('redirects when role not permitted', () => {
-    mockedUseAuth.mockReturnValue({ isAuthenticated: true, role: 'client' } as any);
+    mockedUseAuth.mockReturnValue(
+      createAuthValue({ isAuthenticated: true, role: 'client' })
+    );
     render(
       <RouteGuard roles={['admin']}>
         <div>Secret</div>

--- a/frontend/src/__tests__/serviceApi.test.tsx
+++ b/frontend/src/__tests__/serviceApi.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useServiceApi } from '@/api/services';
 import { useAuth } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
+import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
@@ -16,7 +17,7 @@ const toast = require('react-hot-toast').toast;
 describe('useServiceApi', () => {
   it('shows success toast on create', async () => {
     const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
@@ -29,7 +30,7 @@ describe('useServiceApi', () => {
 
   it('shows error toast on failure', async () => {
     const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue({ apiFetch } as any);
+    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -1,0 +1,14 @@
+import type { useAuth } from '@/contexts/AuthContext';
+
+export const createAuthValue = (
+  overrides: Partial<ReturnType<typeof useAuth>> = {}
+): ReturnType<typeof useAuth> => ({
+  token: null,
+  role: null,
+  isAuthenticated: false,
+  login: jest.fn(),
+  logout: jest.fn(),
+  refreshToken: jest.fn(),
+  apiFetch: jest.fn(),
+  ...overrides,
+});


### PR DESCRIPTION
## Summary
- remove unused waitForNextUpdate binding in auth test
- centralize typed auth mock helper and drop `any` casts across tests
- type contact form fetch mock

## Testing
- `npx eslint src/__tests__`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bd1bc0b0832981953d224cdbd5d3