### PR TITLE
Validate service commission percent range

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -6,10 +6,12 @@ import {
     CreateDateColumn,
     UpdateDateColumn,
     Index,
+    Check,
 } from 'typeorm';
 import { Category } from './category.entity';
 
 @Index(['category', 'name'], { unique: true })
+@Check('"defaultCommissionPercent" >= 0 AND "defaultCommissionPercent" <= 100')
 @Entity()
 export class Service {
     @PrimaryGeneratedColumn()

--- a/backend/src/migrations/20250711192034-AddServiceDefaultCommissionPercentCheck.ts
+++ b/backend/src/migrations/20250711192034-AddServiceDefaultCommissionPercentCheck.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddServiceDefaultCommissionPercentCheck20250711192034 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "service" ADD CONSTRAINT "CHK_service_defaultCommissionPercent" CHECK ("defaultCommissionPercent" >= 0 AND "defaultCommissionPercent" <= 100)',
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "service" DROP CONSTRAINT "CHK_service_defaultCommissionPercent"',
+        );
+    }
+}

--- a/backend/src/services/dto/create-service.dto.ts
+++ b/backend/src/services/dto/create-service.dto.ts
@@ -54,6 +54,8 @@ export class CreateServiceDto {
     })
     @IsOptional()
     @IsNumber()
+    @Min(0)
+    @Max(100)
     defaultCommissionPercent?: number | null;
 
     @ApiProperty({

--- a/backend/src/services/dto/update-service.dto.ts
+++ b/backend/src/services/dto/update-service.dto.ts
@@ -56,6 +56,8 @@ export class UpdateServiceDto {
     })
     @IsOptional()
     @IsNumber()
+    @Min(0)
+    @Max(100)
     defaultCommissionPercent?: number | null;
 
     @ApiPropertyOptional({


### PR DESCRIPTION
## Summary
- validate `defaultCommissionPercent` between 0 and 100 in entity and DTOs
- add database check constraint on `service` table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fb2458dc8329bd0b2d002e9a5487