### PR TITLE
Refactor appointments test to use typed employee ID

### DIFF
--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -24,6 +24,10 @@ interface AppointmentResponse {
     status: string;
 }
 
+interface AppointmentWithEmployee extends AppointmentResponse {
+    employee: { id: number };
+}
+
 describe('Appointments integration', () => {
     let app: INestApplication;
     let server: Parameters<typeof request>[0];
@@ -148,9 +152,10 @@ describe('Appointments integration', () => {
                 endTime: end,
             })
             .expect(201);
-        expect((res.body as { employee: { id: number } }).employee.id).toBe(
-            employee.id,
-        );
+        const {
+            employee: { id },
+        } = res.body as AppointmentWithEmployee;
+        expect(id).toBe(employee.id);
         await request(server)
             .post('/appointments')
             .set('Authorization', `Bearer ${employeeToken}`)


### PR DESCRIPTION
## Summary
- define `AppointmentWithEmployee` interface extending `AppointmentResponse`
- destructure employee id from appointment response in tests

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4081bcc08329b85d8e2f21e017ad