### PR TITLE
Validate appointment users before creation

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -5,10 +5,11 @@ import { AppointmentsService } from './appointments.service';
 import { AppointmentsController } from './appointments.controller';
 import { CommissionsModule } from '../commissions/commissions.module';
 import { Service as SalonService } from '../services/service.entity';
+import { User } from '../users/user.entity';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([Appointment, SalonService]),
+        TypeOrmModule.forFeature([Appointment, SalonService, User]),
         CommissionsModule,
     ],
     providers: [AppointmentsService],


### PR DESCRIPTION
## Summary
- ensure AppointmentsService loads client and employee entities
- enforce presence of client and employee ids before saving
## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b2bedb72c8329a284c63339ca7084