### PR TITLE
feat: enforce nonnegative low stock threshold

### DIFF
--- a/backend/src/catalog/product.entity.ts
+++ b/backend/src/catalog/product.entity.ts
@@ -9,6 +9,7 @@ import {
 
 @Check('CHK_product_unit_price', '"unitPrice" >= 0')
 @Check('CHK_product_stock', '"stock" >= 0')
+@Check('CHK_product_low_stock_threshold', '"lowStockThreshold" >= 0')
 @Entity()
 export class Product {
     @PrimaryGeneratedColumn()

--- a/backend/src/migrations/20250711192027-UpdateProductSchema.ts
+++ b/backend/src/migrations/20250711192027-UpdateProductSchema.ts
@@ -29,12 +29,18 @@ export class UpdateProductSchema20250711192027 implements MigrationInterface {
             'product',
             new TableUnique({ columnNames: ['name'] }),
         );
+        await queryRunner.query(
+            'ALTER TABLE "product" ADD CONSTRAINT "CHK_product_low_stock_threshold" CHECK ("lowStockThreshold" >= 0)',
+        );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.dropUniqueConstraint(
             'product',
             new TableUnique({ columnNames: ['name'] }),
+        );
+        await queryRunner.query(
+            'ALTER TABLE "product" DROP CONSTRAINT "CHK_product_low_stock_threshold"',
         );
         await queryRunner.dropColumn('product', 'lowStockThreshold');
         await queryRunner.dropColumn('product', 'createdAt');

--- a/frontend/src/__tests__/productApi.test.tsx
+++ b/frontend/src/__tests__/productApi.test.tsx
@@ -16,14 +16,27 @@ const toast = require('react-hot-toast').toast;
 
 describe('useProductApi', () => {
   it('shows success toast on create', async () => {
-    const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
+    const apiFetch = jest
+      .fn()
+      .mockResolvedValue({
+        id: 1,
+        name: 'A',
+        unitPrice: 1,
+        stock: 1,
+        lowStockThreshold: 5,
+      });
     mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ToastProvider>{children}</ToastProvider>
     );
     const { result } = renderHook(() => useProductApi(), { wrapper });
     await act(async () => {
-      await result.current.create({ name: 'A', unitPrice: 1, stock: 1 });
+      await result.current.create({
+        name: 'A',
+        unitPrice: 1,
+        stock: 1,
+        lowStockThreshold: 5,
+      });
     });
     expect(toast.success).toHaveBeenCalled();
   });
@@ -37,7 +50,12 @@ describe('useProductApi', () => {
     const { result } = renderHook(() => useProductApi(), { wrapper });
     await expect(
       act(async () => {
-        await result.current.create({ name: 'A', unitPrice: 1, stock: 1 });
+        await result.current.create({
+          name: 'A',
+          unitPrice: 1,
+          stock: 1,
+          lowStockThreshold: 5,
+        });
       })
     ).rejects.toThrow();
     expect(toast.error).toHaveBeenCalled();

--- a/frontend/src/__tests__/productForm.test.tsx
+++ b/frontend/src/__tests__/productForm.test.tsx
@@ -16,9 +16,16 @@ describe('ProductForm', () => {
     fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'P' } });
     fireEvent.change(screen.getByPlaceholderText('Price'), { target: { value: '1' } });
     fireEvent.change(screen.getByPlaceholderText('Stock'), { target: { value: '2' } });
+    // lowStockThreshold left as default (5)
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith({ name: 'P', unitPrice: 1, stock: 2, brand: '' })
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: 'P',
+        unitPrice: 1,
+        stock: 2,
+        lowStockThreshold: 5,
+        brand: '',
+      })
     );
   });
 });

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -10,6 +10,7 @@ export function useProductApi() {
         name: string;
         unitPrice: number;
         stock: number;
+        lowStockThreshold: number;
         brand?: string;
     }) => {
         try {
@@ -32,6 +33,7 @@ export function useProductApi() {
             name?: string;
             unitPrice?: number;
             stock?: number;
+            lowStockThreshold?: number;
             brand?: string;
         },
     ) => {

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -6,12 +6,21 @@ const schema = z.object({
   name: z.string().min(1, { message: 'Name is required' }),
   unitPrice: z.coerce.number().min(0, { message: 'Price must be >= 0' }),
   stock: z.coerce.number().min(0, { message: 'Stock must be >= 0' }),
+  lowStockThreshold: z.coerce.number().min(0, { message: 'Low stock threshold must be >= 0' }),
   brand: z.string().optional(),
 });
 
 interface Props {
   initial?: Partial<Product>;
-  onSubmit: (data: { name: string; unitPrice: number; stock: number; brand?: string }) => Promise<void>;
+  onSubmit: (
+    data: {
+      name: string;
+      unitPrice: number;
+      stock: number;
+      lowStockThreshold: number;
+      brand?: string;
+    }
+  ) => Promise<void>;
   onCancel: () => void;
 }
 
@@ -20,6 +29,7 @@ export default function ProductForm({ initial, onSubmit, onCancel }: Props) {
     name: initial?.name ?? '',
     unitPrice: initial?.unitPrice ?? 0,
     stock: initial?.stock ?? 0,
+    lowStockThreshold: initial?.lowStockThreshold ?? 5,
     brand: initial?.brand ?? '',
   });
   const [error, setError] = useState('');
@@ -42,10 +52,41 @@ export default function ProductForm({ initial, onSubmit, onCancel }: Props) {
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input name="name" value={form.name} onChange={handleChange} className="border p-1 w-full" placeholder="Name" />
-      <input name="brand" value={form.brand} onChange={handleChange} className="border p-1 w-full" placeholder="Brand" />
-      <input name="unitPrice" value={form.unitPrice} onChange={handleChange} className="border p-1 w-full" placeholder="Price" />
-      <input name="stock" value={form.stock} onChange={handleChange} className="border p-1 w-full" placeholder="Stock" />
+      <input
+        name="name"
+        value={form.name}
+        onChange={handleChange}
+        className="border p-1 w-full"
+        placeholder="Name"
+      />
+      <input
+        name="brand"
+        value={form.brand}
+        onChange={handleChange}
+        className="border p-1 w-full"
+        placeholder="Brand"
+      />
+      <input
+        name="unitPrice"
+        value={form.unitPrice}
+        onChange={handleChange}
+        className="border p-1 w-full"
+        placeholder="Price"
+      />
+      <input
+        name="stock"
+        value={form.stock}
+        onChange={handleChange}
+        className="border p-1 w-full"
+        placeholder="Stock"
+      />
+      <input
+        name="lowStockThreshold"
+        value={form.lowStockThreshold}
+        onChange={handleChange}
+        className="border p-1 w-full"
+        placeholder="Low Stock Threshold"
+      />
       {error && (
         <p role="alert" className="text-red-600 text-sm">
           {error}

--- a/frontend/src/pages/products/index.tsx
+++ b/frontend/src/pages/products/index.tsx
@@ -25,12 +25,14 @@ export default function ProductsPage() {
         { header: 'Brand', accessor: 'brand' },
         { header: 'Price', accessor: 'unitPrice' },
         { header: 'Stock', accessor: 'stock' },
+        { header: 'Low Threshold', accessor: 'lowStockThreshold' },
     ];
 
     const handleCreate = async (values: {
         name: string;
         unitPrice: number;
         stock: number;
+        lowStockThreshold: number;
         brand?: string;
     }) => {
         const created = await api.create(values);
@@ -42,6 +44,7 @@ export default function ProductsPage() {
         name: string;
         unitPrice: number;
         stock: number;
+        lowStockThreshold: number;
         brand?: string;
     }) => {
         if (!editing) return;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,6 +38,7 @@ export interface Product {
     brand?: string;
     unitPrice: number;
     stock: number;
+    lowStockThreshold: number;
 }
 
 export interface Review {


### PR DESCRIPTION
## Summary
- add database check ensuring `lowStockThreshold` is non-negative
- support `lowStockThreshold` field across frontend forms, types, and APIs

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963bfe3d1c832995be5b85cbe11ecb