### PR TITLE
feat: add commissions tracking

### DIFF
--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ServicesModule } from './services/services.module';
 import { ProductsModule } from './products/products.module';
 import { AppointmentsModule } from './appointments/appointments.module';
 import { FormulasModule } from './formulas/formulas.module';
+import { CommissionsModule } from './commissions/commissions.module';
 
 @Module({
     imports: [
@@ -32,6 +33,7 @@ import { FormulasModule } from './formulas/formulas.module';
         ProductsModule,
         AppointmentsModule,
         FormulasModule,
+        CommissionsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -82,10 +82,11 @@ export class AppointmentsController {
         const appointment = await this.appointmentsService.findOne(Number(id));
         if (
             !appointment ||
-            (user.role !== Role.Admin && appointment.employee.id !== user.userId)
+            (user.role !== Role.Admin &&
+                appointment.employee.id !== user.userId)
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.complete(Number(id));
+        return this.appointmentsService.completeAppointment(Number(id));
     }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Appointment } from './appointment.entity';
 import { AppointmentsService } from './appointments.service';
 import { AppointmentsController } from './appointments.controller';
+import { CommissionsModule } from '../commissions/commissions.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Appointment])],
+    imports: [TypeOrmModule.forFeature([Appointment]), CommissionsModule],
     providers: [AppointmentsService],
     controllers: [AppointmentsController],
 })

--- a/backend/salonbw-backend/src/commissions/commission.entity.ts
+++ b/backend/salonbw-backend/src/commissions/commission.entity.ts
@@ -1,0 +1,34 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Appointment } from '../appointments/appointment.entity';
+import { Product } from '../products/product.entity';
+
+@Entity('commissions')
+export class Commission {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => User, { eager: true })
+    employee: User;
+
+    @ManyToOne(() => Appointment, { nullable: true, eager: true })
+    appointment?: Appointment | null;
+
+    @ManyToOne(() => Product, { nullable: true, eager: true })
+    product?: Product | null;
+
+    @Column('decimal')
+    amount: number;
+
+    @Column('decimal')
+    percent: number;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/backend/salonbw-backend/src/commissions/commissions.controller.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { CommissionsService } from './commissions.service';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { Commission } from './commission.entity';
+
+@Controller('commissions')
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+export class CommissionsController {
+    constructor(private readonly commissionsService: CommissionsService) {}
+
+    @Roles(Role.Employee, Role.Admin)
+    @Get('me')
+    findMine(@CurrentUser() user: { userId: number }): Promise<Commission[]> {
+        return this.commissionsService.findForUser(user.userId);
+    }
+
+    @Roles(Role.Admin)
+    @Get()
+    findAll(): Promise<Commission[]> {
+        return this.commissionsService.findAll();
+    }
+}

--- a/backend/salonbw-backend/src/commissions/commissions.module.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Commission } from './commission.entity';
+import { CommissionsService } from './commissions.service';
+import { CommissionsController } from './commissions.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Commission])],
+    providers: [CommissionsService],
+    controllers: [CommissionsController],
+    exports: [CommissionsService],
+})
+export class CommissionsModule {}

--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Commission } from './commission.entity';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Injectable()
+export class CommissionsService {
+    constructor(
+        @InjectRepository(Commission)
+        private readonly commissionsRepository: Repository<Commission>,
+    ) {}
+
+    create(data: Partial<Commission>): Promise<Commission> {
+        const commission = this.commissionsRepository.create(data);
+        return this.commissionsRepository.save(commission);
+    }
+
+    async createFromAppointment(appointment: Appointment): Promise<Commission> {
+        const percent = appointment.service.commissionPercent ?? 0;
+        const amount = (appointment.service.price * percent) / 100;
+        return this.create({
+            employee: appointment.employee,
+            appointment,
+            amount,
+            percent,
+        });
+    }
+
+    findForUser(userId: number): Promise<Commission[]> {
+        return this.commissionsRepository.find({
+            where: { employee: { id: userId } },
+            order: { createdAt: 'DESC' },
+        });
+    }
+
+    findAll(): Promise<Commission[]> {
+        return this.commissionsRepository.find({
+            order: { createdAt: 'DESC' },
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add Commission entity and related module/service/controller
- generate commissions when appointments complete
- expose endpoints for employees and admin to view commissions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a15ce142c8329b5d95012d6877448