### PR TITLE
test: add typed argument to appointments repository mock

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -74,16 +74,23 @@ describe('AppointmentsService', () => {
             findOne: jest.fn<
                 Promise<Appointment | null>,
                 [
-                    {
-                        where?: {
-                            id?: number;
-                            employee?: { id: number };
-                            startTime?: { _value: Date };
-                            endTime?: { _value: Date };
-                        };
-                    },
+                    | number
+                    | {
+                          where?: {
+                              id?: number;
+                              employee?: { id: number };
+                              startTime?: { _value: Date };
+                              endTime?: { _value: Date };
+                          };
+                      },
                 ]
-            >(({ where }) => {
+            >((criteria) => {
+                if (typeof criteria === 'number') {
+                    return Promise.resolve(
+                        appointments.find((a) => a.id === criteria) ?? null,
+                    );
+                }
+                const { where } = criteria;
                 if (where?.id !== undefined) {
                     return Promise.resolve(
                         appointments.find((a) => a.id === where.id) ?? null,


### PR DESCRIPTION
## Summary
- refine appointments repo mock to return typed `Appointment | null`

## Testing
- `npm run lint -- src/appointments/appointments.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d159042408329ac12704beb7e87f5