### PR TITLE
Log user context in services

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -60,12 +60,15 @@ export class AppointmentsController {
             (user.role === Role.Employee || user.role === Role.Admin)
                 ? ({ id: body.clientId } as User)
                 : ({ id: user.userId } as User);
-        return this.appointmentsService.create({
-            client,
-            employee: { id: body.employeeId } as User,
-            service: { id: body.serviceId } as SalonService,
-            startTime: new Date(body.startTime),
-        });
+        return this.appointmentsService.create(
+            {
+                client,
+                employee: { id: body.employeeId } as User,
+                service: { id: body.serviceId } as SalonService,
+                startTime: new Date(body.startTime),
+            },
+            { id: user.userId } as User,
+        );
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -93,7 +96,7 @@ export class AppointmentsController {
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.cancel(id);
+        return this.appointmentsService.cancel(id, { id: user.userId } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -113,6 +116,9 @@ export class AppointmentsController {
         ) {
             throw new ForbiddenException();
         }
-        return this.appointmentsService.completeAppointment(id);
+        return this.appointmentsService.completeAppointment(
+            id,
+            { id: user.userId } as User,
+        );
     }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -181,18 +181,21 @@ describe('AppointmentsService', () => {
 
     it('should create an appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const result = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const result = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
         expect(result.id).toBeDefined();
         expect(result.endTime.getTime()).toBe(start.getTime() + 30 * 60 * 1000);
         expect(appointments).toHaveLength(1);
         expect(logActionSpy).toHaveBeenCalledWith(
-            null,
+            users[0],
             LogAction.APPOINTMENT_CREATED,
             expect.objectContaining({ id: result.id }),
         );
@@ -200,34 +203,43 @@ describe('AppointmentsService', () => {
 
     it('should reject overlapping appointments', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
-
-        const overlap = new Date(start.getTime() + 15 * 60 * 1000);
-        await expect(
-            service.create({
+        await service.create(
+            {
                 client: users[0],
                 employee: users[1],
                 service: services[0],
-                startTime: overlap,
-            }),
+                startTime: start,
+            },
+            users[0],
+        );
+
+        const overlap = new Date(start.getTime() + 15 * 60 * 1000);
+        await expect(
+            service.create(
+                {
+                    client: users[0],
+                    employee: users[1],
+                    service: services[0],
+                    startTime: overlap,
+                },
+                users[0],
+            ),
         ).rejects.toBeInstanceOf(ConflictException);
     });
 
     it('should cancel a scheduled appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { id } = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
-        const cancelled = await service.cancel(id);
+        const cancelled = await service.cancel(id, users[0]);
         expect(cancelled?.status).toBe(AppointmentStatus.Cancelled);
         expect(mockAppointmentsRepo.update.mock.calls[0]).toEqual([
             id,
@@ -235,7 +247,7 @@ describe('AppointmentsService', () => {
         ]);
         expect(logActionSpy).toHaveBeenNthCalledWith(
             2,
-            null,
+            users[0],
             LogAction.APPOINTMENT_CANCELLED,
             expect.objectContaining({
                 appointmentId: id,
@@ -246,80 +258,97 @@ describe('AppointmentsService', () => {
 
     it('should not cancel a completed appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { id } = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
-        await service.completeAppointment(id);
-        await expect(service.cancel(id)).rejects.toBeInstanceOf(
+        await service.completeAppointment(id, users[1]);
+        await expect(service.cancel(id, users[0])).rejects.toBeInstanceOf(
             BadRequestException,
         );
     });
 
     it('should not cancel an already cancelled appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { id } = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
-        await service.cancel(id);
-        await expect(service.cancel(id)).rejects.toBeInstanceOf(
+        await service.cancel(id, users[0]);
+        await expect(service.cancel(id, users[0])).rejects.toBeInstanceOf(
             BadRequestException,
         );
     });
 
     it('should not complete a cancelled appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { id } = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
-        await service.cancel(id);
-        await expect(service.completeAppointment(id)).rejects.toBeInstanceOf(
+        await service.cancel(id, users[0]);
+        await expect(service.completeAppointment(id, users[1])).rejects.toBeInstanceOf(
             BadRequestException,
         );
     });
 
     it('should revert completion if commission creation fails', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { id } = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
         mockCommissionsService.createFromAppointment.mockRejectedValueOnce(
             new Error('fail'),
         );
 
-        await expect(service.completeAppointment(id)).rejects.toThrow('fail');
+        await expect(service.completeAppointment(id, users[1])).rejects.toThrow(
+            'fail',
+        );
         const appt = await service.findOne(id);
         expect(appt?.status).toBe(AppointmentStatus.Scheduled);
     });
 
     it('should log when completing an appointment', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
-        const { id } = await service.create({
-            client: users[0],
-            employee: users[1],
-            service: services[0],
-            startTime: start,
-        });
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
 
-        await service.completeAppointment(id);
+        await service.completeAppointment(id, users[1]);
         expect(logActionSpy).toHaveBeenNthCalledWith(
             2,
-            null,
+            users[1],
             LogAction.APPOINTMENT_COMPLETED,
             expect.objectContaining({
                 appointmentId: id,

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -6,6 +6,7 @@ import { Commission } from './commission.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 describe('CommissionsService', () => {
     let service: CommissionsService;
@@ -51,14 +52,15 @@ describe('CommissionsService', () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.create({ amount: 10 })).resolves.toEqual({
+        const user = { id: 1 } as User;
+        await expect(service.create({ amount: 10 }, user)).resolves.toEqual({
             id: 1,
             amount: 10,
         });
         expect(createSpy).toHaveBeenCalledWith({ amount: 10 });
         expect(saveSpy).toHaveBeenCalled();
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.COMMISSION_CREATED,
             expect.objectContaining({ commissionId: 1, amount: 10 }),
         );
@@ -76,13 +78,14 @@ describe('CommissionsService', () => {
             percent: 10,
         };
         const created = { id: 1, ...expected } as Commission;
+        const user = { id: 1 } as User;
         const spy = jest
             .spyOn(service, 'create')
             .mockImplementation(() => Promise.resolve(created));
-        await expect(service.createFromAppointment(appointment)).resolves.toBe(
-            created,
-        );
-        expect(spy).toHaveBeenCalledWith(expected);
+        await expect(
+            service.createFromAppointment(appointment, user),
+        ).resolves.toBe(created);
+        expect(spy).toHaveBeenCalledWith(expected, user);
     });
 
     it('finds commissions for user', async () => {

--- a/backend/salonbw-backend/src/logs/auth-failure.filter.ts
+++ b/backend/salonbw-backend/src/logs/auth-failure.filter.ts
@@ -8,6 +8,7 @@ import {
 import { Request, Response } from 'express';
 import { LogService } from './log.service';
 import { LogAction } from './log-action.enum';
+import { User } from '../users/user.entity';
 
 @Catch(UnauthorizedException, ForbiddenException)
 export class AuthFailureFilter implements ExceptionFilter {
@@ -29,7 +30,7 @@ export class AuthFailureFilter implements ExceptionFilter {
                 ? LogAction.LOGIN_FAIL
                 : LogAction.AUTHORIZATION_FAILURE;
 
-        await this.logService.logAction(null, action, {
+        await this.logService.logAction(req.user as User, action, {
             endpoint: req.url,
             userId: req.user?.id,
         });

--- a/backend/salonbw-backend/src/products/products.controller.ts
+++ b/backend/salonbw-backend/src/products/products.controller.ts
@@ -17,6 +17,8 @@ import { ProductsService } from './products.service';
 import { Product } from './product.entity';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { User } from '../users/user.entity';
 
 @Controller('products')
 export class ProductsController {
@@ -39,8 +41,11 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
-    create(@Body() body: CreateProductDto): Promise<Product> {
-        return this.productsService.create(body);
+    create(
+        @Body() body: CreateProductDto,
+        @CurrentUser() user: { userId: number },
+    ): Promise<Product> {
+        return this.productsService.create(body, { id: user.userId } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -49,14 +54,18 @@ export class ProductsController {
     update(
         @Param('id', ParseIntPipe) id: number,
         @Body() body: UpdateProductDto,
+        @CurrentUser() user: { userId: number },
     ): Promise<Product> {
-        return this.productsService.update(id, body);
+        return this.productsService.update(id, body, { id: user.userId } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
-    remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-        return this.productsService.remove(id);
+    remove(
+        @Param('id', ParseIntPipe) id: number,
+        @CurrentUser() user: { userId: number },
+    ): Promise<void> {
+        return this.productsService.remove(id, { id: user.userId } as User);
     }
 }

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -6,6 +6,7 @@ import { Product } from './product.entity';
 import { NotFoundException } from '@nestjs/common';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 describe('ProductsService', () => {
     let service: ProductsService;
@@ -65,14 +66,15 @@ describe('ProductsService', () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.create(dto as Product)).resolves.toEqual({
+        const user = { id: 1 } as User;
+        await expect(service.create(dto as Product, user)).resolves.toEqual({
             id: 1,
             ...dto,
         });
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.PRODUCT_CREATED,
             expect.objectContaining({ productId: 1, name: 'Shampoo' }),
         );
@@ -102,12 +104,13 @@ describe('ProductsService', () => {
         const dto: Partial<Product> = { name: 'New' };
         const updateSpy = jest.spyOn(repo, 'update');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.update(1, dto as Product)).resolves.toEqual({
+        const user = { id: 1 } as User;
+        await expect(service.update(1, dto as Product, user)).resolves.toEqual({
             id: 1,
         });
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.PRODUCT_UPDATED,
             expect.objectContaining({ productId: 1 }),
         );
@@ -116,10 +119,11 @@ describe('ProductsService', () => {
     it('removes a product', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await service.remove(1);
+        const user = { id: 1 } as User;
+        await service.remove(1, user);
         expect(deleteSpy).toHaveBeenCalledWith(1);
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.PRODUCT_DELETED,
             expect.objectContaining({ productId: 1 }),
         );

--- a/backend/salonbw-backend/src/products/products.service.ts
+++ b/backend/salonbw-backend/src/products/products.service.ts
@@ -6,6 +6,7 @@ import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class ProductsService {
@@ -15,10 +16,10 @@ export class ProductsService {
         private readonly logService: LogService,
     ) {}
 
-    async create(dto: CreateProductDto): Promise<Product> {
+    async create(dto: CreateProductDto, user: User): Promise<Product> {
         const product = this.productsRepository.create(dto);
         const saved = await this.productsRepository.save(product);
-        await this.logService.logAction(null, LogAction.PRODUCT_CREATED, {
+        await this.logService.logAction(user, LogAction.PRODUCT_CREATED, {
             productId: saved.id,
             name: saved.name,
         });
@@ -39,20 +40,24 @@ export class ProductsService {
         return product;
     }
 
-    async update(id: number, dto: UpdateProductDto): Promise<Product> {
+    async update(
+        id: number,
+        dto: UpdateProductDto,
+        user: User,
+    ): Promise<Product> {
         await this.productsRepository.update(id, dto);
         const updated = await this.findOne(id);
-        await this.logService.logAction(null, LogAction.PRODUCT_UPDATED, {
+        await this.logService.logAction(user, LogAction.PRODUCT_UPDATED, {
             productId: updated.id,
             name: updated.name,
         });
         return updated;
     }
 
-    async remove(id: number): Promise<void> {
+    async remove(id: number, user: User): Promise<void> {
         const product = await this.findOne(id);
         await this.productsRepository.delete(id);
-        await this.logService.logAction(null, LogAction.PRODUCT_DELETED, {
+        await this.logService.logAction(user, LogAction.PRODUCT_DELETED, {
             productId: product.id,
             name: product.name,
         });

--- a/backend/salonbw-backend/src/services/services.controller.spec.ts
+++ b/backend/salonbw-backend/src/services/services.controller.spec.ts
@@ -3,6 +3,7 @@ import { ServicesService } from './services.service';
 import { Service } from './service.entity';
 import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
+import { User } from '../users/user.entity';
 
 describe('ServicesController', () => {
     let controller: ServicesController;
@@ -23,17 +24,20 @@ describe('ServicesController', () => {
         service = {
             findAll: jest.fn().mockResolvedValue([serviceEntity]),
             findOne: jest.fn().mockResolvedValue(serviceEntity),
-            create: jest.fn((dto: CreateServiceDto) => {
+            create: jest.fn((dto: CreateServiceDto, user: User) => {
                 void dto;
+                void user;
                 return Promise.resolve(serviceEntity);
             }),
-            update: jest.fn((id: number, dto: UpdateServiceDto) => {
+            update: jest.fn((id: number, dto: UpdateServiceDto, user: User) => {
                 void id;
                 void dto;
+                void user;
                 return Promise.resolve(serviceEntity);
             }),
-            remove: jest.fn((id: number) => {
+            remove: jest.fn((id: number, user: User) => {
                 void id;
+                void user;
                 return Promise.resolve(undefined);
             }),
         } as jest.Mocked<ServicesService>;
@@ -62,20 +66,23 @@ describe('ServicesController', () => {
             commissionPercent: 10,
         };
         const createSpy = jest.spyOn(service, 'create');
-        await expect(controller.create(dto)).resolves.toBe(serviceEntity);
-        expect(createSpy).toHaveBeenCalledWith(dto);
+        const user = { userId: 1 };
+        await expect(controller.create(dto, user)).resolves.toBe(serviceEntity);
+        expect(createSpy).toHaveBeenCalledWith(dto, { id: 1 });
     });
 
     it('delegates update to service', async () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const updateSpy = jest.spyOn(service, 'update');
-        await expect(controller.update(1, dto)).resolves.toBe(serviceEntity);
-        expect(updateSpy).toHaveBeenCalledWith(1, dto);
+        const user = { userId: 1 };
+        await expect(controller.update(1, dto, user)).resolves.toBe(serviceEntity);
+        expect(updateSpy).toHaveBeenCalledWith(1, dto, { id: 1 });
     });
 
     it('delegates remove to service', async () => {
         const removeSpy = jest.spyOn(service, 'remove');
-        await expect(controller.remove(1)).resolves.toBeUndefined();
-        expect(removeSpy).toHaveBeenCalledWith(1);
+        const user = { userId: 1 };
+        await expect(controller.remove(1, user)).resolves.toBeUndefined();
+        expect(removeSpy).toHaveBeenCalledWith(1, { id: 1 });
     });
 });

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -17,6 +17,8 @@ import { ServicesService } from './services.service';
 import { Service } from './service.entity';
 import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { User } from '../users/user.entity';
 
 @Controller('services')
 export class ServicesController {
@@ -35,8 +37,11 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
-    create(@Body() createServiceDto: CreateServiceDto): Promise<Service> {
-        return this.servicesService.create(createServiceDto);
+    create(
+        @Body() createServiceDto: CreateServiceDto,
+        @CurrentUser() user: { userId: number },
+    ): Promise<Service> {
+        return this.servicesService.create(createServiceDto, { id: user.userId } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -45,14 +50,18 @@ export class ServicesController {
     update(
         @Param('id', ParseIntPipe) id: number,
         @Body() updateServiceDto: UpdateServiceDto,
+        @CurrentUser() user: { userId: number },
     ): Promise<Service> {
-        return this.servicesService.update(id, updateServiceDto);
+        return this.servicesService.update(id, updateServiceDto, { id: user.userId } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
-    remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-        return this.servicesService.remove(id);
+    remove(
+        @Param('id', ParseIntPipe) id: number,
+        @CurrentUser() user: { userId: number },
+    ): Promise<void> {
+        return this.servicesService.remove(id, { id: user.userId } as User);
     }
 }

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -7,6 +7,7 @@ import { ServicesService } from './services.service';
 import { UpdateServiceDto } from './dto/update-service.dto';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 describe('ServicesService', () => {
     let service: ServicesService;
@@ -75,11 +76,12 @@ describe('ServicesService', () => {
         const createSpy = jest.spyOn(repo, 'create');
         const saveSpy = jest.spyOn(repo, 'save');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.create(dto)).resolves.toEqual(serviceEntity);
+        const user = { id: 1 } as User;
+        await expect(service.create(dto, user)).resolves.toEqual(serviceEntity);
         expect(createSpy).toHaveBeenCalledWith(dto);
         expect(saveSpy).toHaveBeenCalled();
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.SERVICE_CREATED,
             expect.objectContaining({
                 serviceId: serviceEntity.id,
@@ -112,10 +114,11 @@ describe('ServicesService', () => {
         const dto: UpdateServiceDto = { name: 'New' };
         const updateSpy = jest.spyOn(repo, 'update');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.update(1, dto)).resolves.toBe(serviceEntity);
+        const user = { id: 1 } as User;
+        await expect(service.update(1, dto, user)).resolves.toBe(serviceEntity);
         expect(updateSpy).toHaveBeenCalledWith(1, dto);
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.SERVICE_UPDATED,
             expect.objectContaining({
                 serviceId: serviceEntity.id,
@@ -127,10 +130,11 @@ describe('ServicesService', () => {
     it('removes a service', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
         const logSpy = jest.spyOn(logService, 'logAction');
-        await expect(service.remove(1)).resolves.toBeUndefined();
+        const user = { id: 1 } as User;
+        await expect(service.remove(1, user)).resolves.toBeUndefined();
         expect(deleteSpy).toHaveBeenCalledWith(1);
         expect(logSpy).toHaveBeenCalledWith(
-            null,
+            user,
             LogAction.SERVICE_DELETED,
             expect.objectContaining({
                 serviceId: serviceEntity.id,

--- a/backend/salonbw-backend/src/services/services.service.ts
+++ b/backend/salonbw-backend/src/services/services.service.ts
@@ -6,6 +6,7 @@ import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class ServicesService {
@@ -15,10 +16,10 @@ export class ServicesService {
         private readonly logService: LogService,
     ) {}
 
-    async create(dto: CreateServiceDto): Promise<Service> {
+    async create(dto: CreateServiceDto, user: User): Promise<Service> {
         const service = this.servicesRepository.create(dto);
         const saved = await this.servicesRepository.save(service);
-        await this.logService.logAction(null, LogAction.SERVICE_CREATED, {
+        await this.logService.logAction(user, LogAction.SERVICE_CREATED, {
             serviceId: saved.id,
             name: saved.name,
         });
@@ -39,20 +40,24 @@ export class ServicesService {
         return service;
     }
 
-    async update(id: number, dto: UpdateServiceDto): Promise<Service> {
+    async update(
+        id: number,
+        dto: UpdateServiceDto,
+        user: User,
+    ): Promise<Service> {
         await this.servicesRepository.update(id, dto);
         const updated = await this.findOne(id);
-        await this.logService.logAction(null, LogAction.SERVICE_UPDATED, {
+        await this.logService.logAction(user, LogAction.SERVICE_UPDATED, {
             serviceId: updated.id,
             name: updated.name,
         });
         return updated;
     }
 
-    async remove(id: number): Promise<void> {
+    async remove(id: number, user: User): Promise<void> {
         const service = await this.findOne(id);
         await this.servicesRepository.delete(id);
-        await this.logService.logAction(null, LogAction.SERVICE_DELETED, {
+        await this.logService.logAction(user, LogAction.SERVICE_DELETED, {
             serviceId: service.id,
             name: service.name,
         });


### PR DESCRIPTION
## Summary
- propagate current user from controllers to services
- include user in logService.logAction
- link auth failure logs to the requesting user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e390622bc83299e4e6bfa0c064ae5