### PR TITLE
test: type service controller spec mocks

### DIFF
--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -1,45 +1,72 @@
 import { ServicesController } from './services.controller';
 import { ServicesService } from './services.service';
+import { Service } from './service.entity';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
 
 describe('ServicesController', () => {
   let controller: ServicesController;
   let service: jest.Mocked<ServicesService>;
+  let serviceEntity: Service;
 
   beforeEach(() => {
+    serviceEntity = {
+      id: 1,
+      name: 'Cut',
+      description: 'desc',
+      duration: 30,
+      price: 50,
+      category: 'Hair',
+      commissionPercent: 10,
+    };
+
     service = {
-      findAll: jest.fn().mockResolvedValue(['all'] as any),
-      findOne: jest.fn().mockResolvedValue('one' as any),
-      create: jest.fn().mockResolvedValue('created' as any),
-      update: jest.fn().mockResolvedValue('updated' as any),
+      findAll: jest.fn().mockResolvedValue([serviceEntity]),
+      findOne: jest.fn().mockResolvedValue(serviceEntity),
+      create: jest.fn().mockResolvedValue(serviceEntity),
+      update: jest.fn().mockResolvedValue(serviceEntity),
       remove: jest.fn().mockResolvedValue(undefined),
-    } as any;
+    } as unknown as jest.Mocked<ServicesService>;
+
     controller = new ServicesController(service);
   });
 
   it('delegates findAll to service', async () => {
-    await expect(controller.findAll()).resolves.toEqual(['all']);
+    const callFindAll = () => controller.findAll();
+    await expect(callFindAll()).resolves.toEqual([serviceEntity]);
     expect(service.findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
-    await expect(controller.findOne(1)).resolves.toBe('one');
+    const callFindOne = () => controller.findOne(1);
+    await expect(callFindOne()).resolves.toBe(serviceEntity);
     expect(service.findOne).toHaveBeenCalledWith(1);
   });
 
   it('delegates create to service', async () => {
-    const dto = { name: 'Cut' } as any;
-    await expect(controller.create(dto)).resolves.toBe('created');
+    const dto: CreateServiceDto = {
+      name: 'Cut',
+      description: 'desc',
+      duration: 30,
+      price: 50,
+      category: 'Hair',
+      commissionPercent: 10,
+    };
+    const callCreate = () => controller.create(dto);
+    await expect(callCreate()).resolves.toBe(serviceEntity);
     expect(service.create).toHaveBeenCalledWith(dto);
   });
 
   it('delegates update to service', async () => {
-    const dto = { name: 'New' } as any;
-    await expect(controller.update(1, dto)).resolves.toBe('updated');
+    const dto: UpdateServiceDto = { name: 'New' };
+    const callUpdate = () => controller.update(1, dto);
+    await expect(callUpdate()).resolves.toBe(serviceEntity);
     expect(service.update).toHaveBeenCalledWith(1, dto);
   });
 
   it('delegates remove to service', async () => {
-    await expect(controller.remove(1)).resolves.toBeUndefined();
+    const callRemove = () => controller.remove(1);
+    await expect(callRemove()).resolves.toBeUndefined();
     expect(service.remove).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- type service controller test DTOs and responses
- invoke controller methods via arrow functions for clarity

## Testing
- `npm test` (fails: AppointmentsService should reject overlapping appointments)

------
https://chatgpt.com/codex/tasks/task_e_689c5e608f14832994671c241f74e666