### PR TITLE
Validate appointment state before cancellation or completion

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -82,6 +82,18 @@ export class AppointmentsService {
     }
 
     async cancel(id: number): Promise<Appointment | null> {
+        const appointment = await this.findOne(id);
+        if (!appointment) {
+            return null;
+        }
+        if (
+            appointment.status === AppointmentStatus.Completed ||
+            appointment.status === AppointmentStatus.Cancelled
+        ) {
+            throw new BadRequestException(
+                'Cannot cancel a completed or already cancelled appointment',
+            );
+        }
         await this.appointmentsRepository.update(id, {
             status: AppointmentStatus.Cancelled,
         });
@@ -92,6 +104,11 @@ export class AppointmentsService {
         const appointment = await this.findOne(id);
         if (!appointment) {
             return null;
+        }
+        if (appointment.status !== AppointmentStatus.Scheduled) {
+            throw new BadRequestException(
+                'Only scheduled appointments can be completed',
+            );
         }
         await this.appointmentsRepository.update(id, {
             status: AppointmentStatus.Completed,


### PR DESCRIPTION
## Summary
- Disallow cancelling completed or already cancelled appointments
- Only allow completing scheduled appointments and guard against duplicate commissions

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b185e97608329b10b60c0dad3febd