### PR TITLE
feat: add formulas module

### DIFF
--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth/auth.module';
 import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
 import { AppointmentsModule } from './appointments/appointments.module';
+import { FormulasModule } from './formulas/formulas.module';
 
 @Module({
     imports: [
@@ -30,6 +31,7 @@ import { AppointmentsModule } from './appointments/appointments.module';
         ServicesModule,
         ProductsModule,
         AppointmentsModule,
+        FormulasModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/formulas/formula.entity.ts
+++ b/backend/salonbw-backend/src/formulas/formula.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Entity('formulas')
+export class Formula {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    description: string;
+
+    @Column()
+    date: Date;
+
+    @ManyToOne(() => User, { eager: true })
+    client: User;
+
+    @ManyToOne(() => Appointment, { eager: true, nullable: true })
+    appointment?: Appointment;
+}
+

--- a/backend/salonbw-backend/src/formulas/formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { FormulasService } from './formulas.service';
+import { Formula } from './formula.entity';
+
+@Controller('formulas')
+export class FormulasController {
+    constructor(private readonly formulasService: FormulasService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Employee, Role.Admin)
+    @Post('appointments/:id')
+    addFormula(
+        @Param('id') id: string,
+        @Body() body: { description: string; date: string },
+    ): Promise<Formula> {
+        return this.formulasService.addToAppointment(Number(id), {
+            description: body.description,
+            date: new Date(body.date),
+        });
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Admin)
+    @Get('me')
+    findMine(
+        @CurrentUser() user: { userId: number },
+    ): Promise<Formula[]> {
+        return this.formulasService.findForClient(user.userId);
+    }
+}
+

--- a/backend/salonbw-backend/src/formulas/formulas.module.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Formula } from './formula.entity';
+import { FormulasService } from './formulas.service';
+import { FormulasController } from './formulas.controller';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Formula, Appointment])],
+    providers: [FormulasService],
+    controllers: [FormulasController],
+})
+export class FormulasModule {}
+

--- a/backend/salonbw-backend/src/formulas/formulas.service.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Formula } from './formula.entity';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Injectable()
+export class FormulasService {
+    constructor(
+        @InjectRepository(Formula)
+        private readonly formulasRepository: Repository<Formula>,
+        @InjectRepository(Appointment)
+        private readonly appointmentsRepository: Repository<Appointment>,
+    ) {}
+
+    async addToAppointment(
+        appointmentId: number,
+        data: { description: string; date: Date },
+    ): Promise<Formula> {
+        const appointment = await this.appointmentsRepository.findOne({
+            where: { id: appointmentId },
+        });
+        if (!appointment) {
+            throw new NotFoundException('Appointment not found');
+        }
+        const formula = this.formulasRepository.create({
+            description: data.description,
+            date: data.date,
+            client: appointment.client,
+            appointment,
+        });
+        return this.formulasRepository.save(formula);
+    }
+
+    findForClient(clientId: number): Promise<Formula[]> {
+        return this.formulasRepository.find({
+            where: { client: { id: clientId } },
+            order: { date: 'DESC' },
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Formula entity linked to clients and appointments
- implement service and controller to create and list formulas
- register FormulasModule in the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a14b0caa88329bee4576c58753e57