### PR TITLE
Refine public page detection

### DIFF
--- a/frontend/src/__tests__/isPublicPage.test.ts
+++ b/frontend/src/__tests__/isPublicPage.test.ts
@@ -1,0 +1,11 @@
+import { isPublicPage } from '@/components/Layout';
+
+describe('isPublicPage', () => {
+  it('does not mark /services-old as public', () => {
+    expect(isPublicPage('/services-old')).toBe(false);
+  });
+
+  it('does not mark /gallery123 as public', () => {
+    expect(isPublicPage('/gallery123')).toBe(false);
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,12 +5,16 @@ import PublicLayout from './PublicLayout';
 import DashboardLayout from './DashboardLayout';
 import { publicRoutes } from '@/config/publicRoutes';
 
+export function isPublicPage(pathname: string): boolean {
+  return publicRoutes.some((route) =>
+    route === '/' ? pathname === '/' : pathname.split('/')[1] === route.slice(1)
+  );
+}
+
 export default function Layout({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const isPublicPage = publicRoutes.some((route) =>
-    route === '/' ? router.pathname === '/' : router.pathname.startsWith(route)
-  );
-  return isPublicPage ? (
+  const publicPage = isPublicPage(router.pathname);
+  return publicPage ? (
     <PublicLayout>{children}</PublicLayout>
   ) : (
     <DashboardLayout>{children}</DashboardLayout>


### PR DESCRIPTION
## Summary
- compare URL segments to determine public pages
- add unit tests ensuring similar prefixes aren't treated as public

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689651c87c8c8329a0b7461a93c078b2