### PR TITLE
feat: add product description field

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7362,6 +7362,11 @@
             "description": "Product brand",
             "example": "Acme"
           },
+          "description": {
+            "type": "string",
+            "description": "Product description",
+            "example": "Nourishing shampoo with natural ingredients"
+          },
           "unitPrice": {
             "type": "number",
             "description": "Price per unit",
@@ -7440,6 +7445,12 @@
             "type": "string",
             "description": "Updated product brand",
             "example": "Acme",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Updated product description",
+            "example": "Nourishing shampoo with natural ingredients",
             "nullable": true
           },
           "unitPrice": {

--- a/backend/src/catalog/product.entity.ts
+++ b/backend/src/catalog/product.entity.ts
@@ -20,6 +20,9 @@ export class Product {
     @Column({ nullable: true })
     brand: string;
 
+    @Column('text', { nullable: true })
+    description: string | null;
+
     @Column('decimal', { precision: 10, scale: 2 })
     unitPrice: number;
 

--- a/backend/src/migrations/20250711192036-AddProductDescription.ts
+++ b/backend/src/migrations/20250711192036-AddProductDescription.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddProductDescription20250711192036 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'product',
+            new TableColumn({
+                name: 'description',
+                type: 'text',
+                isNullable: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('product', 'description');
+    }
+}

--- a/backend/src/products/dto/create-product.dto.ts
+++ b/backend/src/products/dto/create-product.dto.ts
@@ -29,6 +29,15 @@ export class CreateProductDto {
     @IsString()
     brand?: string;
 
+    @ApiPropertyOptional({
+        description: 'Product description',
+        type: String,
+        example: 'Nourishing shampoo with natural ingredients',
+    })
+    @IsOptional()
+    @IsString()
+    description?: string;
+
     @ApiProperty({
         description: 'Price per unit',
         type: Number,

--- a/backend/src/products/dto/update-product.dto.ts
+++ b/backend/src/products/dto/update-product.dto.ts
@@ -11,7 +11,7 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import { CreateProductDto } from './create-product.dto';
 
 export class UpdateProductDto extends PartialType(
-    OmitType(CreateProductDto, ['brand'] as const),
+    OmitType(CreateProductDto, ['brand', 'description'] as const),
 ) {
     @ApiPropertyOptional({
         description: 'Updated product name',
@@ -32,6 +32,16 @@ export class UpdateProductDto extends PartialType(
     @IsOptional()
     @IsString()
     brand?: string | null;
+
+    @ApiPropertyOptional({
+        description: 'Updated product description',
+        type: String,
+        example: 'Nourishing shampoo with natural ingredients',
+        nullable: true,
+    })
+    @IsOptional()
+    @IsString()
+    description?: string | null;
 
     @ApiPropertyOptional({
         description: 'Updated unit price',


### PR DESCRIPTION
## Summary
- allow storing optional product descriptions
- expose description field in product DTOs and API spec
- create migration to add description column

## Testing
- `npm test`
- `npm run lint`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_689606af64d48329ba31a9878a88a93d