### PR TITLE
feat: refine service dto validation

### DIFF
--- a/backend/salonbw-backend/src/services/dto/create-service.dto.ts
+++ b/backend/salonbw-backend/src/services/dto/create-service.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsPositive } from 'class-validator';
+import { IsString, IsOptional, IsPositive, IsInt, Min, Max } from 'class-validator';
 
 export class CreateServiceDto {
     @IsString()
@@ -7,7 +7,8 @@ export class CreateServiceDto {
     @IsString()
     description: string;
 
-    @IsPositive()
+    @IsInt()
+    @Min(1)
     duration: number;
 
     @IsPositive()
@@ -18,6 +19,7 @@ export class CreateServiceDto {
     category?: string;
 
     @IsOptional()
-    @IsPositive()
+    @Min(0)
+    @Max(100)
     commissionPercent?: number;
 }


### PR DESCRIPTION
## Summary
- Ensure service duration accepts whole minutes using `@IsInt` and `@Min(1)`
- Restrict optional `commissionPercent` to the 0-100 range

## Testing
- `cd backend/salonbw-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b3946d2008329b6db56b84d07c60a