### PR TITLE
Complete appointments transactionally

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -70,6 +70,37 @@ describe('AppointmentsService', () => {
             Repository<SalonService>
         >;
 
+        const update = jest.fn<
+            Promise<UpdateResult>,
+            [number, Partial<Appointment>]
+        >((id, partial) => {
+            const idx = appointments.findIndex((a) => a.id === id);
+            if (idx >= 0) {
+                appointments[idx] = { ...appointments[idx], ...partial };
+            }
+            return Promise.resolve({
+                affected: idx >= 0 ? 1 : 0,
+            } as UpdateResult);
+        });
+
+        const repoUpdate = jest.fn<
+            Promise<UpdateResult>,
+            [number, Partial<Appointment>]
+        >((id, partial) => {
+            const idx = appointments.findIndex((a) => a.id === id);
+            if (idx >= 0) {
+                appointments[idx] = { ...appointments[idx], ...partial };
+            }
+            return Promise.resolve({
+                affected: idx >= 0 ? 1 : 0,
+            } as UpdateResult);
+        });
+
+        const managerUpdate = jest.fn<
+            Promise<UpdateResult>,
+            [any, number, Partial<Appointment>]
+        >((_entity, id, partial) => repoUpdate(id, partial));
+
         mockAppointmentsRepo = {
             findOne: jest.fn<
                 Promise<Appointment | null>,
@@ -111,18 +142,18 @@ describe('AppointmentsService', () => {
                 appointments.push(appt);
                 return Promise.resolve(appt);
             }),
-            update: jest.fn<
-                Promise<UpdateResult>,
-                [number, Partial<Appointment>]
-            >((id, partial) => {
-                const idx = appointments.findIndex((a) => a.id === id);
-                if (idx >= 0) {
-                    appointments[idx] = { ...appointments[idx], ...partial };
-                }
-                return Promise.resolve({
-                    affected: idx >= 0 ? 1 : 0,
-                } as UpdateResult);
-            }),
+            update: repoUpdate,
+            manager: {
+                transaction: jest.fn(async (cb: any) => {
+                    const snapshot = appointments.map((a) => ({ ...a }));
+                    try {
+                        return await cb({ update: managerUpdate });
+                    } catch (e) {
+                        appointments = snapshot;
+                        throw e;
+                    }
+                }),
+            },
         } as Partial<Repository<Appointment>> as jest.Mocked<
             Repository<Appointment>
         >;
@@ -231,5 +262,23 @@ describe('AppointmentsService', () => {
         await expect(service.completeAppointment(id)).rejects.toBeInstanceOf(
             BadRequestException,
         );
+    });
+
+    it('should revert completion if commission creation fails', async () => {
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        const { id } = await service.create({
+            client: users[0],
+            employee: users[1],
+            service: services[0],
+            startTime: start,
+        });
+
+        mockCommissionsService.createFromAppointment.mockRejectedValueOnce(
+            new Error('fail'),
+        );
+
+        await expect(service.completeAppointment(id)).rejects.toThrow('fail');
+        const appt = await service.findOne(id);
+        expect(appt?.status).toBe(AppointmentStatus.Scheduled);
     });
 });

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -138,10 +138,12 @@ export class AppointmentsService {
                 'Cannot complete a cancelled appointment',
             );
         }
-        await this.appointmentsRepository.update(id, {
-            status: AppointmentStatus.Completed,
+        await this.appointmentsRepository.manager.transaction(async (manager) => {
+            await manager.update(Appointment, id, {
+                status: AppointmentStatus.Completed,
+            });
+            await this.commissionsService.createFromAppointment(appointment);
         });
-        await this.commissionsService.createFromAppointment(appointment);
         return this.findOne(id);
     }
 }


### PR DESCRIPTION
## Summary
- Wrap appointment completion in a transaction to update status and create commissions atomically
- Mock transactional behavior and add test ensuring appointments revert if commission creation fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0e5401788329876c0de2dd2dd6f2