### PR TITLE
feat: allow employees to book on behalf of clients

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -158,6 +158,91 @@
           "auth"
         ]
       }
+    },
+    "/appointments": {
+      "post": {
+        "operationId": "AppointmentsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAppointmentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Appointment created"
+          }
+        },
+        "summary": "Create appointment",
+        "tags": [
+          "appointments"
+        ]
+      }
+    },
+    "/appointments/me": {
+      "get": {
+        "operationId": "AppointmentsController_findMine",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "appointments"
+        ]
+      }
+    },
+    "/appointments/{id}/cancel": {
+      "patch": {
+        "operationId": "AppointmentsController_cancel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "appointments"
+        ]
+      }
+    },
+    "/appointments/{id}/complete": {
+      "patch": {
+        "operationId": "AppointmentsController_complete",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "appointments"
+        ]
+      }
     }
   },
   "info": {
@@ -185,6 +270,28 @@
       "RefreshTokenDto": {
         "type": "object",
         "properties": {}
+      },
+      "CreateAppointmentDto": {
+        "type": "object",
+        "properties": {
+          "employeeId": {
+            "type": "number"
+          },
+          "serviceId": {
+            "type": "number"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "employeeId",
+          "serviceId",
+          "startTime"
+        ]
       }
     }
   }

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -58,7 +58,11 @@ export class AppointmentsService {
         }
         const appointment = this.appointmentsRepository.create(data);
         const saved = await this.appointmentsRepository.save(appointment);
-        return this.findOne(saved.id);
+        const result = await this.findOne(saved.id);
+        if (!result) {
+            throw new Error('Appointment not found after creation');
+        }
+        return result;
     }
 
     findForUser(userId: number): Promise<Appointment[]> {

--- a/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
+++ b/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsPositive, IsString, IsOptional } from 'class-validator';
+
+export class CreateAppointmentDto {
+    @ApiProperty()
+    @IsPositive()
+    employeeId: number;
+
+    @ApiProperty()
+    @IsPositive()
+    serviceId: number;
+
+    @ApiProperty()
+    @IsString()
+    startTime: string;
+
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsPositive()
+    clientId?: number;
+}

--- a/backend/salonbw-backend/swagger.ts
+++ b/backend/salonbw-backend/swagger.ts
@@ -9,9 +9,17 @@ import { UsersController } from './src/users/users.controller';
 import { UsersService } from './src/users/users.service';
 import { AuthController } from './src/auth/auth.controller';
 import { AuthService } from './src/auth/auth.service';
+import { AppointmentsController } from './src/appointments/appointments.controller';
+import { AppointmentsService } from './src/appointments/appointments.service';
 
 @Module({
-  controllers: [AppController, HealthController, UsersController, AuthController],
+  controllers: [
+    AppController,
+    HealthController,
+    UsersController,
+    AuthController,
+    AppointmentsController,
+  ],
   providers: [
     AppService,
     {
@@ -27,6 +35,16 @@ import { AuthService } from './src/auth/auth.service';
       useValue: {
         login: () => ({}),
         refresh: () => ({}),
+      },
+    },
+    {
+      provide: AppointmentsService,
+      useValue: {
+        create: () => ({}),
+        findForUser: () => [],
+        findOne: () => ({}),
+        cancel: () => ({}),
+        completeAppointment: () => ({}),
       },
     },
   ],

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -220,6 +220,40 @@ describe('Appointments integration', () => {
             .expect(409);
     });
 
+    it('allows employees and admins to create appointments for clients', async () => {
+        const startEmpBase = Date.now() + 13 * hour;
+        const startEmp = new Date(startEmpBase).toISOString();
+        const empRes: Response = await request(server)
+            .post('/appointments')
+            .set('Authorization', `Bearer ${employeeToken}`)
+            .send({
+                employeeId: employee.id,
+                serviceId: service.id,
+                startTime: startEmp,
+                clientId: client.id,
+            })
+            .expect(201);
+        expect((empRes.body as { client: { id: number } }).client.id).toBe(
+            client.id,
+        );
+
+        const startAdminBase = Date.now() + 15 * hour;
+        const startAdmin = new Date(startAdminBase).toISOString();
+        const adminRes: Response = await request(server)
+            .post('/appointments')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({
+                employeeId: employee.id,
+                serviceId: service.id,
+                startTime: startAdmin,
+                clientId: client.id,
+            })
+            .expect(201);
+        expect((adminRes.body as { client: { id: number } }).client.id).toBe(
+            client.id,
+        );
+    });
+
     it('allows only assigned employees or admins to complete appointments and creates commissions', async () => {
         const startBase = Date.now() + 7 * hour;
         const start = new Date(startBase).toISOString();


### PR DESCRIPTION
## Summary
- add optional `clientId` to appointment creation DTO
- allow staff to create appointments for specified clients
- document appointments endpoints in Swagger

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_689b1607a45c8329bc87c1ab9ddd3fa9