### PR TITLE
refactor: type current user decorator

### DIFF
--- a/backend/salonbw-backend/src/auth/current-user.decorator.spec.ts
+++ b/backend/salonbw-backend/src/auth/current-user.decorator.spec.ts
@@ -1,17 +1,42 @@
-import { ExecutionContext } from '@nestjs/common';
+import {
+    ExecutionContext,
+    HttpArgumentsHost,
+    RpcArgumentsHost,
+    WsArgumentsHost,
+} from '@nestjs/common';
+import { Request } from 'express';
 import { getCurrentUser } from './current-user.decorator';
 
 describe('CurrentUser decorator', () => {
     it('should return user from request object', () => {
         const mockUser = { id: 1, email: 'test@example.com' };
-        const ctx = {
-            switchToHttp: () => ({
-                getRequest: () => ({ user: mockUser }),
+        const request = { user: mockUser } as Request & {
+            user: typeof mockUser;
+        };
+        const httpHost: HttpArgumentsHost = {
+            getRequest: (): Request & { user: typeof mockUser } => request,
+            getResponse: (): unknown => undefined,
+            getNext: (): unknown => undefined,
+        };
+        const ctx: ExecutionContext = {
+            getArgByIndex: (): unknown => undefined,
+            getArgs: (): unknown[] => [],
+            getClass: () => class {},
+            getHandler: () => () => undefined,
+            getType: () => 'http',
+            switchToHttp: (): HttpArgumentsHost => httpHost,
+            switchToRpc: (): RpcArgumentsHost => ({
+                getContext: (): unknown => undefined,
+                getData: (): unknown => undefined,
             }),
-        } as unknown as ExecutionContext;
+            switchToWs: (): WsArgumentsHost => ({
+                getClient: (): unknown => undefined,
+                getData: (): unknown => undefined,
+                getPattern: (): string => '',
+            }),
+        };
 
         const result = getCurrentUser(ctx);
         expect(result).toEqual(mockUser);
     });
 });
-

--- a/backend/salonbw-backend/src/auth/current-user.decorator.ts
+++ b/backend/salonbw-backend/src/auth/current-user.decorator.ts
@@ -1,11 +1,13 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
 
-export const getCurrentUser = (ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
+type RequestWithUser = Request & { user?: unknown };
+
+export const getCurrentUser = (ctx: ExecutionContext): unknown => {
+    const request = ctx.switchToHttp().getRequest<RequestWithUser>();
     return request.user;
 };
 
-export const CurrentUser = createParamDecorator((_, ctx: ExecutionContext) =>
-    getCurrentUser(ctx),
+export const CurrentUser = createParamDecorator<unknown>(
+    (_: unknown, ctx: ExecutionContext): unknown => getCurrentUser(ctx),
 );
-


### PR DESCRIPTION
## Summary
- type the `CurrentUser` decorator and request object
- update decorator tests with fully typed mocks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689914ba6d24832986d8fce8065b9331