### PR TITLE
Add controllers to swagger and update OpenAPI

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -161,6 +161,7 @@
     },
     "/appointments": {
       "post": {
+        "description": "Employees or admins must specify clientId in the request body.",
         "operationId": "AppointmentsController_create",
         "parameters": [],
         "requestBody": {
@@ -176,6 +177,9 @@
         "responses": {
           "201": {
             "description": "Appointment created"
+          },
+          "400": {
+            "description": "clientId must be provided when creating appointments as staff"
           }
         },
         "summary": "Create appointment",
@@ -243,6 +247,326 @@
           "appointments"
         ]
       }
+    },
+    "/services": {
+      "get": {
+        "operationId": "ServicesController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Services"
+        ]
+      },
+      "post": {
+        "operationId": "ServicesController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateServiceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Services"
+        ]
+      }
+    },
+    "/services/{id}": {
+      "get": {
+        "operationId": "ServicesController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Services"
+        ]
+      },
+      "patch": {
+        "operationId": "ServicesController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateServiceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Services"
+        ]
+      },
+      "delete": {
+        "operationId": "ServicesController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Services"
+        ]
+      }
+    },
+    "/products": {
+      "get": {
+        "operationId": "ProductsController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      },
+      "post": {
+        "operationId": "ProductsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProductDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      }
+    },
+    "/products/{id}": {
+      "get": {
+        "operationId": "ProductsController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      },
+      "patch": {
+        "operationId": "ProductsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      },
+      "delete": {
+        "operationId": "ProductsController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      }
+    },
+    "/appointments/{appointmentId}/formulas": {
+      "post": {
+        "operationId": "AppointmentFormulasController_addFormula",
+        "parameters": [
+          {
+            "name": "appointmentId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFormulaDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "AppointmentFormulas"
+        ]
+      }
+    },
+    "/clients/me/formulas": {
+      "get": {
+        "operationId": "ClientFormulasController_findMine",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ClientFormulas"
+        ]
+      }
+    },
+    "/clients/{id}/formulas": {
+      "get": {
+        "operationId": "ClientFormulasController_findForClient",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ClientFormulas"
+        ]
+      }
+    },
+    "/commissions/me": {
+      "get": {
+        "operationId": "CommissionsController_findMine",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Commissions"
+        ]
+      }
+    },
+    "/commissions": {
+      "get": {
+        "operationId": "CommissionsController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Commissions"
+        ]
+      }
     }
   },
   "info": {
@@ -284,13 +608,45 @@
             "type": "string"
           },
           "clientId": {
-            "type": "number"
+            "type": "number",
+            "description": "Required when creating appointments as Employee or Admin"
           }
         },
         "required": [
           "employeeId",
           "serviceId",
           "startTime"
+        ]
+      },
+      "CreateServiceDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdateServiceDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreateProductDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdateProductDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreateFormulaDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "date"
         ]
       }
     }

--- a/backend/salonbw-backend/swagger.ts
+++ b/backend/salonbw-backend/swagger.ts
@@ -11,6 +11,15 @@ import { AuthController } from './src/auth/auth.controller';
 import { AuthService } from './src/auth/auth.service';
 import { AppointmentsController } from './src/appointments/appointments.controller';
 import { AppointmentsService } from './src/appointments/appointments.service';
+import { ServicesController } from './src/services/services.controller';
+import { ServicesService } from './src/services/services.service';
+import { ProductsController } from './src/products/products.controller';
+import { ProductsService } from './src/products/products.service';
+import { AppointmentFormulasController } from './src/formulas/appointment-formulas.controller';
+import { ClientFormulasController } from './src/formulas/client-formulas.controller';
+import { FormulasService } from './src/formulas/formulas.service';
+import { CommissionsController } from './src/commissions/commissions.controller';
+import { CommissionsService } from './src/commissions/commissions.service';
 
 @Module({
   controllers: [
@@ -19,6 +28,11 @@ import { AppointmentsService } from './src/appointments/appointments.service';
     UsersController,
     AuthController,
     AppointmentsController,
+    ServicesController,
+    ProductsController,
+    AppointmentFormulasController,
+    ClientFormulasController,
+    CommissionsController,
   ],
   providers: [
     AppService,
@@ -45,6 +59,40 @@ import { AppointmentsService } from './src/appointments/appointments.service';
         findOne: () => ({}),
         cancel: () => ({}),
         completeAppointment: () => ({}),
+      },
+    },
+    {
+      provide: ServicesService,
+      useValue: {
+        create: () => ({}),
+        findAll: () => [],
+        findOne: () => ({}),
+        update: () => ({}),
+        remove: () => undefined,
+      },
+    },
+    {
+      provide: ProductsService,
+      useValue: {
+        create: () => ({}),
+        findAll: () => [],
+        findOne: () => ({}),
+        update: () => ({}),
+        remove: () => undefined,
+      },
+    },
+    {
+      provide: FormulasService,
+      useValue: {
+        addToAppointment: () => ({}),
+        findForClient: () => [],
+      },
+    },
+    {
+      provide: CommissionsService,
+      useValue: {
+        findForUser: () => [],
+        findAll: () => [],
       },
     },
   ],


### PR DESCRIPTION
## Summary
- expose Services, Products, Appointment Formulas, Client Formulas, and Commissions controllers in swagger config
- stub service dependencies for new controllers
- regenerate OpenAPI spec

## Testing
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_689b5ae05a008329be78d4e39b6a99ff