### PR TITLE
test: destructure repo methods in commission service tests

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -35,11 +35,11 @@ describe('CommissionsService', () => {
     });
 
     it('creates a commission', async () => {
+        const { create, save, find } = repo;
         await expect(service.create({ amount: 10 })).resolves.toEqual({
             id: 1,
             amount: 10,
         });
-        const { create, save } = repo;
         expect(create).toHaveBeenCalledWith({ amount: 10 });
         expect(save).toHaveBeenCalled();
     });
@@ -66,8 +66,8 @@ describe('CommissionsService', () => {
     });
 
     it('finds commissions for user', async () => {
+        const { create, save, find } = repo;
         await service.findForUser(2);
-        const { find } = repo;
         expect(find).toHaveBeenCalledWith({
             where: { employee: { id: 2 } },
             order: { createdAt: 'DESC' },
@@ -75,8 +75,8 @@ describe('CommissionsService', () => {
     });
 
     it('finds all commissions', async () => {
+        const { create, save, find } = repo;
         await service.findAll();
-        const { find } = repo;
         expect(find).toHaveBeenCalledWith({
             order: { createdAt: 'DESC' },
         });


### PR DESCRIPTION
## Summary
- destructure repository methods before running commission service tests
- assert using local `create`, `save`, and `find` mocks

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c8cc284f48329a20edc672ab8b241