### PR TITLE
refactor: type commission controller mocks

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -1,25 +1,32 @@
 import { CommissionsController } from './commissions.controller';
 import { CommissionsService } from './commissions.service';
+import { Commission } from './commission.entity';
 
 describe('CommissionsController', () => {
   let controller: CommissionsController;
   let service: jest.Mocked<CommissionsService>;
+  let mine: Commission;
+  let all: Commission;
 
   beforeEach(() => {
+    mine = {} as Commission;
+    all = {} as Commission;
     service = {
-      findForUser: jest.fn().mockResolvedValue(['mine'] as any),
-      findAll: jest.fn().mockResolvedValue(['all'] as any),
-    } as any;
+      findForUser: jest.fn().mockResolvedValue([mine]),
+      findAll: jest.fn().mockResolvedValue([all]),
+    } as unknown as jest.Mocked<CommissionsService>;
     controller = new CommissionsController(service);
   });
 
   it('delegates findMine to service', async () => {
-    await expect(controller.findMine({ userId: 1 })).resolves.toEqual(['mine']);
+    const findMine = controller.findMine.bind(controller);
+    await expect(findMine({ userId: 1 })).resolves.toEqual([mine]);
     expect(service.findForUser).toHaveBeenCalledWith(1);
   });
 
   it('delegates findAll to service', async () => {
-    await expect(controller.findAll()).resolves.toEqual(['all']);
+    const list = controller.findAll.bind(controller);
+    await expect(list()).resolves.toEqual([all]);
     expect(service.findAll).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add explicit Commission typing to commissions controller tests
- bind controller methods in unit tests to avoid unbound references

## Testing
- `npm test` (failed: AppointmentsService should reject overlapping appointments: Received constructor ReferenceError)

------
https://chatgpt.com/codex/tasks/task_e_689c5288ea7c832980eef8d3e6d0f5c4