### PR TITLE
chore: run backend steps in correct directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,19 @@ jobs:
           npm run build
       - name: Install backend deps
         run: |
-          cd backend
+          cd backend/salonbw-backend
           npm ci
       - name: Lint backend
         run: |
-          cd backend
+          cd backend/salonbw-backend
           npm run lint
       - name: Test backend
         run: |
-          cd backend
+          cd backend/salonbw-backend
           npm test -- --coverage
       - name: Generate OpenAPI docs
         run: |
-          cd backend
+          cd backend/salonbw-backend
           set -o pipefail
           npm run swagger:generate 2>&1 | tee swagger.log
           git diff --exit-code openapi.json

--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -12,14 +12,16 @@ export class UsersController {
         if (!user) {
             return { email: 'test@example.com', name: 'Test User' };
         }
-        const { password, ...result } = user;
+        const { password: _password, ...result } = user;
+        void _password;
         return result;
     }
 
     @Post()
     async create(@Body() createUserDto: CreateUserDto) {
         const user = await this.usersService.createUser(createUserDto);
-        const { password, ...result } = user;
+        const { password: _password, ...result } = user;
+        void _password;
         return result;
     }
 }

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -23,7 +23,14 @@ export class UsersService {
             throw new Error('Email already exists');
         }
 
-        const hashedPassword = await bcrypt.hash(dto.password, 10);
+        const hashedPassword: string = await (
+            bcrypt as unknown as {
+                hash(
+                    data: string,
+                    saltOrRounds: string | number,
+                ): Promise<string>;
+            }
+        ).hash(dto.password, 10);
 
         const user = this.usersRepository.create({
             email: dto.email,

--- a/backend/salonbw-backend/test/app.e2e-spec.ts
+++ b/backend/salonbw-backend/test/app.e2e-spec.ts
@@ -25,10 +25,12 @@ describe('Health (e2e)', () => {
     });
 
     it('/health (GET)', () => {
-        return request(app.getHttpServer())
+        const server = app.getHttpServer() as unknown as Parameters<
+            typeof request
+        >[0];
+        return request(server)
             .get('/health')
             .expect(200)
             .expect({ status: 'ok' });
     });
 });
-


### PR DESCRIPTION
## Summary
- Run backend CI steps from `backend/salonbw-backend`
- Fix backend lint errors around unused variables and unsafe bcrypt usage

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run swagger:generate` *(fails: Missing script "swagger:generate")*


------
https://chatgpt.com/codex/tasks/task_e_6897854778788329bbf117c3fa9886ae