### PR TITLE
feat: document auth endpoints with Swagger

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -66,6 +66,71 @@
           "Users"
         ]
       }
+    },
+    "/auth/login": {
+      "post": {
+        "operationId": "AuthController_login",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Tokens successfully generated"
+          }
+        },
+        "summary": "Log in user",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "operationId": "AuthController_register",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User successfully registered"
+          }
+        },
+        "summary": "Register new user",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "operationId": "AuthController_refresh",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokenDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tokens successfully refreshed"
+          }
+        },
+        "summary": "Refresh access token",
+        "tags": [
+          "auth"
+        ]
+      }
     }
   },
   "info": {
@@ -79,6 +144,14 @@
   "components": {
     "schemas": {
       "CreateUserDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "RegisterDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "RefreshTokenDto": {
         "type": "object",
         "properties": {}
       }

--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
     UnauthorizedException,
     UseGuards,
 } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { Request as ExpressRequest } from 'express';
 import { RegisterDto } from './dto/register.dto';
@@ -16,6 +17,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { User } from '../users/user.entity';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
     constructor(
@@ -26,12 +28,16 @@ export class AuthController {
     @UseGuards(AuthGuard('local'))
     @Post('login')
     @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Log in user' })
+    @ApiResponse({ status: 200, description: 'Tokens successfully generated' })
     login(@Request() req: ExpressRequest & { user: Omit<User, 'password'> }) {
         return this.authService.login(req.user);
     }
 
     @Post('register')
     @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({ summary: 'Register new user' })
+    @ApiResponse({ status: 201, description: 'User successfully registered' })
     async register(@Body() dto: RegisterDto) {
         const user = await this.usersService.createUser(dto);
         return this.authService.login(user);
@@ -39,6 +45,8 @@ export class AuthController {
 
     @Post('refresh')
     @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Refresh access token' })
+    @ApiResponse({ status: 200, description: 'Tokens successfully refreshed' })
     refresh(
         @Body() dto: RefreshTokenDto,
         @Request()

--- a/backend/salonbw-backend/src/main.ts
+++ b/backend/salonbw-backend/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import cookieParser from 'cookie-parser';
 
@@ -11,6 +12,12 @@ async function bootstrap() {
     );
     app.use(cookieParser());
     const config = app.get(ConfigService);
+    const swaggerConfig = new DocumentBuilder()
+        .setTitle('SalonBW API')
+        .setVersion('1.0')
+        .build();
+    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    SwaggerModule.setup('api', app, document);
     app.enableCors({
         origin: config.get<string>('FRONTEND_URL'),
         credentials: true,

--- a/backend/salonbw-backend/swagger.ts
+++ b/backend/salonbw-backend/swagger.ts
@@ -7,16 +7,26 @@ import { AppService } from './src/app.service';
 import { HealthController } from './src/health.controller';
 import { UsersController } from './src/users/users.controller';
 import { UsersService } from './src/users/users.service';
+import { AuthController } from './src/auth/auth.controller';
+import { AuthService } from './src/auth/auth.service';
 
 @Module({
-  controllers: [AppController, HealthController, UsersController],
+  controllers: [AppController, HealthController, UsersController, AuthController],
   providers: [
     AppService,
     {
       provide: UsersService,
       useValue: {
         findByEmail: async () => null,
-        createUser: async () => ({ id: 0 }),
+        findById: async () => ({ id: 0, role: 'Client' }),
+        createUser: async () => ({ id: 0, role: 'Client' }),
+      },
+    },
+    {
+      provide: AuthService,
+      useValue: {
+        login: () => ({}),
+        refresh: () => ({}),
       },
     },
   ],


### PR DESCRIPTION
## Summary
- add Swagger decorators for auth login/register/refresh endpoints
- enable Swagger UI in main bootstrap
- include AuthController in swagger generation and regenerate OpenAPI spec

## Testing
- `npm test`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_6898f66102a483298e6ba2d36ac5dbe8