### PR TITLE
feat: restrict user creation to admins

### DIFF
--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -33,6 +33,8 @@ export class UsersController {
         });
     }
 
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
     @Post()
     async create(@Body() createUserDto: CreateUserDto) {
         const user = await this.usersService.createUser(createUserDto);

--- a/backend/salonbw-backend/test/auth.e2e-spec.ts
+++ b/backend/salonbw-backend/test/auth.e2e-spec.ts
@@ -226,6 +226,18 @@ describe('Auth & Users (e2e)', () => {
             .expect(403);
     });
 
+    it('denies client from creating a user', async () => {
+        await request(server)
+            .post('/users')
+            .set('Authorization', `Bearer ${accessToken}`)
+            .send({
+                email: 'clientcreate@example.com',
+                password: 'password123',
+                name: 'ClientCreate',
+            })
+            .expect(403);
+    });
+
     it('logs in admin user', async () => {
         const res = await request(server)
             .post('/auth/login')
@@ -242,6 +254,18 @@ describe('Auth & Users (e2e)', () => {
             .expect(200);
         const users = res.body as unknown[];
         expect(users.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('allows admin to create a user', async () => {
+        await request(server)
+            .post('/users')
+            .set('Authorization', `Bearer ${adminAccessToken}`)
+            .send({
+                email: 'newuser@example.com',
+                password: 'password123',
+                name: 'New User',
+            })
+            .expect(201);
     });
 
     it('allows admin to access client endpoint', async () => {


### PR DESCRIPTION
## Summary
- protect POST /users with JWT auth and admin role check
- test that clients cannot create users and admins can

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6899e1e8fbb08329ac06d68b9a5ed6c1