### PR TITLE
refactor: remove unused error variable in ContactForm

### DIFF
--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -66,8 +66,7 @@ export default function ContactForm() {
       toast.success('formularz został wysłany');
       setSubmitted(true);
       setForm({ name: '', email: '', message: '' });
-    } catch (_err: unknown) {
-      void _err;
+    } catch {
       setSubmitError('Nie udało się wysłać formularza');
       toast.error('Nie udało się wysłać formularza');
     }


### PR DESCRIPTION
## Summary
- remove unused error variable from ContactForm catch block

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689521aad3c883299ff3ed40d6b1d9cb