### PR TITLE
Restrict formula creation to appointment employee

### DIFF
--- a/backend/salonbw-backend/src/formulas/formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.controller.ts
@@ -17,8 +17,9 @@ export class FormulasController {
     addFormula(
         @Param('id') id: string,
         @Body() body: { description: string; date: string },
+        @CurrentUser() user: { userId: number },
     ): Promise<Formula> {
-        return this.formulasService.addToAppointment(Number(id), {
+        return this.formulasService.addToAppointment(Number(id), user.userId, {
             description: body.description,
             date: new Date(body.date),
         });
@@ -27,9 +28,7 @@ export class FormulasController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Admin)
     @Get('me')
-    findMine(
-        @CurrentUser() user: { userId: number },
-    ): Promise<Formula[]> {
+    findMine(@CurrentUser() user: { userId: number }): Promise<Formula[]> {
         return this.formulasService.findForClient(user.userId);
     }
 
@@ -40,4 +39,3 @@ export class FormulasController {
         return this.formulasService.findForClient(Number(id));
     }
 }
-

--- a/backend/salonbw-backend/src/formulas/formulas.service.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+    ForbiddenException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Formula } from './formula.entity';
@@ -15,13 +19,18 @@ export class FormulasService {
 
     async addToAppointment(
         appointmentId: number,
+        userId: number,
         data: { description: string; date: Date },
     ): Promise<Formula> {
         const appointment = await this.appointmentsRepository.findOne({
             where: { id: appointmentId },
+            relations: ['employee'],
         });
         if (!appointment) {
             throw new NotFoundException('Appointment not found');
+        }
+        if (appointment.employee.id !== userId) {
+            throw new ForbiddenException();
         }
         const formula = this.formulasRepository.create({
             description: data.description,
@@ -39,4 +48,3 @@ export class FormulasService {
         });
     }
 }
-


### PR DESCRIPTION
## Summary
- ensure FormulasService loads appointment with employee and checks current user
- pass authenticated user ID from FormulasController when adding formulas

## Testing
- `npm test`
- `npx eslint "{src,apps,libs,test}/**/*.ts"` *(fails: Prettier errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a6a45ed08832985643b02c294ab36