### PR TITLE
test: destructure service methods before expectations

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.service.spec.ts
+++ b/backend/salonbw-backend/src/auth/auth.service.spec.ts
@@ -58,7 +58,9 @@ describe('AuthService.validateUser', () => {
         usersService.findByEmail.mockResolvedValue(user);
         bcryptMock.compare.mockResolvedValue(true);
 
-        const result = await service.validateUser(
+        const { validateUser } = service;
+        const result = await validateUser.call(
+            service,
             'test@example.com',
             'password',
         );
@@ -78,8 +80,9 @@ describe('AuthService.validateUser', () => {
     it('throws UnauthorizedException if user not found', async () => {
         usersService.findByEmail.mockResolvedValue(null);
 
+        const { validateUser } = service;
         await expect(
-            service.validateUser('unknown@example.com', 'password'),
+            validateUser.call(service, 'unknown@example.com', 'password'),
         ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -94,8 +97,9 @@ describe('AuthService.validateUser', () => {
         usersService.findByEmail.mockResolvedValue(user);
         bcryptMock.compare.mockResolvedValue(false);
 
+        const { validateUser } = service;
         await expect(
-            service.validateUser('test@example.com', 'wrong'),
+            validateUser.call(service, 'test@example.com', 'wrong'),
         ).rejects.toThrow(UnauthorizedException);
     });
 });
@@ -127,7 +131,8 @@ describe('AuthService.login', () => {
             role: Role.Client,
         } as User;
 
-        const { access_token, refresh_token } = service.login(user);
+        const { login } = service;
+        const { access_token, refresh_token } = login.call(service, user);
 
         const accessPayload = jwt.verify(access_token, accessSecret) as jwt.JwtPayload;
         expect(accessPayload.sub).toBe(1);
@@ -171,8 +176,10 @@ describe('AuthService.refresh', () => {
         } as User;
         usersService.findById.mockResolvedValue(user);
 
-        const refreshToken = service.getRefreshToken(user);
-        const { access_token, refresh_token } = await service.refresh(
+        const { getRefreshToken, refresh } = service;
+        const refreshToken = getRefreshToken.call(service, user);
+        const { access_token, refresh_token } = await refresh.call(
+            service,
             refreshToken,
         );
 

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -35,12 +35,13 @@ describe('CommissionsService', () => {
     });
 
     it('creates a commission', async () => {
-        const { create, save } = repo;
-        await expect(service.create({ amount: 10 })).resolves.toEqual({
+        const { create: repoCreate, save } = repo;
+        const { create } = service;
+        await expect(create.call(service, { amount: 10 })).resolves.toEqual({
             id: 1,
             amount: 10,
         });
-        expect(create).toHaveBeenCalledWith({ amount: 10 });
+        expect(repoCreate).toHaveBeenCalledWith({ amount: 10 });
         expect(save).toHaveBeenCalled();
     });
 
@@ -59,15 +60,17 @@ describe('CommissionsService', () => {
         const spy = jest
             .spyOn(service, 'create')
             .mockImplementation(() => Promise.resolve(created));
-        await expect(service.createFromAppointment(appointment)).resolves.toBe(
-            created,
-        );
+        const { createFromAppointment } = service;
+        await expect(
+            createFromAppointment.call(service, appointment),
+        ).resolves.toBe(created);
         expect(spy).toHaveBeenCalledWith(expected);
     });
 
     it('finds commissions for user', async () => {
         const { find } = repo;
-        await service.findForUser(2);
+        const { findForUser } = service;
+        await findForUser.call(service, 2);
         expect(find).toHaveBeenCalledWith({
             where: { employee: { id: 2 } },
             order: { createdAt: 'DESC' },
@@ -76,7 +79,8 @@ describe('CommissionsService', () => {
 
     it('finds all commissions', async () => {
         const { find } = repo;
-        await service.findAll();
+        const { findAll } = service;
+        await findAll.call(service);
         expect(find).toHaveBeenCalledWith({
             order: { createdAt: 'DESC' },
         });

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -33,46 +33,59 @@ describe('ProductsService', () => {
   });
 
   it('creates a product', async () => {
-    const { create, save } = repo;
+    const { create: repoCreate, save } = repo;
+    const { create } = service;
     const dto: Partial<Product> = {
       name: 'Shampoo',
       brand: 'Brand',
       unitPrice: 5,
       stock: 10,
     };
-    await expect(service.create(dto as Product)).resolves.toEqual({ id: 1, ...dto });
-    expect(create).toHaveBeenCalledWith(dto);
+    await expect(create.call(service, dto as Product)).resolves.toEqual({
+      id: 1,
+      ...dto,
+    });
+    expect(repoCreate).toHaveBeenCalledWith(dto);
     expect(save).toHaveBeenCalled();
   });
 
   it('returns all products', async () => {
     const { find } = repo;
-    await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
+    const { findAll } = service;
+    await expect(findAll.call(service)).resolves.toEqual([{ id: 1 }]);
     expect(find).toHaveBeenCalled();
   });
 
   it('returns a product by id', async () => {
-    const { findOne } = repo;
-    await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
-    expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+    const { findOne: repoFindOne } = repo;
+    const { findOne } = service;
+    await expect(findOne.call(service, 1)).resolves.toEqual({ id: 1 });
+    expect(repoFindOne).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 
   it('throws when product not found', async () => {
-    const { findOne } = repo;
-    findOne.mockResolvedValue(null);
-    await expect(service.findOne(2)).rejects.toBeInstanceOf(NotFoundException);
+    const { findOne: repoFindOne } = repo;
+    const { findOne } = service;
+    repoFindOne.mockResolvedValue(null);
+    await expect(findOne.call(service, 2)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 
   it('updates a product', async () => {
-    const { update } = repo;
+    const { update: repoUpdate } = repo;
+    const { update } = service;
     const dto: Partial<Product> = { name: 'New' };
-    await expect(service.update(1, dto as Product)).resolves.toEqual({ id: 1 });
-    expect(update).toHaveBeenCalledWith(1, dto);
+    await expect(update.call(service, 1, dto as Product)).resolves.toEqual({
+      id: 1,
+    });
+    expect(repoUpdate).toHaveBeenCalledWith(1, dto);
   });
 
   it('removes a product', async () => {
     const { delete: remove } = repo;
-    await service.remove(1);
+    const { remove: removeProduct } = service;
+    await removeProduct.call(service, 1);
     expect(remove).toHaveBeenCalledWith(1);
   });
 });

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -51,51 +51,57 @@ describe('ServicesService', () => {
     });
 
     it('creates a service', async () => {
-        const { create, save } = repo;
+        const { create: repoCreate, save } = repo;
+        const { create } = service;
         const dto = {
             name: 'Cut',
             description: 'Hair cut',
             duration: 30,
             price: 10,
         };
-        const callCreate = () => service.create(dto);
+        const callCreate = () => create.call(service, dto);
         await expect(callCreate()).resolves.toEqual(serviceEntity);
-        expect(create).toHaveBeenCalledWith(dto);
+        expect(repoCreate).toHaveBeenCalledWith(dto);
         expect(save).toHaveBeenCalled();
     });
 
     it('returns all services', async () => {
         const { find } = repo;
-        const callFindAll = () => service.findAll();
+        const { findAll } = service;
+        const callFindAll = () => findAll.call(service);
         await expect(callFindAll()).resolves.toEqual([serviceEntity]);
         expect(find).toHaveBeenCalled();
     });
 
     it('returns a service by id', async () => {
-        const { findOne } = repo;
-        const callFindOne = () => service.findOne(1);
+        const { findOne: repoFindOne } = repo;
+        const { findOne } = service;
+        const callFindOne = () => findOne.call(service, 1);
         await expect(callFindOne()).resolves.toBe(serviceEntity);
-        expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+        expect(repoFindOne).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
     it('throws when service not found', async () => {
-        const { findOne } = repo;
-        findOne.mockResolvedValue(null);
-        const callFindOne = () => service.findOne(2);
+        const { findOne: repoFindOne } = repo;
+        const { findOne } = service;
+        repoFindOne.mockResolvedValue(null);
+        const callFindOne = () => findOne.call(service, 2);
         await expect(callFindOne()).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('updates a service', async () => {
-        const { update } = repo;
+        const { update: repoUpdate } = repo;
+        const { update } = service;
         const dto: UpdateServiceDto = { name: 'New' };
-        const callUpdate = () => service.update(1, dto);
+        const callUpdate = () => update.call(service, 1, dto);
         await expect(callUpdate()).resolves.toBe(serviceEntity);
-        expect(update).toHaveBeenCalledWith(1, dto);
+        expect(repoUpdate).toHaveBeenCalledWith(1, dto);
     });
 
     it('removes a service', async () => {
         const { delete: remove } = repo;
-        const callRemove = () => service.remove(1);
+        const { remove: removeService } = service;
+        const callRemove = () => removeService.call(service, 1);
         await expect(callRemove()).resolves.toBeUndefined();
         expect(remove).toHaveBeenCalledWith(1);
     });

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -77,7 +77,8 @@ describe('UsersService', () => {
             create.mockReturnValue(created);
             save.mockResolvedValue({ ...created, id: 1 });
 
-            const result = await service.createUser(dto);
+            const { createUser } = service;
+            const result = await createUser.call(service, dto);
 
             expect(bcryptMock.hash).toHaveBeenCalledWith(dto.password, 10);
             expect(create).toHaveBeenCalledWith({
@@ -97,7 +98,8 @@ describe('UsersService', () => {
             const user = { id: 1, email: 'known@example.com' } as User;
             qb.getOne.mockResolvedValue(user);
 
-            const result = await service.findByEmail('known@example.com');
+            const { findByEmail } = service;
+            const result = await findByEmail.call(service, 'known@example.com');
 
             expect(result).toEqual(user);
             expect(repo.createQueryBuilder).toHaveBeenCalledWith('user');
@@ -110,7 +112,11 @@ describe('UsersService', () => {
         it('returns null for unknown email', async () => {
             qb.getOne.mockResolvedValue(null);
 
-            const result = await service.findByEmail('unknown@example.com');
+            const { findByEmail } = service;
+            const result = await findByEmail.call(
+                service,
+                'unknown@example.com',
+            );
 
             expect(result).toBeNull();
             expect(repo.createQueryBuilder).toHaveBeenCalledWith('user');


### PR DESCRIPTION
## Summary
- destructure service methods before each assertion
- invoke destructured methods with correct context in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9ee82f74832991543b2288f44b2d