### PR TITLE
test: tighten types in specs

### DIFF
--- a/backend/salonbw-backend/src/auth/roles.guard.spec.ts
+++ b/backend/salonbw-backend/src/auth/roles.guard.spec.ts
@@ -26,7 +26,7 @@ describe('RolesGuard', () => {
             switchToHttp: () => ({ getRequest: () => request }),
             getHandler: () => ({}),
             getClass: () => ({}),
-        } as unknown as ExecutionContext;
+        } as Partial<ExecutionContext> as ExecutionContext;
     };
 
     it('throws UnauthorizedException if no user is present', () => {

--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -9,12 +9,12 @@ describe('CommissionsController', () => {
     let all: Commission;
 
     beforeEach(() => {
-        mine = {} as Commission;
-        all = {} as Commission;
+        mine = { id: 1 } as Commission;
+        all = { id: 2 } as Commission;
         service = {
             findForUser: jest.fn().mockResolvedValue([mine]),
             findAll: jest.fn().mockResolvedValue([all]),
-        } as unknown as jest.Mocked<CommissionsService>;
+        } as jest.Mocked<CommissionsService>;
         controller = new CommissionsController(service);
     });
 

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -10,13 +10,15 @@ describe('CommissionsService', () => {
     let repo: jest.Mocked<Repository<Commission>>;
 
     const mockRepository = () => ({
-        create: jest.fn().mockImplementation((dto) => dto as Commission),
+        create: jest.fn<Commission, [Partial<Commission>]>(
+            (dto) => dto as Commission,
+        ),
         save: jest
-            .fn()
-            .mockImplementation((entity: Commission) =>
+            .fn<Promise<Commission>, [Commission]>()
+            .mockImplementation((entity) =>
                 Promise.resolve({ id: 1, ...entity }),
             ),
-        find: jest.fn().mockResolvedValue([] as Commission[]),
+        find: jest.fn<Promise<Commission[]>, []>().mockResolvedValue([]),
     });
 
     beforeEach(async () => {
@@ -49,7 +51,7 @@ describe('CommissionsService', () => {
         const appointment = {
             service: { price: 100, commissionPercent: 10 },
             employee: { id: 1 },
-        } as unknown as Appointment;
+        } as Appointment;
         const expected = {
             employee: appointment.employee,
             appointment,

--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -23,20 +23,20 @@ describe('ProductsController', () => {
             findOne: jest.fn().mockResolvedValue(product),
             create: jest
                 .fn()
-                .mockImplementation((dto: CreateProductDto) =>
-                    Promise.resolve({ id: 1, ...dto }),
+                .mockImplementation(
+                    (dto: CreateProductDto): Promise<Product> =>
+                        Promise.resolve({ id: 1, ...dto }),
                 ),
-            update: jest
-                .fn()
-                .mockImplementation((id: number, dto: UpdateProductDto) =>
+            update: jest.fn().mockImplementation(
+                (id: number, dto: UpdateProductDto): Promise<Product> =>
                     Promise.resolve({
                         ...product,
                         ...dto,
                         id,
                     }),
-                ),
+            ),
             remove: jest.fn().mockResolvedValue(undefined),
-        } as unknown as jest.Mocked<ProductsService>;
+        } as jest.Mocked<ProductsService>;
         controller = new ProductsController(service);
     });
 

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -26,7 +26,7 @@ describe('ServicesController', () => {
             create: jest.fn().mockResolvedValue(serviceEntity),
             update: jest.fn().mockResolvedValue(serviceEntity),
             remove: jest.fn().mockResolvedValue(undefined),
-        } as unknown as jest.Mocked<ServicesService>;
+        } as jest.Mocked<ServicesService>;
         controller = new ServicesController(service);
     });
 

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -10,11 +10,7 @@ jest.mock('bcrypt', () => ({
     hash: jest.fn(),
 }));
 
-type BcryptMock = {
-    hash: jest.Mock;
-};
-
-const bcryptMock: BcryptMock = bcrypt as unknown as BcryptMock;
+const bcryptMock = jest.mocked(bcrypt);
 
 describe('UsersService', () => {
     let service: UsersService;

--- a/backend/salonbw-backend/test/app.e2e-spec.ts
+++ b/backend/salonbw-backend/test/app.e2e-spec.ts
@@ -25,9 +25,7 @@ describe('Health (e2e)', () => {
     });
 
     it('/health (GET)', () => {
-        const server = app.getHttpServer() as unknown as Parameters<
-            typeof request
-        >[0];
+        const server = app.getHttpServer() as Parameters<typeof request>[0];
         return request(server)
             .get('/health')
             .expect(200)

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -42,7 +42,7 @@ declare global {
 // polyfill for msw/node
 
 global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder as unknown as typeof global.TextDecoder;
+global.TextDecoder = TextDecoder as typeof global.TextDecoder;
 global.ReadableStream = ReadableStream;
 global.WritableStream = WritableStream;
 global.TransformStream = TransformStream;
@@ -78,7 +78,7 @@ global.matchMedia = ((query: string) => ({
   matches: false,
   addEventListener: () => {},
   removeEventListener: () => {},
-})) as unknown as typeof globalThis.matchMedia;
+})) as typeof globalThis.matchMedia;
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),


### PR DESCRIPTION
## Summary
- replace unknown casts with typed mocks across backend specs
- strengthen repository mocks to match entity return types
- remove unknown assertions in frontend Jest setup

## Testing
- `npm run lint` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689ce4c9da9c83299eeada7ed408ffd3