### PR TITLE
Enforce positive quantity for product usage

### DIFF
--- a/backend/src/migrations/20250711192035-AddProductUsageQuantityPositiveCheck.ts
+++ b/backend/src/migrations/20250711192035-AddProductUsageQuantityPositiveCheck.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductUsageQuantityPositiveCheck20250711192035 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "product_usage" ADD CONSTRAINT "CHK_product_usage_quantity_positive" CHECK ("quantity" > 0)',
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "product_usage" DROP CONSTRAINT "CHK_product_usage_quantity_positive"',
+        );
+    }
+}
+

--- a/backend/src/product-usage/product-usage.entity.ts
+++ b/backend/src/product-usage/product-usage.entity.ts
@@ -4,6 +4,7 @@ import {
     ManyToOne,
     Column,
     CreateDateColumn,
+    Check,
 } from 'typeorm';
 import { Appointment } from '../appointments/appointment.entity';
 import { Product } from '../catalog/product.entity';
@@ -11,6 +12,7 @@ import { User } from '../users/user.entity';
 import { UsageType } from './usage-type.enum';
 import { ApiProperty } from '@nestjs/swagger';
 
+@Check('CHK_product_usage_quantity_positive', '"quantity" > 0')
 @Entity()
 export class ProductUsage {
     @PrimaryGeneratedColumn()

--- a/backend/src/product-usage/product-usage.service.ts
+++ b/backend/src/product-usage/product-usage.service.ts
@@ -122,6 +122,9 @@ export class ProductUsageService {
         employeeId: number,
         appointmentId?: number,
     ) {
+        if (quantity <= 0) {
+            throw new BadRequestException('quantity must be > 0');
+        }
         const usage = this.repo.create({
             appointment: appointmentId
                 ? ({ id: appointmentId } as EntityRef<Appointment>)


### PR DESCRIPTION
## Summary
- enforce positive `quantity` at ORM level for `ProductUsage`
- add database constraint ensuring `quantity > 0` on `product_usage`
- validate sale creation to reject non-positive quantities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fd141ffc83299ad65c2df0ace9e2