### PR TITLE
test: destructure repo methods

### DIFF
--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -8,6 +8,12 @@ import { NotFoundException } from '@nestjs/common';
 describe('ProductsService', () => {
   let service: ProductsService;
   let repo: jest.Mocked<Repository<Product>>;
+  let create: jest.Mock;
+  let save: jest.Mock;
+  let find: jest.Mock;
+  let findOne: jest.Mock;
+  let update: jest.Mock;
+  let remove: jest.Mock;
 
   const mockRepository = () => ({
     create: jest.fn((dto: Partial<Product>) => dto as Product),
@@ -30,6 +36,7 @@ describe('ProductsService', () => {
 
     service = module.get<ProductsService>(ProductsService);
     repo = module.get(getRepositoryToken(Product));
+    ({ create, save, find, findOne, update, delete: remove } = repo);
   });
 
   it('creates a product', async () => {
@@ -40,20 +47,17 @@ describe('ProductsService', () => {
       stock: 10,
     };
     await expect(service.create(dto as Product)).resolves.toEqual({ id: 1, ...dto });
-    const { create, save } = repo;
     expect(create).toHaveBeenCalledWith(dto);
     expect(save).toHaveBeenCalled();
   });
 
   it('returns all products', async () => {
     await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
-    const { find } = repo;
     expect(find).toHaveBeenCalled();
   });
 
   it('returns a product by id', async () => {
     await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
-    const { findOne } = repo;
     expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 
@@ -65,14 +69,12 @@ describe('ProductsService', () => {
   it('updates a product', async () => {
     const dto: Partial<Product> = { name: 'New' };
     await expect(service.update(1, dto as Product)).resolves.toEqual({ id: 1 });
-    const { update } = repo;
     expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('removes a product', async () => {
     await service.remove(1);
-    const { delete: deleteFn } = repo;
-    expect(deleteFn).toHaveBeenCalledWith(1);
+    expect(remove).toHaveBeenCalledWith(1);
   });
 });
 

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -11,6 +11,12 @@ describe('ServicesService', () => {
     let service: ServicesService;
     let repo: jest.Mocked<Repository<Service>>;
     let serviceEntity: Service;
+    let create: jest.Mock;
+    let save: jest.Mock;
+    let find: jest.Mock;
+    let findOne: jest.Mock;
+    let update: jest.Mock;
+    let remove: jest.Mock;
 
     const mockRepository = () => ({
         create: jest
@@ -48,6 +54,7 @@ describe('ServicesService', () => {
 
         service = module.get<ServicesService>(ServicesService);
         repo = module.get(getRepositoryToken(Service));
+        ({ create, save, find, findOne, update, delete: remove } = repo);
     });
 
     it('creates a service', async () => {
@@ -59,7 +66,6 @@ describe('ServicesService', () => {
         };
         const callCreate = () => service.create(dto);
         await expect(callCreate()).resolves.toEqual(serviceEntity);
-        const { create, save } = repo;
         expect(create).toHaveBeenCalledWith(dto);
         expect(save).toHaveBeenCalled();
     });
@@ -67,14 +73,12 @@ describe('ServicesService', () => {
     it('returns all services', async () => {
         const callFindAll = () => service.findAll();
         await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-        const { find } = repo;
         expect(find).toHaveBeenCalled();
     });
 
     it('returns a service by id', async () => {
         const callFindOne = () => service.findOne(1);
         await expect(callFindOne()).resolves.toBe(serviceEntity);
-        const { findOne } = repo;
         expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
@@ -88,14 +92,12 @@ describe('ServicesService', () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const callUpdate = () => service.update(1, dto);
         await expect(callUpdate()).resolves.toBe(serviceEntity);
-        const { update } = repo;
         expect(update).toHaveBeenCalledWith(1, dto);
     });
 
     it('removes a service', async () => {
         const callRemove = () => service.remove(1);
         await expect(callRemove()).resolves.toBeUndefined();
-        const { delete: deleteFn } = repo;
-        expect(deleteFn).toHaveBeenCalledWith(1);
+        expect(remove).toHaveBeenCalledWith(1);
     });
 });

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -23,6 +23,12 @@ describe('UsersService', () => {
         create: jest.Mock;
         save: jest.Mock;
     };
+    let create: jest.Mock;
+    let save: jest.Mock;
+    let find: jest.Mock;
+    let findOne: jest.Mock;
+    let update: jest.Mock;
+    let remove: jest.Mock;
     let qb: {
         addSelect: jest.Mock;
         where: jest.Mock;
@@ -46,6 +52,7 @@ describe('UsersService', () => {
 
         service = module.get<UsersService>(UsersService);
         repo = module.get(getRepositoryToken(User));
+        ({ create, save, find, findOne, update, delete: remove } = repo);
         qb = {
             addSelect: jest.fn().mockReturnThis(),
             where: jest.fn().mockReturnThis(),
@@ -79,7 +86,6 @@ describe('UsersService', () => {
             const result = await service.createUser(dto);
 
             expect(bcryptMock.hash).toHaveBeenCalledWith(dto.password, 10);
-            const { create, save } = repo;
             expect(create).toHaveBeenCalledWith({
                 email: dto.email,
                 name: dto.name,


### PR DESCRIPTION
## Summary
- destructure repository methods in service tests
- assert against destructured repo methods

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c91aa46f4832996f868926aebfd93