### PR TITLE
feat: configure typeorm with migrations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,3 +13,7 @@
    curl http://localhost:3000/health
    ```
    Expected output: `{"status":"ok"}` with HTTP status `200`.
+
+## Notes
+
+- TypeORM synchronization is enabled only for development. In production environments set `NODE_ENV=production` and run migrations instead of relying on synchronization.

--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -11,6 +11,10 @@ import { HealthController } from './health.controller';
             type: 'postgres',
             url: process.env.DATABASE_URL,
             autoLoadEntities: true,
+            // NOTE: synchronize is convenient for development but
+            // should be disabled in production where migrations are used.
+            synchronize: process.env.NODE_ENV !== 'production',
+            migrations: [__dirname + '/migrations/*{.ts,.js}'],
         }),
     ],
     controllers: [AppController, HealthController],

--- a/backend/salonbw-backend/src/migrations/1710000000000-CreateUsersTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000000000-CreateUsersTable.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateUsersTable1710000000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'users',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'email',
+                        type: 'varchar',
+                        isUnique: true,
+                    },
+                    {
+                        name: 'password',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'name',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'role',
+                        type: 'enum',
+                        enum: ['client', 'employee', 'admin'],
+                        default: `'client'`,
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('users');
+    }
+}

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { Role } from './role.enum';
 
-@Entity()
+@Entity('users')
 export class User {
     @PrimaryGeneratedColumn()
     id: number;


### PR DESCRIPTION
## Summary
- configure TypeORM to sync only outside production and load migrations
- add migration creating users table with unique email
- document disabling sync in production

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977ca2a9bc8329a8a6058b06cea36c