### PR TITLE
chore: ignore jest config in eslint

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,3 +1,4 @@
 design/
 public/assets/js/
 cypress/
+jest.config.js


### PR DESCRIPTION
## Summary
- ignore `jest.config.js` in ESLint to avoid parser error

## Testing
- `npm run lint >/tmp/lint.log ; tail -n 20 /tmp/lint.log`
- `grep -i 'Parsing error' /tmp/lint.log`


------
https://chatgpt.com/codex/tasks/task_e_6894c3a9b81483298c43b146867917f2