### PR TITLE
refactor: improve service tests

### DIFF
--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -1,66 +1,96 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ServicesService } from './services.service';
 import { Service } from './service.entity';
-import { NotFoundException } from '@nestjs/common';
+import { ServicesService } from './services.service';
+import { UpdateServiceDto } from './dto/update-service.dto';
 
 describe('ServicesService', () => {
-  let service: ServicesService;
-  let repo: jest.Mocked<Repository<Service>>;
+    let service: ServicesService;
+    let repo: jest.Mocked<Repository<Service>>;
+    let serviceEntity: Service;
 
-  const mockRepository = () => ({
-    create: jest.fn().mockImplementation((dto) => dto),
-    save: jest.fn().mockImplementation(async (entity) => ({ id: 1, ...entity })),
-    find: jest.fn().mockResolvedValue([{ id: 1 } as Service]),
-    findOne: jest.fn().mockResolvedValue({ id: 1 } as Service),
-    update: jest.fn().mockResolvedValue(undefined),
-    delete: jest.fn().mockResolvedValue(undefined),
-  });
+    const mockRepository = () => ({
+        create: jest
+            .fn()
+            .mockImplementation((dto: Partial<Service>) => dto as Service),
+        save: jest
+            .fn()
+            .mockImplementation((entity: Service) =>
+                Promise.resolve({ ...serviceEntity, ...entity }),
+            ),
+        find: jest.fn().mockResolvedValue([serviceEntity]),
+        findOne: jest.fn().mockResolvedValue(serviceEntity),
+        update: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+    });
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ServicesService,
-        { provide: getRepositoryToken(Service), useValue: mockRepository() },
-      ],
-    }).compile();
+    beforeEach(async () => {
+        serviceEntity = {
+            id: 1,
+            name: 'Cut',
+            description: 'Hair cut',
+            duration: 30,
+            price: 10,
+        };
 
-    service = module.get<ServicesService>(ServicesService);
-    repo = module.get(getRepositoryToken(Service));
-  });
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ServicesService,
+                {
+                    provide: getRepositoryToken(Service),
+                    useValue: mockRepository(),
+                },
+            ],
+        }).compile();
 
-  it('creates a service', async () => {
-    const dto = { name: 'Cut', description: 'Hair cut', duration: 30, price: 10 } as any;
-    await expect(service.create(dto)).resolves.toEqual({ id: 1, ...dto });
-    expect(repo.create).toHaveBeenCalledWith(dto);
-    expect(repo.save).toHaveBeenCalled();
-  });
+        service = module.get<ServicesService>(ServicesService);
+        repo = module.get(getRepositoryToken(Service));
+    });
 
-  it('returns all services', async () => {
-    await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
-    expect(repo.find).toHaveBeenCalled();
-  });
+    it('creates a service', async () => {
+        const dto = {
+            name: 'Cut',
+            description: 'Hair cut',
+            duration: 30,
+            price: 10,
+        };
+        const callCreate = () => service.create(dto);
+        await expect(callCreate()).resolves.toEqual(serviceEntity);
+        expect(repo.create).toHaveBeenCalledWith(dto);
+        expect(repo.save).toHaveBeenCalled();
+    });
 
-  it('returns a service by id', async () => {
-    await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
-    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
-  });
+    it('returns all services', async () => {
+        const callFindAll = () => service.findAll();
+        await expect(callFindAll()).resolves.toEqual([serviceEntity]);
+        expect(repo.find).toHaveBeenCalled();
+    });
 
-  it('throws when service not found', async () => {
-    repo.findOne.mockResolvedValue(null);
-    await expect(service.findOne(2)).rejects.toBeInstanceOf(NotFoundException);
-  });
+    it('returns a service by id', async () => {
+        const callFindOne = () => service.findOne(1);
+        await expect(callFindOne()).resolves.toBe(serviceEntity);
+        expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
 
-  it('updates a service', async () => {
-    const dto = { name: 'New' } as any;
-    await expect(service.update(1, dto)).resolves.toEqual({ id: 1 });
-    expect(repo.update).toHaveBeenCalledWith(1, dto);
-  });
+    it('throws when service not found', async () => {
+        repo.findOne.mockResolvedValue(null);
+        const callFindOne = () => service.findOne(2);
+        await expect(callFindOne()).rejects.toBeInstanceOf(NotFoundException);
+    });
 
-  it('removes a service', async () => {
-    await service.remove(1);
-    expect(repo.delete).toHaveBeenCalledWith(1);
-  });
+    it('updates a service', async () => {
+        const dto: UpdateServiceDto = { name: 'New' };
+        const callUpdate = () => service.update(1, dto);
+        await expect(callUpdate()).resolves.toBe(serviceEntity);
+        expect(repo.update).toHaveBeenCalledWith(1, dto);
+    });
+
+    it('removes a service', async () => {
+        const callRemove = () => service.remove(1);
+        await expect(callRemove()).resolves.toBeUndefined();
+        expect(repo.delete).toHaveBeenCalledWith(1);
+    });
 });
-


### PR DESCRIPTION
## Summary
- improve services service tests with typed entities and arrow functions

## Testing
- `npm test src/services/services.service.spec.ts`
- `npm test` *(fails: AppointmentsService should reject overlapping appointments)*
- `npm run lint` *(fails: multiple lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c5f854334832992714bec9235eddb