### PR TITLE
feat: apply numeric transformer to decimal fields

### DIFF
--- a/backend/salonbw-backend/src/column-numeric.transformer.ts
+++ b/backend/salonbw-backend/src/column-numeric.transformer.ts
@@ -1,0 +1,14 @@
+import { ValueTransformer } from 'typeorm';
+
+export class ColumnNumericTransformer implements ValueTransformer {
+    to(data?: number | null): number | null {
+        return data === null || data === undefined ? null : data;
+    }
+
+    from(data?: string | number | null): number | null {
+        if (data === null || data === undefined) {
+            return null;
+        }
+        return typeof data === 'number' ? data : Number(data);
+    }
+}

--- a/backend/salonbw-backend/src/commissions/commission.entity.ts
+++ b/backend/salonbw-backend/src/commissions/commission.entity.ts
@@ -5,6 +5,7 @@ import {
     Column,
     CreateDateColumn,
 } from 'typeorm';
+import { ColumnNumericTransformer } from '../column-numeric.transformer';
 import { User } from '../users/user.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { Product } from '../products/product.entity';
@@ -23,10 +24,10 @@ export class Commission {
     @ManyToOne(() => Product, { nullable: true, eager: true })
     product?: Product | null;
 
-    @Column('decimal')
+    @Column('decimal', { transformer: new ColumnNumericTransformer() })
     amount: number;
 
-    @Column('decimal')
+    @Column('decimal', { transformer: new ColumnNumericTransformer() })
     percent: number;
 
     @CreateDateColumn()

--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -17,8 +17,9 @@ export class CommissionsService {
     }
 
     async createFromAppointment(appointment: Appointment): Promise<Commission> {
-        const percent = appointment.service.commissionPercent ?? 0;
-        const amount = (appointment.service.price * percent) / 100;
+        const price = Number(appointment.service.price);
+        const percent = Number(appointment.service.commissionPercent ?? 0);
+        const amount = (price * percent) / 100;
         return this.create({
             employee: appointment.employee,
             appointment,

--- a/backend/salonbw-backend/src/products/product.entity.ts
+++ b/backend/salonbw-backend/src/products/product.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ColumnNumericTransformer } from '../column-numeric.transformer';
 
 @Entity('products')
 export class Product {
@@ -11,7 +12,7 @@ export class Product {
     @Column()
     brand: string;
 
-    @Column('decimal')
+    @Column('decimal', { transformer: new ColumnNumericTransformer() })
     unitPrice: number;
 
     @Column('int')

--- a/backend/salonbw-backend/src/services/service.entity.ts
+++ b/backend/salonbw-backend/src/services/service.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ColumnNumericTransformer } from '../column-numeric.transformer';
 
 @Entity('services')
 export class Service {
@@ -14,12 +15,15 @@ export class Service {
     @Column('int')
     duration: number;
 
-    @Column('decimal')
+    @Column('decimal', { transformer: new ColumnNumericTransformer() })
     price: number;
 
     @Column({ nullable: true })
     category?: string;
 
-    @Column('decimal', { nullable: true })
+    @Column('decimal', {
+        nullable: true,
+        transformer: new ColumnNumericTransformer(),
+    })
     commissionPercent?: number;
 }


### PR DESCRIPTION
## Summary
- add ColumnNumericTransformer to normalize numeric values from decimal columns
- apply transformer to price, commissionPercent, unitPrice, amount, and percent fields
- ensure CommissionsService.createFromAppointment casts price and percent to numbers before calculating amount

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b60f309108329bab2fc717bb604c9