### PR TITLE
refactor: remove unused repo method destructures

### DIFF
--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -50,43 +50,38 @@ describe('ProductsService', () => {
   });
 
   it('returns all products', async () => {
-    const { find } = repo;
     const { findAll } = service;
     await expect(findAll.call(service)).resolves.toEqual([{ id: 1 }]);
-    expect(find).toHaveBeenCalled();
+    expect(repo.find).toHaveBeenCalled();
   });
 
   it('returns a product by id', async () => {
-    const { findOne: repoFindOne } = repo;
     const { findOne } = service;
     await expect(findOne.call(service, 1)).resolves.toEqual({ id: 1 });
-    expect(repoFindOne).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 
   it('throws when product not found', async () => {
-    const { findOne: repoFindOne } = repo;
     const { findOne } = service;
-    repoFindOne.mockResolvedValue(null);
+    repo.findOne.mockResolvedValue(null);
     await expect(findOne.call(service, 2)).rejects.toBeInstanceOf(
       NotFoundException,
     );
   });
 
   it('updates a product', async () => {
-    const { update: repoUpdate } = repo;
     const { update } = service;
     const dto: Partial<Product> = { name: 'New' };
     await expect(update.call(service, 1, dto as Product)).resolves.toEqual({
       id: 1,
     });
-    expect(repoUpdate).toHaveBeenCalledWith(1, dto);
+    expect(repo.update).toHaveBeenCalledWith(1, dto);
   });
 
   it('removes a product', async () => {
-    const { delete: remove } = repo;
     const { remove: removeProduct } = service;
     await removeProduct.call(service, 1);
-    expect(remove).toHaveBeenCalledWith(1);
+    expect(repo.delete).toHaveBeenCalledWith(1);
   });
 });
 

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -66,43 +66,38 @@ describe('ServicesService', () => {
     });
 
     it('returns all services', async () => {
-        const { find } = repo;
         const { findAll } = service;
         const callFindAll = () => findAll.call(service);
         await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-        expect(find).toHaveBeenCalled();
+        expect(repo.find).toHaveBeenCalled();
     });
 
     it('returns a service by id', async () => {
-        const { findOne: repoFindOne } = repo;
         const { findOne } = service;
         const callFindOne = () => findOne.call(service, 1);
         await expect(callFindOne()).resolves.toBe(serviceEntity);
-        expect(repoFindOne).toHaveBeenCalledWith({ where: { id: 1 } });
+        expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
     it('throws when service not found', async () => {
-        const { findOne: repoFindOne } = repo;
         const { findOne } = service;
-        repoFindOne.mockResolvedValue(null);
+        repo.findOne.mockResolvedValue(null);
         const callFindOne = () => findOne.call(service, 2);
         await expect(callFindOne()).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('updates a service', async () => {
-        const { update: repoUpdate } = repo;
         const { update } = service;
         const dto: UpdateServiceDto = { name: 'New' };
         const callUpdate = () => update.call(service, 1, dto);
         await expect(callUpdate()).resolves.toBe(serviceEntity);
-        expect(repoUpdate).toHaveBeenCalledWith(1, dto);
+        expect(repo.update).toHaveBeenCalledWith(1, dto);
     });
 
     it('removes a service', async () => {
-        const { delete: remove } = repo;
         const { remove: removeService } = service;
         const callRemove = () => removeService.call(service, 1);
         await expect(callRemove()).resolves.toBeUndefined();
-        expect(remove).toHaveBeenCalledWith(1);
+        expect(repo.delete).toHaveBeenCalledWith(1);
     });
 });


### PR DESCRIPTION
## Summary
- avoid unused repository method destructuring in service tests
- assert on repository methods directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc74a77188329afe2ddedd1c5dfb7