### PR TITLE
Include user context in service logging

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -60,12 +60,15 @@ export class AppointmentsController {
             (user.role === Role.Employee || user.role === Role.Admin)
                 ? ({ id: body.clientId } as User)
                 : ({ id: user.userId } as User);
-        return this.appointmentsService.create({
-            client,
-            employee: { id: body.employeeId } as User,
-            service: { id: body.serviceId } as SalonService,
-            startTime: new Date(body.startTime),
-        });
+        return this.appointmentsService.create(
+            {
+                client,
+                employee: { id: body.employeeId } as User,
+                service: { id: body.serviceId } as SalonService,
+                startTime: new Date(body.startTime),
+            },
+            { id: user.userId } as User,
+        );
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -93,7 +96,7 @@ export class AppointmentsController {
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.cancel(id);
+        return this.appointmentsService.cancel(id, { id: user.userId } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -113,6 +116,9 @@ export class AppointmentsController {
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.completeAppointment(id);
+        return this.appointmentsService.completeAppointment(
+            id,
+            { id: user.userId } as User,
+        );
     }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -26,7 +26,10 @@ export class AppointmentsService {
         private readonly logService: LogService,
     ) {}
 
-    async create(data: Partial<Appointment>): Promise<Appointment> {
+    async create(
+        data: Partial<Appointment>,
+        user: User,
+    ): Promise<Appointment> {
         if (!data.client?.id) {
             throw new BadRequestException('clientId is required');
         }
@@ -93,7 +96,7 @@ export class AppointmentsService {
         if (!result) {
             throw new Error('Appointment not found after creation');
         }
-        await this.logService.logAction(null, LogAction.APPOINTMENT_CREATED, {
+        await this.logService.logAction(user, LogAction.APPOINTMENT_CREATED, {
             appointmentId: result.id,
             serviceId: result.service.id,
             serviceName: result.service.name,
@@ -121,7 +124,7 @@ export class AppointmentsService {
         return appointment ?? null;
     }
 
-    async cancel(id: number): Promise<Appointment | null> {
+    async cancel(id: number, user: User): Promise<Appointment | null> {
         const appointment = await this.findOne(id);
         if (!appointment) {
             return null;
@@ -139,7 +142,7 @@ export class AppointmentsService {
         });
         const updated = await this.findOne(id);
         if (updated) {
-            await this.logService.logAction(null, LogAction.APPOINTMENT_CANCELLED, {
+            await this.logService.logAction(user, LogAction.APPOINTMENT_CANCELLED, {
                 action: 'cancel',
                 id: updated.id,
                 appointmentId: updated.id,
@@ -149,7 +152,10 @@ export class AppointmentsService {
         return updated;
     }
 
-    async completeAppointment(id: number): Promise<Appointment | null> {
+    async completeAppointment(
+        id: number,
+        user: User,
+    ): Promise<Appointment | null> {
         const appointment = await this.findOne(id);
         if (!appointment) {
             return null;
@@ -163,11 +169,11 @@ export class AppointmentsService {
             await manager.update(Appointment, id, {
                 status: AppointmentStatus.Completed,
             });
-            await this.commissionsService.createFromAppointment(appointment);
+            await this.commissionsService.createFromAppointment(appointment, user);
         });
         const updated = await this.findOne(id);
         if (updated) {
-            await this.logService.logAction(null, LogAction.APPOINTMENT_COMPLETED, {
+            await this.logService.logAction(user, LogAction.APPOINTMENT_COMPLETED, {
                 action: 'complete',
                 id: updated.id,
                 appointmentId: updated.id,

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -10,6 +10,7 @@ describe('CommissionsService', () => {
     let service: CommissionsService;
     let repo: jest.Mocked<Repository<Commission>>;
     let logService: LogService;
+    const user = { userId: 1 };
 
     const mockRepository = (): jest.Mocked<Repository<Commission>> =>
         ({
@@ -50,13 +51,17 @@ describe('CommissionsService', () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.create({ amount: 10 })).resolves.toEqual({
+        await expect(service.create({ amount: 10 }, user)).resolves.toEqual({
             id: 1,
             amount: 10,
         });
         expect(createSpy).toHaveBeenCalledWith({ amount: 10 });
         expect(saveSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 
     it('creates commission from appointment', async () => {
@@ -74,10 +79,10 @@ describe('CommissionsService', () => {
         const spy = jest
             .spyOn(service, 'create')
             .mockImplementation(() => Promise.resolve(created));
-        await expect(service.createFromAppointment(appointment)).resolves.toBe(
-            created,
-        );
-        expect(spy).toHaveBeenCalledWith(expected);
+        await expect(
+            service.createFromAppointment(appointment, user),
+        ).resolves.toBe(created);
+        expect(spy).toHaveBeenCalledWith(expected, user);
     });
 
     it('finds commissions for user', async () => {

--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -5,6 +5,7 @@ import { Commission } from './commission.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class CommissionsService {
@@ -14,28 +15,41 @@ export class CommissionsService {
         private readonly logService: LogService,
     ) {}
 
-    async create(data: Partial<Commission>): Promise<Commission> {
+    async create(
+        data: Partial<Commission>,
+        user: { userId: number },
+    ): Promise<Commission> {
         const commission = this.commissionsRepository.create(data);
         const saved = await this.commissionsRepository.save(commission);
-        await this.logService.logAction(null, LogAction.COMMISSION_CREATED, {
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.COMMISSION_CREATED,
+            {
             commissionId: saved.id,
             appointmentId: saved.appointment?.id,
             employeeId: saved.employee?.id,
             amount: saved.amount,
-        });
+            },
+        );
         return saved;
     }
 
-    async createFromAppointment(appointment: Appointment): Promise<Commission> {
+    async createFromAppointment(
+        appointment: Appointment,
+        user: { userId: number },
+    ): Promise<Commission> {
         const price = Number(appointment.service.price);
         const percent = Number(appointment.service.commissionPercent ?? 0);
         const amount = (price * percent) / 100;
-        return this.create({
-            employee: appointment.employee,
-            appointment,
-            amount,
-            percent,
-        });
+        return this.create(
+            {
+                employee: appointment.employee,
+                appointment,
+                amount,
+                percent,
+            },
+            user,
+        );
     }
 
     findForUser(userId: number): Promise<Commission[]> {

--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -24,18 +24,29 @@ describe('ProductsController', () => {
             create: jest
                 .fn()
                 .mockImplementation(
-                    (dto: CreateProductDto): Promise<Product> =>
-                        Promise.resolve({ id: 1, ...dto }),
+                    (
+                        dto: CreateProductDto,
+                        _user: { userId: number },
+                    ): Promise<Product> => Promise.resolve({ id: 1, ...dto }),
                 ),
             update: jest.fn().mockImplementation(
-                (id: number, dto: UpdateProductDto): Promise<Product> =>
+                (
+                    id: number,
+                    dto: UpdateProductDto,
+                    _user: { userId: number },
+                ): Promise<Product> =>
                     Promise.resolve({
                         ...product,
                         ...dto,
                         id,
                     }),
             ),
-            remove: jest.fn().mockResolvedValue(undefined),
+            remove: jest
+                .fn()
+                .mockImplementation(
+                    (_id: number, _user: { userId: number }) =>
+                        Promise.resolve(undefined),
+                ),
         } as jest.Mocked<ProductsService>;
         controller = new ProductsController(service);
     });
@@ -60,24 +71,26 @@ describe('ProductsController', () => {
             stock: 5,
         };
         const createSpy = jest.spyOn(service, 'create');
-        await expect(controller.create(dto)).resolves.toEqual({
+        await expect(controller.create(dto, { userId: 1 })).resolves.toEqual({
             id: 1,
             ...dto,
         });
-        expect(createSpy).toHaveBeenCalledWith(dto);
+        expect(createSpy).toHaveBeenCalledWith(dto, { userId: 1 });
     });
 
     it('delegates update to service', async () => {
         const dto: UpdateProductDto = { name: 'New' };
         const updated = { ...product, ...dto };
         const updateSpy = jest.spyOn(service, 'update');
-        await expect(controller.update(1, dto)).resolves.toEqual(updated);
-        expect(updateSpy).toHaveBeenCalledWith(1, dto);
+        await expect(controller.update(1, dto, { userId: 1 })).resolves.toEqual(
+            updated,
+        );
+        expect(updateSpy).toHaveBeenCalledWith(1, dto, { userId: 1 });
     });
 
     it('delegates remove to service', async () => {
         const removeSpy = jest.spyOn(service, 'remove');
-        await expect(controller.remove(1)).resolves.toBeUndefined();
-        expect(removeSpy).toHaveBeenCalledWith(1);
+        await expect(controller.remove(1, { userId: 1 })).resolves.toBeUndefined();
+        expect(removeSpy).toHaveBeenCalledWith(1, { userId: 1 });
     });
 });

--- a/backend/salonbw-backend/src/products/products.controller.ts
+++ b/backend/salonbw-backend/src/products/products.controller.ts
@@ -13,6 +13,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
+import { CurrentUser } from '../auth/current-user.decorator';
 import { ProductsService } from './products.service';
 import { Product } from './product.entity';
 import { CreateProductDto } from './dto/create-product.dto';
@@ -39,8 +40,11 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
-    create(@Body() body: CreateProductDto): Promise<Product> {
-        return this.productsService.create(body);
+    create(
+        @Body() body: CreateProductDto,
+        @CurrentUser() user: { userId: number },
+    ): Promise<Product> {
+        return this.productsService.create(body, user);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -49,14 +53,18 @@ export class ProductsController {
     update(
         @Param('id', ParseIntPipe) id: number,
         @Body() body: UpdateProductDto,
+        @CurrentUser() user: { userId: number },
     ): Promise<Product> {
-        return this.productsService.update(id, body);
+        return this.productsService.update(id, body, user);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
-    remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-        return this.productsService.remove(id);
+    remove(
+        @Param('id', ParseIntPipe) id: number,
+        @CurrentUser() user: { userId: number },
+    ): Promise<void> {
+        return this.productsService.remove(id, user);
     }
 }

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -10,6 +10,7 @@ describe('ProductsService', () => {
     let service: ProductsService;
     let repo: jest.Mocked<Repository<Product>>;
     let logService: LogService;
+    const user = { userId: 1 };
 
     const mockRepository = (): jest.Mocked<Repository<Product>> =>
         ({
@@ -64,13 +65,17 @@ describe('ProductsService', () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.create(dto as Product)).resolves.toEqual({
+        await expect(service.create(dto as Product, user)).resolves.toEqual({
             id: 1,
             ...dto,
         });
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 
     it('returns all products', async () => {
@@ -97,18 +102,26 @@ describe('ProductsService', () => {
         const dto: Partial<Product> = { name: 'New' };
         const updateSpy = jest.spyOn(repo, 'update');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.update(1, dto as Product)).resolves.toEqual({
+        await expect(service.update(1, dto as Product, user)).resolves.toEqual({
             id: 1,
         });
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 
     it('removes a product', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await service.remove(1);
+        await service.remove(1, user);
         expect(deleteSpy).toHaveBeenCalledWith(1);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 });

--- a/backend/salonbw-backend/src/products/products.service.ts
+++ b/backend/salonbw-backend/src/products/products.service.ts
@@ -6,6 +6,7 @@ import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class ProductsService {
@@ -15,13 +16,20 @@ export class ProductsService {
         private readonly logService: LogService,
     ) {}
 
-    async create(dto: CreateProductDto): Promise<Product> {
+    async create(
+        dto: CreateProductDto,
+        user: { userId: number },
+    ): Promise<Product> {
         const product = this.productsRepository.create(dto);
         const saved = await this.productsRepository.save(product);
-        await this.logService.logAction(null, LogAction.PRODUCT_CREATED, {
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.PRODUCT_CREATED,
+            {
             productId: saved.id,
             name: saved.name,
-        });
+            },
+        );
         return saved;
     }
 
@@ -39,22 +47,34 @@ export class ProductsService {
         return product;
     }
 
-    async update(id: number, dto: UpdateProductDto): Promise<Product> {
+    async update(
+        id: number,
+        dto: UpdateProductDto,
+        user: { userId: number },
+    ): Promise<Product> {
         await this.productsRepository.update(id, dto);
         const updated = await this.findOne(id);
-        await this.logService.logAction(null, LogAction.PRODUCT_UPDATED, {
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.PRODUCT_UPDATED,
+            {
             productId: updated.id,
             name: updated.name,
-        });
+            },
+        );
         return updated;
     }
 
-    async remove(id: number): Promise<void> {
+    async remove(id: number, user: { userId: number }): Promise<void> {
         const product = await this.findOne(id);
         await this.productsRepository.delete(id);
-        await this.logService.logAction(null, LogAction.PRODUCT_DELETED, {
-            productId: product.id,
-            name: product.name,
-        });
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.PRODUCT_DELETED,
+            {
+                productId: product.id,
+                name: product.name,
+            },
+        );
     }
 }

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -23,9 +23,29 @@ describe('ServicesController', () => {
         service = {
             findAll: jest.fn().mockResolvedValue([serviceEntity]),
             findOne: jest.fn().mockResolvedValue(serviceEntity),
-            create: jest.fn().mockResolvedValue(serviceEntity),
-            update: jest.fn().mockResolvedValue(serviceEntity),
-            remove: jest.fn().mockResolvedValue(undefined),
+            create: jest
+                .fn()
+                .mockImplementation(
+                    (
+                        dto: CreateServiceDto,
+                        _user: { userId: number },
+                    ): Promise<Service> => Promise.resolve(serviceEntity),
+                ),
+            update: jest
+                .fn()
+                .mockImplementation(
+                    (
+                        id: number,
+                        dto: UpdateServiceDto,
+                        _user: { userId: number },
+                    ): Promise<Service> => Promise.resolve(serviceEntity),
+                ),
+            remove: jest
+                .fn()
+                .mockImplementation(
+                    (_id: number, _user: { userId: number }) =>
+                        Promise.resolve(undefined),
+                ),
         } as jest.Mocked<ServicesService>;
         controller = new ServicesController(service);
     });
@@ -52,20 +72,24 @@ describe('ServicesController', () => {
             commissionPercent: 10,
         };
         const createSpy = jest.spyOn(service, 'create');
-        await expect(controller.create(dto)).resolves.toBe(serviceEntity);
-        expect(createSpy).toHaveBeenCalledWith(dto);
+        await expect(controller.create(dto, { userId: 1 })).resolves.toBe(
+            serviceEntity,
+        );
+        expect(createSpy).toHaveBeenCalledWith(dto, { userId: 1 });
     });
 
     it('delegates update to service', async () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const updateSpy = jest.spyOn(service, 'update');
-        await expect(controller.update(1, dto)).resolves.toBe(serviceEntity);
-        expect(updateSpy).toHaveBeenCalledWith(1, dto);
+        await expect(controller.update(1, dto, { userId: 1 })).resolves.toBe(
+            serviceEntity,
+        );
+        expect(updateSpy).toHaveBeenCalledWith(1, dto, { userId: 1 });
     });
 
     it('delegates remove to service', async () => {
         const removeSpy = jest.spyOn(service, 'remove');
-        await expect(controller.remove(1)).resolves.toBeUndefined();
-        expect(removeSpy).toHaveBeenCalledWith(1);
+        await expect(controller.remove(1, { userId: 1 })).resolves.toBeUndefined();
+        expect(removeSpy).toHaveBeenCalledWith(1, { userId: 1 });
     });
 });

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -13,6 +13,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
+import { CurrentUser } from '../auth/current-user.decorator';
 import { ServicesService } from './services.service';
 import { Service } from './service.entity';
 import { CreateServiceDto } from './dto/create-service.dto';
@@ -35,8 +36,11 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
-    create(@Body() createServiceDto: CreateServiceDto): Promise<Service> {
-        return this.servicesService.create(createServiceDto);
+    create(
+        @Body() createServiceDto: CreateServiceDto,
+        @CurrentUser() user: { userId: number },
+    ): Promise<Service> {
+        return this.servicesService.create(createServiceDto, user);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -45,14 +49,18 @@ export class ServicesController {
     update(
         @Param('id', ParseIntPipe) id: number,
         @Body() updateServiceDto: UpdateServiceDto,
+        @CurrentUser() user: { userId: number },
     ): Promise<Service> {
-        return this.servicesService.update(id, updateServiceDto);
+        return this.servicesService.update(id, updateServiceDto, user);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
-    remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-        return this.servicesService.remove(id);
+    remove(
+        @Param('id', ParseIntPipe) id: number,
+        @CurrentUser() user: { userId: number },
+    ): Promise<void> {
+        return this.servicesService.remove(id, user);
     }
 }

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -12,6 +12,7 @@ describe('ServicesService', () => {
     let repo: jest.Mocked<Repository<Service>>;
     let serviceEntity: Service;
     let logService: LogService;
+    const user = { userId: 1 };
 
     const mockRepository = (): jest.Mocked<Repository<Service>> =>
         ({
@@ -74,10 +75,14 @@ describe('ServicesService', () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.create(dto)).resolves.toEqual(serviceEntity);
+        await expect(service.create(dto, user)).resolves.toEqual(serviceEntity);
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 
     it('returns all services', async () => {
@@ -104,16 +109,24 @@ describe('ServicesService', () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const updateSpy = jest.spyOn(repo, 'update');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.update(1, dto)).resolves.toBe(serviceEntity);
+        await expect(service.update(1, dto, user)).resolves.toBe(serviceEntity);
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 
     it('removes a service', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.remove(1)).resolves.toBeUndefined();
+        await expect(service.remove(1, user)).resolves.toBeUndefined();
         expect(deleteSpy).toHaveBeenCalledWith(1);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ id: user.userId }),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 });

--- a/backend/salonbw-backend/src/services/services.service.ts
+++ b/backend/salonbw-backend/src/services/services.service.ts
@@ -6,6 +6,7 @@ import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class ServicesService {
@@ -15,13 +16,20 @@ export class ServicesService {
         private readonly logService: LogService,
     ) {}
 
-    async create(dto: CreateServiceDto): Promise<Service> {
+    async create(
+        dto: CreateServiceDto,
+        user: { userId: number },
+    ): Promise<Service> {
         const service = this.servicesRepository.create(dto);
         const saved = await this.servicesRepository.save(service);
-        await this.logService.logAction(null, LogAction.SERVICE_CREATED, {
-            serviceId: saved.id,
-            name: saved.name,
-        });
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.SERVICE_CREATED,
+            {
+                serviceId: saved.id,
+                name: saved.name,
+            },
+        );
         return saved;
     }
 
@@ -39,22 +47,34 @@ export class ServicesService {
         return service;
     }
 
-    async update(id: number, dto: UpdateServiceDto): Promise<Service> {
+    async update(
+        id: number,
+        dto: UpdateServiceDto,
+        user: { userId: number },
+    ): Promise<Service> {
         await this.servicesRepository.update(id, dto);
         const updated = await this.findOne(id);
-        await this.logService.logAction(null, LogAction.SERVICE_UPDATED, {
-            serviceId: updated.id,
-            name: updated.name,
-        });
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.SERVICE_UPDATED,
+            {
+                serviceId: updated.id,
+                name: updated.name,
+            },
+        );
         return updated;
     }
 
-    async remove(id: number): Promise<void> {
+    async remove(id: number, user: { userId: number }): Promise<void> {
         const service = await this.findOne(id);
         await this.servicesRepository.delete(id);
-        await this.logService.logAction(null, LogAction.SERVICE_DELETED, {
-            serviceId: service.id,
-            name: service.name,
-        });
+        await this.logService.logAction(
+            { id: user.userId } as User,
+            LogAction.SERVICE_DELETED,
+            {
+                serviceId: service.id,
+                name: service.name,
+            },
+        );
     }
 }


### PR DESCRIPTION
## Summary
- forward authenticated user from product, service, and appointment controllers to their services
- log with user context in product, service, appointment, and commission services
- adjust tests for updated signatures and log expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e10bec0c483298a6db30f935cab82