### PR TITLE
feat: add current user decorator

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -16,6 +16,7 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { User } from '../users/user.entity';
+import { CurrentUser } from './current-user.decorator';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -30,8 +31,8 @@ export class AuthController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Log in user' })
     @ApiResponse({ status: 200, description: 'Tokens successfully generated' })
-    login(@Request() req: ExpressRequest & { user: Omit<User, 'password'> }) {
-        return this.authService.login(req.user);
+    login(@CurrentUser() user: Omit<User, 'password'>) {
+        return this.authService.login(user);
     }
 
     @Post('register')

--- a/backend/salonbw-backend/src/auth/current-user.decorator.spec.ts
+++ b/backend/salonbw-backend/src/auth/current-user.decorator.spec.ts
@@ -1,0 +1,17 @@
+import { ExecutionContext } from '@nestjs/common';
+import { getCurrentUser } from './current-user.decorator';
+
+describe('CurrentUser decorator', () => {
+    it('should return user from request object', () => {
+        const mockUser = { id: 1, email: 'test@example.com' };
+        const ctx = {
+            switchToHttp: () => ({
+                getRequest: () => ({ user: mockUser }),
+            }),
+        } as unknown as ExecutionContext;
+
+        const result = getCurrentUser(ctx);
+        expect(result).toEqual(mockUser);
+    });
+});
+

--- a/backend/salonbw-backend/src/auth/current-user.decorator.ts
+++ b/backend/salonbw-backend/src/auth/current-user.decorator.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const getCurrentUser = (ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+};
+
+export const CurrentUser = createParamDecorator((_, ctx: ExecutionContext) =>
+    getCurrentUser(ctx),
+);
+

--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import type { Request } from 'express';
+import { CurrentUser } from '../auth/current-user.decorator';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 
@@ -10,8 +10,8 @@ export class UsersController {
 
     @UseGuards(AuthGuard('jwt'))
     @Get('profile')
-    getProfile(@Req() req: Request) {
-        return req.user;
+    getProfile(@CurrentUser() user: { userId: number; role: string }) {
+        return user;
     }
 
     @Post()


### PR DESCRIPTION
## Summary
- add `@CurrentUser` param decorator
- use `@CurrentUser` in auth and user controllers
- test decorator to return current user

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6898f81640c083298a885da31eadebe1