### PR TITLE
chore: regenerate swagger spec with numeric path ids

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -211,7 +211,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -234,7 +234,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -293,7 +293,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -314,7 +314,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -345,7 +345,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -404,7 +404,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -425,7 +425,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -456,7 +456,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -479,7 +479,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -526,7 +526,7 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],


### PR DESCRIPTION
## Summary
- regenerate swagger spec so path parameters use numeric IDs

## Testing
- `npm run swagger:generate`
- `npm test`
- `npm run lint` *(fails: Unsafe member access on `any` values)*

------
https://chatgpt.com/codex/tasks/task_e_689b952d70108329ba0cc439f8b7d217