### PR TITLE
feat: log authorization failures

### DIFF
--- a/backend/salonbw-backend/src/logs/log.entity.ts
+++ b/backend/salonbw-backend/src/logs/log.entity.ts
@@ -13,6 +13,7 @@ export enum LogAction {
     Create = 'create',
     Update = 'update',
     Delete = 'delete',
+    AUTHORIZATION_FAIL = 'authorization_fail',
 }
 
 @Entity('logs')

--- a/backend/salonbw-backend/src/main.ts
+++ b/backend/salonbw-backend/src/main.ts
@@ -4,9 +4,13 @@ import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import cookieParser from 'cookie-parser';
+import { LogService } from './logs/log.service';
+import { AuthFailureFilter } from './logs/auth-failure.filter';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
+    const logService = app.get(LogService);
+    app.useGlobalFilters(new AuthFailureFilter(logService));
     app.useGlobalPipes(
         new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
     );


### PR DESCRIPTION
## Summary
- add `AUTHORIZATION_FAIL` log action and filter to capture unauthorized/forbidden requests
- register `AuthFailureFilter` globally to log failed authorization attempts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dab2205348329af1591446f8f11c4