### PR TITLE
test: refine controller mocks

### DIFF
--- a/backend/salonbw-backend/src/app.controller.spec.ts
+++ b/backend/salonbw-backend/src/app.controller.spec.ts
@@ -16,7 +16,8 @@ describe('AppController', () => {
 
     describe('root', () => {
         it('should return "Hello World!"', () => {
-            expect(appController.getHello()).toBe('Hello World!');
+            const callGetHello = () => appController.getHello();
+            expect(callGetHello()).toBe('Hello World!');
         });
     });
 });

--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -21,13 +21,15 @@ describe('CommissionsController', () => {
   it('delegates findMine to service', async () => {
     const callFindMine = (dto: { userId: number }) => controller.findMine(dto);
     await expect(callFindMine({ userId: 1 })).resolves.toEqual([mine]);
-    expect(service.findForUser).toHaveBeenCalledWith(1);
+    const { findForUser } = service;
+    expect(findForUser).toHaveBeenCalledWith(1);
   });
 
   it('delegates findAll to service', async () => {
     const callFindAll = () => controller.findAll();
     await expect(callFindAll()).resolves.toEqual([all]);
-    expect(service.findAll).toHaveBeenCalled();
+    const { findAll } = service;
+    expect(findAll).toHaveBeenCalled();
   });
 });
 

--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -23,27 +23,35 @@ describe('ProductsController', () => {
       findOne: jest.fn().mockResolvedValue(product),
       create: jest
         .fn()
-        .mockImplementation(async (dto: CreateProductDto) => ({ id: 1, ...dto })),
+        .mockImplementation((dto: CreateProductDto) =>
+          Promise.resolve({ id: 1, ...dto }),
+        ),
       update: jest
         .fn()
-        .mockImplementation(async (id: number, dto: UpdateProductDto) => ({
-          ...product,
-          ...dto,
-          id,
-        })),
+        .mockImplementation((id: number, dto: UpdateProductDto) =>
+          Promise.resolve({
+            ...product,
+            ...dto,
+            id,
+          }),
+        ),
       remove: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ProductsService>;
     controller = new ProductsController(service);
   });
 
   it('delegates findAll to service', async () => {
-    await expect(controller.findAll()).resolves.toEqual([product]);
-    expect(service.findAll).toHaveBeenCalled();
+    const callFindAll = () => controller.findAll();
+    await expect(callFindAll()).resolves.toEqual([product]);
+    const { findAll } = service;
+    expect(findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
-    await expect(controller.findOne(1)).resolves.toBe(product);
-    expect(service.findOne).toHaveBeenCalledWith(1);
+    const callFindOne = () => controller.findOne(1);
+    await expect(callFindOne()).resolves.toBe(product);
+    const { findOne } = service;
+    expect(findOne).toHaveBeenCalledWith(1);
   });
 
   it('delegates create to service', async () => {
@@ -53,20 +61,26 @@ describe('ProductsController', () => {
       unitPrice: 10,
       stock: 5,
     };
-    await expect(controller.create(dto)).resolves.toEqual({ id: 1, ...dto });
-    expect(service.create).toHaveBeenCalledWith(dto);
+    const callCreate = () => controller.create(dto);
+    await expect(callCreate()).resolves.toEqual({ id: 1, ...dto });
+    const { create } = service;
+    expect(create).toHaveBeenCalledWith(dto);
   });
 
   it('delegates update to service', async () => {
     const dto: UpdateProductDto = { name: 'New' };
     const updated = { ...product, ...dto };
-    await expect(controller.update(1, dto)).resolves.toEqual(updated);
-    expect(service.update).toHaveBeenCalledWith(1, dto);
+    const callUpdate = () => controller.update(1, dto);
+    await expect(callUpdate()).resolves.toEqual(updated);
+    const { update } = service;
+    expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('delegates remove to service', async () => {
-    await expect(controller.remove(1)).resolves.toBeUndefined();
-    expect(service.remove).toHaveBeenCalledWith(1);
+    const callRemove = () => controller.remove(1);
+    await expect(callRemove()).resolves.toBeUndefined();
+    const { remove } = service;
+    expect(remove).toHaveBeenCalledWith(1);
   });
 });
 

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -34,13 +34,15 @@ describe('ServicesController', () => {
   it('delegates findAll to service', async () => {
     const callFindAll = () => controller.findAll();
     await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-    expect(service.findAll).toHaveBeenCalled();
+    const { findAll } = service;
+    expect(findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
     const callFindOne = () => controller.findOne(1);
     await expect(callFindOne()).resolves.toBe(serviceEntity);
-    expect(service.findOne).toHaveBeenCalledWith(1);
+    const { findOne } = service;
+    expect(findOne).toHaveBeenCalledWith(1);
   });
 
   it('delegates create to service', async () => {
@@ -54,20 +56,23 @@ describe('ServicesController', () => {
     };
     const callCreate = () => controller.create(dto);
     await expect(callCreate()).resolves.toBe(serviceEntity);
-    expect(service.create).toHaveBeenCalledWith(dto);
+    const { create } = service;
+    expect(create).toHaveBeenCalledWith(dto);
   });
 
   it('delegates update to service', async () => {
     const dto: UpdateServiceDto = { name: 'New' };
     const callUpdate = () => controller.update(1, dto);
     await expect(callUpdate()).resolves.toBe(serviceEntity);
-    expect(service.update).toHaveBeenCalledWith(1, dto);
+    const { update } = service;
+    expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('delegates remove to service', async () => {
     const callRemove = () => controller.remove(1);
     await expect(callRemove()).resolves.toBeUndefined();
-    expect(service.remove).toHaveBeenCalledWith(1);
+    const { remove } = service;
+    expect(remove).toHaveBeenCalledWith(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove async callbacks for product service mocks
- wrap controller calls in arrow helpers
- destructure service mocks before expectations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8349d33c8329b9e4fccb60befff6