### PR TITLE
test: strongly type repository mocks

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -9,17 +9,18 @@ describe('CommissionsService', () => {
     let service: CommissionsService;
     let repo: jest.Mocked<Repository<Commission>>;
 
-    const mockRepository = () => ({
-        create: jest.fn<Commission, [Partial<Commission>]>(
-            (dto) => dto as Commission,
-        ),
-        save: jest
-            .fn<Promise<Commission>, [Commission]>()
-            .mockImplementation((entity) =>
-                Promise.resolve({ id: 1, ...entity }),
+    const mockRepository = (): jest.Mocked<Repository<Commission>> =>
+        ({
+            create: jest.fn<Commission, [Partial<Commission>]>(
+                (dto) => dto as Commission,
             ),
-        find: jest.fn<Promise<Commission[]>, []>().mockResolvedValue([]),
-    });
+            save: jest
+                .fn<Promise<Commission>, [Commission]>()
+                .mockImplementation((entity) =>
+                    Promise.resolve({ id: 1, ...entity }),
+                ),
+            find: jest.fn<Promise<Commission[]>, []>().mockResolvedValue([]),
+        }) as jest.Mocked<Repository<Commission>>;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -33,7 +34,9 @@ describe('CommissionsService', () => {
         }).compile();
 
         service = module.get<CommissionsService>(CommissionsService);
-        repo = module.get(getRepositoryToken(Commission));
+        repo = module.get<jest.Mocked<Repository<Commission>>>(
+            getRepositoryToken(Commission),
+        );
     });
 
     it('creates a commission', async () => {

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -7,24 +7,28 @@ import { NotFoundException } from '@nestjs/common';
 
 describe('ProductsService', () => {
     let service: ProductsService;
-    let repo: jest.Mocked<Partial<Repository<Product>>>;
+    let repo: jest.Mocked<Repository<Product>>;
 
-    const mockRepository = (): jest.Mocked<Partial<Repository<Product>>> => ({
-        create: jest.fn<Product, [Partial<Product>]>((dto) => dto as Product),
-        save: jest.fn<Promise<Product>, [Product]>((entity) =>
-            Promise.resolve({ id: 1, ...entity } as Product),
-        ),
-        find: jest.fn<Promise<Product[]>, []>(() =>
-            Promise.resolve([{ id: 1 } as Product]),
-        ),
-        findOne: jest.fn<Promise<Product | null>, [{ where: { id: number } }]>(
-            () => Promise.resolve({ id: 1 } as Product),
-        ),
-        update: jest.fn<Promise<void>, [number, Partial<Product>]>(() =>
-            Promise.resolve(),
-        ),
-        delete: jest.fn<Promise<void>, [number]>(() => Promise.resolve()),
-    });
+    const mockRepository = (): jest.Mocked<Repository<Product>> =>
+        ({
+            create: jest.fn<Product, [Partial<Product>]>(
+                (dto) => dto as Product,
+            ),
+            save: jest.fn<Promise<Product>, [Product]>((entity) =>
+                Promise.resolve({ id: 1, ...entity } as Product),
+            ),
+            find: jest.fn<Promise<Product[]>, []>(() =>
+                Promise.resolve([{ id: 1 } as Product]),
+            ),
+            findOne: jest.fn<
+                Promise<Product | null>,
+                [{ where: { id: number } }]
+            >(() => Promise.resolve({ id: 1 } as Product)),
+            update: jest.fn<Promise<void>, [number, Partial<Product>]>(() =>
+                Promise.resolve(),
+            ),
+            delete: jest.fn<Promise<void>, [number]>(() => Promise.resolve()),
+        }) as jest.Mocked<Repository<Product>>;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -38,7 +42,7 @@ describe('ProductsService', () => {
         }).compile();
 
         service = module.get<ProductsService>(ProductsService);
-        repo = module.get<jest.Mocked<Partial<Repository<Product>>>>(
+        repo = module.get<jest.Mocked<Repository<Product>>>(
             getRepositoryToken(Product),
         );
     });

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -8,25 +8,29 @@ import { UpdateServiceDto } from './dto/update-service.dto';
 
 describe('ServicesService', () => {
     let service: ServicesService;
-    let repo: jest.Mocked<Partial<Repository<Service>>>;
+    let repo: jest.Mocked<Repository<Service>>;
     let serviceEntity: Service;
 
-    const mockRepository = (): jest.Mocked<Partial<Repository<Service>>> => ({
-        create: jest.fn<Service, [Partial<Service>]>((dto) => dto as Service),
-        save: jest.fn<Promise<Service>, [Service]>((entity) =>
-            Promise.resolve({ ...serviceEntity, ...entity }),
-        ),
-        find: jest.fn<Promise<Service[]>, []>(() =>
-            Promise.resolve([serviceEntity]),
-        ),
-        findOne: jest.fn<Promise<Service | null>, [{ where: { id: number } }]>(
-            () => Promise.resolve(serviceEntity),
-        ),
-        update: jest.fn<Promise<void>, [number, Partial<Service>]>(() =>
-            Promise.resolve(),
-        ),
-        delete: jest.fn<Promise<void>, [number]>(() => Promise.resolve()),
-    });
+    const mockRepository = (): jest.Mocked<Repository<Service>> =>
+        ({
+            create: jest.fn<Service, [Partial<Service>]>(
+                (dto) => dto as Service,
+            ),
+            save: jest.fn<Promise<Service>, [Service]>((entity) =>
+                Promise.resolve({ ...serviceEntity, ...entity }),
+            ),
+            find: jest.fn<Promise<Service[]>, []>(() =>
+                Promise.resolve([serviceEntity]),
+            ),
+            findOne: jest.fn<
+                Promise<Service | null>,
+                [{ where: { id: number } }]
+            >(() => Promise.resolve(serviceEntity)),
+            update: jest.fn<Promise<void>, [number, Partial<Service>]>(() =>
+                Promise.resolve(),
+            ),
+            delete: jest.fn<Promise<void>, [number]>(() => Promise.resolve()),
+        }) as jest.Mocked<Repository<Service>>;
 
     beforeEach(async () => {
         serviceEntity = {
@@ -48,7 +52,7 @@ describe('ServicesService', () => {
         }).compile();
 
         service = module.get<ServicesService>(ServicesService);
-        repo = module.get<jest.Mocked<Partial<Repository<Service>>>>(
+        repo = module.get<jest.Mocked<Repository<Service>>>(
             getRepositoryToken(Service),
         );
     });

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -15,7 +15,7 @@ const bcryptMock = jest.mocked(bcrypt);
 
 describe('UsersService', () => {
     let service: UsersService;
-    let repo: jest.Mocked<Partial<Repository<User>>>;
+    let repo: jest.Mocked<Repository<User>>;
     let qb: jest.Mocked<
         Pick<SelectQueryBuilder<User>, 'addSelect' | 'where' | 'getOne'>
     >;
@@ -47,13 +47,13 @@ describe('UsersService', () => {
                             .mockReturnValue(qb),
                         create: jest.fn<User, [Partial<User>]>(),
                         save: jest.fn<Promise<User>, [User]>(),
-                    } as jest.Mocked<Partial<Repository<User>>>,
+                    } as jest.Mocked<Repository<User>>,
                 },
             ],
         }).compile();
 
         service = module.get<UsersService>(UsersService);
-        repo = module.get<jest.Mocked<Partial<Repository<User>>>>(
+        repo = module.get<jest.Mocked<Repository<User>>>(
             getRepositoryToken(User),
         );
     });


### PR DESCRIPTION
## Summary
- type TypeORM repository mocks in service unit tests
- ensure mock methods specify explicit return types

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d0511b25483298c8d2cd7842e557c