### PR TITLE
test: type repository mocks

### DIFF
--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -7,17 +7,23 @@ import { NotFoundException } from '@nestjs/common';
 
 describe('ProductsService', () => {
     let service: ProductsService;
-    let repo: jest.Mocked<Repository<Product>>;
+    let repo: jest.Mocked<Partial<Repository<Product>>>;
 
-    const mockRepository = () => ({
-        create: jest.fn((dto: Partial<Product>) => dto as Product),
-        save: jest.fn((entity: Product) =>
+    const mockRepository = (): jest.Mocked<Partial<Repository<Product>>> => ({
+        create: jest.fn<Product, [Partial<Product>]>((dto) => dto as Product),
+        save: jest.fn<Promise<Product>, [Product]>((entity) =>
             Promise.resolve({ id: 1, ...entity } as Product),
         ),
-        find: jest.fn(() => Promise.resolve([{ id: 1 } as Product])),
-        findOne: jest.fn(() => Promise.resolve({ id: 1 } as Product)),
-        update: jest.fn(() => Promise.resolve(undefined)),
-        delete: jest.fn(() => Promise.resolve(undefined)),
+        find: jest.fn<Promise<Product[]>, []>(() =>
+            Promise.resolve([{ id: 1 } as Product]),
+        ),
+        findOne: jest.fn<Promise<Product | null>, [{ where: { id: number } }]>(
+            () => Promise.resolve({ id: 1 } as Product),
+        ),
+        update: jest.fn<Promise<void>, [number, Partial<Product>]>(() =>
+            Promise.resolve(),
+        ),
+        delete: jest.fn<Promise<void>, [number]>(() => Promise.resolve()),
     });
 
     beforeEach(async () => {
@@ -32,7 +38,9 @@ describe('ProductsService', () => {
         }).compile();
 
         service = module.get<ProductsService>(ProductsService);
-        repo = module.get(getRepositoryToken(Product));
+        repo = module.get<jest.Mocked<Partial<Repository<Product>>>>(
+            getRepositoryToken(Product),
+        );
     });
 
     it('creates a product', async () => {

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -8,22 +8,24 @@ import { UpdateServiceDto } from './dto/update-service.dto';
 
 describe('ServicesService', () => {
     let service: ServicesService;
-    let repo: jest.Mocked<Repository<Service>>;
+    let repo: jest.Mocked<Partial<Repository<Service>>>;
     let serviceEntity: Service;
 
-    const mockRepository = () => ({
-        create: jest
-            .fn()
-            .mockImplementation((dto: Partial<Service>) => dto as Service),
-        save: jest
-            .fn()
-            .mockImplementation((entity: Service) =>
-                Promise.resolve({ ...serviceEntity, ...entity }),
-            ),
-        find: jest.fn().mockResolvedValue([serviceEntity]),
-        findOne: jest.fn().mockResolvedValue(serviceEntity),
-        update: jest.fn().mockResolvedValue(undefined),
-        delete: jest.fn().mockResolvedValue(undefined),
+    const mockRepository = (): jest.Mocked<Partial<Repository<Service>>> => ({
+        create: jest.fn<Service, [Partial<Service>]>((dto) => dto as Service),
+        save: jest.fn<Promise<Service>, [Service]>((entity) =>
+            Promise.resolve({ ...serviceEntity, ...entity }),
+        ),
+        find: jest.fn<Promise<Service[]>, []>(() =>
+            Promise.resolve([serviceEntity]),
+        ),
+        findOne: jest.fn<Promise<Service | null>, [{ where: { id: number } }]>(
+            () => Promise.resolve(serviceEntity),
+        ),
+        update: jest.fn<Promise<void>, [number, Partial<Service>]>(() =>
+            Promise.resolve(),
+        ),
+        delete: jest.fn<Promise<void>, [number]>(() => Promise.resolve()),
     });
 
     beforeEach(async () => {
@@ -46,7 +48,9 @@ describe('ServicesService', () => {
         }).compile();
 
         service = module.get<ServicesService>(ServicesService);
-        repo = module.get(getRepositoryToken(Service));
+        repo = module.get<jest.Mocked<Partial<Repository<Service>>>>(
+            getRepositoryToken(Service),
+        );
     });
 
     it('creates a service', async () => {


### PR DESCRIPTION
## Summary
- add explicit types to ServicesService repository mock
- use typed repository mocks in product and user service tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce810fedc83298397e541b825c12f