### PR TITLE
refactor: destructure products service mocks in tests

### DIFF
--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -8,6 +8,11 @@ describe('ProductsController', () => {
   let controller: ProductsController;
   let service: jest.Mocked<ProductsService>;
   let product: Product;
+  let findAll: jest.Mock;
+  let findOne: jest.Mock;
+  let create: jest.Mock;
+  let update: jest.Mock;
+  let remove: jest.Mock;
 
   beforeEach(() => {
     product = {
@@ -37,20 +42,19 @@ describe('ProductsController', () => {
         ),
       remove: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ProductsService>;
+    ({ findAll, findOne, create, update, remove } = service);
     controller = new ProductsController(service);
   });
 
   it('delegates findAll to service', async () => {
     const callFindAll = () => controller.findAll();
     await expect(callFindAll()).resolves.toEqual([product]);
-    const { findAll } = service;
     expect(findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
     const callFindOne = () => controller.findOne(1);
     await expect(callFindOne()).resolves.toBe(product);
-    const { findOne } = service;
     expect(findOne).toHaveBeenCalledWith(1);
   });
 
@@ -63,7 +67,6 @@ describe('ProductsController', () => {
     };
     const callCreate = () => controller.create(dto);
     await expect(callCreate()).resolves.toEqual({ id: 1, ...dto });
-    const { create } = service;
     expect(create).toHaveBeenCalledWith(dto);
   });
 
@@ -72,14 +75,12 @@ describe('ProductsController', () => {
     const updated = { ...product, ...dto };
     const callUpdate = () => controller.update(1, dto);
     await expect(callUpdate()).resolves.toEqual(updated);
-    const { update } = service;
     expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('delegates remove to service', async () => {
     const callRemove = () => controller.remove(1);
     await expect(callRemove()).resolves.toBeUndefined();
-    const { remove } = service;
     expect(remove).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- destructure product service mock methods once in controller spec
- simplify assertions to use destructured mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c908f07a08329ac018770da1a237a