### PR TITLE
Derive appointment end time from service duration

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -7,7 +7,6 @@ import {
     Post,
     UseGuards,
     ForbiddenException,
-    BadRequestException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -32,29 +31,15 @@ export class AppointmentsController {
             employeeId: number;
             serviceId: number;
             startTime: string;
-            endTime?: string;
-            notes?: string;
-            clientId?: number;
         },
         @CurrentUser() user: { userId: number; role: Role },
     ): Promise<Appointment> {
-        const clientId =
-            user.role === Role.Client || user.role === Role.Admin
-                ? user.userId
-                : body.clientId;
-        if (user.role === Role.Employee && !clientId) {
-            throw new BadRequestException('clientId is required');
-        }
         return this.appointmentsService.create(
             {
-                client: { id: clientId } as User,
+                client: { id: user.userId } as User,
                 employee: { id: body.employeeId } as User,
                 service: { id: body.serviceId } as SalonService,
                 startTime: new Date(body.startTime),
-                endTime: body.endTime
-                    ? new Date(body.endTime)
-                    : undefined,
-                notes: body.notes,
             },
             user,
         );

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -33,17 +33,16 @@ export class AppointmentsService {
         if (!data.startTime || data.startTime < new Date()) {
             throw new BadRequestException('startTime must be in the future');
         }
-        if (!data.endTime && data.service?.id) {
-            const service = await this.servicesRepository.findOne({
-                where: { id: data.service.id },
-            });
-            if (service) {
-                data.endTime = new Date(
-                    (data.startTime as Date).getTime() +
-                        service.duration * 60 * 1000,
-                );
-            }
+        const service = await this.servicesRepository.findOne({
+            where: { id: data.service?.id },
+        });
+        if (!service) {
+            throw new BadRequestException('Invalid serviceId');
         }
+        data.service = service;
+        data.endTime = new Date(
+            (data.startTime as Date).getTime() + service.duration * 60 * 1000,
+        );
         const conflict = await this.appointmentsRepository.findOne({
             where: {
                 employee: { id: data.employee!.id },

--- a/frontend/src/__tests__/appointmentForm.test.tsx
+++ b/frontend/src/__tests__/appointmentForm.test.tsx
@@ -2,10 +2,6 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import AppointmentForm from '@/components/AppointmentForm';
 
-const clients = [
-  { id: 1, name: 'A' },
-  { id: 2, name: 'B' },
-];
 const services = [
   { id: 1, name: 'S' },
 ];
@@ -14,9 +10,8 @@ describe('AppointmentForm', () => {
   it('shows conflict error', async () => {
     const onSubmit = jest.fn().mockRejectedValue({ status: 409 });
     render(
-      <AppointmentForm clients={clients} services={services} onSubmit={onSubmit} onCancel={() => {}} />
+      <AppointmentForm services={services} onSubmit={onSubmit} onCancel={() => {}} />
     );
-    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: '1' } });
     fireEvent.change(screen.getByDisplayValue('S'), { target: { value: '1' } });
     fireEvent.change(screen.getByDisplayValue(''), { target: { value: '2024-01-01T10:00' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/frontend/src/__tests__/receptionistAppointments.test.tsx
+++ b/frontend/src/__tests__/receptionistAppointments.test.tsx
@@ -4,7 +4,6 @@ import { useAuth } from '@/contexts/AuthContext';
 import { createAuthValue } from '../testUtils';
 
 jest.mock('@/hooks/useAppointments', () => ({ useAppointments: () => ({ data: [], loading: false, error: null }) }));
-jest.mock('@/hooks/useClients', () => ({ useClients: () => ({ data: [], loading: false }) }));
 jest.mock('@/hooks/useServices', () => ({ useServices: () => ({ data: [], loading: false }) }));
 jest.mock('@/api/appointments', () => ({ useAppointmentsApi: () => ({ create: jest.fn(), update: jest.fn() }) }));
 // eslint-disable-next-line react/display-name

--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -7,7 +7,6 @@ export function useAppointmentsApi() {
   const toast = useToast();
 
   const create = async (data: {
-    clientId: number;
     employeeId: number;
     serviceId: number;
     startTime: string;

--- a/frontend/src/components/AppointmentForm.tsx
+++ b/frontend/src/components/AppointmentForm.tsx
@@ -1,16 +1,14 @@
 import { FormEvent, useState } from 'react';
-import { Client, Service } from '@/types';
+import { Service } from '@/types';
 
 interface Props {
-  clients: Client[];
   services: Service[];
-  initial?: { clientId?: number; serviceId?: number; startTime?: string };
-  onSubmit: (data: { clientId: number; serviceId: number; startTime: string }) => Promise<void>;
+  initial?: { serviceId?: number; startTime?: string };
+  onSubmit: (data: { serviceId: number; startTime: string }) => Promise<void>;
   onCancel: () => void;
 }
 
-export default function AppointmentForm({ clients, services, initial, onSubmit, onCancel }: Props) {
-  const [clientId, setClientId] = useState(initial?.clientId ?? clients[0]?.id);
+export default function AppointmentForm({ services, initial, onSubmit, onCancel }: Props) {
   const [serviceId, setServiceId] = useState(initial?.serviceId ?? services[0]?.id);
   const [startTime, setStartTime] = useState(initial?.startTime ?? '');
   const [error, setError] = useState('');
@@ -19,7 +17,7 @@ export default function AppointmentForm({ clients, services, initial, onSubmit, 
     e.preventDefault();
     setError('');
     try {
-      await onSubmit({ clientId: Number(clientId), serviceId: Number(serviceId), startTime });
+      await onSubmit({ serviceId: Number(serviceId), startTime });
     } catch (err: unknown) {
       if (
         typeof err === 'object' &&
@@ -38,13 +36,6 @@ export default function AppointmentForm({ clients, services, initial, onSubmit, 
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <select value={clientId} onChange={(e) => setClientId(Number(e.target.value))} className="border p-1 w-full">
-        {clients.map((c) => (
-          <option key={c.id} value={c.id}>
-            {c.name}
-          </option>
-        ))}
-      </select>
       <select value={serviceId} onChange={(e) => setServiceId(Number(e.target.value))} className="border p-1 w-full">
         {services.map((s) => (
           <option key={s.id} value={s.id}>

--- a/frontend/src/pages/appointments/index.tsx
+++ b/frontend/src/pages/appointments/index.tsx
@@ -3,7 +3,6 @@ import DashboardLayout from '@/components/DashboardLayout';
 import Modal from '@/components/Modal';
 import AppointmentForm from '@/components/AppointmentForm';
 import { useAppointments } from '@/hooks/useAppointments';
-import { useClients } from '@/hooks/useClients';
 import { useServices } from '@/hooks/useServices';
 import { useAppointmentsApi } from '@/api/appointments';
 import { useAuth } from '@/contexts/AuthContext';
@@ -20,14 +19,12 @@ const FullCalendar = dynamic(() => import('@fullcalendar/react'), {
 import { useState } from 'react';
 
 interface AppointmentPayload {
-    clientId: number;
     serviceId: number;
     startTime: string;
 }
 
 export default function AppointmentsPage() {
     const { data: appointments, loading, error } = useAppointments();
-    const { data: clients } = useClients();
     const { data: services } = useServices();
     const api = useAppointmentsApi();
     const { role } = useAuth();
@@ -35,7 +32,7 @@ export default function AppointmentsPage() {
     const [editId, setEditId] = useState<number | null>(null);
     const [startTime, setStartTime] = useState('');
 
-    if (loading || !clients || !services) return <div>Loading...</div>;
+    if (loading || !services) return <div>Loading...</div>;
     if (error) return <div>Error</div>;
 
     const events = appointments?.map((a) => ({
@@ -95,7 +92,6 @@ export default function AppointmentsPage() {
                 />
                 <Modal open={formOpen} onClose={() => setFormOpen(false)}>
                     <AppointmentForm
-                        clients={clients}
                         services={services}
                         initial={{ startTime }}
                         onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
- Restrict appointment creation to `startTime`, `serviceId`, and `employeeId` and derive `endTime` automatically
- Load service in `AppointmentsService.create` and compute `endTime` from its duration
- Update frontend API, form, and tests for new appointment payload

## Testing
- `npm test`
- `npm run test:e2e`
- `(cd frontend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_689b02ab06e08329a7f4f58e8e0eb1a2