### PR TITLE
Add check constraints for service price and duration

### DIFF
--- a/backend/src/catalog/service.entity.ts
+++ b/backend/src/catalog/service.entity.ts
@@ -12,6 +12,8 @@ import { Category } from './category.entity';
 
 @Index(['category', 'name'], { unique: true })
 @Check('"defaultCommissionPercent" >= 0 AND "defaultCommissionPercent" <= 100')
+@Check('"price" >= 0')
+@Check('"duration" > 0')
 @Entity()
 export class Service {
     @PrimaryGeneratedColumn()

--- a/backend/src/migrations/20250711192037-AddServicePriceDurationCheck.ts
+++ b/backend/src/migrations/20250711192037-AddServicePriceDurationCheck.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddServicePriceDurationCheck20250711192037 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "service" ADD CONSTRAINT "CHK_service_price_nonnegative" CHECK ("price" >= 0)',
+        );
+        await queryRunner.query(
+            'ALTER TABLE "service" ADD CONSTRAINT "CHK_service_duration_positive" CHECK ("duration" > 0)',
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "service" DROP CONSTRAINT "CHK_service_duration_positive"',
+        );
+        await queryRunner.query(
+            'ALTER TABLE "service" DROP CONSTRAINT "CHK_service_price_nonnegative"',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- ensure service price is non-negative and duration positive
- add migration enforcing new service constraints

## Testing
- `npm test`
- `npm run lint`
- `npx ts-node -e "const { DataSource, getMetadataArgsStorage } = require('typeorm'); const { Service } = require('./src/catalog/service.entity'); const { Category } = require('./src/catalog/category.entity'); (async () => { const storage = getMetadataArgsStorage(); storage.columns.forEach(col => { if (col.options.type === 'timestamptz') col.options.type = 'datetime'; if (col.options.type === 'enum') col.options.type = 'simple-enum'; }); const ds = new DataSource({ type: 'sqlite', database: ':memory:', entities: [Service, Category] }); await ds.initialize(); await ds.synchronize(); try { await ds.getRepository(Service).save({ name: 'badDuration', duration: -1, price: 10 }); } catch (e) { console.log('duration check works'); } try { await ds.getRepository(Service).save({ name: 'badPrice', duration: 10, price: -1 }); } catch (e) { console.log('price check works'); } await ds.destroy(); })();"`

------
https://chatgpt.com/codex/tasks/task_e_689638d378dc8329806594c2301d95c5