### PR TITLE
Expect null for missing user lookups

### DIFF
--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -93,12 +93,12 @@ describe('UsersService', () => {
             });
         });
 
-        it('returns undefined for unknown email', async () => {
-            repo.findOne.mockResolvedValue(undefined);
+        it('returns null for unknown email', async () => {
+            repo.findOne.mockResolvedValue(null);
 
             const result = await service.findByEmail('unknown@example.com');
 
-            expect(result).toBeUndefined();
+            expect(result).toBeNull();
             expect(repo.findOne).toHaveBeenCalledWith({
                 where: { email: 'unknown@example.com' },
             });

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -14,7 +14,9 @@ export class UsersService {
     ) {}
 
     async findByEmail(email: string): Promise<User | null> {
-        return await this.usersRepository.findOne({ where: { email } });
+        const user = await this.usersRepository.findOne({ where: { email } });
+        // Ensure null is returned instead of undefined for unknown emails
+        return user ?? null;
     }
 
     async createUser(dto: CreateUserDto): Promise<User> {


### PR DESCRIPTION
## Summary
- Ensure `findByEmail` returns `null` instead of `undefined`
- Update users service tests to expect `null`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b21251b88329ba5c0501334a5d11