### PR TITLE
Add user service for user creation and lookup

### DIFF
--- a/backend/salonbw-backend/package-lock.json
+++ b/backend/salonbw-backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
+        "bcrypt": "^6.0.0",
         "dotenv": "^17.2.1",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
@@ -4038,6 +4039,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7794,6 +7809,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -7802,6 +7826,17 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/backend/salonbw-backend/package.json
+++ b/backend/salonbw-backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
+    "bcrypt": "^6.0.0",
     "dotenv": "^17.2.1",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",

--- a/backend/salonbw-backend/src/users/dto/create-user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/create-user.dto.ts
@@ -1,0 +1,5 @@
+export class CreateUserDto {
+    email: string;
+    password: string;
+    name: string;
+}

--- a/backend/salonbw-backend/src/users/users.module.ts
+++ b/backend/salonbw-backend/src/users/users.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
+import { UsersService } from './users.service';
 
 @Module({
     imports: [TypeOrmModule.forFeature([User])],
+    providers: [UsersService],
+    exports: [UsersService],
 })
 export class UsersModule {}

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { User } from './user.entity';
+import { Role } from './role.enum';
+import { CreateUserDto } from './dto/create-user.dto';
+
+@Injectable()
+export class UsersService {
+    constructor(
+        @InjectRepository(User)
+        private readonly usersRepository: Repository<User>,
+    ) {}
+
+    async findByEmail(email: string): Promise<User | null> {
+        return await this.usersRepository.findOne({ where: { email } });
+    }
+
+    async createUser(dto: CreateUserDto): Promise<User> {
+        const existing = await this.findByEmail(dto.email);
+        if (existing) {
+            throw new Error('Email already exists');
+        }
+
+        const hashedPassword = await bcrypt.hash(dto.password, 10);
+
+        const user = this.usersRepository.create({
+            email: dto.email,
+            name: dto.name,
+            password: hashedPassword,
+            role: Role.Client,
+        });
+
+        return await this.usersRepository.save(user);
+    }
+}


### PR DESCRIPTION
## Summary
- create UsersService with email lookup and user creation
- hash passwords with bcrypt and enforce unique emails
- expose UsersService via UsersModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977258599c8329bb4cb741f5a00b08