### PR TITLE
feat: enhance navigation styling and behavior

### DIFF
--- a/frontend/src/__tests__/faq.test.tsx
+++ b/frontend/src/__tests__/faq.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import FAQPage from '@/pages/faq';
+import { useAuth } from '@/contexts/AuthContext';
+import { createAuthValue } from '../testUtils';
+
+jest.mock('@/contexts/AuthContext');
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('FAQ page', () => {
   it('renders without crashing', () => {
+    mockedUseAuth.mockReturnValue(createAuthValue());
     render(<FAQPage />);
     expect(
       screen.getByText(/Frequently Asked Questions/i)

--- a/frontend/src/__tests__/layout.test.tsx
+++ b/frontend/src/__tests__/layout.test.tsx
@@ -12,15 +12,23 @@ const mockedUseRouter = useRouter as jest.Mock;
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('Layout', () => {
+  beforeEach(() => {
+    mockedUseRouter.mockReset();
+    mockedUseAuth.mockReset();
+  });
+
   it('renders PublicNav on public routes', () => {
     mockedUseRouter.mockReturnValue({ pathname: '/services' });
+    mockedUseAuth.mockReturnValue(createAuthValue());
     render(<Layout>content</Layout>);
     expect(screen.getByText('Login')).toBeInTheDocument();
   });
 
   it('renders dashboard navigation on private routes', () => {
     mockedUseRouter.mockReturnValue({ pathname: '/products' });
-    mockedUseAuth.mockReturnValue(createAuthValue({ isAuthenticated: true, role: 'admin' }));
+    mockedUseAuth.mockReturnValue(
+      createAuthValue({ isAuthenticated: true, role: 'admin' })
+    );
     render(<Layout>content</Layout>);
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/receptionistNav.test.tsx
+++ b/frontend/src/__tests__/receptionistNav.test.tsx
@@ -1,14 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import DashboardNav from '@/components/DashboardNav';
 import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/router';
 import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockedUseRouter = useRouter as jest.Mock;
 
 describe('DashboardNav receptionist', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedUseRouter.mockReset();
+  });
+
   it('shows receptionist links', () => {
     mockedUseAuth.mockReturnValue(createAuthValue({ role: 'receptionist' }));
+    mockedUseRouter.mockReturnValue({ pathname: '/dashboard/receptionist' });
     render(<DashboardNav />);
     expect(screen.getByText('Home')).toBeInTheDocument();
     expect(screen.getByText('Appointments')).toBeInTheDocument();

--- a/frontend/src/components/DashboardNav.tsx
+++ b/frontend/src/components/DashboardNav.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useAuth } from '@/contexts/AuthContext';
 import type { Role } from '@/types';
 
@@ -31,6 +32,7 @@ const navLinks: Record<Role, { href: string; label: string }[]> = {
 
 export default function DashboardNav() {
     const { logout, role } = useAuth();
+    const router = useRouter();
     const currentRole: Role =
         role === 'client' ||
         role === 'employee' ||
@@ -40,15 +42,22 @@ export default function DashboardNav() {
             : 'client';
 
     return (
-        <aside className="w-48 bg-gray-200 p-4 space-y-2">
+        <aside className="w-48 bg-gray-200 p-4 space-y-2 border-r-2 border-gray-300">
             <h2 className="font-bold mb-2">Menu</h2>
             <nav className="space-y-1">
                 {navLinks[currentRole].map((l) => (
-                    <Link key={l.href} href={l.href} className="block">
+                    <Link
+                        key={l.href}
+                        href={l.href}
+                        className={`block px-2 py-1 ${router.pathname.startsWith(l.href) ? 'font-bold text-blue-600 border-l-4 border-blue-500 pl-2' : ''}`}
+                    >
                         {l.label}
                     </Link>
                 ))}
-                <button className="block text-left" onClick={logout}>
+                <button
+                    className="block text-left px-2 py-1 hover:underline"
+                    onClick={logout}
+                >
                     Logout
                 </button>
             </nav>

--- a/frontend/src/components/PublicNav.tsx
+++ b/frontend/src/components/PublicNav.tsx
@@ -1,19 +1,33 @@
 'use client';
 import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function PublicNav() {
+  const { role } = useAuth();
+
   return (
-    <nav className="flex space-x-4 p-2 border-b">
-      <Link href="/">Home</Link>
-      <Link href="/services">Services</Link>
-      <Link href="/gallery">Gallery</Link>
-      <Link href="/faq">FAQ</Link>
-      <Link href="/contact">Contact</Link>
-      <Link href="/appointments">Book Now</Link>
-      <Link href="/auth/login">Login</Link>
-      <Link href="/auth/register">Register</Link>
-      <Link href="/policy">Policy</Link>
-      <Link href="/privacy">Privacy</Link>
+    <nav className="flex justify-between items-center p-4 bg-gray-100 shadow-md">
+      <Link href="/" className="font-bold text-xl mr-4">
+        Salon Black & White
+      </Link>
+      <div className="flex space-x-4">
+        <Link href="/">Home</Link>
+        <Link href="/services">Services</Link>
+        <Link href="/gallery">Gallery</Link>
+        <Link href="/faq">FAQ</Link>
+        <Link href="/contact">Contact</Link>
+        <Link href="/appointments">Book Now</Link>
+        {role ? (
+          <Link href={`/dashboard/${role}`}>Dashboard</Link>
+        ) : (
+          <>
+            <Link href="/auth/login">Login</Link>
+            <Link href="/auth/register">Register</Link>
+          </>
+        )}
+        <Link href="/policy">Policy</Link>
+        <Link href="/privacy">Privacy</Link>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- add salon brand link and conditional Dashboard/Login/Register links in PublicNav
- highlight active links and improve sidebar styling in DashboardNav
- mock auth context and router in navigation tests

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966e86e0c48329a92a9c242c90a001