### PR TITLE
feat: expose service read endpoints

### DIFF
--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -21,15 +21,11 @@ import { UpdateServiceDto } from './dto/update-service.dto';
 export class ServicesController {
     constructor(private readonly servicesService: ServicesService) {}
 
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
-    @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get()
     findAll(): Promise<Service[]> {
         return this.servicesService.findAll();
     }
 
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
-    @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get(':id')
     findOne(@Param('id') id: string): Promise<Service> {
         return this.servicesService.findOne(Number(id));


### PR DESCRIPTION
## Summary
- remove auth guards from service list and detail queries
- keep create/update/delete service endpoints restricted to admins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6669877883298aa16120e1d8b22e