### PR TITLE
docs: describe users endpoint

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -49,9 +49,24 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserDto"
+                  }
+                }
+              }
+            }
           }
         },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "tags": [
           "Users"
         ]
@@ -155,6 +170,10 @@
   "servers": [],
   "components": {
     "schemas": {
+      "UserDto": {
+        "type": "object",
+        "properties": {}
+      },
       "CreateUserDto": {
         "type": "object",
         "properties": {}

--- a/backend/salonbw-backend/src/users/dto/user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/user.dto.ts
@@ -1,0 +1,8 @@
+import { Role } from '../role.enum';
+
+export class UserDto {
+    id: number;
+    email: string;
+    name: string;
+    role: Role;
+}

--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -1,10 +1,12 @@
 import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
+import { UserDto } from './dto/user.dto';
 import { Role } from './role.enum';
 
 @Controller('users')
@@ -21,7 +23,9 @@ export class UsersController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Get()
-    async findAll() {
+    @ApiBearerAuth()
+    @ApiOkResponse({ type: UserDto, isArray: true })
+    async findAll(): Promise<UserDto[]> {
         const users = await this.usersService.findAll();
         return users.map(({ password: _password, ...rest }) => {
             void _password;


### PR DESCRIPTION
## Summary
- add UserDto and apply `ApiBearerAuth`/`ApiOkResponse` to `UsersController.findAll`
- regenerate OpenAPI spec for user listing endpoint

## Testing
- `npm test`
- `npm run lint`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_6899cbed3cac832996f30bbf12e1c83d