### PR TITLE
test: ensure logAction invoked in service specs

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -9,6 +9,7 @@ import { LogService } from '../logs/log.service';
 describe('CommissionsService', () => {
     let service: CommissionsService;
     let repo: jest.Mocked<Repository<Commission>>;
+    let logService: LogService;
 
     const mockRepository = (): jest.Mocked<Repository<Commission>> =>
         ({
@@ -42,17 +43,20 @@ describe('CommissionsService', () => {
         repo = module.get<jest.Mocked<Repository<Commission>>>(
             getRepositoryToken(Commission),
         );
+        logService = module.get<LogService>(LogService);
     });
 
     it('creates a commission', async () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.create({ amount: 10 })).resolves.toEqual({
             id: 1,
             amount: 10,
         });
         expect(createSpy).toHaveBeenCalledWith({ amount: 10 });
         expect(saveSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalled();
     });
 
     it('creates commission from appointment', async () => {

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -9,6 +9,7 @@ import { LogService } from '../logs/log.service';
 describe('ProductsService', () => {
     let service: ProductsService;
     let repo: jest.Mocked<Repository<Product>>;
+    let logService: LogService;
 
     const mockRepository = (): jest.Mocked<Repository<Product>> =>
         ({
@@ -50,6 +51,7 @@ describe('ProductsService', () => {
         repo = module.get<jest.Mocked<Repository<Product>>>(
             getRepositoryToken(Product),
         );
+        logService = module.get<LogService>(LogService);
     });
 
     it('creates a product', async () => {
@@ -61,12 +63,14 @@ describe('ProductsService', () => {
         };
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.create(dto as Product)).resolves.toEqual({
             id: 1,
             ...dto,
         });
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalled();
     });
 
     it('returns all products', async () => {
@@ -92,15 +96,19 @@ describe('ProductsService', () => {
     it('updates a product', async () => {
         const dto: Partial<Product> = { name: 'New' };
         const updateSpy = jest.spyOn(repo, 'update');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.update(1, dto as Product)).resolves.toEqual({
             id: 1,
         });
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
+        expect(logSpy).toHaveBeenCalled();
     });
 
     it('removes a product', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await service.remove(1);
         expect(deleteSpy).toHaveBeenCalledWith(1);
+        expect(logSpy).toHaveBeenCalled();
     });
 });

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -11,6 +11,7 @@ describe('ServicesService', () => {
     let service: ServicesService;
     let repo: jest.Mocked<Repository<Service>>;
     let serviceEntity: Service;
+    let logService: LogService;
 
     const mockRepository = (): jest.Mocked<Repository<Service>> =>
         ({
@@ -60,6 +61,7 @@ describe('ServicesService', () => {
         repo = module.get<jest.Mocked<Repository<Service>>>(
             getRepositoryToken(Service),
         );
+        logService = module.get<LogService>(LogService);
     });
 
     it('creates a service', async () => {
@@ -71,9 +73,11 @@ describe('ServicesService', () => {
         };
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.create(dto)).resolves.toEqual(serviceEntity);
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalled();
     });
 
     it('returns all services', async () => {
@@ -99,13 +103,17 @@ describe('ServicesService', () => {
     it('updates a service', async () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const updateSpy = jest.spyOn(repo, 'update');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.update(1, dto)).resolves.toBe(serviceEntity);
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
+        expect(logSpy).toHaveBeenCalled();
     });
 
     it('removes a service', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
+        const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.remove(1)).resolves.toBeUndefined();
         expect(deleteSpy).toHaveBeenCalledWith(1);
+        expect(logSpy).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- spy on LogService.logAction in product service tests and expect calls on create/update/remove
- add similar log action assertions in services and commissions service specs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfab65b2c8329b22e06a812e37eb2