### PR TITLE
test: improve commission service mocks

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -6,61 +6,76 @@ import { Commission } from './commission.entity';
 import { Appointment } from '../appointments/appointment.entity';
 
 describe('CommissionsService', () => {
-  let service: CommissionsService;
-  let repo: jest.Mocked<Repository<Commission>>;
+    let service: CommissionsService;
+    let repo: jest.Mocked<Repository<Commission>>;
 
-  const mockRepository = () => ({
-    create: jest.fn().mockImplementation((dto) => dto),
-    save: jest.fn().mockImplementation(async (entity) => ({ id: 1, ...entity })),
-    find: jest.fn().mockResolvedValue(['commission'] as any),
-  });
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        CommissionsService,
-        { provide: getRepositoryToken(Commission), useValue: mockRepository() },
-      ],
-    }).compile();
-
-    service = module.get<CommissionsService>(CommissionsService);
-    repo = module.get(getRepositoryToken(Commission));
-  });
-
-  it('creates a commission', async () => {
-    await expect(service.create({ amount: 10 })).resolves.toEqual({ id: 1, amount: 10 });
-    expect(repo.create).toHaveBeenCalledWith({ amount: 10 });
-    expect(repo.save).toHaveBeenCalled();
-  });
-
-  it('creates commission from appointment', async () => {
-    const appointment = {
-      service: { price: 100, commissionPercent: 10 },
-      employee: { id: 1 },
-    } as unknown as Appointment;
-    const expected = {
-      employee: appointment.employee,
-      appointment,
-      amount: 10,
-      percent: 10,
-    };
-    const created = { id: 1, ...expected } as Commission;
-    const spy = jest.spyOn(service, 'create').mockResolvedValue(created);
-    await expect(service.createFromAppointment(appointment)).resolves.toBe(created);
-    expect(spy).toHaveBeenCalledWith(expected);
-  });
-
-  it('finds commissions for user', async () => {
-    await service.findForUser(2);
-    expect(repo.find).toHaveBeenCalledWith({
-      where: { employee: { id: 2 } },
-      order: { createdAt: 'DESC' },
+    const mockRepository = () => ({
+        create: jest.fn().mockImplementation((dto) => dto as Commission),
+        save: jest
+            .fn()
+            .mockImplementation((entity: Commission) =>
+                Promise.resolve({ id: 1, ...entity }),
+            ),
+        find: jest.fn().mockResolvedValue([] as Commission[]),
     });
-  });
 
-  it('finds all commissions', async () => {
-    await service.findAll();
-    expect(repo.find).toHaveBeenCalledWith({ order: { createdAt: 'DESC' } });
-  });
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CommissionsService,
+                {
+                    provide: getRepositoryToken(Commission),
+                    useValue: mockRepository(),
+                },
+            ],
+        }).compile();
+
+        service = module.get<CommissionsService>(CommissionsService);
+        repo = module.get(getRepositoryToken(Commission));
+    });
+
+    it('creates a commission', async () => {
+        await expect(service.create({ amount: 10 })).resolves.toEqual({
+            id: 1,
+            amount: 10,
+        });
+        expect(repo.create).toHaveBeenCalledWith({ amount: 10 });
+        expect(repo.save).toHaveBeenCalled();
+    });
+
+    it('creates commission from appointment', async () => {
+        const appointment = {
+            service: { price: 100, commissionPercent: 10 },
+            employee: { id: 1 },
+        } as unknown as Appointment;
+        const expected = {
+            employee: appointment.employee,
+            appointment,
+            amount: 10,
+            percent: 10,
+        };
+        const created = { id: 1, ...expected } as Commission;
+        const spy = jest
+            .spyOn(service, 'create')
+            .mockImplementation(() => Promise.resolve(created));
+        await expect(service.createFromAppointment(appointment)).resolves.toBe(
+            created,
+        );
+        expect(spy).toHaveBeenCalledWith(expected);
+    });
+
+    it('finds commissions for user', async () => {
+        await service.findForUser(2);
+        expect(repo.find).toHaveBeenCalledWith({
+            where: { employee: { id: 2 } },
+            order: { createdAt: 'DESC' },
+        });
+    });
+
+    it('finds all commissions', async () => {
+        await service.findAll();
+        expect(repo.find).toHaveBeenCalledWith({
+            order: { createdAt: 'DESC' },
+        });
+    });
 });
-


### PR DESCRIPTION
## Summary
- ensure commission repository mocks return Commission objects
- use arrow function spy in commission service tests

## Testing
- `npm test` *(fails: AppointmentsService › should reject overlapping appointments)*
- `npm run lint` *(fails: 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c550aeed4832989734fd815024738