### PR TITLE
feat(auth): add jwt strategy and guard profile route

### DIFF
--- a/backend/salonbw-backend/package-lock.json
+++ b/backend/salonbw-backend/package-lock.json
@@ -38,6 +38,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
+        "@types/passport-jwt": "^4.0.1",
         "@types/passport-local": "^1.0.38",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
@@ -2960,6 +2961,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
       }
     },
     "node_modules/@types/passport-local": {

--- a/backend/salonbw-backend/package.json
+++ b/backend/salonbw-backend/package.json
@@ -50,6 +50,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",

--- a/backend/salonbw-backend/src/auth/auth.module.ts
+++ b/backend/salonbw-backend/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { LocalStrategy } from './local.strategy';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
     imports: [
@@ -15,7 +16,7 @@ import { LocalStrategy } from './local.strategy';
         }),
         UsersModule,
     ],
-    providers: [AuthService, LocalStrategy],
+    providers: [AuthService, LocalStrategy, JwtStrategy],
     controllers: [AuthController],
     exports: [AuthService, UsersModule],
 })

--- a/backend/salonbw-backend/src/auth/jwt.strategy.ts
+++ b/backend/salonbw-backend/src/auth/jwt.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+    constructor() {
+        super({
+            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            secretOrKey: process.env.JWT_SECRET,
+        });
+    }
+
+    validate(payload: { sub: number; role: string }) {
+        return { userId: payload.sub, role: payload.role };
+    }
+}

--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -1,4 +1,6 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 
@@ -6,15 +8,10 @@ import { CreateUserDto } from './dto/create-user.dto';
 export class UsersController {
     constructor(private readonly usersService: UsersService) {}
 
+    @UseGuards(AuthGuard('jwt'))
     @Get('profile')
-    async getProfile() {
-        const user = await this.usersService.findByEmail('test@example.com');
-        if (!user) {
-            return { email: 'test@example.com', name: 'Test User' };
-        }
-        const { password: _password, ...result } = user;
-        void _password;
-        return result;
+    getProfile(@Req() req: Request) {
+        return req.user;
     }
 
     @Post()


### PR DESCRIPTION
## Summary
- add JWT strategy for bearer tokens
- secure user profile endpoint with JWT auth
- include type definitions for passport-jwt

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897d1d8ac24832980e0ecb68879c209