### PR TITLE
feat: add logs endpoint

### DIFF
--- a/backend/salonbw-backend/src/logs/logs.controller.ts
+++ b/backend/salonbw-backend/src/logs/logs.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { LogAction } from './log.entity';
+import { LogService } from './log.service';
+
+@Controller('logs')
+export class LogsController {
+    constructor(private readonly logService: LogService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin)
+    @Get()
+    getLogs(
+        @Query('userId') userId?: string,
+        @Query('action') action?: LogAction,
+        @Query('from') from?: string,
+        @Query('to') to?: string,
+        @Query('page') page = '1',
+        @Query('limit') limit = '10',
+    ) {
+        return this.logService.findAll({
+            userId: userId ? Number(userId) : undefined,
+            action,
+            from: from ? new Date(from) : undefined,
+            to: to ? new Date(to) : undefined,
+            page: Number(page),
+            limit: Number(limit),
+        });
+    }
+}

--- a/backend/salonbw-backend/src/logs/logs.module.ts
+++ b/backend/salonbw-backend/src/logs/logs.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Log } from './log.entity';
 import { LogService } from './log.service';
+import { LogsController } from './logs.controller';
 
 @Module({
     imports: [TypeOrmModule.forFeature([Log])],
+    controllers: [LogsController],
     providers: [LogService],
     exports: [LogService],
 })


### PR DESCRIPTION
## Summary
- add logs controller to list application logs with filters and pagination
- extend log service with filtered pagination
- expose logs controller via logs module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d245c6df08329828be3ae2c9d6c10