### PR TITLE
feat: add users module with user entity

### DIFF
--- a/backend/salonbw-backend/src/users/role.enum.ts
+++ b/backend/salonbw-backend/src/users/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+    Client = 'client',
+    Employee = 'employee',
+    Admin = 'admin',
+}

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Role } from './role.enum';
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ unique: true })
+    email: string;
+
+    @Column()
+    password: string;
+
+    @Column()
+    name: string;
+
+    @Column({ type: 'enum', enum: Role, default: Role.Client })
+    role: Role;
+}

--- a/backend/salonbw-backend/src/users/users.module.ts
+++ b/backend/salonbw-backend/src/users/users.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './user.entity';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([User])],
+})
+export class UsersModule {}


### PR DESCRIPTION
## Summary
- add Role enum and User entity
- set up UsersModule with TypeORM integration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897711e2c588329aac86cb91e2a6f1c