### PR TITLE
chore: regenerate OpenAPI spec

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -1,677 +1,614 @@
 {
-  "openapi": "3.0.0",
-  "paths": {
-    "/": {
-      "get": {
-        "operationId": "AppController_getHello",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
+    "openapi": "3.0.0",
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "AppController_getHello",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["App"]
+            }
         },
-        "tags": [
-          "App"
-        ]
-      }
+        "/health": {
+            "get": {
+                "operationId": "HealthController_getHealth",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Health"]
+            }
+        },
+        "/users/profile": {
+            "get": {
+                "operationId": "UsersController_getProfile",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Users"]
+            }
+        },
+        "/users": {
+            "get": {
+                "operationId": "UsersController_findAll",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/UserDto"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearer": []
+                    }
+                ],
+                "tags": ["Users"]
+            },
+            "post": {
+                "operationId": "UsersController_create",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateUserDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Users"]
+            }
+        },
+        "/auth/login": {
+            "post": {
+                "operationId": "AuthController_login",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Tokens successfully generated"
+                    }
+                },
+                "summary": "Log in user",
+                "tags": ["auth"]
+            }
+        },
+        "/auth/register": {
+            "post": {
+                "operationId": "AuthController_register",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RegisterDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "User successfully registered"
+                    }
+                },
+                "summary": "Register new user",
+                "tags": ["auth"]
+            }
+        },
+        "/auth/refresh": {
+            "post": {
+                "operationId": "AuthController_refresh",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RefreshTokenDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Tokens successfully refreshed"
+                    }
+                },
+                "summary": "Refresh access token",
+                "tags": ["auth"]
+            }
+        },
+        "/appointments": {
+            "post": {
+                "description": "Employees or admins must specify clientId in the request body.",
+                "operationId": "AppointmentsController_create",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAppointmentDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Appointment created"
+                    },
+                    "400": {
+                        "description": "clientId must be provided when creating appointments as staff"
+                    }
+                },
+                "summary": "Create appointment",
+                "tags": ["appointments"]
+            }
+        },
+        "/appointments/me": {
+            "get": {
+                "operationId": "AppointmentsController_findMine",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["appointments"]
+            }
+        },
+        "/appointments/{id}/cancel": {
+            "patch": {
+                "operationId": "AppointmentsController_cancel",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["appointments"]
+            }
+        },
+        "/appointments/{id}/complete": {
+            "patch": {
+                "operationId": "AppointmentsController_complete",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["appointments"]
+            }
+        },
+        "/services": {
+            "get": {
+                "operationId": "ServicesController_findAll",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Services"]
+            },
+            "post": {
+                "operationId": "ServicesController_create",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateServiceDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Services"]
+            }
+        },
+        "/services/{id}": {
+            "get": {
+                "operationId": "ServicesController_findOne",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Services"]
+            },
+            "patch": {
+                "operationId": "ServicesController_update",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateServiceDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Services"]
+            },
+            "delete": {
+                "operationId": "ServicesController_remove",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Services"]
+            }
+        },
+        "/products": {
+            "get": {
+                "operationId": "ProductsController_findAll",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Products"]
+            },
+            "post": {
+                "operationId": "ProductsController_create",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateProductDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Products"]
+            }
+        },
+        "/products/{id}": {
+            "get": {
+                "operationId": "ProductsController_findOne",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Products"]
+            },
+            "patch": {
+                "operationId": "ProductsController_update",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateProductDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Products"]
+            },
+            "delete": {
+                "operationId": "ProductsController_remove",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Products"]
+            }
+        },
+        "/appointments/{appointmentId}/formulas": {
+            "post": {
+                "operationId": "AppointmentFormulasController_addFormula",
+                "parameters": [
+                    {
+                        "name": "appointmentId",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateFormulaDto"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": ""
+                    }
+                },
+                "tags": ["AppointmentFormulas"]
+            }
+        },
+        "/clients/me/formulas": {
+            "get": {
+                "operationId": "ClientFormulasController_findMine",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["ClientFormulas"]
+            }
+        },
+        "/clients/{id}/formulas": {
+            "get": {
+                "operationId": "ClientFormulasController_findForClient",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["ClientFormulas"]
+            }
+        },
+        "/commissions/me": {
+            "get": {
+                "operationId": "CommissionsController_findMine",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Commissions"]
+            }
+        },
+        "/commissions/employees/{id}": {
+            "get": {
+                "operationId": "CommissionsController_findForEmployee",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Commissions"]
+            }
+        },
+        "/commissions": {
+            "get": {
+                "operationId": "CommissionsController_findAll",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": ["Commissions"]
+            }
+        }
     },
-    "/health": {
-      "get": {
-        "operationId": "HealthController_getHealth",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Health"
-        ]
-      }
+    "info": {
+        "title": "SalonBW API",
+        "description": "",
+        "version": "1.0",
+        "contact": {}
     },
-    "/users/profile": {
-      "get": {
-        "operationId": "UsersController_getProfile",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Users"
-        ]
-      }
-    },
-    "/users": {
-      "get": {
-        "operationId": "UsersController_findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserDto"
-                  }
-                }
-              }
+    "tags": [],
+    "servers": [],
+    "components": {
+        "schemas": {
+            "UserDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "CreateUserDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "RegisterDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "RefreshTokenDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "CreateAppointmentDto": {
+                "type": "object",
+                "properties": {
+                    "employeeId": {
+                        "type": "number"
+                    },
+                    "serviceId": {
+                        "type": "number"
+                    },
+                    "startTime": {
+                        "type": "string"
+                    },
+                    "clientId": {
+                        "type": "number",
+                        "description": "Required when creating appointments as Employee or Admin"
+                    }
+                },
+                "required": ["employeeId", "serviceId", "startTime"]
+            },
+            "CreateServiceDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "UpdateServiceDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "CreateProductDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "UpdateProductDto": {
+                "type": "object",
+                "properties": {}
+            },
+            "CreateFormulaDto": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "date": {
+                        "type": "string"
+                    }
+                },
+                "required": ["description", "date"]
             }
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Users"
-        ]
-      },
-      "post": {
-        "operationId": "UsersController_create",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateUserDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Users"
-        ]
-      }
-    },
-    "/auth/login": {
-      "post": {
-        "operationId": "AuthController_login",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Tokens successfully generated"
-          }
-        },
-        "summary": "Log in user",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/auth/register": {
-      "post": {
-        "operationId": "AuthController_register",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RegisterDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "User successfully registered"
-          }
-        },
-        "summary": "Register new user",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/auth/refresh": {
-      "post": {
-        "operationId": "AuthController_refresh",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RefreshTokenDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Tokens successfully refreshed"
-          }
-        },
-        "summary": "Refresh access token",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/appointments": {
-      "post": {
-        "description": "Employees or admins must specify clientId in the request body.",
-        "operationId": "AppointmentsController_create",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAppointmentDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Appointment created"
-          },
-          "400": {
-            "description": "clientId must be provided when creating appointments as staff"
-          }
-        },
-        "summary": "Create appointment",
-        "tags": [
-          "appointments"
-        ]
-      }
-    },
-    "/appointments/me": {
-      "get": {
-        "operationId": "AppointmentsController_findMine",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "appointments"
-        ]
-      }
-    },
-    "/appointments/{id}/cancel": {
-      "patch": {
-        "operationId": "AppointmentsController_cancel",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "appointments"
-        ]
-      }
-    },
-    "/appointments/{id}/complete": {
-      "patch": {
-        "operationId": "AppointmentsController_complete",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "appointments"
-        ]
-      }
-    },
-    "/services": {
-      "get": {
-        "operationId": "ServicesController_findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Services"
-        ]
-      },
-      "post": {
-        "operationId": "ServicesController_create",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateServiceDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Services"
-        ]
-      }
-    },
-    "/services/{id}": {
-      "get": {
-        "operationId": "ServicesController_findOne",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Services"
-        ]
-      },
-      "patch": {
-        "operationId": "ServicesController_update",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateServiceDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Services"
-        ]
-      },
-      "delete": {
-        "operationId": "ServicesController_remove",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Services"
-        ]
-      }
-    },
-    "/products": {
-      "get": {
-        "operationId": "ProductsController_findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Products"
-        ]
-      },
-      "post": {
-        "operationId": "ProductsController_create",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateProductDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Products"
-        ]
-      }
-    },
-    "/products/{id}": {
-      "get": {
-        "operationId": "ProductsController_findOne",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Products"
-        ]
-      },
-      "patch": {
-        "operationId": "ProductsController_update",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateProductDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Products"
-        ]
-      },
-      "delete": {
-        "operationId": "ProductsController_remove",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Products"
-        ]
-      }
-    },
-    "/appointments/{appointmentId}/formulas": {
-      "post": {
-        "operationId": "AppointmentFormulasController_addFormula",
-        "parameters": [
-          {
-            "name": "appointmentId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateFormulaDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "AppointmentFormulas"
-        ]
-      }
-    },
-    "/clients/me/formulas": {
-      "get": {
-        "operationId": "ClientFormulasController_findMine",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "ClientFormulas"
-        ]
-      }
-    },
-    "/clients/{id}/formulas": {
-      "get": {
-        "operationId": "ClientFormulasController_findForClient",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "ClientFormulas"
-        ]
-      }
-    },
-    "/commissions/me": {
-      "get": {
-        "operationId": "CommissionsController_findMine",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Commissions"
-        ]
-      }
-    },
-    "/commissions/employees/{id}": {
-      "get": {
-        "operationId": "CommissionsController_findForEmployee",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Commissions"
-        ]
-      }
-    },
-    "/commissions": {
-      "get": {
-        "operationId": "CommissionsController_findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Commissions"
-        ]
-      }
+        }
     }
-  },
-  "info": {
-    "title": "SalonBW API",
-    "description": "",
-    "version": "1.0",
-    "contact": {}
-  },
-  "tags": [],
-  "servers": [],
-  "components": {
-    "schemas": {
-      "UserDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "CreateUserDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "RegisterDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "RefreshTokenDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "CreateAppointmentDto": {
-        "type": "object",
-        "properties": {
-          "employeeId": {
-            "type": "number"
-          },
-          "serviceId": {
-            "type": "number"
-          },
-          "startTime": {
-            "type": "string"
-          },
-          "clientId": {
-            "type": "number",
-            "description": "Required when creating appointments as Employee or Admin"
-          }
-        },
-        "required": [
-          "employeeId",
-          "serviceId",
-          "startTime"
-        ]
-      },
-      "CreateServiceDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "UpdateServiceDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "CreateProductDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "UpdateProductDto": {
-        "type": "object",
-        "properties": {}
-      },
-      "CreateFormulaDto": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "description",
-          "date"
-        ]
-      }
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- regenerate and reformat OpenAPI spec for backend

## Testing
- `npm install`
- `npm run swagger:generate`
- `npm test` *(fails: AppointmentsService expectations)*

------
https://chatgpt.com/codex/tasks/task_e_689dbe70ca6c8329bc375c54f0c9dd1d