### PR TITLE
Validate user roles when creating appointments

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -58,15 +58,12 @@ export class AppointmentsController {
             (user.role === Role.Employee || user.role === Role.Admin)
                 ? ({ id: body.clientId } as User)
                 : ({ id: user.userId } as User);
-        return this.appointmentsService.create(
-            {
-                client,
-                employee: { id: body.employeeId } as User,
-                service: { id: body.serviceId } as SalonService,
-                startTime: new Date(body.startTime),
-            },
-            user,
-        );
+        return this.appointmentsService.create({
+            client,
+            employee: { id: body.employeeId } as User,
+            service: { id: body.serviceId } as SalonService,
+            startTime: new Date(body.startTime),
+        });
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -23,11 +23,7 @@ export class AppointmentsService {
         private readonly commissionsService: CommissionsService,
     ) {}
 
-    async create(
-        data: Partial<Appointment>,
-        booker: { userId: number; role: Role },
-    ): Promise<Appointment> {
-        void booker;
+    async create(data: Partial<Appointment>): Promise<Appointment> {
         if (!data.client?.id) {
             throw new BadRequestException('clientId is required');
         }
@@ -40,11 +36,21 @@ export class AppointmentsService {
         if (!client) {
             throw new BadRequestException('Invalid clientId');
         }
+        if (client.role !== Role.Client) {
+            throw new BadRequestException(
+                'Provided clientId does not belong to a client',
+            );
+        }
         const employee = await this.usersRepository.findOne({
             where: { id: data.employee.id },
         });
         if (!employee) {
             throw new BadRequestException('Invalid employeeId');
+        }
+        if (employee.role !== Role.Employee) {
+            throw new BadRequestException(
+                'Provided employeeId does not belong to an employee',
+            );
         }
         data.client = client;
         data.employee = employee;

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -168,6 +168,7 @@ describe('Appointments integration', () => {
             .post('/appointments')
             .set('Authorization', `Bearer ${employeeToken}`)
             .send({
+                clientId: client.id,
                 employeeId: employee.id,
                 serviceId: service.id,
                 startTime: empStart,


### PR DESCRIPTION
## Summary
- Ensure appointment creation checks client and employee roles, rejecting mismatches
- Remove unused booker parameter and update controller to match
- Adjust integration test to supply clientId for staff-created appointments

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b51359e9483299717abb462aa95f8