### PR TITLE
chore: regenerate OpenAPI spec

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -554,6 +554,29 @@
         ]
       }
     },
+    "/commissions/employees/{id}": {
+      "get": {
+        "operationId": "CommissionsController_findForEmployee",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Commissions"
+        ]
+      }
+    },
     "/commissions": {
       "get": {
         "operationId": "CommissionsController_findAll",


### PR DESCRIPTION
## Summary
- regenerate backend OpenAPI spec to match current implementation

## Testing
- `npm test`
- `npm run swagger:generate`
- `git diff --exit-code openapi.json && echo "openapi.json is up to date"`


------
https://chatgpt.com/codex/tasks/task_e_689d20574840832986b10803be7e7487