### PR TITLE
feat: add formulas module with appointments integration

### DIFF
--- a/backend/salonbw-backend/src/formulas/formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.controller.ts
@@ -32,5 +32,12 @@ export class FormulasController {
     ): Promise<Formula[]> {
         return this.formulasService.findForClient(user.userId);
     }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Employee, Role.Admin)
+    @Get('clients/:id')
+    findForClient(@Param('id') id: string): Promise<Formula[]> {
+        return this.formulasService.findForClient(Number(id));
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow staff to add formulas for appointments
- expose endpoints for clients to view their formulas and staff to view a client's formulas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a24d84dc48329988556cabdfe325f