### PR TITLE
test: handle remove id parameter in products controller spec

### DIFF
--- a/backend/salonbw-backend/src/products/products.controller.spec.ts
+++ b/backend/salonbw-backend/src/products/products.controller.spec.ts
@@ -35,7 +35,10 @@ describe('ProductsController', () => {
                         id,
                     }),
             ),
-            remove: jest.fn().mockResolvedValue(undefined),
+            remove: jest.fn().mockImplementation((id: number) => {
+                void id;
+                return Promise.resolve(undefined);
+            }),
         } as jest.Mocked<ProductsService>;
         controller = new ProductsController(service);
     });


### PR DESCRIPTION
## Summary
- reference id in products controller remove mock to avoid unused parameter warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e13d40878832982d238f7a90c22d1