### PR TITLE
docs: add audit log pruning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ can be scheduled via cron:
 The script moves old logs to `ARCHIVE_DIR` if provided, or deletes them when no
 archive destination is configured.
 
+Database audit entries stored in the `logs` table can also accumulate. Remove
+rows older than your retention period with
+[`scripts/prune-audit-logs.ts`](scripts/prune-audit-logs.ts):
+
+```bash
+MAX_LOG_AGE_DAYS=90 DATABASE_URL=postgres://user:pass@host/db \
+  npx ts-node -p pg scripts/prune-audit-logs.ts
+```
+
+Schedule this command via cron to keep the table size manageable.
+
 ## Instagram integration
 
 The backend fetches the latest posts from Instagram for the gallery page.

--- a/scripts/prune-audit-logs.ts
+++ b/scripts/prune-audit-logs.ts
@@ -1,0 +1,36 @@
+import { Client } from "pg";
+
+/**
+ * Example script to delete audit logs older than N days.
+ *
+ * Usage:
+ *   MAX_LOG_AGE_DAYS=90 DATABASE_URL=postgres://user:pass@host/db \
+ *     npx ts-node -p pg scripts/prune-audit-logs.ts
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const MAX_LOG_AGE_DAYS = parseInt(process.env.MAX_LOG_AGE_DAYS ?? "30", 10);
+
+if (!DATABASE_URL) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+}
+
+async function pruneLogs() {
+    const client = new Client({ connectionString: DATABASE_URL });
+    await client.connect();
+
+    const res = await client.query(
+        "DELETE FROM logs WHERE \"timestamp\" < NOW() - $1 * INTERVAL '1 day'",
+        [MAX_LOG_AGE_DAYS],
+    );
+
+    console.log(
+        `Deleted ${res.rowCount} log entries older than ${MAX_LOG_AGE_DAYS} days`,
+    );
+    await client.end();
+}
+
+pruneLogs().catch((err) => {
+    console.error("Failed to prune logs:", err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document pruning old rows from the `logs` table
- add example script to delete aged audit logs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e0ace6b48832985c3634e8d07bed5