### PR TITLE
feat(users): hide password column by default

### DIFF
--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -9,7 +9,7 @@ export class User {
     @Column({ unique: true })
     email: string;
 
-    @Column()
+    @Column({ select: false })
     password: string;
 
     @Column()

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -14,7 +14,11 @@ export class UsersService {
     ) {}
 
     async findByEmail(email: string): Promise<User | null> {
-        const user = await this.usersRepository.findOne({ where: { email } });
+        const user = await this.usersRepository
+            .createQueryBuilder('user')
+            .addSelect('user.password')
+            .where('user.email = :email', { email })
+            .getOne();
         // Ensure null is returned instead of undefined for unknown emails
         return user ?? null;
     }


### PR DESCRIPTION
## Summary
- hide user password column from default selects
- explicitly include password in UsersService.findByEmail
- adjust user service tests for new query builder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b6eaf52ec8329a7e320d255b5a045