### PR TITLE
Add validated DTOs for services

### DIFF
--- a/backend/salonbw-backend/src/services/dto/create-service.dto.ts
+++ b/backend/salonbw-backend/src/services/dto/create-service.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsOptional, IsPositive } from 'class-validator';
+
+export class CreateServiceDto {
+    @IsString()
+    name: string;
+
+    @IsString()
+    description: string;
+
+    @IsPositive()
+    duration: number;
+
+    @IsPositive()
+    price: number;
+
+    @IsOptional()
+    @IsString()
+    category?: string;
+
+    @IsOptional()
+    @IsPositive()
+    commissionPercent?: number;
+}

--- a/backend/salonbw-backend/src/services/dto/update-service.dto.ts
+++ b/backend/salonbw-backend/src/services/dto/update-service.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateServiceDto } from './create-service.dto';
+
+export class UpdateServiceDto extends PartialType(CreateServiceDto) {}

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -14,6 +14,8 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
 import { ServicesService } from './services.service';
 import { Service } from './service.entity';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
 
 @Controller('services')
 export class ServicesController {
@@ -36,8 +38,8 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
-    create(@Body() body: Service): Promise<Service> {
-        return this.servicesService.create(body);
+    create(@Body() createServiceDto: CreateServiceDto): Promise<Service> {
+        return this.servicesService.create(createServiceDto);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -45,9 +47,9 @@ export class ServicesController {
     @Patch(':id')
     update(
         @Param('id') id: string,
-        @Body() body: Partial<Service>,
+        @Body() updateServiceDto: UpdateServiceDto,
     ): Promise<Service | null> {
-        return this.servicesService.update(Number(id), body);
+        return this.servicesService.update(Number(id), updateServiceDto);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)

--- a/backend/salonbw-backend/src/services/services.service.ts
+++ b/backend/salonbw-backend/src/services/services.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Service } from './service.entity';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
 
 @Injectable()
 export class ServicesService {
@@ -10,8 +12,8 @@ export class ServicesService {
         private readonly servicesRepository: Repository<Service>,
     ) {}
 
-    async create(data: Service): Promise<Service> {
-        const service = this.servicesRepository.create(data);
+    async create(dto: CreateServiceDto): Promise<Service> {
+        const service = this.servicesRepository.create(dto);
         return this.servicesRepository.save(service);
     }
 
@@ -26,8 +28,8 @@ export class ServicesService {
         return service ?? null;
     }
 
-    async update(id: number, data: Partial<Service>): Promise<Service | null> {
-        await this.servicesRepository.update(id, data);
+    async update(id: number, dto: UpdateServiceDto): Promise<Service | null> {
+        await this.servicesRepository.update(id, dto);
         return this.findOne(id);
     }
 


### PR DESCRIPTION
## Summary
- add CreateServiceDto and UpdateServiceDto with validation rules
- use service DTOs in controller and service

## Testing
- `npm test`
- `npx eslint src/services/**/*.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a451b7c80832986263f7400125b6a