### PR TITLE
feat: add products module

### DIFF
--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { HealthController } from './health.controller';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { ServicesModule } from './services/services.module';
+import { ProductsModule } from './products/products.module';
 
 @Module({
     imports: [
@@ -26,6 +27,7 @@ import { ServicesModule } from './services/services.module';
         UsersModule,
         AuthModule,
         ServicesModule,
+        ProductsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/products/product.entity.ts
+++ b/backend/salonbw-backend/src/products/product.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('products')
+export class Product {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    brand: string;
+
+    @Column('decimal')
+    unitPrice: number;
+
+    @Column('int')
+    stock: number;
+}

--- a/backend/salonbw-backend/src/products/products.controller.ts
+++ b/backend/salonbw-backend/src/products/products.controller.ts
@@ -1,0 +1,59 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { ProductsService } from './products.service';
+import { Product } from './product.entity';
+
+@Controller('products')
+export class ProductsController {
+    constructor(private readonly productsService: ProductsService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Get()
+    findAll(): Promise<Product[]> {
+        return this.productsService.findAll();
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Get(':id')
+    findOne(@Param('id') id: string): Promise<Product | null> {
+        return this.productsService.findOne(Number(id));
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Post()
+    create(@Body() body: Product): Promise<Product> {
+        return this.productsService.create(body);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Patch(':id')
+    update(
+        @Param('id') id: string,
+        @Body() body: Partial<Product>,
+    ): Promise<Product | null> {
+        return this.productsService.update(Number(id), body);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Delete(':id')
+    remove(@Param('id') id: string): Promise<void> {
+        return this.productsService.remove(Number(id));
+    }
+}

--- a/backend/salonbw-backend/src/products/products.module.ts
+++ b/backend/salonbw-backend/src/products/products.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RolesGuard } from '../auth/roles.guard';
+import { Product } from './product.entity';
+import { ProductsService } from './products.service';
+import { ProductsController } from './products.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Product])],
+    providers: [ProductsService, RolesGuard],
+    controllers: [ProductsController],
+})
+export class ProductsModule {}

--- a/backend/salonbw-backend/src/products/products.service.ts
+++ b/backend/salonbw-backend/src/products/products.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product } from './product.entity';
+
+@Injectable()
+export class ProductsService {
+    constructor(
+        @InjectRepository(Product)
+        private readonly productsRepository: Repository<Product>,
+    ) {}
+
+    async create(data: Product): Promise<Product> {
+        const product = this.productsRepository.create(data);
+        return this.productsRepository.save(product);
+    }
+
+    findAll(): Promise<Product[]> {
+        return this.productsRepository.find();
+    }
+
+    async findOne(id: number): Promise<Product | null> {
+        const product = await this.productsRepository.findOne({ where: { id } });
+        return product ?? null;
+    }
+
+    async update(id: number, data: Partial<Product>): Promise<Product | null> {
+        await this.productsRepository.update(id, data);
+        return this.findOne(id);
+    }
+
+    async remove(id: number): Promise<void> {
+        await this.productsRepository.delete(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add Product entity and CRUD service
- expose admin-only endpoints for managing products
- register ProductsModule in AppModule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0b46e59c8329aaa227f276c37b01