### PR TITLE
Handle missing appointments in cancel/complete

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -8,6 +8,7 @@ import {
     UseGuards,
     ForbiddenException,
     BadRequestException,
+    NotFoundException,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -81,11 +82,13 @@ export class AppointmentsController {
         @CurrentUser() user: { userId: number; role: Role },
     ): Promise<Appointment | null> {
         const appointment = await this.appointmentsService.findOne(Number(id));
+        if (!appointment) {
+            throw new NotFoundException();
+        }
         if (
-            !appointment ||
-            (user.role !== Role.Admin &&
-                appointment.client.id !== user.userId &&
-                appointment.employee.id !== user.userId)
+            user.role !== Role.Admin &&
+            appointment.client.id !== user.userId &&
+            appointment.employee.id !== user.userId
         ) {
             throw new ForbiddenException();
         }
@@ -100,10 +103,12 @@ export class AppointmentsController {
         @CurrentUser() user: { userId: number; role: Role },
     ): Promise<Appointment | null> {
         const appointment = await this.appointmentsService.findOne(Number(id));
+        if (!appointment) {
+            throw new NotFoundException();
+        }
         if (
-            !appointment ||
-            (user.role !== Role.Admin &&
-                appointment.employee.id !== user.userId)
+            user.role !== Role.Admin &&
+            appointment.employee.id !== user.userId
         ) {
             throw new ForbiddenException();
         }

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -315,6 +315,20 @@ describe('Appointments integration', () => {
         );
     });
 
+    it('returns 404 when completing a non-existent appointment', async () => {
+        await request(server)
+            .patch('/appointments/999999/complete')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(404);
+    });
+
+    it('returns 404 when cancelling a non-existent appointment', async () => {
+        await request(server)
+            .patch('/appointments/999999/cancel')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(404);
+    });
+
     it('restricts formula creation to employees or admins', async () => {
         const startBase = Date.now() + 11 * hour;
         const start = new Date(startBase).toISOString();


### PR DESCRIPTION
## Summary
- return 404 when cancelling or completing a non-existent appointment
- add integration tests for cancel and complete unknown IDs

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b5cd65e108329814f3fc2879e7d90