### PR TITLE
refactor: destructure service methods in tests

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -19,16 +19,16 @@ describe('CommissionsController', () => {
   });
 
   it('delegates findMine to service', async () => {
+    const { findForUser } = service;
     const findMine = (dto: { userId: number }) => controller.findMine(dto);
     await expect(findMine({ userId: 1 })).resolves.toEqual([mine]);
-    const { findForUser } = service;
     expect(findForUser).toHaveBeenCalledWith(1);
   });
 
   it('delegates findAll to service', async () => {
+    const { findAll: findAllSvc } = service;
     const findAll = () => controller.findAll();
     await expect(findAll()).resolves.toEqual([all]);
-    const { findAll: findAllSvc } = service;
     expect(findAllSvc).toHaveBeenCalled();
   });
 });

--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -8,11 +8,6 @@ describe('ProductsController', () => {
   let controller: ProductsController;
   let service: jest.Mocked<ProductsService>;
   let product: Product;
-  let findAll: jest.Mock;
-  let findOne: jest.Mock;
-  let create: jest.Mock;
-  let update: jest.Mock;
-  let remove: jest.Mock;
 
   beforeEach(() => {
     product = {
@@ -42,23 +37,25 @@ describe('ProductsController', () => {
         ),
       remove: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ProductsService>;
-    ({ findAll, findOne, create, update, remove } = service);
     controller = new ProductsController(service);
   });
 
   it('delegates findAll to service', async () => {
+    const { findAll } = service;
     const callFindAll = () => controller.findAll();
     await expect(callFindAll()).resolves.toEqual([product]);
     expect(findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
+    const { findOne } = service;
     const callFindOne = () => controller.findOne(1);
     await expect(callFindOne()).resolves.toBe(product);
     expect(findOne).toHaveBeenCalledWith(1);
   });
 
   it('delegates create to service', async () => {
+    const { create } = service;
     const dto: CreateProductDto = {
       name: 'Shampoo',
       brand: 'Brand',
@@ -71,6 +68,7 @@ describe('ProductsController', () => {
   });
 
   it('delegates update to service', async () => {
+    const { update } = service;
     const dto: UpdateProductDto = { name: 'New' };
     const updated = { ...product, ...dto };
     const callUpdate = () => controller.update(1, dto);
@@ -79,6 +77,7 @@ describe('ProductsController', () => {
   });
 
   it('delegates remove to service', async () => {
+    const { remove } = service;
     const callRemove = () => controller.remove(1);
     await expect(callRemove()).resolves.toBeUndefined();
     expect(remove).toHaveBeenCalledWith(1);

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -8,11 +8,6 @@ describe('ServicesController', () => {
   let controller: ServicesController;
   let service: jest.Mocked<ServicesService>;
   let serviceEntity: Service;
-  let findAll: jest.Mock;
-  let findOne: jest.Mock;
-  let create: jest.Mock;
-  let update: jest.Mock;
-  let remove: jest.Mock;
 
   beforeEach(() => {
     serviceEntity = {
@@ -32,23 +27,25 @@ describe('ServicesController', () => {
       update: jest.fn().mockResolvedValue(serviceEntity),
       remove: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ServicesService>;
-    ({ findAll, findOne, create, update, remove } = service);
     controller = new ServicesController(service);
   });
 
   it('delegates findAll to service', async () => {
+    const { findAll } = service;
     const callFindAll = () => controller.findAll();
     await expect(callFindAll()).resolves.toEqual([serviceEntity]);
     expect(findAll).toHaveBeenCalled();
   });
 
   it('delegates findOne to service', async () => {
+    const { findOne } = service;
     const callFindOne = () => controller.findOne(1);
     await expect(callFindOne()).resolves.toBe(serviceEntity);
     expect(findOne).toHaveBeenCalledWith(1);
   });
 
   it('delegates create to service', async () => {
+    const { create } = service;
     const dto: CreateServiceDto = {
       name: 'Cut',
       description: 'desc',
@@ -63,6 +60,7 @@ describe('ServicesController', () => {
   });
 
   it('delegates update to service', async () => {
+    const { update } = service;
     const dto: UpdateServiceDto = { name: 'New' };
     const callUpdate = () => controller.update(1, dto);
     await expect(callUpdate()).resolves.toBe(serviceEntity);
@@ -70,6 +68,7 @@ describe('ServicesController', () => {
   });
 
   it('delegates remove to service', async () => {
+    const { remove } = service;
     const callRemove = () => controller.remove(1);
     await expect(callRemove()).resolves.toBeUndefined();
     expect(remove).toHaveBeenCalledWith(1);


### PR DESCRIPTION
## Summary
- destructure mocked service methods within controller tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb47290e88329bdc955c2ceadc985