### PR TITLE
chore: run backend steps in correct directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,19 @@ jobs:
           npm run build
       - name: Install backend deps
         run: |
-          cd backend
+          cd backend/salonbw-backend
           npm ci
       - name: Lint backend
         run: |
-          cd backend
+          cd backend/salonbw-backend
           npm run lint
       - name: Test backend
         run: |
-          cd backend
+          cd backend/salonbw-backend
           npm test -- --coverage
       - name: Generate OpenAPI docs
         run: |
-          cd backend
+          cd backend/salonbw-backend
           set -o pipefail
           npm run swagger:generate 2>&1 | tee swagger.log
           git diff --exit-code openapi.json


### PR DESCRIPTION
## Summary
- Run backend CI steps from `backend/salonbw-backend`

## Testing
- `npm ci`
- `npm run lint` *(fails: no-unused-vars, no-unsafe-assignment)*
- `npm test`
- `npm run swagger:generate` *(fails: Missing script "swagger:generate")*


------
https://chatgpt.com/codex/tasks/task_e_6897854778788329bbf117c3fa9886ae