### PR TITLE
Handle empty API responses

### DIFF
--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -1,0 +1,29 @@
+import { ApiClient } from '@/api/apiClient';
+
+describe('ApiClient', () => {
+  const client = new ApiClient(() => null, () => {});
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    }
+    jest.resetAllMocks();
+  });
+
+  it('returns undefined for 204 responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(null, { status: 204, statusText: 'No Content' })
+    ) as jest.MockedFunction<typeof fetch>;
+    const res = await client.request('/test');
+    expect(res).toBeUndefined();
+  });
+
+  it('returns undefined for empty bodies', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response('', { status: 200 })
+    ) as jest.MockedFunction<typeof fetch>;
+    const res = await client.request('/test');
+    expect(res).toBeUndefined();
+  });
+});

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -36,6 +36,13 @@ export class ApiClient {
       error.status = response.status;
       throw error;
     }
-    return (await response.json()) as T;
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    const text = await response.text();
+    if (!text) {
+      return undefined as T;
+    }
+    return JSON.parse(text) as T;
   }
 }

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -38,7 +38,7 @@ export function useClientApi() {
 
   const remove = async (id: number) => {
     try {
-      await apiFetch<void>(`/clients/${id}`, { method: 'DELETE' });
+      await apiFetch(`/clients/${id}`, { method: 'DELETE' });
       toast.success('Client deleted');
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Error');

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -38,7 +38,7 @@ export function useEmployeeApi() {
 
   const remove = async (id: number) => {
     try {
-      await apiFetch<void>(`/employees/${id}`, { method: 'DELETE' });
+      await apiFetch(`/employees/${id}`, { method: 'DELETE' });
       toast.success('Employee deleted');
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Error');

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -68,7 +68,7 @@ export function useProductApi() {
 
     const remove = async (id: number) => {
         try {
-            await apiFetch<void>(`/products/admin/${id}`, { method: 'DELETE' });
+            await apiFetch(`/products/admin/${id}`, { method: 'DELETE' });
             toast.success('Product deleted');
         } catch (err: unknown) {
             toast.error(err instanceof Error ? err.message : 'Error');

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -74,7 +74,7 @@ export function useReviewApi() {
 
   const remove = async (id: number) => {
     try {
-      await apiFetch<void>(`/reviews/${id}`, { method: 'DELETE' });
+      await apiFetch(`/reviews/${id}`, { method: 'DELETE' });
       toast.success('Review deleted');
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Error');

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -38,7 +38,7 @@ export function useServiceApi() {
 
   const remove = async (id: number) => {
     try {
-      await apiFetch<void>(`/services/${id}`, { method: 'DELETE' });
+      await apiFetch(`/services/${id}`, { method: 'DELETE' });
       toast.success('Service deleted');
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Error');


### PR DESCRIPTION
## Summary
- Avoid JSON parsing errors by returning `undefined` on 204 or empty responses in API client
- Skip specifying `void` return types for delete API calls
- Add tests confirming `ApiClient` handles empty responses

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b69fda6608329b791292e2b9f37c2