### PR TITLE
test: update appointment logging expectations

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -233,10 +233,14 @@ describe('AppointmentsService', () => {
             id,
             { status: AppointmentStatus.Cancelled },
         ]);
-        expect(logActionSpy).toHaveBeenCalledWith(
+        expect(logActionSpy).toHaveBeenNthCalledWith(
+            2,
             null,
             LogAction.Update,
-            expect.objectContaining({ action: 'cancel', id }),
+            expect.objectContaining({
+                appointmentId: id,
+                status: AppointmentStatus.Cancelled,
+            }),
         );
     });
 
@@ -313,10 +317,14 @@ describe('AppointmentsService', () => {
         });
 
         await service.completeAppointment(id);
-        expect(logActionSpy).toHaveBeenCalledWith(
+        expect(logActionSpy).toHaveBeenNthCalledWith(
+            2,
             null,
             LogAction.Update,
-            expect.objectContaining({ action: 'complete', id }),
+            expect.objectContaining({
+                appointmentId: id,
+                status: AppointmentStatus.Completed,
+            }),
         );
     });
 });


### PR DESCRIPTION
## Summary
- verify cancel appointment logs include updated status
- verify complete appointment logs include updated status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dcb910f4c83298347c9e0bc6b9064