### PR TITLE
Validate appointment start time and derive end time

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -32,7 +32,7 @@ export class AppointmentsController {
             employeeId: number;
             serviceId: number;
             startTime: string;
-            endTime: string;
+            endTime?: string;
             notes?: string;
             clientId?: number;
         },
@@ -51,7 +51,9 @@ export class AppointmentsController {
                 employee: { id: body.employeeId } as User,
                 service: { id: body.serviceId } as SalonService,
                 startTime: new Date(body.startTime),
-                endTime: new Date(body.endTime),
+                endTime: body.endTime
+                    ? new Date(body.endTime)
+                    : undefined,
                 notes: body.notes,
             },
             user,

--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -4,9 +4,13 @@ import { Appointment } from './appointment.entity';
 import { AppointmentsService } from './appointments.service';
 import { AppointmentsController } from './appointments.controller';
 import { CommissionsModule } from '../commissions/commissions.module';
+import { Service as SalonService } from '../services/service.entity';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Appointment]), CommissionsModule],
+    imports: [
+        TypeOrmModule.forFeature([Appointment, SalonService]),
+        CommissionsModule,
+    ],
     providers: [AppointmentsService],
     controllers: [AppointmentsController],
 })


### PR DESCRIPTION
## Summary
- ensure appointments cannot start in the past and compute end times from service duration when absent
- allow appointment creation without end time in controller
- expand appointment tests with dynamic future times and past-date rejection

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689afae496008329b18c14b82cb30a72