### PR TITLE
Refactor layout into public and dashboard variants

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,32 +1,18 @@
 'use client';
 import { ReactNode } from 'react';
 import { useRouter } from 'next/router';
-import PublicNav from './PublicNav';
-import DashboardNav from './DashboardNav';
+import PublicLayout from './PublicLayout';
+import DashboardLayout from './DashboardLayout';
+import { publicRoutes } from '@/config/publicRoutes';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const isPublicPage =
-    router.pathname === '/' ||
-    router.pathname.startsWith('/services') ||
-    router.pathname.startsWith('/gallery') ||
-    router.pathname.startsWith('/contact') ||
-    router.pathname.startsWith('/faq') ||
-    router.pathname.startsWith('/policy') ||
-    router.pathname.startsWith('/privacy') ||
-    router.pathname.startsWith('/auth');
-
-  return (
-    <div className="min-h-screen flex flex-col">
-      {isPublicPage && <PublicNav />}
-      <div className="flex flex-1">
-        {!isPublicPage && (
-          <aside>
-            <DashboardNav />
-          </aside>
-        )}
-        <main className="flex-1 p-4">{children}</main>
-      </div>
-    </div>
+  const isPublicPage = publicRoutes.some((route) =>
+    route === '/' ? router.pathname === '/' : router.pathname.startsWith(route)
+  );
+  return isPublicPage ? (
+    <PublicLayout>{children}</PublicLayout>
+  ) : (
+    <DashboardLayout>{children}</DashboardLayout>
   );
 }

--- a/frontend/src/components/PublicLayout.tsx
+++ b/frontend/src/components/PublicLayout.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { ReactNode } from 'react';
+import PublicNav from './PublicNav';
+
+export default function PublicLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <PublicNav />
+      <main className="flex-1 p-4">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/config/publicRoutes.ts
+++ b/frontend/src/config/publicRoutes.ts
@@ -1,0 +1,10 @@
+export const publicRoutes = [
+  '/',
+  '/services',
+  '/gallery',
+  '/contact',
+  '/faq',
+  '/policy',
+  '/privacy',
+  '/auth',
+];

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,16 +1,13 @@
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
-import Layout from '@/components/Layout';
 import '@/styles/globals.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
       <ToastProvider>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <Component {...pageProps} />
       </ToastProvider>
     </AuthProvider>
   );

--- a/frontend/src/pages/about/index.tsx
+++ b/frontend/src/pages/about/index.tsx
@@ -1,3 +1,9 @@
+import PublicLayout from '@/components/PublicLayout';
+
 export default function AboutPage() {
-    return <div>About Page</div>;
+    return (
+        <PublicLayout>
+            <div>About Page</div>
+        </PublicLayout>
+    );
 }

--- a/frontend/src/pages/appointments/index.tsx
+++ b/frontend/src/pages/appointments/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import Modal from '@/components/Modal';
 import AppointmentForm from '@/components/AppointmentForm';
 import { useAppointments } from '@/hooks/useAppointments';
@@ -78,7 +78,7 @@ export default function AppointmentsPage() {
 
     return (
         <RouteGuard roles={['client', 'employee', 'receptionist', 'admin']}>
-            <Layout>
+            <DashboardLayout>
                 {role === 'receptionist' && (
                     <div>Viewing appointments for all employees</div>
                 )}
@@ -102,7 +102,7 @@ export default function AppointmentsPage() {
                         onCancel={() => setFormOpen(false)}
                     />
                 </Modal>
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/router';
 import { z } from 'zod';
 import { useAuth } from '@/contexts/AuthContext';
+import PublicLayout from '@/components/PublicLayout';
 
 export default function LoginPage() {
   const { login } = useAuth();
@@ -33,24 +34,26 @@ export default function LoginPage() {
   };
 
   return (
-    <form onSubmit={(e) => void handleSubmit(e)}>
-      <input
-        placeholder="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        placeholder="password"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit">Login</button>
-      {error && (
-        <p role="alert" style={{ color: 'red' }}>
-          {error}
-        </p>
-      )}
-    </form>
+    <PublicLayout>
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <input
+          placeholder="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          placeholder="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Login</button>
+        {error && (
+          <p role="alert" style={{ color: 'red' }}>
+            {error}
+          </p>
+        )}
+      </form>
+    </PublicLayout>
   );
 }

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/router';
+import PublicLayout from '@/components/PublicLayout';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -28,36 +29,38 @@ export default function RegisterPage() {
   };
 
   return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2 p-4">
-      <h1 className="text-2xl font-bold">Register</h1>
-      <input
-        className="border p-1 w-full"
-        placeholder="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-      />
-      <input
-        className="border p-1 w-full"
-        placeholder="Email"
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        className="border p-1 w-full"
-        placeholder="Password"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button className="border px-2 py-1" type="submit">
-        Register
-      </button>
-      {error && (
-        <p role="alert" className="text-red-600">
-          {error}
-        </p>
-      )}
-    </form>
+    <PublicLayout>
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2 p-4">
+        <h1 className="text-2xl font-bold">Register</h1>
+        <input
+          className="border p-1 w-full"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="border p-1 w-full"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-1 w-full"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="border px-2 py-1" type="submit">
+          Register
+        </button>
+        {error && (
+          <p role="alert" className="text-red-600">
+            {error}
+          </p>
+        )}
+      </form>
+    </PublicLayout>
   );
 }

--- a/frontend/src/pages/clients/[id]/reviews.tsx
+++ b/frontend/src/pages/clients/[id]/reviews.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useReviews } from '@/hooks/useReviews';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import RouteGuard from '@/components/RouteGuard';
 import DataTable, { Column } from '@/components/DataTable';
 import { Review } from '@/types';
@@ -20,7 +20,7 @@ export default function ClientReviewsPage() {
   ];
   return (
     <RouteGuard>
-      <Layout>
+      <DashboardLayout>
         <div className="mb-2 flex justify-between">
           <div className="flex items-center gap-2">
             <label>
@@ -56,7 +56,7 @@ export default function ClientReviewsPage() {
             Next
           </button>
         </div>
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/clients/index.tsx
+++ b/frontend/src/pages/clients/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DataTable, { Column } from '@/components/DataTable';
 import Modal from '@/components/Modal';
 import ClientForm from '@/components/ClientForm';
@@ -45,7 +45,7 @@ export default function ClientsPage() {
 
   return (
     <RouteGuard>
-      <Layout>
+      <DashboardLayout>
         <div className="mb-2 flex justify-end">
           <button
             className="border px-2 py-1"
@@ -99,7 +99,7 @@ export default function ClientsPage() {
             onSubmit={editing ? handleUpdate : handleCreate}
           />
         </Modal>
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/contact.tsx
+++ b/frontend/src/pages/contact.tsx
@@ -1,9 +1,10 @@
 import ContactForm from '@/components/ContactForm';
 import Head from 'next/head';
+import PublicLayout from '@/components/PublicLayout';
 
 export default function ContactPage() {
     return (
-        <>
+        <PublicLayout>
             <Head>
                 <title>Contact Us | Salon Black &amp; White</title>
                 <meta
@@ -22,6 +23,6 @@ export default function ContactPage() {
                 <p>Phone: 123-456-789</p>
                 <ContactForm />
             </div>
-        </>
+        </PublicLayout>
     );
 }

--- a/frontend/src/pages/dashboard/admin/index.tsx
+++ b/frontend/src/pages/dashboard/admin/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function AdminDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['admin']}>
-            <Layout>
+            <DashboardLayout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-3">
                     <DashboardWidget
                         label="Clients"
@@ -25,7 +25,7 @@ export default function AdminDashboard() {
                         loading={loading}
                     />
                 </div>
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/client/index.tsx
+++ b/frontend/src/pages/dashboard/client/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function ClientDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['client']}>
-            <Layout>
+            <DashboardLayout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                     <DashboardWidget
                         label="Upcoming"
@@ -15,7 +15,7 @@ export default function ClientDashboard() {
                         loading={loading}
                     />
                 </div>
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/employee/index.tsx
+++ b/frontend/src/pages/dashboard/employee/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function EmployeeDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['employee']}>
-            <Layout>
+            <DashboardLayout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                     <DashboardWidget
                         label="Today Appointments"
@@ -20,7 +20,7 @@ export default function EmployeeDashboard() {
                         loading={loading}
                     />
                 </div>
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/receptionist/index.tsx
+++ b/frontend/src/pages/dashboard/receptionist/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DashboardWidget from '@/components/DashboardWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 
@@ -7,7 +7,7 @@ export default function ReceptionistDashboard() {
     const { data, loading } = useDashboard();
     return (
         <RouteGuard roles={['receptionist']}>
-            <Layout>
+            <DashboardLayout>
                 <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
                     <DashboardWidget
                         label="All Appointments"
@@ -15,7 +15,7 @@ export default function ReceptionistDashboard() {
                         loading={loading}
                     />
                 </div>
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/dashboard/services/index.tsx
+++ b/frontend/src/pages/dashboard/services/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DataTable, { Column } from '@/components/DataTable';
 import Modal from '@/components/Modal';
 import ServiceForm from '@/components/ServiceForm';
@@ -44,8 +44,8 @@ export default function ServicesPage() {
 
   return (
     <RouteGuard>
-      <Layout>
-                <div className="mb-2 flex justify-end">
+      <DashboardLayout>
+        <div className="mb-2 flex justify-end">
             <button
               className="border px-2 py-1"
               onClick={() => {
@@ -95,7 +95,7 @@ export default function ServicesPage() {
               onSubmit={editing ? handleUpdate : handleCreate}
             />
           </Modal>
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/emails/index.tsx
+++ b/frontend/src/pages/emails/index.tsx
@@ -1,13 +1,13 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import EmailList from '@/components/EmailList';
 
 export default function EmailsPage() {
     return (
         <RouteGuard>
-            <Layout>
+            <DashboardLayout>
                 <EmailList />
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/employees/[id]/reviews.tsx
+++ b/frontend/src/pages/employees/[id]/reviews.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useReviews } from '@/hooks/useReviews';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import RouteGuard from '@/components/RouteGuard';
 import DataTable, { Column } from '@/components/DataTable';
 import { Review } from '@/types';
@@ -20,7 +20,7 @@ export default function EmployeeReviewsPage() {
   ];
   return (
     <RouteGuard>
-      <Layout>
+      <DashboardLayout>
         <div className="mb-2 flex justify-between">
           <div className="flex items-center gap-2">
             <label>
@@ -56,7 +56,7 @@ export default function EmployeeReviewsPage() {
             Next
           </button>
         </div>
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/employees/index.tsx
+++ b/frontend/src/pages/employees/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DataTable, { Column } from '@/components/DataTable';
 import Modal from '@/components/Modal';
 import EmployeeForm from '@/components/EmployeeForm';
@@ -44,7 +44,7 @@ export default function EmployeesPage() {
 
   return (
     <RouteGuard>
-      <Layout>
+      <DashboardLayout>
         <div className="mb-2 flex justify-end">
           <button
             className="border px-2 py-1"
@@ -95,7 +95,7 @@ export default function EmployeesPage() {
             onSubmit={editing ? handleUpdate : handleCreate}
           />
         </Modal>
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/faq.tsx
+++ b/frontend/src/pages/faq.tsx
@@ -1,5 +1,6 @@
 import FAQAccordion, { FAQItem } from '@/components/FAQAccordion';
 import Head from 'next/head';
+import PublicLayout from '@/components/PublicLayout';
 
 const faqs: FAQItem[] = [
     {
@@ -18,7 +19,7 @@ const faqs: FAQItem[] = [
 
 export default function FAQPage() {
     return (
-        <>
+        <PublicLayout>
             <Head>
                 <title>
                     Frequently Asked Questions | Salon Black &amp; White
@@ -34,6 +35,6 @@ export default function FAQPage() {
                 </h1>
                 <FAQAccordion items={faqs} />
             </div>
-        </>
+        </PublicLayout>
     );
 }

--- a/frontend/src/pages/gallery.tsx
+++ b/frontend/src/pages/gallery.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
+import PublicLayout from '@/components/PublicLayout';
 
 interface GalleryItem {
     id: string;
@@ -25,7 +26,7 @@ interface InstagramResponse {
 
 export default function GalleryPage({ items }: GalleryPageProps) {
     return (
-        <>
+        <PublicLayout>
             <Head>
                 <title>Gallery | Salon Black &amp; White</title>
                 <meta
@@ -48,7 +49,7 @@ export default function GalleryPage({ items }: GalleryPageProps) {
                     ))}
                 </div>
             </div>
-        </>
+        </PublicLayout>
     );
 }
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
 import FAQAccordion, { FAQItem } from '@/components/FAQAccordion';
+import PublicLayout from '@/components/PublicLayout';
 
 export default function HomePage() {
     const heroImages = [
@@ -65,7 +66,7 @@ export default function HomePage() {
     }, [testimonials.length]);
 
     return (
-        <>
+        <PublicLayout>
             <Head>
                 <title>
                     Salon Black &amp; White | Professional Hair &amp; Beauty
@@ -171,7 +172,7 @@ export default function HomePage() {
                     </div>
                 </section>
             </div>
-        </>
+        </PublicLayout>
     );
 }
 

--- a/frontend/src/pages/invoices/index.tsx
+++ b/frontend/src/pages/invoices/index.tsx
@@ -1,5 +1,5 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import { useInvoices } from '@/hooks/useInvoices';
 
 export default function InvoicesPage() {
@@ -7,7 +7,7 @@ export default function InvoicesPage() {
 
     return (
         <RouteGuard>
-            <Layout>
+            <DashboardLayout>
                 {loading ? (
                     <div>Loading...</div>
                 ) : (
@@ -36,7 +36,7 @@ export default function InvoicesPage() {
                         </tbody>
                     </table>
                 )}
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/notifications/index.tsx
+++ b/frontend/src/pages/notifications/index.tsx
@@ -1,13 +1,13 @@
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import NotificationList from '@/components/NotificationList';
 
 export default function NotificationsPage() {
   return (
     <RouteGuard>
-      <Layout>
+      <DashboardLayout>
         <NotificationList />
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/policy.tsx
+++ b/frontend/src/pages/policy.tsx
@@ -1,8 +1,9 @@
 import Head from 'next/head';
+import PublicLayout from '@/components/PublicLayout';
 
 export default function PolicyPage() {
   return (
-    <>
+    <PublicLayout>
       <Head>
         <title>Policy | Salon Black & White</title>
         <meta
@@ -14,6 +15,6 @@ export default function PolicyPage() {
         <h1 className="text-2xl font-bold">Policy</h1>
         <p>Placeholder for the salon&apos;s policy information.</p>
       </div>
-    </>
+    </PublicLayout>
   );
 }

--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -1,8 +1,9 @@
 import Head from 'next/head';
+import PublicLayout from '@/components/PublicLayout';
 
 export default function PrivacyPage() {
   return (
-    <>
+    <PublicLayout>
       <Head>
         <title>Privacy Policy | Salon Black & White</title>
         <meta
@@ -14,6 +15,6 @@ export default function PrivacyPage() {
         <h1 className="text-2xl font-bold">Privacy Policy</h1>
         <p>Placeholder for the privacy policy content.</p>
       </div>
-    </>
+    </PublicLayout>
   );
 }

--- a/frontend/src/pages/products/index.tsx
+++ b/frontend/src/pages/products/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DataTable, { Column } from '@/components/DataTable';
 import Modal from '@/components/Modal';
 import ProductForm from '@/components/ProductForm';
@@ -73,7 +73,7 @@ export default function ProductsPage() {
 
     return (
         <RouteGuard>
-            <Layout>
+            <DashboardLayout>
                 <div className="mb-2 flex justify-end">
                     <button
                         className="border px-2 py-1"
@@ -142,7 +142,7 @@ export default function ProductsPage() {
                         onSubmit={handleStockUpdate}
                     />
                 </Modal>
-            </Layout>
+            </DashboardLayout>
         </RouteGuard>
     );
 }

--- a/frontend/src/pages/reviews/index.tsx
+++ b/frontend/src/pages/reviews/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import RouteGuard from '@/components/RouteGuard';
-import Layout from '@/components/Layout';
+import DashboardLayout from '@/components/DashboardLayout';
 import DataTable, { Column } from '@/components/DataTable';
 import Modal from '@/components/Modal';
 import ReviewForm from '@/components/ReviewForm';
@@ -64,7 +64,7 @@ export default function ReviewsPage() {
 
   return (
     <RouteGuard>
-      <Layout>
+      <DashboardLayout>
         <div className="mb-2 flex justify-between">
           <div className="flex items-center gap-2">
             <label>
@@ -156,7 +156,7 @@ export default function ReviewsPage() {
             onSubmit={editing ? handleUpdate : handleCreate}
           />
         </Modal>
-      </Layout>
+      </DashboardLayout>
     </RouteGuard>
   );
 }

--- a/frontend/src/pages/services.tsx
+++ b/frontend/src/pages/services.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { Service } from '@/types';
+import PublicLayout from '@/components/PublicLayout';
 
 interface ServiceCategory {
     id: number | null;
@@ -14,7 +15,7 @@ interface ServicesPageProps {
 
 export default function ServicesPage({ categories }: ServicesPageProps) {
     return (
-        <>
+        <PublicLayout>
             <Head>
                 <title>Our Services | Salon Black &amp; White</title>
                 <meta
@@ -40,7 +41,7 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                     </div>
                 ))}
             </div>
-        </>
+        </PublicLayout>
     );
 }
 


### PR DESCRIPTION
## Summary
- extract list of public routes to `src/config/publicRoutes.ts`
- introduce `PublicLayout` and use existing `DashboardLayout`
- update pages to use the appropriate layout and drop global layout wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68964ced68e883298c7f07019d7fca10