### PR TITLE
test: destructure repository methods before assertions

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -39,8 +39,9 @@ describe('CommissionsService', () => {
             id: 1,
             amount: 10,
         });
-        expect(repo.create).toHaveBeenCalledWith({ amount: 10 });
-        expect(repo.save).toHaveBeenCalled();
+        const { create, save } = repo;
+        expect(create).toHaveBeenCalledWith({ amount: 10 });
+        expect(save).toHaveBeenCalled();
     });
 
     it('creates commission from appointment', async () => {

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -40,8 +40,9 @@ describe('ProductsService', () => {
       stock: 10,
     };
     await expect(service.create(dto as Product)).resolves.toEqual({ id: 1, ...dto });
-    expect(repo.create).toHaveBeenCalledWith(dto);
-    expect(repo.save).toHaveBeenCalled();
+    const { create, save } = repo;
+    expect(create).toHaveBeenCalledWith(dto);
+    expect(save).toHaveBeenCalled();
   });
 
   it('returns all products', async () => {

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -59,8 +59,9 @@ describe('ServicesService', () => {
         };
         const callCreate = () => service.create(dto);
         await expect(callCreate()).resolves.toEqual(serviceEntity);
-        expect(repo.create).toHaveBeenCalledWith(dto);
-        expect(repo.save).toHaveBeenCalled();
+        const { create, save } = repo;
+        expect(create).toHaveBeenCalledWith(dto);
+        expect(save).toHaveBeenCalled();
     });
 
     it('returns all services', async () => {

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -79,13 +79,14 @@ describe('UsersService', () => {
             const result = await service.createUser(dto);
 
             expect(bcryptMock.hash).toHaveBeenCalledWith(dto.password, 10);
-            expect(repo.create).toHaveBeenCalledWith({
+            const { create, save } = repo;
+            expect(create).toHaveBeenCalledWith({
                 email: dto.email,
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
             });
-            expect(repo.save).toHaveBeenCalledWith(created);
+            expect(save).toHaveBeenCalledWith(created);
             expect(result.role).toBe(Role.Client);
             expect(result.password).toBe('hashedPass');
         });


### PR DESCRIPTION
## Summary
- destructure mocked repository methods before verifying calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c85f20dd88329818ae47737f295fc