### PR TITLE
refactor: destructure repo methods in tests

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -35,7 +35,7 @@ describe('CommissionsService', () => {
     });
 
     it('creates a commission', async () => {
-        const { create, save, find } = repo;
+        const { create, save } = repo;
         await expect(service.create({ amount: 10 })).resolves.toEqual({
             id: 1,
             amount: 10,
@@ -66,7 +66,7 @@ describe('CommissionsService', () => {
     });
 
     it('finds commissions for user', async () => {
-        const { create, save, find } = repo;
+        const { find } = repo;
         await service.findForUser(2);
         expect(find).toHaveBeenCalledWith({
             where: { employee: { id: 2 } },
@@ -75,7 +75,7 @@ describe('CommissionsService', () => {
     });
 
     it('finds all commissions', async () => {
-        const { create, save, find } = repo;
+        const { find } = repo;
         await service.findAll();
         expect(find).toHaveBeenCalledWith({
             order: { createdAt: 'DESC' },

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -8,12 +8,6 @@ import { NotFoundException } from '@nestjs/common';
 describe('ProductsService', () => {
   let service: ProductsService;
   let repo: jest.Mocked<Repository<Product>>;
-  let create: jest.Mock;
-  let save: jest.Mock;
-  let find: jest.Mock;
-  let findOne: jest.Mock;
-  let update: jest.Mock;
-  let remove: jest.Mock;
 
   const mockRepository = () => ({
     create: jest.fn((dto: Partial<Product>) => dto as Product),
@@ -36,10 +30,10 @@ describe('ProductsService', () => {
 
     service = module.get<ProductsService>(ProductsService);
     repo = module.get(getRepositoryToken(Product));
-    ({ create, save, find, findOne, update, delete: remove } = repo);
   });
 
   it('creates a product', async () => {
+    const { create, save } = repo;
     const dto: Partial<Product> = {
       name: 'Shampoo',
       brand: 'Brand',
@@ -52,27 +46,32 @@ describe('ProductsService', () => {
   });
 
   it('returns all products', async () => {
+    const { find } = repo;
     await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
     expect(find).toHaveBeenCalled();
   });
 
   it('returns a product by id', async () => {
+    const { findOne } = repo;
     await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
     expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 
   it('throws when product not found', async () => {
-    repo.findOne.mockResolvedValue(null);
+    const { findOne } = repo;
+    findOne.mockResolvedValue(null);
     await expect(service.findOne(2)).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('updates a product', async () => {
+    const { update } = repo;
     const dto: Partial<Product> = { name: 'New' };
     await expect(service.update(1, dto as Product)).resolves.toEqual({ id: 1 });
     expect(update).toHaveBeenCalledWith(1, dto);
   });
 
   it('removes a product', async () => {
+    const { delete: remove } = repo;
     await service.remove(1);
     expect(remove).toHaveBeenCalledWith(1);
   });

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -11,12 +11,6 @@ describe('ServicesService', () => {
     let service: ServicesService;
     let repo: jest.Mocked<Repository<Service>>;
     let serviceEntity: Service;
-    let create: jest.Mock;
-    let save: jest.Mock;
-    let find: jest.Mock;
-    let findOne: jest.Mock;
-    let update: jest.Mock;
-    let remove: jest.Mock;
 
     const mockRepository = () => ({
         create: jest
@@ -54,10 +48,10 @@ describe('ServicesService', () => {
 
         service = module.get<ServicesService>(ServicesService);
         repo = module.get(getRepositoryToken(Service));
-        ({ create, save, find, findOne, update, delete: remove } = repo);
     });
 
     it('creates a service', async () => {
+        const { create, save } = repo;
         const dto = {
             name: 'Cut',
             description: 'Hair cut',
@@ -71,24 +65,28 @@ describe('ServicesService', () => {
     });
 
     it('returns all services', async () => {
+        const { find } = repo;
         const callFindAll = () => service.findAll();
         await expect(callFindAll()).resolves.toEqual([serviceEntity]);
         expect(find).toHaveBeenCalled();
     });
 
     it('returns a service by id', async () => {
+        const { findOne } = repo;
         const callFindOne = () => service.findOne(1);
         await expect(callFindOne()).resolves.toBe(serviceEntity);
         expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
     it('throws when service not found', async () => {
-        repo.findOne.mockResolvedValue(null);
+        const { findOne } = repo;
+        findOne.mockResolvedValue(null);
         const callFindOne = () => service.findOne(2);
         await expect(callFindOne()).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('updates a service', async () => {
+        const { update } = repo;
         const dto: UpdateServiceDto = { name: 'New' };
         const callUpdate = () => service.update(1, dto);
         await expect(callUpdate()).resolves.toBe(serviceEntity);
@@ -96,6 +94,7 @@ describe('ServicesService', () => {
     });
 
     it('removes a service', async () => {
+        const { delete: remove } = repo;
         const callRemove = () => service.remove(1);
         await expect(callRemove()).resolves.toBeUndefined();
         expect(remove).toHaveBeenCalledWith(1);

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -23,12 +23,6 @@ describe('UsersService', () => {
         create: jest.Mock;
         save: jest.Mock;
     };
-    let create: jest.Mock;
-    let save: jest.Mock;
-    let find: jest.Mock;
-    let findOne: jest.Mock;
-    let update: jest.Mock;
-    let remove: jest.Mock;
     let qb: {
         addSelect: jest.Mock;
         where: jest.Mock;
@@ -52,7 +46,6 @@ describe('UsersService', () => {
 
         service = module.get<UsersService>(UsersService);
         repo = module.get(getRepositoryToken(User));
-        ({ create, save, find, findOne, update, delete: remove } = repo);
         qb = {
             addSelect: jest.fn().mockReturnThis(),
             where: jest.fn().mockReturnThis(),
@@ -67,6 +60,7 @@ describe('UsersService', () => {
 
     describe('createUser', () => {
         it('hashes the password, sets default role and saves user', async () => {
+            const { create, save } = repo;
             const dto: CreateUserDto = {
                 email: 'test@example.com',
                 name: 'Test User',
@@ -80,8 +74,8 @@ describe('UsersService', () => {
                 password: 'hashedPass',
                 role: Role.Client,
             };
-            repo.create.mockReturnValue(created);
-            repo.save.mockResolvedValue({ ...created, id: 1 });
+            create.mockReturnValue(created);
+            save.mockResolvedValue({ ...created, id: 1 });
 
             const result = await service.createUser(dto);
 


### PR DESCRIPTION
## Summary
- destructure only required repository methods per test
- replace repo.* expectations with local variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9cc522f08329a9264e9a93deebe0