### PR TITLE
Load formulas with appointments

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointment.entity.ts
+++ b/backend/salonbw-backend/src/appointments/appointment.entity.ts
@@ -1,6 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    OneToMany,
+} from 'typeorm';
 import { User } from '../users/user.entity';
 import { Service } from '../services/service.entity';
+import { Formula } from '../formulas/formula.entity';
 
 export enum AppointmentStatus {
     Scheduled = 'scheduled',
@@ -28,9 +35,16 @@ export class Appointment {
     @Column()
     endTime: Date;
 
-    @Column({ type: 'simple-enum', enum: AppointmentStatus, default: AppointmentStatus.Scheduled })
+    @Column({
+        type: 'simple-enum',
+        enum: AppointmentStatus,
+        default: AppointmentStatus.Scheduled,
+    })
     status: AppointmentStatus;
 
     @Column({ nullable: true })
     notes?: string;
+
+    @OneToMany(() => Formula, (f) => f.appointment)
+    formulas: Formula[];
 }

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -27,19 +27,22 @@ export class AppointmentsService {
             );
         }
         const appointment = this.appointmentsRepository.create(data);
-        return this.appointmentsRepository.save(appointment);
+        const saved = await this.appointmentsRepository.save(appointment);
+        return this.findOne(saved.id);
     }
 
     findForUser(userId: number): Promise<Appointment[]> {
         return this.appointmentsRepository.find({
             where: [{ client: { id: userId } }, { employee: { id: userId } }],
             order: { startTime: 'ASC' },
+            relations: ['formulas'],
         });
     }
 
     async findOne(id: number): Promise<Appointment | null> {
         const appointment = await this.appointmentsRepository.findOne({
             where: { id },
+            relations: ['formulas'],
         });
         return appointment ?? null;
     }

--- a/backend/salonbw-backend/src/formulas/formula.entity.ts
+++ b/backend/salonbw-backend/src/formulas/formula.entity.ts
@@ -16,7 +16,9 @@ export class Formula {
     @ManyToOne(() => User, { eager: true })
     client: User;
 
-    @ManyToOne(() => Appointment, { eager: true, nullable: true })
+    @ManyToOne(() => Appointment, (a) => a.formulas, {
+        eager: true,
+        nullable: true,
+    })
     appointment?: Appointment;
 }
-


### PR DESCRIPTION
## Summary
- link formulas to appointments with one-to-many relation
- ensure formula entity references appointment and services load formulas

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a438f37c88329a6db3322e4743195