### PR TITLE
test: type-safe appointment repository mock

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -85,7 +85,7 @@ describe('AppointmentsService', () => {
 
         const managerUpdate = jest.fn<
             Promise<UpdateResult>,
-            [any, number, Partial<Appointment>]
+            [unknown, number, Partial<Appointment>]
         >((_entity, id, partial) => repoUpdate(id, partial));
 
         mockAppointmentsRepo = {
@@ -138,21 +138,18 @@ describe('AppointmentsService', () => {
             }),
             update: repoUpdate,
             manager: {
-                transaction: jest.fn(
-                    async (
-                        cb: (em: {
-                            update: typeof managerUpdate;
-                        }) => Promise<unknown>,
-                    ) => {
-                        const snapshot = appointments.map((a) => ({ ...a }));
-                        try {
-                            return await cb({ update: managerUpdate });
-                        } catch (e) {
-                            appointments = snapshot;
-                            throw e;
-                        }
-                    },
-                ),
+                transaction: jest.fn<
+                    Promise<unknown>,
+                    [(em: { update: typeof managerUpdate }) => Promise<unknown>]
+                >(async (cb) => {
+                    const snapshot = appointments.map((a) => ({ ...a }));
+                    try {
+                        return await cb({ update: managerUpdate });
+                    } catch (e) {
+                        appointments = snapshot;
+                        throw e;
+                    }
+                }),
             },
         } as Partial<Repository<Appointment>> as jest.Mocked<
             Repository<Appointment>


### PR DESCRIPTION
## Summary
- specify type-safe update and transaction mocks in appointment service tests

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d1da27e6083299a89f886ac49f08a