### PR TITLE
chore: refine ESLint settings for tests and configs

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -2,3 +2,6 @@ design/
 public/assets/js/
 cypress/
 jest.config.js
+jest.setup.ts
+cypress.config.ts
+tailwind.config.ts

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -18,4 +18,18 @@ module.exports = {
         '@typescript-eslint/no-misused-promises': 'error',
         'no-unused-vars': 'error',
     },
+    overrides: [
+        {
+            files: ['src/__tests__/**/*', 'jest.setup.ts'],
+            parserOptions: {
+                project: './tsconfig.jest.json',
+            },
+        },
+        {
+            files: ['cypress.config.ts', 'tailwind.config.ts'],
+            parserOptions: {
+                project: null,
+            },
+        },
+    ],
 };


### PR DESCRIPTION
## Summary
- add ESLint overrides for test files using `tsconfig.jest.json`
- disable project parsing for Cypress and Tailwind configs
- ignore Jest setup and config files in ESLint

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6895ef7014c48329aae77548b0e2201e