### PR TITLE
Refine error typing for frontend hooks

### DIFF
--- a/frontend/src/hooks/useList.ts
+++ b/frontend/src/hooks/useList.ts
@@ -14,8 +14,8 @@ export function useList<T>(endpoint: string) {
       .then((res) => {
         if (mounted) setData(res);
       })
-      .catch((err) => {
-        if (mounted) setError(err);
+      .catch((err: unknown) => {
+        if (mounted) setError(err instanceof Error ? err : new Error(String(err)));
       })
       .finally(() => {
         if (mounted) setLoading(false);

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -37,7 +37,9 @@ export function useReviews(options: Options = {}) {
         setTotal(res.total);
         setLimit(res.limit);
       })
-      .catch((err) => setError(err))
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err : new Error(String(err)))
+      )
       .finally(() => setLoading(false));
   }, [options.employeeId, options.clientId, page, limit, rating, apiFetch]);
 


### PR DESCRIPTION
## Summary
- normalize caught values into Error objects in useList and useReviews hooks

## Testing
- `npm run lint` *(fails: Existing lint errors in src/pages/appointments/index.tsx and others)*
- `npx eslint src/hooks/useList.ts src/hooks/useReviews.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d29c93dc8329bcbd7ab593a054f5