### PR TITLE
Refactor layout navigation logic

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,12 +6,25 @@ import DashboardNav from './DashboardNav';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const onDashboard = router.pathname.startsWith('/dashboard');
+  const isPublicPage =
+    router.pathname === '/' ||
+    router.pathname.startsWith('/services') ||
+    router.pathname.startsWith('/gallery') ||
+    router.pathname.startsWith('/contact') ||
+    router.pathname.startsWith('/faq') ||
+    router.pathname.startsWith('/policy') ||
+    router.pathname.startsWith('/privacy') ||
+    router.pathname.startsWith('/auth');
+
   return (
     <div className="min-h-screen flex flex-col">
-      {!onDashboard && <PublicNav />}
+      {isPublicPage && <PublicNav />}
       <div className="flex flex-1">
-        {onDashboard && <DashboardNav />}
+        {!isPublicPage && (
+          <aside>
+            <DashboardNav />
+          </aside>
+        )}
         <main className="flex-1 p-4">{children}</main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace dashboard flag with granular public route detection in layout
- toggle PublicNav and DashboardNav based on page context

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964345834c8329b5a0f970f3fb7513