### PR TITLE
feat: add employee commissions endpoint

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -26,6 +26,12 @@ describe('CommissionsController', () => {
         expect(findForUserSpy).toHaveBeenCalledWith(1);
     });
 
+    it('delegates findForEmployee to service', async () => {
+        const findForUserSpy = jest.spyOn(service, 'findForUser');
+        await expect(controller.findForEmployee(2)).resolves.toEqual([mine]);
+        expect(findForUserSpy).toHaveBeenCalledWith(2);
+    });
+
     it('delegates findAll to service', async () => {
         const findAllSpy = jest.spyOn(service, 'findAll');
         await expect(controller.findAll()).resolves.toEqual([all]);

--- a/backend/salonbw-backend/src/commissions/commissions.controller.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CommissionsService } from './commissions.service';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -16,6 +16,14 @@ export class CommissionsController {
     @Get('me')
     findMine(@CurrentUser() user: { userId: number }): Promise<Commission[]> {
         return this.commissionsService.findForUser(user.userId);
+    }
+
+    @Roles(Role.Admin)
+    @Get('employees/:id')
+    findForEmployee(
+        @Param('id', ParseIntPipe) id: number,
+    ): Promise<Commission[]> {
+        return this.commissionsService.findForUser(id);
     }
 
     @Roles(Role.Admin)


### PR DESCRIPTION
## Summary
- allow admins to fetch commissions for any employee
- test commissions controller new endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d07553b248329ac05dda946002e50