### PR TITLE
Protect log descriptions from sensitive data

### DIFF
--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -38,7 +38,6 @@ export class AuthController {
         const result = this.authService.login(user);
         void this.logService.logAction(user as User, LogAction.USER_LOGIN, {
             userId: user.id,
-            email: user.email,
         });
         return result;
     }
@@ -52,7 +51,6 @@ export class AuthController {
         const result = this.authService.login(user);
         await this.logService.logAction(user, LogAction.USER_REGISTERED, {
             userId: user.id,
-            email: user.email,
         });
         return result;
     }

--- a/backend/salonbw-backend/src/logs/log.service.spec.ts
+++ b/backend/salonbw-backend/src/logs/log.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LogService } from './log.service';
+import { Log } from './log.entity';
+import { LogAction } from './log-action.enum';
+
+describe('LogService', () => {
+    let service: LogService;
+    let repo: jest.Mocked<Repository<Log>>;
+
+    beforeEach(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                LogService,
+                {
+                    provide: getRepositoryToken(Log),
+                    useValue: {
+                        create: jest.fn().mockImplementation((entity) => entity),
+                        save: jest.fn().mockImplementation((log) => Promise.resolve(log)),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get(LogService);
+        repo = module.get<Repository<Log>>(getRepositoryToken(Log)) as jest.Mocked<Repository<Log>>;
+    });
+
+    it('rejects description with password key', async () => {
+        await expect(
+            service.logAction(null, LogAction.USER_LOGIN, { password: 'secret' }),
+        ).rejects.toThrow('Description contains sensitive information');
+        expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects description with token key', async () => {
+        await expect(
+            service.logAction(null, LogAction.USER_LOGIN, { token: 'abc' }),
+        ).rejects.toThrow('Description contains sensitive information');
+        expect(repo.save).not.toHaveBeenCalled();
+    });
+});
+


### PR DESCRIPTION
## Summary
- prevent `logAction` from storing descriptions containing password or token fields
- avoid logging user email addresses for authentication actions
- add unit tests covering sensitive description rejection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dedc68ccc83299e26ad1bc50c2d55