### PR TITLE
feat: add logging module

### DIFF
--- a/backend/salonbw-backend/.gitignore
+++ b/backend/salonbw-backend/.gitignore
@@ -6,6 +6,7 @@
 # Logs
 logs
 *.log
+!src/logs/
 npm-debug.log*
 pnpm-debug.log*
 yarn-debug.log*

--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { ProductsModule } from './products/products.module';
 import { AppointmentsModule } from './appointments/appointments.module';
 import { FormulasModule } from './formulas/formulas.module';
 import { CommissionsModule } from './commissions/commissions.module';
+import { LogsModule } from './logs/logs.module';
 
 @Module({
     imports: [
@@ -34,6 +35,7 @@ import { CommissionsModule } from './commissions/commissions.module';
         AppointmentsModule,
         FormulasModule,
         CommissionsModule,
+        LogsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/logs/log.entity.ts
+++ b/backend/salonbw-backend/src/logs/log.entity.ts
@@ -1,0 +1,34 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    Column,
+    CreateDateColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+export enum LogAction {
+    Login = 'login',
+    Logout = 'logout',
+    Create = 'create',
+    Update = 'update',
+    Delete = 'delete',
+}
+
+@Entity('logs')
+export class Log {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => User, { nullable: true, eager: true })
+    user?: User | null;
+
+    @Column({ type: 'simple-enum', enum: LogAction })
+    action: LogAction;
+
+    @Column({ type: 'jsonb', nullable: true })
+    description?: string | Record<string, any>;
+
+    @CreateDateColumn()
+    timestamp: Date;
+}

--- a/backend/salonbw-backend/src/logs/log.service.ts
+++ b/backend/salonbw-backend/src/logs/log.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Log, LogAction } from './log.entity';
+import { User } from '../users/user.entity';
+
+@Injectable()
+export class LogService {
+    constructor(
+        @InjectRepository(Log)
+        private readonly logRepository: Repository<Log>,
+    ) {}
+
+    async logAction(
+        user: User | null,
+        action: LogAction,
+        description?: string | Record<string, any>,
+    ): Promise<Log> {
+        const log = this.logRepository.create({
+            user: user ?? null,
+            action,
+            description,
+        });
+        return this.logRepository.save(log);
+    }
+}

--- a/backend/salonbw-backend/src/logs/logs.module.ts
+++ b/backend/salonbw-backend/src/logs/logs.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Log } from './log.entity';
+import { LogService } from './log.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Log])],
+    providers: [LogService],
+    exports: [LogService],
+})
+export class LogsModule {}


### PR DESCRIPTION
## Summary
- add Log entity and service for recording user actions
- expose logging features via LogsModule and register in AppModule
- allow tracking logs directory in backend `.gitignore`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d2301079c832991ab867d2c5760ba