### PR TITLE
feat: add auth validation tests

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.service.spec.ts
+++ b/backend/salonbw-backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,85 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { User } from '../users/user.entity';
+import { Role } from '../users/role.enum';
+import * as bcrypt from 'bcrypt';
+
+jest.mock('bcrypt', () => ({
+    compare: jest.fn(),
+}));
+
+type BcryptMock = {
+    compare: jest.Mock;
+};
+
+const bcryptMock: BcryptMock = bcrypt as unknown as BcryptMock;
+
+describe('AuthService.validateUser', () => {
+    let service: AuthService;
+    let usersService: { findByEmail: jest.Mock };
+
+    beforeEach(() => {
+        usersService = { findByEmail: jest.fn() };
+        service = new AuthService(
+            usersService as unknown as UsersService,
+            {} as any,
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns user without password on valid credentials', async () => {
+        const user: User = {
+            id: 1,
+            email: 'test@example.com',
+            name: 'Test User',
+            password: 'hashed',
+            role: Role.Client,
+        } as User;
+        usersService.findByEmail.mockResolvedValue(user);
+        bcryptMock.compare.mockResolvedValue(true);
+
+        const result = await service.validateUser(
+            'test@example.com',
+            'password',
+        );
+
+        expect(usersService.findByEmail).toHaveBeenCalledWith(
+            'test@example.com',
+        );
+        expect(bcryptMock.compare).toHaveBeenCalledWith('password', 'hashed');
+        expect(result).toEqual({
+            id: 1,
+            email: 'test@example.com',
+            name: 'Test User',
+            role: Role.Client,
+        });
+    });
+
+    it('throws UnauthorizedException if user not found', async () => {
+        usersService.findByEmail.mockResolvedValue(null);
+
+        await expect(
+            service.validateUser('unknown@example.com', 'password'),
+        ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException on invalid password', async () => {
+        const user: User = {
+            id: 1,
+            email: 'test@example.com',
+            name: 'Test User',
+            password: 'hashed',
+            role: Role.Client,
+        } as User;
+        usersService.findByEmail.mockResolvedValue(user);
+        bcryptMock.compare.mockResolvedValue(false);
+
+        await expect(
+            service.validateUser('test@example.com', 'wrong'),
+        ).rejects.toThrow(UnauthorizedException);
+    });
+});

--- a/backend/salonbw-backend/src/auth/auth.service.ts
+++ b/backend/salonbw-backend/src/auth/auth.service.ts
@@ -14,14 +14,14 @@ export class AuthService {
     async validateUser(
         email: string,
         pass: string,
-    ): Promise<Omit<User, 'password'> | null> {
+    ): Promise<Omit<User, 'password'>> {
         const user = await this.usersService.findByEmail(email);
-        if (user && (await bcrypt.compare(pass, user.password))) {
-            const { password: _password, ...result } = user;
-            void _password;
-            return result as Omit<User, 'password'>;
+        if (!user || !(await bcrypt.compare(pass, user.password))) {
+            throw new UnauthorizedException('Invalid credentials');
         }
-        return null;
+        const { password: _password, ...result } = user;
+        void _password;
+        return result as Omit<User, 'password'>;
     }
 
     login(user: Omit<User, 'password'>) {


### PR DESCRIPTION
## Summary
- throw UnauthorizedException when credentials invalid
- add tests covering AuthService.validateUser success and failure cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897d41cb538832986b6de9f31887a8b