### PR TITLE
handle router promises in auth pages

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,12 @@
 'use client';
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useRouter } from 'next/router';
 import { ApiClient } from '@/api/apiClient';
 import type { Role } from '@/types';
@@ -38,15 +45,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     setToken(null);
     setRole(null);
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(ROLE_KEY);
     void router.push('/auth/login');
-  };
+  }, [router]);
 
-  const client = useMemo(() => new ApiClient(() => token, handleLogout), [token]);
+  const client = useMemo(
+    () => new ApiClient(() => token, handleLogout),
+    [token, handleLogout]
+  );
 
   const decodeRole = (jwt: string): Role | null => {
     try {

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -20,7 +20,7 @@ export default function LoginPage() {
     try {
       const creds = schema.parse({ email, password });
       await login(creds.email, creds.password);
-      await router.push('/dashboard');
+      void router.push('/dashboard');
     } catch (err: unknown) {
       if (err instanceof z.ZodError) {
         setError(err.issues[0]?.message ?? 'Login failed');

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -21,7 +21,7 @@ export default function RegisterPage() {
         }
       );
       if (!res.ok) throw new Error('Registration failed');
-      await router.push('/auth/login');
+      void router.push('/auth/login');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Registration failed');
     }

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -14,7 +14,7 @@ export default function DashboardRedirect() {
       role === 'admin'
         ? role
         : 'client';
-    void router.replace(`/dashboard/${current}`);
+    void router.replace(`/dashboard/${current}`).catch(() => {});
   }, [router, role]);
   return null;
 }


### PR DESCRIPTION
## Summary
- mark Next.js router navigation promises as intentionally ignored and catch dashboard redirect
- stabilize `AuthContext` client memoization

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894db36d7948329861f1557c4d72c5a