### PR TITLE
chore(frontend): tighten BroadcastChannel types in tests

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -7,7 +7,7 @@ process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
 declare global {
   interface BroadcastChannel {
     readonly name: string;
-    postMessage(message: any): void;
+    postMessage(message: unknown): void;
     close(): void;
     addEventListener(
       type: string,
@@ -47,18 +47,28 @@ global.WritableStream = WritableStream;
 global.TransformStream = TransformStream;
 global.BroadcastChannel = class {
   constructor(public readonly name: string) {}
-  postMessage(message: any) {}
+  postMessage(_message: unknown) {
+    void _message;
+  }
   close() {}
   addEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
-  ) {}
+    _type: string,
+    _listener: EventListenerOrEventListenerObject,
+    _options?: boolean | AddEventListenerOptions,
+  ) {
+    void _type;
+    void _listener;
+    void _options;
+  }
   removeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions,
-  ) {}
+    _type: string,
+    _listener: EventListenerOrEventListenerObject,
+    _options?: boolean | EventListenerOptions,
+  ) {
+    void _type;
+    void _listener;
+    void _options;
+  }
 };
 
 // polyfill window.matchMedia used by react-hot-toast

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -66,7 +66,8 @@ export default function ContactForm() {
       toast.success('formularz został wysłany');
       setSubmitted(true);
       setForm({ name: '', email: '', message: '' });
-    } catch (err: unknown) {
+    } catch (_err: unknown) {
+      void _err;
       setSubmitError('Nie udało się wysłać formularza');
       toast.error('Nie udało się wysłać formularza');
     }


### PR DESCRIPTION
## Summary
- use `unknown` for BroadcastChannel message payloads
- mark unused BroadcastChannel handler arguments and test catch error with underscores

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68951fec44508329a297d447a1ffd5d8