### PR TITLE
feat: add refresh token support

### DIFF
--- a/backend/salonbw-backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/salonbw-backend/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+    @IsString()
+    refreshToken: string;
+}


### PR DESCRIPTION
## Summary
- add refresh token generation and verification in `AuthService`
- expose `POST /auth/refresh` endpoint
- provide DTO for refresh requests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bda7f3cc83298139a83a5f6085aa