### PR TITLE
Use ParseIntPipe for route IDs and test invalid IDs

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -9,6 +9,7 @@ import {
     ForbiddenException,
     BadRequestException,
     NotFoundException,
+    ParseIntPipe,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -78,10 +79,10 @@ export class AppointmentsController {
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Patch(':id/cancel')
     async cancel(
-        @Param('id') id: string,
+        @Param('id', ParseIntPipe) id: number,
         @CurrentUser() user: { userId: number; role: Role },
     ): Promise<Appointment | null> {
-        const appointment = await this.appointmentsService.findOne(Number(id));
+        const appointment = await this.appointmentsService.findOne(id);
         if (!appointment) {
             throw new NotFoundException();
         }
@@ -92,17 +93,17 @@ export class AppointmentsController {
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.cancel(Number(id));
+        return this.appointmentsService.cancel(id);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Employee, Role.Admin)
     @Patch(':id/complete')
     async complete(
-        @Param('id') id: string,
+        @Param('id', ParseIntPipe) id: number,
         @CurrentUser() user: { userId: number; role: Role },
     ): Promise<Appointment | null> {
-        const appointment = await this.appointmentsService.findOne(Number(id));
+        const appointment = await this.appointmentsService.findOne(id);
         if (!appointment) {
             throw new NotFoundException();
         }
@@ -112,6 +113,6 @@ export class AppointmentsController {
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.completeAppointment(Number(id));
+        return this.appointmentsService.completeAppointment(id);
     }
 }

--- a/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Param,
+    Post,
+    UseGuards,
+    ParseIntPipe,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
@@ -16,11 +23,11 @@ export class AppointmentFormulasController {
     @Roles(Role.Employee, Role.Admin)
     @Post()
     addFormula(
-        @Param('appointmentId') id: string,
+        @Param('appointmentId', ParseIntPipe) appointmentId: number,
         @Body() body: CreateFormulaDto,
         @CurrentUser() user: { userId: number },
     ): Promise<Formula> {
-        return this.formulasService.addToAppointment(Number(id), user.userId, {
+        return this.formulasService.addToAppointment(appointmentId, user.userId, {
             description: body.description,
             date: new Date(body.date),
         });

--- a/backend/salonbw-backend/src/formulas/client-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/client-formulas.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards, ParseIntPipe } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
@@ -21,7 +21,9 @@ export class ClientFormulasController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Employee, Role.Admin)
     @Get(':id/formulas')
-    findForClient(@Param('id') id: string): Promise<Formula[]> {
-        return this.formulasService.findForClient(Number(id));
+    findForClient(
+        @Param('id', ParseIntPipe) id: number,
+    ): Promise<Formula[]> {
+        return this.formulasService.findForClient(id);
     }
 }

--- a/backend/salonbw-backend/src/products/products.controller.ts
+++ b/backend/salonbw-backend/src/products/products.controller.ts
@@ -7,6 +7,7 @@ import {
     Patch,
     Post,
     UseGuards,
+    ParseIntPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Roles } from '../auth/roles.decorator';
@@ -31,8 +32,8 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin, Role.Employee)
     @Get(':id')
-    findOne(@Param('id') id: string): Promise<Product> {
-        return this.productsService.findOne(Number(id));
+    findOne(@Param('id', ParseIntPipe) id: number): Promise<Product> {
+        return this.productsService.findOne(id);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -46,16 +47,16 @@ export class ProductsController {
     @Roles(Role.Admin)
     @Patch(':id')
     update(
-        @Param('id') id: string,
+        @Param('id', ParseIntPipe) id: number,
         @Body() body: UpdateProductDto,
     ): Promise<Product> {
-        return this.productsService.update(Number(id), body);
+        return this.productsService.update(id, body);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
-    remove(@Param('id') id: string): Promise<void> {
-        return this.productsService.remove(Number(id));
+    remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+        return this.productsService.remove(id);
     }
 }

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -7,6 +7,7 @@ import {
     Patch,
     Post,
     UseGuards,
+    ParseIntPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Roles } from '../auth/roles.decorator';
@@ -27,8 +28,8 @@ export class ServicesController {
     }
 
     @Get(':id')
-    findOne(@Param('id') id: string): Promise<Service> {
-        return this.servicesService.findOne(Number(id));
+    findOne(@Param('id', ParseIntPipe) id: number): Promise<Service> {
+        return this.servicesService.findOne(id);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -42,16 +43,16 @@ export class ServicesController {
     @Roles(Role.Admin)
     @Patch(':id')
     update(
-        @Param('id') id: string,
+        @Param('id', ParseIntPipe) id: number,
         @Body() updateServiceDto: UpdateServiceDto,
     ): Promise<Service> {
-        return this.servicesService.update(Number(id), updateServiceDto);
+        return this.servicesService.update(id, updateServiceDto);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
-    remove(@Param('id') id: string): Promise<void> {
-        return this.servicesService.remove(Number(id));
+    remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+        return this.servicesService.remove(id);
     }
 }

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -12,6 +12,7 @@ import { AuthModule } from '../src/auth/auth.module';
 import { AppointmentsModule } from '../src/appointments/appointments.module';
 import { ServicesModule } from '../src/services/services.module';
 import { FormulasModule } from '../src/formulas/formulas.module';
+import { ProductsModule } from '../src/products/products.module';
 import { User } from '../src/users/user.entity';
 import { Service } from '../src/services/service.entity';
 import { Appointment } from '../src/appointments/appointment.entity';
@@ -69,6 +70,7 @@ describe('Appointments integration', () => {
                 ServicesModule,
                 AppointmentsModule,
                 FormulasModule,
+                ProductsModule,
             ],
         }).compile();
 
@@ -363,5 +365,38 @@ describe('Appointments integration', () => {
         const formulas = await formulaRepo.find();
         expect(formulas).toHaveLength(1);
         expect(formulas[0].appointment!.id).toBe(appointmentId);
+    });
+
+    it('rejects non-numeric service id', async () => {
+        await request(server).get('/services/abc').expect(400);
+    });
+
+    it('rejects non-numeric product id', async () => {
+        await request(server)
+            .get('/products/abc')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(400);
+    });
+
+    it('rejects non-numeric appointment id', async () => {
+        await request(server)
+            .patch('/appointments/abc/cancel')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(400);
+    });
+
+    it('rejects non-numeric appointment id when adding formulas', async () => {
+        await request(server)
+            .post('/appointments/abc/formulas')
+            .set('Authorization', `Bearer ${employeeToken}`)
+            .send({ description: 'x', date: new Date().toISOString() })
+            .expect(400);
+    });
+
+    it('rejects non-numeric client id for formulas', async () => {
+        await request(server)
+            .get('/clients/abc/formulas')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(400);
     });
 });


### PR DESCRIPTION
## Summary
- parse numeric route parameters with NestJS `ParseIntPipe` instead of manual `Number()` casts
- cover invalid ID requests in e2e tests

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b7576c6cc832987fb48e3cf338de3