### PR TITLE
feat: add CreateFormulaDto for appointment formulas

### DIFF
--- a/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
@@ -6,6 +6,7 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
 import { FormulasService } from './formulas.service';
 import { Formula } from './formula.entity';
+import { CreateFormulaDto } from './dto/create-formula.dto';
 
 @Controller('appointments/:appointmentId/formulas')
 export class AppointmentFormulasController {
@@ -16,7 +17,7 @@ export class AppointmentFormulasController {
     @Post()
     addFormula(
         @Param('appointmentId') id: string,
-        @Body() body: { description: string; date: string },
+        @Body() body: CreateFormulaDto,
         @CurrentUser() user: { userId: number },
     ): Promise<Formula> {
         return this.formulasService.addToAppointment(Number(id), user.userId, {

--- a/backend/salonbw-backend/src/formulas/dto/create-formula.dto.ts
+++ b/backend/salonbw-backend/src/formulas/dto/create-formula.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsISO8601 } from 'class-validator';
+
+export class CreateFormulaDto {
+    @ApiProperty()
+    @IsString()
+    description: string;
+
+    @ApiProperty()
+    @IsISO8601()
+    date: string;
+}


### PR DESCRIPTION
## Summary
- add CreateFormulaDto with description and ISO date fields
- use CreateFormulaDto in AppointmentFormulasController

## Testing
- `npm run lint`
- `npm test`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_689b23f2f05c8329b696c3fa9730230a