### PR TITLE
Wrap async router calls to satisfy lint

### DIFF
--- a/frontend/src/components/RouteGuard.tsx
+++ b/frontend/src/components/RouteGuard.tsx
@@ -14,9 +14,9 @@ export default function RouteGuard({ children, roles }: Props) {
 
   useEffect(() => {
     if (!isAuthenticated) {
-      router.replace('/auth/login');
+      void router.replace('/auth/login');
     } else if (roles && role && !roles.includes(role)) {
-      router.replace('/dashboard');
+      void router.replace('/dashboard');
     }
   }, [isAuthenticated, role, roles, router]);
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setRole(null);
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(ROLE_KEY);
-    router.push('/auth/login');
+    void router.push('/auth/login');
   };
 
   const client = useMemo(() => new ApiClient(() => token, handleLogout), [token]);

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -11,7 +11,7 @@ export function useDashboard() {
 
   useEffect(() => {
     let mounted = true;
-    apiFetch<DashboardData>('/dashboard')
+    void apiFetch<DashboardData>('/dashboard')
       .then((d) => mounted && setData(d))
       .finally(() => mounted && setLoading(false));
     return () => {

--- a/frontend/src/hooks/useEmails.ts
+++ b/frontend/src/hooks/useEmails.ts
@@ -9,12 +9,15 @@ export function useEmails() {
 
     useEffect(() => {
         let active = true;
-        const fetchData = () =>
-            apiFetch<EmailLog[]>('/emails')
+        const fetchData = () => {
+            void apiFetch<EmailLog[]>('/emails')
                 .then((d) => active && setData(d))
                 .catch((e) => active && setError(e));
+        };
         fetchData();
-        const id = setInterval(fetchData, 30000);
+        const id = setInterval(() => {
+            fetchData();
+        }, 30000);
         return () => {
             active = false;
             clearInterval(id);

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -9,12 +9,15 @@ export function useNotifications() {
 
   useEffect(() => {
     let active = true;
-    const fetchData = () =>
-      apiFetch<Notification[]>('/notifications')
+    const fetchData = () => {
+      void apiFetch<Notification[]>('/notifications')
         .then((d) => active && setData(d))
         .catch((e) => active && setError(e));
+    };
     fetchData();
-    const id = setInterval(fetchData, 30000);
+    const id = setInterval(() => {
+      fetchData();
+    }, 30000);
     return () => {
       active = false;
       clearInterval(id);

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -20,7 +20,7 @@ export default function LoginPage() {
     try {
       const creds = schema.parse({ email, password });
       await login(creds.email, creds.password);
-      router.push('/dashboard');
+      await router.push('/dashboard');
     } catch (err: unknown) {
       if (err instanceof z.ZodError) {
         setError(err.issues[0]?.message ?? 'Login failed');

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -21,7 +21,7 @@ export default function RegisterPage() {
         }
       );
       if (!res.ok) throw new Error('Registration failed');
-      router.push('/auth/login');
+      await router.push('/auth/login');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Registration failed');
     }

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -14,7 +14,7 @@ export default function DashboardRedirect() {
       role === 'admin'
         ? role
         : 'client';
-    router.replace(`/dashboard/${current}`);
+    void router.replace(`/dashboard/${current}`);
   }, [router, role]);
   return null;
 }


### PR DESCRIPTION
## Summary
- prefix router navigation with `void` to avoid floating promises in route guards and auth context
- await or explicitly ignore router promises in login/register pages, dashboard redirect, and data hooks
- ensure data fetching hooks use `void` for `apiFetch` calls

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c5bc9d488329976ab4e49145e2e8