### PR TITLE
test: verify log actions in service specs

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -5,6 +5,7 @@ import { CommissionsService } from './commissions.service';
 import { Commission } from './commission.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { LogService } from '../logs/log.service';
+import { LogAction } from '../logs/log-action.enum';
 
 describe('CommissionsService', () => {
     let service: CommissionsService;
@@ -56,7 +57,11 @@ describe('CommissionsService', () => {
         });
         expect(createSpy).toHaveBeenCalledWith({ amount: 10 });
         expect(saveSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.COMMISSION_CREATED,
+            expect.objectContaining({ commissionId: 1, amount: 10 }),
+        );
     });
 
     it('creates commission from appointment', async () => {

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -5,6 +5,7 @@ import { ProductsService } from './products.service';
 import { Product } from './product.entity';
 import { NotFoundException } from '@nestjs/common';
 import { LogService } from '../logs/log.service';
+import { LogAction } from '../logs/log-action.enum';
 
 describe('ProductsService', () => {
     let service: ProductsService;
@@ -70,7 +71,11 @@ describe('ProductsService', () => {
         });
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.PRODUCT_CREATED,
+            expect.objectContaining({ productId: 1, name: 'Shampoo' }),
+        );
     });
 
     it('returns all products', async () => {
@@ -101,7 +106,11 @@ describe('ProductsService', () => {
             id: 1,
         });
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.PRODUCT_UPDATED,
+            expect.objectContaining({ productId: 1 }),
+        );
     });
 
     it('removes a product', async () => {
@@ -109,6 +118,10 @@ describe('ProductsService', () => {
         const logSpy = jest.spyOn(logService, 'logAction');
         await service.remove(1);
         expect(deleteSpy).toHaveBeenCalledWith(1);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.PRODUCT_DELETED,
+            expect.objectContaining({ productId: 1 }),
+        );
     });
 });

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -6,6 +6,7 @@ import { Service } from './service.entity';
 import { ServicesService } from './services.service';
 import { UpdateServiceDto } from './dto/update-service.dto';
 import { LogService } from '../logs/log.service';
+import { LogAction } from '../logs/log-action.enum';
 
 describe('ServicesService', () => {
     let service: ServicesService;
@@ -77,7 +78,14 @@ describe('ServicesService', () => {
         await expect(service.create(dto)).resolves.toEqual(serviceEntity);
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.SERVICE_CREATED,
+            expect.objectContaining({
+                serviceId: serviceEntity.id,
+                name: serviceEntity.name,
+            }),
+        );
     });
 
     it('returns all services', async () => {
@@ -106,7 +114,14 @@ describe('ServicesService', () => {
         const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.update(1, dto)).resolves.toBe(serviceEntity);
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.SERVICE_UPDATED,
+            expect.objectContaining({
+                serviceId: serviceEntity.id,
+                name: serviceEntity.name,
+            }),
+        );
     });
 
     it('removes a service', async () => {
@@ -114,6 +129,13 @@ describe('ServicesService', () => {
         const logSpy = jest.spyOn(logService, 'logAction');
         await expect(service.remove(1)).resolves.toBeUndefined();
         expect(deleteSpy).toHaveBeenCalledWith(1);
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            null,
+            LogAction.SERVICE_DELETED,
+            expect.objectContaining({
+                serviceId: serviceEntity.id,
+                name: serviceEntity.name,
+            }),
+        );
     });
 });


### PR DESCRIPTION
## Summary
- test products service logging with explicit LogAction and productId metadata
- ensure service updates and deletions log proper actions with serviceId info
- verify commissions creation logs include commissionId and amount

## Testing
- `npm test --prefix backend/salonbw-backend`
- `npm run lint --prefix backend/salonbw-backend`


------
https://chatgpt.com/codex/tasks/task_e_689e1772879c8329b638291897d8c5d9