### PR TITLE
feat(auth): return 200 on login

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -25,6 +25,7 @@ export class AuthController {
 
     @UseGuards(AuthGuard('local'))
     @Post('login')
+    @HttpCode(HttpStatus.OK)
     login(@Request() req: ExpressRequest & { user: Omit<User, 'password'> }) {
         return this.authService.login(req.user);
     }

--- a/backend/salonbw-backend/test/auth.e2e-spec.ts
+++ b/backend/salonbw-backend/test/auth.e2e-spec.ts
@@ -96,7 +96,7 @@ describe('Auth & Users (e2e)', () => {
         const res = await request(server)
             .post('/auth/login')
             .send({ email: 'john@example.com', password: 'password123' })
-            .expect(201);
+            .expect(200);
         const { access_token, refresh_token } = res.body as AuthTokens;
 
         expect(access_token).toBeDefined();


### PR DESCRIPTION
## Summary
- ensure login endpoint responds with 200 OK
- update e2e test to expect 200 on successful login

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6898d6811eac83299cc8c450b41a359c