### PR TITLE
Add health check e2e test

### DIFF
--- a/backend/salonbw-backend/test/app.e2e-spec.ts
+++ b/backend/salonbw-backend/test/app.e2e-spec.ts
@@ -1,26 +1,34 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+import { INestApplication, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import request from 'supertest';
+import { HealthController } from '../src/health.controller';
 
-describe('AppController (e2e)', () => {
-    let app: INestApplication<App>;
+@Module({
+    controllers: [HealthController],
+})
+class TestAppModule {}
 
-    beforeEach(async () => {
+describe('Health (e2e)', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
-            imports: [AppModule],
+            imports: [TestAppModule],
         }).compile();
 
         app = moduleFixture.createNestApplication();
         await app.init();
     });
 
-    it('/ (GET)', () => {
+    afterAll(async () => {
+        await app.close();
+    });
+
+    it('/health (GET)', () => {
         return request(app.getHttpServer())
-            .get('/')
+            .get('/health')
             .expect(200)
-            .expect('Hello World!');
+            .expect({ status: 'ok' });
     });
 });
+


### PR DESCRIPTION
## Summary
- add e2e test for /health endpoint verifying 200 response and JSON { status: 'ok' }

## Testing
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68975795f1ac8329a6b661b543e9e7e2