### PR TITLE
Add navigation coverage tests

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -1,0 +1,24 @@
+describe('navigation visibility', () => {
+  it('shows dashboard navigation for authenticated users on /products', () => {
+    localStorage.setItem('jwtToken', 'x');
+    localStorage.setItem('role', 'admin');
+    cy.intercept('GET', '**/products**', { fixture: 'products.json' }).as('getProd');
+    cy.visit('/products');
+    cy.wait('@getProd');
+    cy.contains('Dashboard');
+    cy.contains('Products');
+  });
+
+  it('redirects unauthenticated users away from /products', () => {
+    cy.visit('/products');
+    cy.url().should('include', '/auth/login');
+  });
+
+  it('renders public navigation on public pages', () => {
+    cy.intercept('GET', '**/services**', { fixture: 'services.json' }).as('getServices');
+    cy.visit('/services');
+    cy.wait('@getServices');
+    cy.get('nav').contains('Login');
+    cy.get('nav').contains('Services');
+  });
+});

--- a/frontend/src/__tests__/layout.test.tsx
+++ b/frontend/src/__tests__/layout.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Layout from '@/components/Layout';
+import { useRouter } from 'next/router';
+import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('@/contexts/AuthContext');
+
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+describe('Layout', () => {
+  it('renders PublicNav on public routes', () => {
+    mockedUseRouter.mockReturnValue({ pathname: '/services' });
+    render(<Layout>content</Layout>);
+    expect(screen.getByText('Login')).toBeInTheDocument();
+  });
+
+  it('renders dashboard navigation on private routes', () => {
+    mockedUseRouter.mockReturnValue({ pathname: '/products' });
+    mockedUseAuth.mockReturnValue(createAuthValue({ isAuthenticated: true, role: 'admin' }));
+    render(<Layout>content</Layout>);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- cover navigation behavior in Cypress for authenticated, unauthenticated and public visits
- test Layout to ensure public and private routes render appropriate navigation

## Testing
- `npm test`
- `npm run lint`
- `npm run e2e` *(fails: dashboard-client.cy.ts, dashboard-employee.cy.ts, dashboard.cy.ts, employees.cy.ts, navigation.cy.ts, products.cy.ts, reviews.cy.ts, services.cy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689653129d888329be4b329c4ddb0b2b