### PR TITLE
chore(frontend): exclude test files from build

### DIFF
--- a/frontend/tsconfig.jest.json
+++ b/frontend/tsconfig.jest.json
@@ -2,5 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx"
-  }
+  },
+  "include": [
+    "next-env.d.ts",
+    "src/**/*",
+    ".next/types/**/*.ts",
+    "jest.setup.ts"
+  ],
+  "exclude": ["node_modules"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,6 +23,13 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["next-env.d.ts", "src/**/*", ".next/types/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "jest.config.js",
+    "jest.setup.ts",
+    "src/__tests__",
+    "cypress",
+    "cypress.config.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- restrict tsconfig include to `src` and drop test-only files from production build
- configure Jest tsconfig to include its setup file and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ec3eb96c8329b8911fd06baea30a