### PR TITLE
fix: remove unnecessary await in auth controller register

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -49,7 +49,7 @@ export class AuthController {
     @ApiResponse({ status: 201, description: 'User successfully registered' })
     async register(@Body() dto: RegisterDto) {
         const user = await this.usersService.createUser(dto);
-        const result = await this.authService.login(user);
+        const result = this.authService.login(user);
         await this.logService.logAction(user, LogAction.Create, {
             userId: user.id,
             email: user.email,


### PR DESCRIPTION
## Summary
- remove unnecessary await from AuthController register

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unsafe-assignment in test/logs.e2e-spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689db46fce5883298310cbb2a3a1b6d4