### PR TITLE
refactor(product dto): validate stock as non-negative integer

### DIFF
--- a/backend/salonbw-backend/src/products/dto/create-product.dto.ts
+++ b/backend/salonbw-backend/src/products/dto/create-product.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsPositive } from 'class-validator';
+import { IsString, IsPositive, IsInt, Min } from 'class-validator';
 
 export class CreateProductDto {
     @IsString()
@@ -10,6 +10,7 @@ export class CreateProductDto {
     @IsPositive()
     unitPrice: number;
 
-    @IsPositive()
+    @IsInt()
+    @Min(0)
     stock: number;
 }

--- a/backend/salonbw-backend/src/products/dto/update-product.dto.ts
+++ b/backend/salonbw-backend/src/products/dto/update-product.dto.ts
@@ -1,4 +1,10 @@
 import { PartialType } from '@nestjs/mapped-types';
+import { IsInt, Min, IsOptional } from 'class-validator';
 import { CreateProductDto } from './create-product.dto';
 
-export class UpdateProductDto extends PartialType(CreateProductDto) {}
+export class UpdateProductDto extends PartialType(CreateProductDto) {
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    stock?: number;
+}


### PR DESCRIPTION
## Summary
- validate CreateProductDto.stock as non-negative int
- ensure UpdateProductDto.stock uses same validation via PartialType

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2f0725bc832992021c1246fcf230