### PR TITLE
Display email field validation message

### DIFF
--- a/frontend/src/__tests__/contactForm.test.tsx
+++ b/frontend/src/__tests__/contactForm.test.tsx
@@ -33,4 +33,25 @@ describe('ContactForm', () => {
       })
     );
   });
+
+  it('shows email validation error', async () => {
+    render(
+      <ToastProvider>
+        <ContactForm />
+      </ToastProvider>
+    );
+    fireEvent.change(screen.getByPlaceholderText('Your name'), {
+      target: { value: 'John' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Your email'), {
+      target: { value: 'invalid' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Message'), {
+      target: { value: 'Hello' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(
+      await screen.findByText(/nieprawidłowy format adresu email/i)
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- show email address validation error directly under the email input
- translate email validation message to "Nieprawidłowy format adresu email"
- add test covering invalid email submission

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f33e546c8329aad971d74ae1c450