### PR TITLE
test: destructure repo methods in service specs

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -66,7 +66,8 @@ describe('CommissionsService', () => {
 
     it('finds commissions for user', async () => {
         await service.findForUser(2);
-        expect(repo.find).toHaveBeenCalledWith({
+        const { find } = repo;
+        expect(find).toHaveBeenCalledWith({
             where: { employee: { id: 2 } },
             order: { createdAt: 'DESC' },
         });
@@ -74,7 +75,8 @@ describe('CommissionsService', () => {
 
     it('finds all commissions', async () => {
         await service.findAll();
-        expect(repo.find).toHaveBeenCalledWith({
+        const { find } = repo;
+        expect(find).toHaveBeenCalledWith({
             order: { createdAt: 'DESC' },
         });
     });

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -46,12 +46,14 @@ describe('ProductsService', () => {
 
   it('returns all products', async () => {
     await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
-    expect(repo.find).toHaveBeenCalled();
+    const { find } = repo;
+    expect(find).toHaveBeenCalled();
   });
 
   it('returns a product by id', async () => {
     await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
-    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+    const { findOne } = repo;
+    expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 
   it('throws when product not found', async () => {
@@ -62,12 +64,14 @@ describe('ProductsService', () => {
   it('updates a product', async () => {
     const dto: Partial<Product> = { name: 'New' };
     await expect(service.update(1, dto as Product)).resolves.toEqual({ id: 1 });
-    expect(repo.update).toHaveBeenCalledWith(1, dto);
+    const { update } = repo;
+    expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('removes a product', async () => {
     await service.remove(1);
-    expect(repo.delete).toHaveBeenCalledWith(1);
+    const { delete: deleteFn } = repo;
+    expect(deleteFn).toHaveBeenCalledWith(1);
   });
 });
 

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -66,13 +66,15 @@ describe('ServicesService', () => {
     it('returns all services', async () => {
         const callFindAll = () => service.findAll();
         await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-        expect(repo.find).toHaveBeenCalled();
+        const { find } = repo;
+        expect(find).toHaveBeenCalled();
     });
 
     it('returns a service by id', async () => {
         const callFindOne = () => service.findOne(1);
         await expect(callFindOne()).resolves.toBe(serviceEntity);
-        expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+        const { findOne } = repo;
+        expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
     it('throws when service not found', async () => {
@@ -85,12 +87,14 @@ describe('ServicesService', () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const callUpdate = () => service.update(1, dto);
         await expect(callUpdate()).resolves.toBe(serviceEntity);
-        expect(repo.update).toHaveBeenCalledWith(1, dto);
+        const { update } = repo;
+        expect(update).toHaveBeenCalledWith(1, dto);
     });
 
     it('removes a service', async () => {
         const callRemove = () => service.remove(1);
         await expect(callRemove()).resolves.toBeUndefined();
-        expect(repo.delete).toHaveBeenCalledWith(1);
+        const { delete: deleteFn } = repo;
+        expect(deleteFn).toHaveBeenCalledWith(1);
     });
 });


### PR DESCRIPTION
## Summary
- destructure repository methods before Jest assertions in service specs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8484ea688329bfcdaa13acc0c7c4