### PR TITLE
Validate appointment start time format

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -30,7 +30,11 @@ export class AppointmentsService {
         ) {
             throw new BadRequestException('clientId is required');
         }
-        if (!data.startTime || data.startTime < new Date()) {
+        if (
+            !data.startTime ||
+            isNaN(new Date(data.startTime).getTime()) ||
+            data.startTime < new Date()
+        ) {
             throw new BadRequestException('startTime must be in the future');
         }
         const service = await this.servicesRepository.findOne({

--- a/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
+++ b/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsPositive, IsString, IsOptional } from 'class-validator';
+import { IsPositive, IsOptional, IsISO8601 } from 'class-validator';
 
 export class CreateAppointmentDto {
     @ApiProperty()
@@ -11,7 +11,7 @@ export class CreateAppointmentDto {
     serviceId: number;
 
     @ApiProperty()
-    @IsString()
+    @IsISO8601()
     startTime: string;
 
     @ApiProperty({ required: false })


### PR DESCRIPTION
## Summary
- enforce ISO 8601 format for appointment `startTime`
- guard against invalid `startTime` values during appointment creation

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1db1ef30832990fb58771ed86ad7