### PR TITLE
docs: regenerate swagger spec

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -44,6 +44,18 @@
       }
     },
     "/users": {
+      "get": {
+        "operationId": "UsersController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Users"
+        ]
+      },
       "post": {
         "operationId": "UsersController_create",
         "parameters": [],


### PR DESCRIPTION
## Summary
- regenerate OpenAPI spec to include GET /users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c7a15b7c8329b6a94aa26322f1d1