### PR TITLE
fix: enforce 404 for missing services and products

### DIFF
--- a/backend/salonbw-backend/src/products/products.controller.ts
+++ b/backend/salonbw-backend/src/products/products.controller.ts
@@ -31,7 +31,7 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin, Role.Employee)
     @Get(':id')
-    findOne(@Param('id') id: string): Promise<Product | null> {
+    findOne(@Param('id') id: string): Promise<Product> {
         return this.productsService.findOne(Number(id));
     }
 
@@ -48,7 +48,7 @@ export class ProductsController {
     update(
         @Param('id') id: string,
         @Body() body: UpdateProductDto,
-    ): Promise<Product | null> {
+    ): Promise<Product> {
         return this.productsService.update(Number(id), body);
     }
 

--- a/backend/salonbw-backend/src/products/products.service.ts
+++ b/backend/salonbw-backend/src/products/products.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Product } from './product.entity';
@@ -21,14 +21,17 @@ export class ProductsService {
         return this.productsRepository.find();
     }
 
-    async findOne(id: number): Promise<Product | null> {
+    async findOne(id: number): Promise<Product> {
         const product = await this.productsRepository.findOne({
             where: { id },
         });
-        return product ?? null;
+        if (!product) {
+            throw new NotFoundException('Product not found');
+        }
+        return product;
     }
 
-    async update(id: number, dto: UpdateProductDto): Promise<Product | null> {
+    async update(id: number, dto: UpdateProductDto): Promise<Product> {
         await this.productsRepository.update(id, dto);
         return this.findOne(id);
     }

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -31,7 +31,7 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get(':id')
-    findOne(@Param('id') id: string): Promise<Service | null> {
+    findOne(@Param('id') id: string): Promise<Service> {
         return this.servicesService.findOne(Number(id));
     }
 
@@ -48,7 +48,7 @@ export class ServicesController {
     update(
         @Param('id') id: string,
         @Body() updateServiceDto: UpdateServiceDto,
-    ): Promise<Service | null> {
+    ): Promise<Service> {
         return this.servicesService.update(Number(id), updateServiceDto);
     }
 

--- a/backend/salonbw-backend/src/services/services.service.ts
+++ b/backend/salonbw-backend/src/services/services.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Service } from './service.entity';
@@ -21,14 +21,17 @@ export class ServicesService {
         return this.servicesRepository.find();
     }
 
-    async findOne(id: number): Promise<Service | null> {
+    async findOne(id: number): Promise<Service> {
         const service = await this.servicesRepository.findOne({
             where: { id },
         });
-        return service ?? null;
+        if (!service) {
+            throw new NotFoundException('Service not found');
+        }
+        return service;
     }
 
-    async update(id: number, dto: UpdateServiceDto): Promise<Service | null> {
+    async update(id: number, dto: UpdateServiceDto): Promise<Service> {
         await this.servicesRepository.update(id, dto);
         return this.findOne(id);
     }


### PR DESCRIPTION
## Summary
- return 404 when a requested product is missing
- return 404 when a requested service is missing
- controllers rely on thrown NotFoundException

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b5413346c832996dd3ec0b90b9091