### PR TITLE
Add log service tests and LogsController integration coverage

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -6,11 +6,13 @@ import { AppointmentsController } from './appointments.controller';
 import { CommissionsModule } from '../commissions/commissions.module';
 import { Service as SalonService } from '../services/service.entity';
 import { User } from '../users/user.entity';
+import { LogsModule } from '../logs/logs.module';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([Appointment, SalonService, User]),
         CommissionsModule,
+        LogsModule,
     ],
     providers: [AppointmentsService],
     controllers: [AppointmentsController],

--- a/backend/salonbw-backend/src/logs/log.entity.ts
+++ b/backend/salonbw-backend/src/logs/log.entity.ts
@@ -27,7 +27,7 @@ export class Log {
     @Column({ type: 'simple-enum', enum: LogAction })
     action: LogAction;
 
-    @Column({ type: 'jsonb', nullable: true })
+    @Column({ type: 'simple-json', nullable: true })
     description?: string | Record<string, any>;
 
     @CreateDateColumn()

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -19,6 +19,7 @@ import { Appointment } from '../src/appointments/appointment.entity';
 import { Commission } from '../src/commissions/commission.entity';
 import { Formula } from '../src/formulas/formula.entity';
 import { Product } from '../src/products/product.entity';
+import { Log } from '../src/logs/log.entity';
 
 interface AppointmentResponse {
     id: number;
@@ -63,6 +64,7 @@ describe('Appointments integration', () => {
                         Commission,
                         Formula,
                         Product,
+                        Log,
                     ],
                     synchronize: true,
                 }),
@@ -317,7 +319,7 @@ describe('Appointments integration', () => {
         );
     });
     it('prevents cancelling completed appointments', async () => {
-        const startBase = Date.now() + 13 * hour;
+        const startBase = Date.now() + 17 * hour;
         const start = new Date(startBase).toISOString();
         const createRes: Response = await request(server)
             .post('/appointments')
@@ -342,7 +344,7 @@ describe('Appointments integration', () => {
     });
 
     it('prevents completing cancelled appointments', async () => {
-        const startBase = Date.now() + 15 * hour;
+        const startBase = Date.now() + 19 * hour;
         const start = new Date(startBase).toISOString();
         const createRes: Response = await request(server)
             .post('/appointments')

--- a/backend/salonbw-backend/test/logs.e2e-spec.ts
+++ b/backend/salonbw-backend/test/logs.e2e-spec.ts
@@ -1,0 +1,108 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+import * as jwt from 'jsonwebtoken';
+import { Repository } from 'typeorm';
+
+import { AuthModule } from '../src/auth/auth.module';
+import { LogsModule } from '../src/logs/logs.module';
+import { LogService } from '../src/logs/log.service';
+import { Log, LogAction } from '../src/logs/log.entity';
+import { User } from '../src/users/user.entity';
+import { AuthFailureFilter } from '../src/logs/auth-failure.filter';
+
+interface LogsResponse {
+    data: Log[];
+    total: number;
+}
+
+describe('LogsController (e2e)', () => {
+    let app: INestApplication;
+    let server: Parameters<typeof request>[0];
+    let logService: LogService;
+    let userRepo: Repository<User>;
+    let adminToken: string;
+    let userToken: string;
+
+    beforeAll(async () => {
+        process.env.JWT_SECRET = 'test-secret';
+        process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({ isGlobal: true }),
+                TypeOrmModule.forRoot({
+                    type: 'sqlite',
+                    database: ':memory:',
+                    dropSchema: true,
+                    entities: [User, Log],
+                    synchronize: true,
+                }),
+                AuthModule,
+                LogsModule,
+            ],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.use(cookieParser());
+        logService = moduleFixture.get(LogService);
+        app.useGlobalFilters(new AuthFailureFilter(logService));
+        await app.init();
+        server = app.getHttpServer() as Parameters<typeof request>[0];
+
+        userRepo = moduleFixture.get<Repository<User>>(getRepositoryToken(User));
+        const admin = await userRepo.save({
+            email: 'admin@example.com',
+            password: 'pass',
+            name: 'Admin',
+            role: 'admin',
+        });
+        const user = await userRepo.save({
+            email: 'user@example.com',
+            password: 'pass',
+            name: 'User',
+            role: 'client',
+        });
+
+        const secret = process.env.JWT_SECRET ?? '';
+        adminToken = jwt.sign({ sub: admin.id, role: 'admin' }, secret);
+        userToken = jwt.sign({ sub: user.id, role: 'client' }, secret);
+
+        await logService.logAction(admin, LogAction.Login, { note: 'admin log' });
+        await logService.logAction(user, LogAction.Login, { note: 'user log' });
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    it('returns logs for admin users', async () => {
+        const res = await request(server)
+            .get('/logs')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(200);
+
+        const body = res.body as LogsResponse;
+        expect(body.total).toBe(2);
+        expect(body.data).toHaveLength(2);
+    });
+
+    it('forbids access for non-admin and logs the attempt', async () => {
+        const before = await logService.findAll({
+            action: LogAction.AUTHORIZATION_FAIL,
+        });
+
+        await request(server)
+            .get('/logs')
+            .set('Authorization', `Bearer ${userToken}`)
+            .expect(403);
+
+        const after = await logService.findAll({
+            action: LogAction.AUTHORIZATION_FAIL,
+        });
+        expect(after.total).toBe(before.total + 1);
+    });
+});


### PR DESCRIPTION
## Summary
- log appointments on create/cancel/complete via LogService
- cover log actions in unit tests and add LogsController e2e tests
- support SQLite by using simple-json for log descriptions

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689dad6f968883298ceaf28432438109