### PR TITLE
docs: add backend verification steps

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,15 @@
 # Gliwicka111 v2
+
+## Verification
+
+1. Copy `.env.example` to `.env` and ensure it contains `DATABASE_URL` (e.g., `postgres://user:password@localhost:5432/database`).
+2. Start PostgreSQL using those credentials. One way is:
+   - `sudo service postgresql start`
+   - `sudo -u postgres psql -c "CREATE USER \"user\" WITH PASSWORD 'password';"`
+   - `sudo -u postgres psql -c "CREATE DATABASE database OWNER \"user\";"`
+3. From `backend/salonbw-backend` run `npm run start:dev` and confirm it connects to the database without errors.
+4. In a separate terminal, check the health endpoint:
+   ```bash
+   curl http://localhost:3000/health
+   ```
+   Expected output: `{"status":"ok"}` with HTTP status `200`.


### PR DESCRIPTION
## Summary
- document how to verify backend server with local PostgreSQL and health check

## Testing
- `npm test`
- `curl -i http://localhost:3000/health`


------
https://chatgpt.com/codex/tasks/task_e_689758eb179c8329914f619121216d3a