### PR TITLE
refactor: wrap async callbacks in hooks

### DIFF
--- a/frontend/src/hooks/useEmails.ts
+++ b/frontend/src/hooks/useEmails.ts
@@ -9,14 +9,21 @@ export function useEmails() {
 
     useEffect(() => {
         let active = true;
-        const fetchData = () => {
-            void apiFetch<EmailLog[]>('/emails')
-                .then((d) => active && setData(d))
-                .catch((e) => active && setError(e));
+        const fetchData = async () => {
+            try {
+                const d = await apiFetch<EmailLog[]>('/emails');
+                if (active) {
+                    setData(d);
+                }
+            } catch (err: unknown) {
+                if (active) {
+                    setError(err instanceof Error ? err : new Error(String(err)));
+                }
+            }
         };
-        fetchData();
+        void fetchData();
         const id = setInterval(() => {
-            fetchData();
+            void fetchData();
         }, 30000);
         return () => {
             active = false;

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -9,14 +9,21 @@ export function useNotifications() {
 
   useEffect(() => {
     let active = true;
-    const fetchData = () => {
-      void apiFetch<Notification[]>('/notifications')
-        .then((d) => active && setData(d))
-        .catch((e) => active && setError(e));
+    const fetchData = async () => {
+      try {
+        const d = await apiFetch<Notification[]>('/notifications');
+        if (active) {
+          setData(d);
+        }
+      } catch (err: unknown) {
+        if (active) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
     };
-    fetchData();
+    void fetchData();
     const id = setInterval(() => {
-      fetchData();
+      void fetchData();
     }, 30000);
     return () => {
       active = false;


### PR DESCRIPTION
## Summary
- wrap email and notification fetchers in async functions
- narrow error handling and avoid returning promises from interval callbacks

## Testing
- `cd frontend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6894cbf5ca4c83298d3b8ee52ba28db6