### PR TITLE
Handle log failures without blocking operations

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -96,15 +96,19 @@ export class AppointmentsService {
         if (!result) {
             throw new Error('Appointment not found after creation');
         }
-        await this.logService.logAction(user, LogAction.APPOINTMENT_CREATED, {
-            appointmentId: result.id,
-            serviceId: result.service.id,
-            serviceName: result.service.name,
-            clientId: result.client.id,
-            employeeId: result.employee.id,
-            entity: 'appointment',
-            id: result.id,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.APPOINTMENT_CREATED, {
+                appointmentId: result.id,
+                serviceId: result.service.id,
+                serviceName: result.service.name,
+                clientId: result.client.id,
+                employeeId: result.employee.id,
+                entity: 'appointment',
+                id: result.id,
+            });
+        } catch (error) {
+            console.error('Failed to log appointment creation action', error);
+        }
         return result;
     }
 
@@ -142,12 +146,20 @@ export class AppointmentsService {
         });
         const updated = await this.findOne(id);
         if (updated) {
-            await this.logService.logAction(user, LogAction.APPOINTMENT_CANCELLED, {
-                action: 'cancel',
-                id: updated.id,
-                appointmentId: updated.id,
-                status: AppointmentStatus.Cancelled,
-            });
+            try {
+                await this.logService.logAction(
+                    user,
+                    LogAction.APPOINTMENT_CANCELLED,
+                    {
+                        action: 'cancel',
+                        id: updated.id,
+                        appointmentId: updated.id,
+                        status: AppointmentStatus.Cancelled,
+                    },
+                );
+            } catch (error) {
+                console.error('Failed to log appointment cancellation action', error);
+            }
         }
         return updated;
     }
@@ -176,12 +188,20 @@ export class AppointmentsService {
         });
         const updated = await this.findOne(id);
         if (updated) {
-            await this.logService.logAction(user, LogAction.APPOINTMENT_COMPLETED, {
-                action: 'complete',
-                id: updated.id,
-                appointmentId: updated.id,
-                status: AppointmentStatus.Completed,
-            });
+            try {
+                await this.logService.logAction(
+                    user,
+                    LogAction.APPOINTMENT_COMPLETED,
+                    {
+                        action: 'complete',
+                        id: updated.id,
+                        appointmentId: updated.id,
+                        status: AppointmentStatus.Completed,
+                    },
+                );
+            } catch (error) {
+                console.error('Failed to log appointment completion action', error);
+            }
         }
         return updated;
     }

--- a/backend/salonbw-backend/src/auth/auth.controller.ts
+++ b/backend/salonbw-backend/src/auth/auth.controller.ts
@@ -53,9 +53,13 @@ export class AuthController {
     async register(@Body() dto: RegisterDto) {
         const user = await this.usersService.createUser(dto);
         const result = this.authService.login(user);
-        await this.logService.logAction(user, LogAction.USER_REGISTERED, {
-            userId: user.id,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.USER_REGISTERED, {
+                userId: user.id,
+            });
+        } catch (error) {
+            console.error('Failed to log user registration action', error);
+        }
         return result;
     }
 

--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -18,12 +18,16 @@ export class CommissionsService {
     async create(data: Partial<Commission>, user: User): Promise<Commission> {
         const commission = this.commissionsRepository.create(data);
         const saved = await this.commissionsRepository.save(commission);
-        await this.logService.logAction(user, LogAction.COMMISSION_CREATED, {
-            commissionId: saved.id,
-            appointmentId: saved.appointment?.id,
-            employeeId: saved.employee?.id,
-            amount: saved.amount,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.COMMISSION_CREATED, {
+                commissionId: saved.id,
+                appointmentId: saved.appointment?.id,
+                employeeId: saved.employee?.id,
+                amount: saved.amount,
+            });
+        } catch (error) {
+            console.error('Failed to log commission creation action', error);
+        }
         return saved;
     }
 

--- a/backend/salonbw-backend/src/logs/auth-failure.filter.ts
+++ b/backend/salonbw-backend/src/logs/auth-failure.filter.ts
@@ -30,10 +30,18 @@ export class AuthFailureFilter implements ExceptionFilter {
                 ? LogAction.LOGIN_FAIL
                 : LogAction.AUTHORIZATION_FAILURE;
 
-        await this.logService.logAction(req.user as User, action, {
-            endpoint: req.url,
-            userId: req.user?.id,
-        });
+        const userId = (req.user as { id?: number; userId?: number } | undefined)
+            ?.id ?? (req.user as { userId?: number } | undefined)?.userId;
+        const user = userId ? ({ id: userId } as User) : null;
+
+        try {
+            await this.logService.logAction(user, action, {
+                endpoint: req.url,
+                userId,
+            });
+        } catch (error) {
+            console.error('Failed to log authentication failure action', error);
+        }
 
         res.status(exception.getStatus()).json(exception.getResponse());
     }

--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -128,4 +128,56 @@ describe('ProductsService', () => {
             expect.objectContaining({ productId: 1 }),
         );
     });
+
+    describe('when logging fails', () => {
+        it('allows creation to succeed', async () => {
+            logService.logAction = jest
+                .fn()
+                .mockRejectedValue(new Error('fail')) as any;
+            const consoleSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const dto: Partial<Product> = {
+                name: 'Shampoo',
+                brand: 'Brand',
+                unitPrice: 5,
+                stock: 10,
+            };
+            const user = { id: 1 } as User;
+            await expect(service.create(dto as Product, user)).resolves.toEqual({
+                id: 1,
+                ...dto,
+            });
+            expect(consoleSpy).toHaveBeenCalled();
+            consoleSpy.mockRestore();
+        });
+
+        it('allows update to succeed', async () => {
+            logService.logAction = jest
+                .fn()
+                .mockRejectedValue(new Error('fail')) as any;
+            const consoleSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const user = { id: 1 } as User;
+            await expect(service.update(1, {}, user)).resolves.toEqual({
+                id: 1,
+            });
+            expect(consoleSpy).toHaveBeenCalled();
+            consoleSpy.mockRestore();
+        });
+
+        it('allows removal to succeed', async () => {
+            logService.logAction = jest
+                .fn()
+                .mockRejectedValue(new Error('fail')) as any;
+            const consoleSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const user = { id: 1 } as User;
+            await expect(service.remove(1, user)).resolves.toBeUndefined();
+            expect(consoleSpy).toHaveBeenCalled();
+            consoleSpy.mockRestore();
+        });
+    });
 });

--- a/backend/salonbw-backend/src/products/products.service.ts
+++ b/backend/salonbw-backend/src/products/products.service.ts
@@ -19,10 +19,14 @@ export class ProductsService {
     async create(dto: CreateProductDto, user: User): Promise<Product> {
         const product = this.productsRepository.create(dto);
         const saved = await this.productsRepository.save(product);
-        await this.logService.logAction(user, LogAction.PRODUCT_CREATED, {
-            productId: saved.id,
-            name: saved.name,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.PRODUCT_CREATED, {
+                productId: saved.id,
+                name: saved.name,
+            });
+        } catch (error) {
+            console.error('Failed to log product creation action', error);
+        }
         return saved;
     }
 
@@ -47,19 +51,27 @@ export class ProductsService {
     ): Promise<Product> {
         await this.productsRepository.update(id, dto);
         const updated = await this.findOne(id);
-        await this.logService.logAction(user, LogAction.PRODUCT_UPDATED, {
-            productId: updated.id,
-            name: updated.name,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.PRODUCT_UPDATED, {
+                productId: updated.id,
+                name: updated.name,
+            });
+        } catch (error) {
+            console.error('Failed to log product update action', error);
+        }
         return updated;
     }
 
     async remove(id: number, user: User): Promise<void> {
         const product = await this.findOne(id);
         await this.productsRepository.delete(id);
-        await this.logService.logAction(user, LogAction.PRODUCT_DELETED, {
-            productId: product.id,
-            name: product.name,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.PRODUCT_DELETED, {
+                productId: product.id,
+                name: product.name,
+            });
+        } catch (error) {
+            console.error('Failed to log product deletion action', error);
+        }
     }
 }

--- a/backend/salonbw-backend/src/services/services.service.ts
+++ b/backend/salonbw-backend/src/services/services.service.ts
@@ -19,10 +19,14 @@ export class ServicesService {
     async create(dto: CreateServiceDto, user: User): Promise<Service> {
         const service = this.servicesRepository.create(dto);
         const saved = await this.servicesRepository.save(service);
-        await this.logService.logAction(user, LogAction.SERVICE_CREATED, {
-            serviceId: saved.id,
-            name: saved.name,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.SERVICE_CREATED, {
+                serviceId: saved.id,
+                name: saved.name,
+            });
+        } catch (error) {
+            console.error('Failed to log service creation action', error);
+        }
         return saved;
     }
 
@@ -47,19 +51,27 @@ export class ServicesService {
     ): Promise<Service> {
         await this.servicesRepository.update(id, dto);
         const updated = await this.findOne(id);
-        await this.logService.logAction(user, LogAction.SERVICE_UPDATED, {
-            serviceId: updated.id,
-            name: updated.name,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.SERVICE_UPDATED, {
+                serviceId: updated.id,
+                name: updated.name,
+            });
+        } catch (error) {
+            console.error('Failed to log service update action', error);
+        }
         return updated;
     }
 
     async remove(id: number, user: User): Promise<void> {
         const service = await this.findOne(id);
         await this.servicesRepository.delete(id);
-        await this.logService.logAction(user, LogAction.SERVICE_DELETED, {
-            serviceId: service.id,
-            name: service.name,
-        });
+        try {
+            await this.logService.logAction(user, LogAction.SERVICE_DELETED, {
+                serviceId: service.id,
+                name: service.name,
+            });
+        } catch (error) {
+            console.error('Failed to log service deletion action', error);
+        }
     }
 }

--- a/backend/salonbw-backend/test/logs.e2e-spec.ts
+++ b/backend/salonbw-backend/test/logs.e2e-spec.ts
@@ -70,12 +70,16 @@ describe('LogsController (e2e)', () => {
             role: 'client',
         });
 
-        await logService.logAction(admin, LogAction.USER_LOGIN, {
-            note: 'admin log',
-        });
-        await logService.logAction(user, LogAction.USER_LOGIN, {
-            note: 'user log',
-        });
+        try {
+            await logService.logAction(admin, LogAction.USER_LOGIN, {
+                note: 'admin log',
+            });
+            await logService.logAction(user, LogAction.USER_LOGIN, {
+                note: 'user log',
+            });
+        } catch (error) {
+            console.error('Failed to seed log entries', error);
+        }
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## Summary
- guard all logService.logAction calls with try/catch and log errors locally
- add tests ensuring create/update/delete continue when logging fails
- improve auth failure filter to accept tokens with userId

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689e3bd15a6883298cdeefa314e7db8b