### PR TITLE
Use shared Layout component in dashboard pages

### DIFF
--- a/frontend/src/pages/dashboard/admin/index.tsx
+++ b/frontend/src/pages/dashboard/admin/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import DashboardLayout from '@/components/DashboardLayout';
+import Layout from '@/components/Layout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function AdminDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['admin']}>
-            <DashboardLayout>
+            <Layout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-3">
                     <DashboardWidget
                         label="Clients"
@@ -25,7 +25,7 @@ export default function AdminDashboard() {
                         loading={loading}
                     />
                 </div>
-            </DashboardLayout>
+            </Layout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/client/index.tsx
+++ b/frontend/src/pages/dashboard/client/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import DashboardLayout from '@/components/DashboardLayout';
+import Layout from '@/components/Layout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function ClientDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['client']}>
-            <DashboardLayout>
+            <Layout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                     <DashboardWidget
                         label="Upcoming"
@@ -15,7 +15,7 @@ export default function ClientDashboard() {
                         loading={loading}
                     />
                 </div>
-            </DashboardLayout>
+            </Layout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/employee/index.tsx
+++ b/frontend/src/pages/dashboard/employee/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import DashboardLayout from '@/components/DashboardLayout';
+import Layout from '@/components/Layout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function EmployeeDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['employee']}>
-            <DashboardLayout>
+            <Layout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                     <DashboardWidget
                         label="Today Appointments"
@@ -20,7 +20,7 @@ export default function EmployeeDashboard() {
                         loading={loading}
                     />
                 </div>
-            </DashboardLayout>
+            </Layout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/receptionist/index.tsx
+++ b/frontend/src/pages/dashboard/receptionist/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import DashboardLayout from '@/components/DashboardLayout';
+import Layout from '@/components/Layout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function ReceptionistDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['receptionist']}>
-            <DashboardLayout>
+            <Layout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                     <DashboardWidget
                         label="All Appointments"
@@ -15,7 +15,7 @@ export default function ReceptionistDashboard() {
                         loading={loading}
                     />
                 </div>
-            </DashboardLayout>
+            </Layout>
         </RouteGuard>
     );
 }


### PR DESCRIPTION
## Summary
- Replace `DashboardLayout` with shared `Layout` component in all dashboard variants
- Wrap dashboard contents with `<Layout>` to ensure consistent navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68964ab2f24c8329a7dea70d17df3a71