### PR TITLE
test: use update mock in appointments spec

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -186,6 +186,10 @@ describe('AppointmentsService', () => {
 
         const cancelled = await service.cancel(id);
         expect(cancelled?.status).toBe(AppointmentStatus.Cancelled);
+        expect(mockAppointmentsRepo.update.mock.calls[0]).toEqual([
+            id,
+            { status: AppointmentStatus.Cancelled },
+        ]);
     });
 
     it('should not cancel a completed appointment', async () => {


### PR DESCRIPTION
## Summary
- verify appointments repository update mock is invoked when cancelling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d1148bb3883298215031f6d0c9be6