### PR TITLE
chore: type jwt tokens in logs tests

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -49,7 +49,7 @@ export class AuthController {
     @ApiResponse({ status: 201, description: 'User successfully registered' })
     async register(@Body() dto: RegisterDto) {
         const user = await this.usersService.createUser(dto);
-        const result = await this.authService.login(user);
+        const result = this.authService.login(user);
         await this.logService.logAction(user, LogAction.Create, {
             userId: user.id,
             email: user.email,


### PR DESCRIPTION
## Summary
- import jwt with typings and generate tokens within logs e2e tests
- drop unnecessary await in auth controller register method

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689db7252978832998ccc17390f9adda