### PR TITLE
feat: add service management

### DIFF
--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { HealthController } from './health.controller';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { ServicesModule } from './services/services.module';
 
 @Module({
     imports: [
@@ -24,6 +25,7 @@ import { AuthModule } from './auth/auth.module';
         }),
         UsersModule,
         AuthModule,
+        ServicesModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/services/service.entity.ts
+++ b/backend/salonbw-backend/src/services/service.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('services')
+export class Service {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    description: string;
+
+    @Column('int')
+    duration: number;
+
+    @Column('decimal')
+    price: number;
+
+    @Column({ nullable: true })
+    category?: string;
+
+    @Column('decimal', { nullable: true })
+    commissionPercent?: number;
+}

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -1,0 +1,59 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { ServicesService } from './services.service';
+import { Service } from './service.entity';
+
+@Controller('services')
+export class ServicesController {
+    constructor(private readonly servicesService: ServicesService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
+    @Get()
+    findAll(): Promise<Service[]> {
+        return this.servicesService.findAll();
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
+    @Get(':id')
+    findOne(@Param('id') id: string): Promise<Service | null> {
+        return this.servicesService.findOne(Number(id));
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Post()
+    create(@Body() body: Service): Promise<Service> {
+        return this.servicesService.create(body);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Patch(':id')
+    update(
+        @Param('id') id: string,
+        @Body() body: Partial<Service>,
+    ): Promise<Service | null> {
+        return this.servicesService.update(Number(id), body);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Delete(':id')
+    remove(@Param('id') id: string): Promise<void> {
+        return this.servicesService.remove(Number(id));
+    }
+}

--- a/backend/salonbw-backend/src/services/services.module.ts
+++ b/backend/salonbw-backend/src/services/services.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RolesGuard } from '../auth/roles.guard';
+import { Service } from './service.entity';
+import { ServicesService } from './services.service';
+import { ServicesController } from './services.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Service])],
+    providers: [ServicesService, RolesGuard],
+    controllers: [ServicesController],
+})
+export class ServicesModule {}

--- a/backend/salonbw-backend/src/services/services.service.ts
+++ b/backend/salonbw-backend/src/services/services.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Service } from './service.entity';
+
+@Injectable()
+export class ServicesService {
+    constructor(
+        @InjectRepository(Service)
+        private readonly servicesRepository: Repository<Service>,
+    ) {}
+
+    async create(data: Service): Promise<Service> {
+        const service = this.servicesRepository.create(data);
+        return this.servicesRepository.save(service);
+    }
+
+    findAll(): Promise<Service[]> {
+        return this.servicesRepository.find();
+    }
+
+    async findOne(id: number): Promise<Service | null> {
+        const service = await this.servicesRepository.findOne({
+            where: { id },
+        });
+        return service ?? null;
+    }
+
+    async update(id: number, data: Partial<Service>): Promise<Service | null> {
+        await this.servicesRepository.update(id, data);
+        return this.findOne(id);
+    }
+
+    async remove(id: number): Promise<void> {
+        await this.servicesRepository.delete(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add Service entity and data access layer
- expose CRUD API for services with role protection
- register ServicesModule in application setup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f91d14fc8329a034e1378db6575b