### PR TITLE
Nest formulas under appointment and client routes

### DIFF
--- a/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
@@ -7,15 +7,15 @@ import { Role } from '../users/role.enum';
 import { FormulasService } from './formulas.service';
 import { Formula } from './formula.entity';
 
-@Controller('formulas')
-export class FormulasController {
+@Controller('appointments/:appointmentId/formulas')
+export class AppointmentFormulasController {
     constructor(private readonly formulasService: FormulasService) {}
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Employee, Role.Admin)
-    @Post('appointments/:id')
+    @Post()
     addFormula(
-        @Param('id') id: string,
+        @Param('appointmentId') id: string,
         @Body() body: { description: string; date: string },
         @CurrentUser() user: { userId: number },
     ): Promise<Formula> {
@@ -23,19 +23,5 @@ export class FormulasController {
             description: body.description,
             date: new Date(body.date),
         });
-    }
-
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
-    @Roles(Role.Client, Role.Admin)
-    @Get('me')
-    findMine(@CurrentUser() user: { userId: number }): Promise<Formula[]> {
-        return this.formulasService.findForClient(user.userId);
-    }
-
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
-    @Roles(Role.Employee, Role.Admin)
-    @Get('clients/:id')
-    findForClient(@Param('id') id: string): Promise<Formula[]> {
-        return this.formulasService.findForClient(Number(id));
     }
 }

--- a/backend/salonbw-backend/src/formulas/client-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/client-formulas.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { FormulasService } from './formulas.service';
+import { Formula } from './formula.entity';
+
+@Controller('clients')
+export class ClientFormulasController {
+    constructor(private readonly formulasService: FormulasService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Admin)
+    @Get('me/formulas')
+    findMine(@CurrentUser() user: { userId: number }): Promise<Formula[]> {
+        return this.formulasService.findForClient(user.userId);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Employee, Role.Admin)
+    @Get(':id/formulas')
+    findForClient(@Param('id') id: string): Promise<Formula[]> {
+        return this.formulasService.findForClient(Number(id));
+    }
+}

--- a/backend/salonbw-backend/src/formulas/formulas.module.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.module.ts
@@ -2,13 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Formula } from './formula.entity';
 import { FormulasService } from './formulas.service';
-import { FormulasController } from './formulas.controller';
+import { AppointmentFormulasController } from './appointment-formulas.controller';
+import { ClientFormulasController } from './client-formulas.controller';
 import { Appointment } from '../appointments/appointment.entity';
 
 @Module({
     imports: [TypeOrmModule.forFeature([Formula, Appointment])],
     providers: [FormulasService],
-    controllers: [FormulasController],
+    controllers: [AppointmentFormulasController, ClientFormulasController],
 })
 export class FormulasModule {}
-

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -334,13 +334,13 @@ describe('Appointments integration', () => {
             .expect(200);
 
         await request(server)
-            .post(`/formulas/appointments/${appointmentId}`)
+            .post(`/appointments/${appointmentId}/formulas`)
             .set('Authorization', `Bearer ${clientToken}`)
             .send({ description: 'test', date: new Date().toISOString() })
             .expect(403);
 
         await request(server)
-            .post(`/formulas/appointments/${appointmentId}`)
+            .post(`/appointments/${appointmentId}/formulas`)
             .set('Authorization', `Bearer ${employeeToken}`)
             .send({ description: 'formula', date: new Date().toISOString() })
             .expect(201);


### PR DESCRIPTION
## Summary
- Nest formula creation under `/appointments/:appointmentId/formulas`
- Expose client formula retrieval via `/clients/:id/formulas` and `/clients/me/formulas`
- Adjust integration tests for new formula routes

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b1a234b708329ad6a2641787781d3