### PR TITLE
test: clean up unused params in ServicesService mock

### DIFF
--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -23,9 +23,19 @@ describe('ServicesController', () => {
         service = {
             findAll: jest.fn().mockResolvedValue([serviceEntity]),
             findOne: jest.fn().mockResolvedValue(serviceEntity),
-            create: jest.fn().mockResolvedValue(serviceEntity),
-            update: jest.fn().mockResolvedValue(serviceEntity),
-            remove: jest.fn().mockResolvedValue(undefined),
+            create: jest.fn((dto: CreateServiceDto) => {
+                void dto;
+                return Promise.resolve(serviceEntity);
+            }),
+            update: jest.fn((id: number, dto: UpdateServiceDto) => {
+                void id;
+                void dto;
+                return Promise.resolve(serviceEntity);
+            }),
+            remove: jest.fn((id: number) => {
+                void id;
+                return Promise.resolve(undefined);
+            }),
         } as jest.Mocked<ServicesService>;
         controller = new ServicesController(service);
     });


### PR DESCRIPTION
## Summary
- avoid unused param warnings in ServicesController tests by referencing or removing unused params in mock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e15bbd1f08329b8127436f3edcc19