### PR TITLE
chore: add type-safe TextDecoder polyfill

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -41,7 +41,7 @@ declare global {
 
 // polyfill for msw/node
 global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
+global.TextDecoder = TextDecoder as unknown as typeof global.TextDecoder;
 global.ReadableStream = ReadableStream;
 global.WritableStream = WritableStream;
 global.TransformStream = TransformStream;


### PR DESCRIPTION
## Summary
- cast TextDecoder polyfill to satisfy TypeScript in Jest setup

## Testing
- `npm run build` *(fails: Type 'typeof ReadableStream' is not assignable to type '{ new (underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number | undefined; } | undefined): ReadableStream<Uint8Array<ArrayBufferLike>>; ... }')*

------
https://chatgpt.com/codex/tasks/task_e_689526196c2483298ac109c9ace17115