### PR TITLE
refactor: bind service methods in specs

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -159,8 +159,7 @@ describe('AppointmentsService', () => {
 
     it('should create an appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { create } = service;
-        const result = await create.call(service, {
+        const result = await service.create({
             client: users[0],
             employee: users[1],
             service: services[0],
@@ -174,8 +173,7 @@ describe('AppointmentsService', () => {
 
     it('should reject overlapping appointments', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { create } = service;
-        await create.call(service, {
+        await service.create({
             client: users[0],
             employee: users[1],
             service: services[0],
@@ -184,7 +182,7 @@ describe('AppointmentsService', () => {
 
         const overlap = new Date(start.getTime() + 15 * 60 * 1000);
         await expect(
-            create.call(service, {
+            service.create({
                 client: users[0],
                 employee: users[1],
                 service: services[0],
@@ -195,63 +193,59 @@ describe('AppointmentsService', () => {
 
     it('should cancel a scheduled appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { create, cancel } = service;
-        const { id } = await create.call(service, {
+        const { id } = await service.create({
             client: users[0],
             employee: users[1],
             service: services[0],
             startTime: start,
         });
 
-        const cancelled = await cancel.call(service, id);
+        const cancelled = await service.cancel(id);
         expect(cancelled?.status).toBe(AppointmentStatus.Cancelled);
     });
 
     it('should not cancel a completed appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { create, cancel, completeAppointment } = service;
-        const { id } = await create.call(service, {
+        const { id } = await service.create({
             client: users[0],
             employee: users[1],
             service: services[0],
             startTime: start,
         });
 
-        await completeAppointment.call(service, id);
-        await expect(cancel.call(service, id)).rejects.toBeInstanceOf(
+        await service.completeAppointment(id);
+        await expect(service.cancel(id)).rejects.toBeInstanceOf(
             BadRequestException,
         );
     });
 
     it('should not cancel an already cancelled appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { create, cancel } = service;
-        const { id } = await create.call(service, {
+        const { id } = await service.create({
             client: users[0],
             employee: users[1],
             service: services[0],
             startTime: start,
         });
 
-        await cancel.call(service, id);
-        await expect(cancel.call(service, id)).rejects.toBeInstanceOf(
+        await service.cancel(id);
+        await expect(service.cancel(id)).rejects.toBeInstanceOf(
             BadRequestException,
         );
     });
 
     it('should not complete a cancelled appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { create, cancel, completeAppointment } = service;
-        const { id } = await create.call(service, {
+        const { id } = await service.create({
             client: users[0],
             employee: users[1],
             service: services[0],
             startTime: start,
         });
 
-        await cancel.call(service, id);
-        await expect(
-            completeAppointment.call(service, id),
-        ).rejects.toBeInstanceOf(BadRequestException);
+        await service.cancel(id);
+        await expect(service.completeAppointment(id)).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
     });
 });

--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -3,33 +3,32 @@ import { CommissionsService } from './commissions.service';
 import { Commission } from './commission.entity';
 
 describe('CommissionsController', () => {
-  let controller: CommissionsController;
-  let service: jest.Mocked<CommissionsService>;
-  let mine: Commission;
-  let all: Commission;
+    let controller: CommissionsController;
+    let service: jest.Mocked<CommissionsService>;
+    let mine: Commission;
+    let all: Commission;
 
-  beforeEach(() => {
-    mine = {} as Commission;
-    all = {} as Commission;
-    service = {
-      findForUser: jest.fn().mockResolvedValue([mine]),
-      findAll: jest.fn().mockResolvedValue([all]),
-    } as unknown as jest.Mocked<CommissionsService>;
-    controller = new CommissionsController(service);
-  });
+    beforeEach(() => {
+        mine = {} as Commission;
+        all = {} as Commission;
+        service = {
+            findForUser: jest.fn().mockResolvedValue([mine]),
+            findAll: jest.fn().mockResolvedValue([all]),
+        } as unknown as jest.Mocked<CommissionsService>;
+        controller = new CommissionsController(service);
+    });
 
-  it('delegates findMine to service', async () => {
-    const { findForUser } = service;
-    const findMine = (dto: { userId: number }) => controller.findMine(dto);
-    await expect(findMine({ userId: 1 })).resolves.toEqual([mine]);
-    expect(findForUser).toHaveBeenCalledWith(1);
-  });
+    it('delegates findMine to service', async () => {
+        const findForUserSpy = jest.spyOn(service, 'findForUser');
+        await expect(controller.findMine({ userId: 1 })).resolves.toEqual([
+            mine,
+        ]);
+        expect(findForUserSpy).toHaveBeenCalledWith(1);
+    });
 
-  it('delegates findAll to service', async () => {
-    const { findAll: findAllSvc } = service;
-    const findAll = () => controller.findAll();
-    await expect(findAll()).resolves.toEqual([all]);
-    expect(findAllSvc).toHaveBeenCalled();
-  });
+    it('delegates findAll to service', async () => {
+        const findAllSpy = jest.spyOn(service, 'findAll');
+        await expect(controller.findAll()).resolves.toEqual([all]);
+        expect(findAllSpy).toHaveBeenCalled();
+    });
 });
-

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -35,14 +35,14 @@ describe('CommissionsService', () => {
     });
 
     it('creates a commission', async () => {
-        const { create: repoCreate, save } = repo;
-        const { create } = service;
-        await expect(create.call(service, { amount: 10 })).resolves.toEqual({
+        const createSpy = jest.spyOn(repo, 'create');
+        const saveSpy = jest.spyOn(repo, 'save');
+        await expect(service.create({ amount: 10 })).resolves.toEqual({
             id: 1,
             amount: 10,
         });
-        expect(repoCreate).toHaveBeenCalledWith({ amount: 10 });
-        expect(save).toHaveBeenCalled();
+        expect(createSpy).toHaveBeenCalledWith({ amount: 10 });
+        expect(saveSpy).toHaveBeenCalled();
     });
 
     it('creates commission from appointment', async () => {
@@ -60,28 +60,25 @@ describe('CommissionsService', () => {
         const spy = jest
             .spyOn(service, 'create')
             .mockImplementation(() => Promise.resolve(created));
-        const { createFromAppointment } = service;
-        await expect(
-            createFromAppointment.call(service, appointment),
-        ).resolves.toBe(created);
+        await expect(service.createFromAppointment(appointment)).resolves.toBe(
+            created,
+        );
         expect(spy).toHaveBeenCalledWith(expected);
     });
 
     it('finds commissions for user', async () => {
-        const { find } = repo;
-        const { findForUser } = service;
-        await findForUser.call(service, 2);
-        expect(find).toHaveBeenCalledWith({
+        const findSpy = jest.spyOn(repo, 'find');
+        await service.findForUser(2);
+        expect(findSpy).toHaveBeenCalledWith({
             where: { employee: { id: 2 } },
             order: { createdAt: 'DESC' },
         });
     });
 
     it('finds all commissions', async () => {
-        const { find } = repo;
-        const { findAll } = service;
-        await findAll.call(service);
-        expect(find).toHaveBeenCalledWith({
+        const findSpy = jest.spyOn(repo, 'find');
+        await service.findAll();
+        expect(findSpy).toHaveBeenCalledWith({
             order: { createdAt: 'DESC' },
         });
     });

--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -5,82 +5,79 @@ import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 
 describe('ProductsController', () => {
-  let controller: ProductsController;
-  let service: jest.Mocked<ProductsService>;
-  let product: Product;
+    let controller: ProductsController;
+    let service: jest.Mocked<ProductsService>;
+    let product: Product;
 
-  beforeEach(() => {
-    product = {
-      id: 1,
-      name: 'Shampoo',
-      brand: 'Brand',
-      unitPrice: 10,
-      stock: 5,
-    };
+    beforeEach(() => {
+        product = {
+            id: 1,
+            name: 'Shampoo',
+            brand: 'Brand',
+            unitPrice: 10,
+            stock: 5,
+        };
 
-    service = {
-      findAll: jest.fn().mockResolvedValue([product]),
-      findOne: jest.fn().mockResolvedValue(product),
-      create: jest
-        .fn()
-        .mockImplementation((dto: CreateProductDto) =>
-          Promise.resolve({ id: 1, ...dto }),
-        ),
-      update: jest
-        .fn()
-        .mockImplementation((id: number, dto: UpdateProductDto) =>
-          Promise.resolve({
-            ...product,
+        service = {
+            findAll: jest.fn().mockResolvedValue([product]),
+            findOne: jest.fn().mockResolvedValue(product),
+            create: jest
+                .fn()
+                .mockImplementation((dto: CreateProductDto) =>
+                    Promise.resolve({ id: 1, ...dto }),
+                ),
+            update: jest
+                .fn()
+                .mockImplementation((id: number, dto: UpdateProductDto) =>
+                    Promise.resolve({
+                        ...product,
+                        ...dto,
+                        id,
+                    }),
+                ),
+            remove: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<ProductsService>;
+        controller = new ProductsController(service);
+    });
+
+    it('delegates findAll to service', async () => {
+        const findAllSpy = jest.spyOn(service, 'findAll');
+        await expect(controller.findAll()).resolves.toEqual([product]);
+        expect(findAllSpy).toHaveBeenCalled();
+    });
+
+    it('delegates findOne to service', async () => {
+        const findOneSpy = jest.spyOn(service, 'findOne');
+        await expect(controller.findOne(1)).resolves.toBe(product);
+        expect(findOneSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('delegates create to service', async () => {
+        const dto: CreateProductDto = {
+            name: 'Shampoo',
+            brand: 'Brand',
+            unitPrice: 10,
+            stock: 5,
+        };
+        const createSpy = jest.spyOn(service, 'create');
+        await expect(controller.create(dto)).resolves.toEqual({
+            id: 1,
             ...dto,
-            id,
-          }),
-        ),
-      remove: jest.fn().mockResolvedValue(undefined),
-    } as unknown as jest.Mocked<ProductsService>;
-    controller = new ProductsController(service);
-  });
+        });
+        expect(createSpy).toHaveBeenCalledWith(dto);
+    });
 
-  it('delegates findAll to service', async () => {
-    const { findAll } = service;
-    const callFindAll = () => controller.findAll();
-    await expect(callFindAll()).resolves.toEqual([product]);
-    expect(findAll).toHaveBeenCalled();
-  });
+    it('delegates update to service', async () => {
+        const dto: UpdateProductDto = { name: 'New' };
+        const updated = { ...product, ...dto };
+        const updateSpy = jest.spyOn(service, 'update');
+        await expect(controller.update(1, dto)).resolves.toEqual(updated);
+        expect(updateSpy).toHaveBeenCalledWith(1, dto);
+    });
 
-  it('delegates findOne to service', async () => {
-    const { findOne } = service;
-    const callFindOne = () => controller.findOne(1);
-    await expect(callFindOne()).resolves.toBe(product);
-    expect(findOne).toHaveBeenCalledWith(1);
-  });
-
-  it('delegates create to service', async () => {
-    const { create } = service;
-    const dto: CreateProductDto = {
-      name: 'Shampoo',
-      brand: 'Brand',
-      unitPrice: 10,
-      stock: 5,
-    };
-    const callCreate = () => controller.create(dto);
-    await expect(callCreate()).resolves.toEqual({ id: 1, ...dto });
-    expect(create).toHaveBeenCalledWith(dto);
-  });
-
-  it('delegates update to service', async () => {
-    const { update } = service;
-    const dto: UpdateProductDto = { name: 'New' };
-    const updated = { ...product, ...dto };
-    const callUpdate = () => controller.update(1, dto);
-    await expect(callUpdate()).resolves.toEqual(updated);
-    expect(update).toHaveBeenCalledWith(1, dto);
-  });
-
-  it('delegates remove to service', async () => {
-    const { remove } = service;
-    const callRemove = () => controller.remove(1);
-    await expect(callRemove()).resolves.toBeUndefined();
-    expect(remove).toHaveBeenCalledWith(1);
-  });
+    it('delegates remove to service', async () => {
+        const removeSpy = jest.spyOn(service, 'remove');
+        await expect(controller.remove(1)).resolves.toBeUndefined();
+        expect(removeSpy).toHaveBeenCalledWith(1);
+    });
 });
-

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -6,82 +6,84 @@ import { Product } from './product.entity';
 import { NotFoundException } from '@nestjs/common';
 
 describe('ProductsService', () => {
-  let service: ProductsService;
-  let repo: jest.Mocked<Repository<Product>>;
+    let service: ProductsService;
+    let repo: jest.Mocked<Repository<Product>>;
 
-  const mockRepository = () => ({
-    create: jest.fn((dto: Partial<Product>) => dto as Product),
-    save: jest.fn((entity: Product) =>
-      Promise.resolve({ id: 1, ...entity } as Product),
-    ),
-    find: jest.fn(() => Promise.resolve([{ id: 1 } as Product])),
-    findOne: jest.fn(() => Promise.resolve({ id: 1 } as Product)),
-    update: jest.fn(() => Promise.resolve(undefined)),
-    delete: jest.fn(() => Promise.resolve(undefined)),
-  });
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ProductsService,
-        { provide: getRepositoryToken(Product), useValue: mockRepository() },
-      ],
-    }).compile();
-
-    service = module.get<ProductsService>(ProductsService);
-    repo = module.get(getRepositoryToken(Product));
-  });
-
-  it('creates a product', async () => {
-    const { create: repoCreate, save } = repo;
-    const { create } = service;
-    const dto: Partial<Product> = {
-      name: 'Shampoo',
-      brand: 'Brand',
-      unitPrice: 5,
-      stock: 10,
-    };
-    await expect(create.call(service, dto as Product)).resolves.toEqual({
-      id: 1,
-      ...dto,
+    const mockRepository = () => ({
+        create: jest.fn((dto: Partial<Product>) => dto as Product),
+        save: jest.fn((entity: Product) =>
+            Promise.resolve({ id: 1, ...entity } as Product),
+        ),
+        find: jest.fn(() => Promise.resolve([{ id: 1 } as Product])),
+        findOne: jest.fn(() => Promise.resolve({ id: 1 } as Product)),
+        update: jest.fn(() => Promise.resolve(undefined)),
+        delete: jest.fn(() => Promise.resolve(undefined)),
     });
-    expect(repoCreate).toHaveBeenCalledWith(dto);
-    expect(save).toHaveBeenCalled();
-  });
 
-  it('returns all products', async () => {
-    const { findAll } = service;
-    await expect(findAll.call(service)).resolves.toEqual([{ id: 1 }]);
-    expect(repo.find).toHaveBeenCalled();
-  });
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ProductsService,
+                {
+                    provide: getRepositoryToken(Product),
+                    useValue: mockRepository(),
+                },
+            ],
+        }).compile();
 
-  it('returns a product by id', async () => {
-    const { findOne } = service;
-    await expect(findOne.call(service, 1)).resolves.toEqual({ id: 1 });
-    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
-  });
-
-  it('throws when product not found', async () => {
-    const { findOne } = service;
-    repo.findOne.mockResolvedValue(null);
-    await expect(findOne.call(service, 2)).rejects.toBeInstanceOf(
-      NotFoundException,
-    );
-  });
-
-  it('updates a product', async () => {
-    const { update } = service;
-    const dto: Partial<Product> = { name: 'New' };
-    await expect(update.call(service, 1, dto as Product)).resolves.toEqual({
-      id: 1,
+        service = module.get<ProductsService>(ProductsService);
+        repo = module.get(getRepositoryToken(Product));
     });
-    expect(repo.update).toHaveBeenCalledWith(1, dto);
-  });
 
-  it('removes a product', async () => {
-    const { remove: removeProduct } = service;
-    await removeProduct.call(service, 1);
-    expect(repo.delete).toHaveBeenCalledWith(1);
-  });
+    it('creates a product', async () => {
+        const dto: Partial<Product> = {
+            name: 'Shampoo',
+            brand: 'Brand',
+            unitPrice: 5,
+            stock: 10,
+        };
+        const createSpy = jest.spyOn(repo, 'create');
+        const saveSpy = jest.spyOn(repo, 'save');
+        await expect(service.create(dto as Product)).resolves.toEqual({
+            id: 1,
+            ...dto,
+        });
+        expect(createSpy).toHaveBeenCalledWith(dto);
+        expect(saveSpy).toHaveBeenCalled();
+    });
+
+    it('returns all products', async () => {
+        const findSpy = jest.spyOn(repo, 'find');
+        await expect(service.findAll()).resolves.toEqual([{ id: 1 }]);
+        expect(findSpy).toHaveBeenCalled();
+    });
+
+    it('returns a product by id', async () => {
+        const findOneSpy = jest.spyOn(repo, 'findOne');
+        await expect(service.findOne(1)).resolves.toEqual({ id: 1 });
+        expect(findOneSpy).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
+
+    it('throws when product not found', async () => {
+        const findOneSpy = jest.spyOn(repo, 'findOne').mockResolvedValue(null);
+        await expect(service.findOne(2)).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(findOneSpy).toHaveBeenCalledWith({ where: { id: 2 } });
+    });
+
+    it('updates a product', async () => {
+        const dto: Partial<Product> = { name: 'New' };
+        const updateSpy = jest.spyOn(repo, 'update');
+        await expect(service.update(1, dto as Product)).resolves.toEqual({
+            id: 1,
+        });
+        expect(updateSpy).toHaveBeenCalledWith(1, dto);
+    });
+
+    it('removes a product', async () => {
+        const deleteSpy = jest.spyOn(repo, 'delete');
+        await service.remove(1);
+        expect(deleteSpy).toHaveBeenCalledWith(1);
+    });
 });
-

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -5,73 +5,67 @@ import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
 
 describe('ServicesController', () => {
-  let controller: ServicesController;
-  let service: jest.Mocked<ServicesService>;
-  let serviceEntity: Service;
+    let controller: ServicesController;
+    let service: jest.Mocked<ServicesService>;
+    let serviceEntity: Service;
 
-  beforeEach(() => {
-    serviceEntity = {
-      id: 1,
-      name: 'Cut',
-      description: 'desc',
-      duration: 30,
-      price: 50,
-      category: 'Hair',
-      commissionPercent: 10,
-    };
+    beforeEach(() => {
+        serviceEntity = {
+            id: 1,
+            name: 'Cut',
+            description: 'desc',
+            duration: 30,
+            price: 50,
+            category: 'Hair',
+            commissionPercent: 10,
+        };
 
-    service = {
-      findAll: jest.fn().mockResolvedValue([serviceEntity]),
-      findOne: jest.fn().mockResolvedValue(serviceEntity),
-      create: jest.fn().mockResolvedValue(serviceEntity),
-      update: jest.fn().mockResolvedValue(serviceEntity),
-      remove: jest.fn().mockResolvedValue(undefined),
-    } as unknown as jest.Mocked<ServicesService>;
-    controller = new ServicesController(service);
-  });
+        service = {
+            findAll: jest.fn().mockResolvedValue([serviceEntity]),
+            findOne: jest.fn().mockResolvedValue(serviceEntity),
+            create: jest.fn().mockResolvedValue(serviceEntity),
+            update: jest.fn().mockResolvedValue(serviceEntity),
+            remove: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<ServicesService>;
+        controller = new ServicesController(service);
+    });
 
-  it('delegates findAll to service', async () => {
-    const { findAll } = service;
-    const callFindAll = () => controller.findAll();
-    await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-    expect(findAll).toHaveBeenCalled();
-  });
+    it('delegates findAll to service', async () => {
+        const findAllSpy = jest.spyOn(service, 'findAll');
+        await expect(controller.findAll()).resolves.toEqual([serviceEntity]);
+        expect(findAllSpy).toHaveBeenCalled();
+    });
 
-  it('delegates findOne to service', async () => {
-    const { findOne } = service;
-    const callFindOne = () => controller.findOne(1);
-    await expect(callFindOne()).resolves.toBe(serviceEntity);
-    expect(findOne).toHaveBeenCalledWith(1);
-  });
+    it('delegates findOne to service', async () => {
+        const findOneSpy = jest.spyOn(service, 'findOne');
+        await expect(controller.findOne(1)).resolves.toBe(serviceEntity);
+        expect(findOneSpy).toHaveBeenCalledWith(1);
+    });
 
-  it('delegates create to service', async () => {
-    const { create } = service;
-    const dto: CreateServiceDto = {
-      name: 'Cut',
-      description: 'desc',
-      duration: 30,
-      price: 50,
-      category: 'Hair',
-      commissionPercent: 10,
-    };
-    const callCreate = () => controller.create(dto);
-    await expect(callCreate()).resolves.toBe(serviceEntity);
-    expect(create).toHaveBeenCalledWith(dto);
-  });
+    it('delegates create to service', async () => {
+        const dto: CreateServiceDto = {
+            name: 'Cut',
+            description: 'desc',
+            duration: 30,
+            price: 50,
+            category: 'Hair',
+            commissionPercent: 10,
+        };
+        const createSpy = jest.spyOn(service, 'create');
+        await expect(controller.create(dto)).resolves.toBe(serviceEntity);
+        expect(createSpy).toHaveBeenCalledWith(dto);
+    });
 
-  it('delegates update to service', async () => {
-    const { update } = service;
-    const dto: UpdateServiceDto = { name: 'New' };
-    const callUpdate = () => controller.update(1, dto);
-    await expect(callUpdate()).resolves.toBe(serviceEntity);
-    expect(update).toHaveBeenCalledWith(1, dto);
-  });
+    it('delegates update to service', async () => {
+        const dto: UpdateServiceDto = { name: 'New' };
+        const updateSpy = jest.spyOn(service, 'update');
+        await expect(controller.update(1, dto)).resolves.toBe(serviceEntity);
+        expect(updateSpy).toHaveBeenCalledWith(1, dto);
+    });
 
-  it('delegates remove to service', async () => {
-    const { remove } = service;
-    const callRemove = () => controller.remove(1);
-    await expect(callRemove()).resolves.toBeUndefined();
-    expect(remove).toHaveBeenCalledWith(1);
-  });
+    it('delegates remove to service', async () => {
+        const removeSpy = jest.spyOn(service, 'remove');
+        await expect(controller.remove(1)).resolves.toBeUndefined();
+        expect(removeSpy).toHaveBeenCalledWith(1);
+    });
 });
-

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -51,53 +50,49 @@ describe('ServicesService', () => {
     });
 
     it('creates a service', async () => {
-        const { create: repoCreate, save } = repo;
-        const { create } = service;
         const dto = {
             name: 'Cut',
             description: 'Hair cut',
             duration: 30,
             price: 10,
         };
-        const callCreate = () => create.call(service, dto);
-        await expect(callCreate()).resolves.toEqual(serviceEntity);
-        expect(repoCreate).toHaveBeenCalledWith(dto);
-        expect(save).toHaveBeenCalled();
+        const createSpy = jest.spyOn(repo, 'create');
+        const saveSpy = jest.spyOn(repo, 'save');
+        await expect(service.create(dto)).resolves.toEqual(serviceEntity);
+        expect(createSpy).toHaveBeenCalledWith(dto);
+        expect(saveSpy).toHaveBeenCalled();
     });
 
     it('returns all services', async () => {
-        const { findAll } = service;
-        const callFindAll = () => findAll.call(service);
-        await expect(callFindAll()).resolves.toEqual([serviceEntity]);
-        expect(repo.find).toHaveBeenCalled();
+        const findSpy = jest.spyOn(repo, 'find');
+        await expect(service.findAll()).resolves.toEqual([serviceEntity]);
+        expect(findSpy).toHaveBeenCalled();
     });
 
     it('returns a service by id', async () => {
-        const { findOne } = service;
-        const callFindOne = () => findOne.call(service, 1);
-        await expect(callFindOne()).resolves.toBe(serviceEntity);
-        expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+        const findOneSpy = jest.spyOn(repo, 'findOne');
+        await expect(service.findOne(1)).resolves.toBe(serviceEntity);
+        expect(findOneSpy).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
     it('throws when service not found', async () => {
-        const { findOne } = service;
-        repo.findOne.mockResolvedValue(null);
-        const callFindOne = () => findOne.call(service, 2);
-        await expect(callFindOne()).rejects.toBeInstanceOf(NotFoundException);
+        const findOneSpy = jest.spyOn(repo, 'findOne').mockResolvedValue(null);
+        await expect(service.findOne(2)).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(findOneSpy).toHaveBeenCalledWith({ where: { id: 2 } });
     });
 
     it('updates a service', async () => {
-        const { update } = service;
         const dto: UpdateServiceDto = { name: 'New' };
-        const callUpdate = () => update.call(service, 1, dto);
-        await expect(callUpdate()).resolves.toBe(serviceEntity);
-        expect(repo.update).toHaveBeenCalledWith(1, dto);
+        const updateSpy = jest.spyOn(repo, 'update');
+        await expect(service.update(1, dto)).resolves.toBe(serviceEntity);
+        expect(updateSpy).toHaveBeenCalledWith(1, dto);
     });
 
     it('removes a service', async () => {
-        const { remove: removeService } = service;
-        const callRemove = () => removeService.call(service, 1);
-        await expect(callRemove()).resolves.toBeUndefined();
-        expect(repo.delete).toHaveBeenCalledWith(1);
+        const deleteSpy = jest.spyOn(repo, 'delete');
+        await expect(service.remove(1)).resolves.toBeUndefined();
+        expect(deleteSpy).toHaveBeenCalledWith(1);
     });
 });


### PR DESCRIPTION
## Summary
- replace unbound service and repository method references in specs with direct calls or bound spies
- add jest.spyOn usage for assertions to satisfy `@typescript-eslint/unbound-method`

## Testing
- `cd backend/salonbw-backend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ce22c5c7c8329aada97c9a18da412