### PR TITLE
test: add unit tests for services, products, and commissions

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -1,0 +1,26 @@
+import { CommissionsController } from './commissions.controller';
+import { CommissionsService } from './commissions.service';
+
+describe('CommissionsController', () => {
+  let controller: CommissionsController;
+  let service: jest.Mocked<CommissionsService>;
+
+  beforeEach(() => {
+    service = {
+      findForUser: jest.fn().mockResolvedValue(['mine'] as any),
+      findAll: jest.fn().mockResolvedValue(['all'] as any),
+    } as any;
+    controller = new CommissionsController(service);
+  });
+
+  it('delegates findMine to service', async () => {
+    await expect(controller.findMine({ userId: 1 })).resolves.toEqual(['mine']);
+    expect(service.findForUser).toHaveBeenCalledWith(1);
+  });
+
+  it('delegates findAll to service', async () => {
+    await expect(controller.findAll()).resolves.toEqual(['all']);
+    expect(service.findAll).toHaveBeenCalled();
+  });
+});
+

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CommissionsService } from './commissions.service';
+import { Commission } from './commission.entity';
+import { Appointment } from '../appointments/appointment.entity';
+
+describe('CommissionsService', () => {
+  let service: CommissionsService;
+  let repo: jest.Mocked<Repository<Commission>>;
+
+  const mockRepository = () => ({
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation(async (entity) => ({ id: 1, ...entity })),
+    find: jest.fn().mockResolvedValue(['commission'] as any),
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommissionsService,
+        { provide: getRepositoryToken(Commission), useValue: mockRepository() },
+      ],
+    }).compile();
+
+    service = module.get<CommissionsService>(CommissionsService);
+    repo = module.get(getRepositoryToken(Commission));
+  });
+
+  it('creates a commission', async () => {
+    await expect(service.create({ amount: 10 })).resolves.toEqual({ id: 1, amount: 10 });
+    expect(repo.create).toHaveBeenCalledWith({ amount: 10 });
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  it('creates commission from appointment', async () => {
+    const appointment = {
+      service: { price: 100, commissionPercent: 10 },
+      employee: { id: 1 },
+    } as unknown as Appointment;
+    const expected = {
+      employee: appointment.employee,
+      appointment,
+      amount: 10,
+      percent: 10,
+    };
+    const created = { id: 1, ...expected } as Commission;
+    const spy = jest.spyOn(service, 'create').mockResolvedValue(created);
+    await expect(service.createFromAppointment(appointment)).resolves.toBe(created);
+    expect(spy).toHaveBeenCalledWith(expected);
+  });
+
+  it('finds commissions for user', async () => {
+    await service.findForUser(2);
+    expect(repo.find).toHaveBeenCalledWith({
+      where: { employee: { id: 2 } },
+      order: { createdAt: 'DESC' },
+    });
+  });
+
+  it('finds all commissions', async () => {
+    await service.findAll();
+    expect(repo.find).toHaveBeenCalledWith({ order: { createdAt: 'DESC' } });
+  });
+});
+

--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -1,0 +1,46 @@
+import { ProductsController } from './products.controller';
+import { ProductsService } from './products.service';
+
+describe('ProductsController', () => {
+  let controller: ProductsController;
+  let service: jest.Mocked<ProductsService>;
+
+  beforeEach(() => {
+    service = {
+      findAll: jest.fn().mockResolvedValue(['all'] as any),
+      findOne: jest.fn().mockResolvedValue('one' as any),
+      create: jest.fn().mockResolvedValue('created' as any),
+      update: jest.fn().mockResolvedValue('updated' as any),
+      remove: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    controller = new ProductsController(service);
+  });
+
+  it('delegates findAll to service', async () => {
+    await expect(controller.findAll()).resolves.toEqual(['all']);
+    expect(service.findAll).toHaveBeenCalled();
+  });
+
+  it('delegates findOne to service', async () => {
+    await expect(controller.findOne(1)).resolves.toBe('one');
+    expect(service.findOne).toHaveBeenCalledWith(1);
+  });
+
+  it('delegates create to service', async () => {
+    const dto = { name: 'Shampoo' } as any;
+    await expect(controller.create(dto)).resolves.toBe('created');
+    expect(service.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('delegates update to service', async () => {
+    const dto = { name: 'New' } as any;
+    await expect(controller.update(1, dto)).resolves.toBe('updated');
+    expect(service.update).toHaveBeenCalledWith(1, dto);
+  });
+
+  it('delegates remove to service', async () => {
+    await expect(controller.remove(1)).resolves.toBeUndefined();
+    expect(service.remove).toHaveBeenCalledWith(1);
+  });
+});
+

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProductsService } from './products.service';
+import { Product } from './product.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ProductsService', () => {
+  let service: ProductsService;
+  let repo: jest.Mocked<Repository<Product>>;
+
+  const mockRepository = () => ({
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation(async (entity) => ({ id: 1, ...entity })),
+    find: jest.fn().mockResolvedValue([{ id: 1 } as Product]),
+    findOne: jest.fn().mockResolvedValue({ id: 1 } as Product),
+    update: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductsService,
+        { provide: getRepositoryToken(Product), useValue: mockRepository() },
+      ],
+    }).compile();
+
+    service = module.get<ProductsService>(ProductsService);
+    repo = module.get(getRepositoryToken(Product));
+  });
+
+  it('creates a product', async () => {
+    const dto = { name: 'Shampoo', brand: 'Brand', unitPrice: 5, stock: 10 } as any;
+    await expect(service.create(dto)).resolves.toEqual({ id: 1, ...dto });
+    expect(repo.create).toHaveBeenCalledWith(dto);
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  it('returns all products', async () => {
+    await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
+    expect(repo.find).toHaveBeenCalled();
+  });
+
+  it('returns a product by id', async () => {
+    await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('throws when product not found', async () => {
+    repo.findOne.mockResolvedValue(null);
+    await expect(service.findOne(2)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('updates a product', async () => {
+    const dto = { name: 'New' } as any;
+    await expect(service.update(1, dto)).resolves.toEqual({ id: 1 });
+    expect(repo.update).toHaveBeenCalledWith(1, dto);
+  });
+
+  it('removes a product', async () => {
+    await service.remove(1);
+    expect(repo.delete).toHaveBeenCalledWith(1);
+  });
+});
+

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -1,0 +1,46 @@
+import { ServicesController } from './services.controller';
+import { ServicesService } from './services.service';
+
+describe('ServicesController', () => {
+  let controller: ServicesController;
+  let service: jest.Mocked<ServicesService>;
+
+  beforeEach(() => {
+    service = {
+      findAll: jest.fn().mockResolvedValue(['all'] as any),
+      findOne: jest.fn().mockResolvedValue('one' as any),
+      create: jest.fn().mockResolvedValue('created' as any),
+      update: jest.fn().mockResolvedValue('updated' as any),
+      remove: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    controller = new ServicesController(service);
+  });
+
+  it('delegates findAll to service', async () => {
+    await expect(controller.findAll()).resolves.toEqual(['all']);
+    expect(service.findAll).toHaveBeenCalled();
+  });
+
+  it('delegates findOne to service', async () => {
+    await expect(controller.findOne(1)).resolves.toBe('one');
+    expect(service.findOne).toHaveBeenCalledWith(1);
+  });
+
+  it('delegates create to service', async () => {
+    const dto = { name: 'Cut' } as any;
+    await expect(controller.create(dto)).resolves.toBe('created');
+    expect(service.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('delegates update to service', async () => {
+    const dto = { name: 'New' } as any;
+    await expect(controller.update(1, dto)).resolves.toBe('updated');
+    expect(service.update).toHaveBeenCalledWith(1, dto);
+  });
+
+  it('delegates remove to service', async () => {
+    await expect(controller.remove(1)).resolves.toBeUndefined();
+    expect(service.remove).toHaveBeenCalledWith(1);
+  });
+});
+

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ServicesService } from './services.service';
+import { Service } from './service.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ServicesService', () => {
+  let service: ServicesService;
+  let repo: jest.Mocked<Repository<Service>>;
+
+  const mockRepository = () => ({
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation(async (entity) => ({ id: 1, ...entity })),
+    find: jest.fn().mockResolvedValue([{ id: 1 } as Service]),
+    findOne: jest.fn().mockResolvedValue({ id: 1 } as Service),
+    update: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ServicesService,
+        { provide: getRepositoryToken(Service), useValue: mockRepository() },
+      ],
+    }).compile();
+
+    service = module.get<ServicesService>(ServicesService);
+    repo = module.get(getRepositoryToken(Service));
+  });
+
+  it('creates a service', async () => {
+    const dto = { name: 'Cut', description: 'Hair cut', duration: 30, price: 10 } as any;
+    await expect(service.create(dto)).resolves.toEqual({ id: 1, ...dto });
+    expect(repo.create).toHaveBeenCalledWith(dto);
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  it('returns all services', async () => {
+    await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
+    expect(repo.find).toHaveBeenCalled();
+  });
+
+  it('returns a service by id', async () => {
+    await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('throws when service not found', async () => {
+    repo.findOne.mockResolvedValue(null);
+    await expect(service.findOne(2)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('updates a service', async () => {
+    const dto = { name: 'New' } as any;
+    await expect(service.update(1, dto)).resolves.toEqual({ id: 1 });
+    expect(repo.update).toHaveBeenCalledWith(1, dto);
+  });
+
+  it('removes a service', async () => {
+    await service.remove(1);
+    expect(repo.delete).toHaveBeenCalledWith(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for services module covering CRUD and missing service
- add unit tests for products module covering CRUD and missing product
- add unit tests for commissions module including creation from appointments

## Testing
- `npm test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_689c4fb0d41883299b53209c9c296f33