### PR TITLE
Add appointments scheduling module

### DIFF
--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
+import { AppointmentsModule } from './appointments/appointments.module';
 
 @Module({
     imports: [
@@ -28,6 +29,7 @@ import { ProductsModule } from './products/products.module';
         AuthModule,
         ServicesModule,
         ProductsModule,
+        AppointmentsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/appointments/appointment.entity.ts
+++ b/backend/salonbw-backend/src/appointments/appointment.entity.ts
@@ -1,0 +1,36 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Service } from '../services/service.entity';
+
+export enum AppointmentStatus {
+    Scheduled = 'scheduled',
+    Cancelled = 'cancelled',
+    Completed = 'completed',
+}
+
+@Entity('appointments')
+export class Appointment {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => User, { eager: true })
+    client: User;
+
+    @ManyToOne(() => User, { eager: true })
+    employee: User;
+
+    @ManyToOne(() => Service, { eager: true })
+    service: Service;
+
+    @Column()
+    startTime: Date;
+
+    @Column()
+    endTime: Date;
+
+    @Column({ type: 'simple-enum', enum: AppointmentStatus, default: AppointmentStatus.Scheduled })
+    status: AppointmentStatus;
+
+    @Column({ nullable: true })
+    notes?: string;
+}

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -1,0 +1,91 @@
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+    ForbiddenException,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { AppointmentsService } from './appointments.service';
+import { Appointment } from './appointment.entity';
+import { User } from '../users/user.entity';
+import { Service as SalonService } from '../services/service.entity';
+
+@Controller('appointments')
+export class AppointmentsController {
+    constructor(private readonly appointmentsService: AppointmentsService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Admin)
+    @Post()
+    create(
+        @Body()
+        body: {
+            employeeId: number;
+            serviceId: number;
+            startTime: string;
+            endTime: string;
+            notes?: string;
+        },
+        @CurrentUser() user: { userId: number; role: Role },
+    ): Promise<Appointment> {
+        return this.appointmentsService.create({
+            client: { id: user.userId } as User,
+            employee: { id: body.employeeId } as User,
+            service: { id: body.serviceId } as SalonService,
+            startTime: new Date(body.startTime),
+            endTime: new Date(body.endTime),
+            notes: body.notes,
+        });
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
+    @Get('me')
+    findMine(@CurrentUser() user: { userId: number }): Promise<Appointment[]> {
+        return this.appointmentsService.findForUser(user.userId);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
+    @Patch(':id/cancel')
+    async cancel(
+        @Param('id') id: string,
+        @CurrentUser() user: { userId: number; role: Role },
+    ): Promise<Appointment | null> {
+        const appointment = await this.appointmentsService.findOne(Number(id));
+        if (
+            !appointment ||
+            (user.role !== Role.Admin &&
+                appointment.client.id !== user.userId &&
+                appointment.employee.id !== user.userId)
+        ) {
+            throw new ForbiddenException();
+        }
+        return this.appointmentsService.cancel(Number(id));
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Employee, Role.Admin)
+    @Patch(':id/complete')
+    async complete(
+        @Param('id') id: string,
+        @CurrentUser() user: { userId: number; role: Role },
+    ): Promise<Appointment | null> {
+        const appointment = await this.appointmentsService.findOne(Number(id));
+        if (
+            !appointment ||
+            (user.role !== Role.Admin && appointment.employee.id !== user.userId)
+        ) {
+            throw new ForbiddenException();
+        }
+        return this.appointmentsService.complete(Number(id));
+    }
+}

--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Appointment } from './appointment.entity';
+import { AppointmentsService } from './appointments.service';
+import { AppointmentsController } from './appointments.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Appointment])],
+    providers: [AppointmentsService],
+    controllers: [AppointmentsController],
+})
+export class AppointmentsModule {}

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -1,0 +1,56 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan, MoreThan, Not } from 'typeorm';
+import { Appointment, AppointmentStatus } from './appointment.entity';
+
+@Injectable()
+export class AppointmentsService {
+    constructor(
+        @InjectRepository(Appointment)
+        private readonly appointmentsRepository: Repository<Appointment>,
+    ) {}
+
+    async create(data: Partial<Appointment>): Promise<Appointment> {
+        const conflict = await this.appointmentsRepository.findOne({
+            where: {
+                employee: { id: data.employee!.id },
+                status: Not(AppointmentStatus.Cancelled),
+                startTime: LessThan(data.endTime as Date),
+                endTime: MoreThan(data.startTime as Date),
+            },
+        });
+        if (conflict) {
+            throw new ConflictException('Employee is already booked for this time');
+        }
+        const appointment = this.appointmentsRepository.create(data);
+        return this.appointmentsRepository.save(appointment);
+    }
+
+    findForUser(userId: number): Promise<Appointment[]> {
+        return this.appointmentsRepository.find({
+            where: [{ client: { id: userId } }, { employee: { id: userId } }],
+            order: { startTime: 'ASC' },
+        });
+    }
+
+    async findOne(id: number): Promise<Appointment | null> {
+        const appointment = await this.appointmentsRepository.findOne({
+            where: { id },
+        });
+        return appointment ?? null;
+    }
+
+    async cancel(id: number): Promise<Appointment | null> {
+        await this.appointmentsRepository.update(id, {
+            status: AppointmentStatus.Cancelled,
+        });
+        return this.findOne(id);
+    }
+
+    async complete(id: number): Promise<Appointment | null> {
+        await this.appointmentsRepository.update(id, {
+            status: AppointmentStatus.Completed,
+        });
+        return this.findOne(id);
+    }
+}

--- a/backend/salonbw-backend/src/auth/jwt.strategy.ts
+++ b/backend/salonbw-backend/src/auth/jwt.strategy.ts
@@ -8,7 +8,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     constructor(private readonly configService: ConfigService) {
         super({
             jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-            secretOrKey: configService.get<string>('JWT_SECRET'),
+            secretOrKey: configService.get<string>('JWT_SECRET') as string,
         });
     }
 


### PR DESCRIPTION
## Summary
- add appointment entity, service, controller, and module for scheduling visits
- validate overlapping bookings and allow users to cancel or complete their appointments
- wire new module into main app module and fix jwt secret typing for build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a10c338d88329b5d5335046fe2907