### PR TITLE
refactor: use type-only import for Request

### DIFF
--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { Request } from 'express';
+import type { Request } from 'express';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 


### PR DESCRIPTION
## Summary
- use type-only import for Request in UsersController

## Testing
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_6897d671f21c8329a1f4f083e7928092