### PR TITLE
test: destructure mocked service methods

### DIFF
--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -8,6 +8,11 @@ describe('ServicesController', () => {
   let controller: ServicesController;
   let service: jest.Mocked<ServicesService>;
   let serviceEntity: Service;
+  let findAll: jest.Mock;
+  let findOne: jest.Mock;
+  let create: jest.Mock;
+  let update: jest.Mock;
+  let remove: jest.Mock;
 
   beforeEach(() => {
     serviceEntity = {
@@ -27,21 +32,19 @@ describe('ServicesController', () => {
       update: jest.fn().mockResolvedValue(serviceEntity),
       remove: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ServicesService>;
-
+    ({ findAll, findOne, create, update, remove } = service);
     controller = new ServicesController(service);
   });
 
   it('delegates findAll to service', async () => {
     const callFindAll = () => controller.findAll();
     await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-    const { findAll } = service;
     expect(findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
     const callFindOne = () => controller.findOne(1);
     await expect(callFindOne()).resolves.toBe(serviceEntity);
-    const { findOne } = service;
     expect(findOne).toHaveBeenCalledWith(1);
   });
 
@@ -56,7 +59,6 @@ describe('ServicesController', () => {
     };
     const callCreate = () => controller.create(dto);
     await expect(callCreate()).resolves.toBe(serviceEntity);
-    const { create } = service;
     expect(create).toHaveBeenCalledWith(dto);
   });
 
@@ -64,14 +66,12 @@ describe('ServicesController', () => {
     const dto: UpdateServiceDto = { name: 'New' };
     const callUpdate = () => controller.update(1, dto);
     await expect(callUpdate()).resolves.toBe(serviceEntity);
-    const { update } = service;
     expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('delegates remove to service', async () => {
     const callRemove = () => controller.remove(1);
     await expect(callRemove()).resolves.toBeUndefined();
-    const { remove } = service;
     expect(remove).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- refactor service controller tests to destructure mock service methods

## Testing
- `cd backend/salonbw-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c958e3d788329954a9d0c00b08220