### PR TITLE
test: use spyOn for log action failures

### DIFF
--- a/backend/salonbw-backend/src/products/products.service.spec.ts
+++ b/backend/salonbw-backend/src/products/products.service.spec.ts
@@ -131,9 +131,9 @@ describe('ProductsService', () => {
 
     describe('when logging fails', () => {
         it('allows creation to succeed', async () => {
-            logService.logAction = jest
-                .fn()
-                .mockRejectedValue(new Error('fail')) as any;
+            const logActionSpy = jest
+                .spyOn(logService, 'logAction')
+                .mockRejectedValue(new Error('fail'));
             const consoleSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => {});
@@ -144,18 +144,21 @@ describe('ProductsService', () => {
                 stock: 10,
             };
             const user = { id: 1 } as User;
-            await expect(service.create(dto as Product, user)).resolves.toEqual({
-                id: 1,
-                ...dto,
-            });
+            await expect(service.create(dto as Product, user)).resolves.toEqual(
+                {
+                    id: 1,
+                    ...dto,
+                },
+            );
             expect(consoleSpy).toHaveBeenCalled();
             consoleSpy.mockRestore();
+            logActionSpy.mockRestore();
         });
 
         it('allows update to succeed', async () => {
-            logService.logAction = jest
-                .fn()
-                .mockRejectedValue(new Error('fail')) as any;
+            const logActionSpy = jest
+                .spyOn(logService, 'logAction')
+                .mockRejectedValue(new Error('fail'));
             const consoleSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => {});
@@ -165,12 +168,13 @@ describe('ProductsService', () => {
             });
             expect(consoleSpy).toHaveBeenCalled();
             consoleSpy.mockRestore();
+            logActionSpy.mockRestore();
         });
 
         it('allows removal to succeed', async () => {
-            logService.logAction = jest
-                .fn()
-                .mockRejectedValue(new Error('fail')) as any;
+            const logActionSpy = jest
+                .spyOn(logService, 'logAction')
+                .mockRejectedValue(new Error('fail'));
             const consoleSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => {});
@@ -178,6 +182,7 @@ describe('ProductsService', () => {
             await expect(service.remove(1, user)).resolves.toBeUndefined();
             expect(consoleSpy).toHaveBeenCalled();
             consoleSpy.mockRestore();
+            logActionSpy.mockRestore();
         });
     });
 });


### PR DESCRIPTION
## Summary
- mock failing log service calls with jest.spyOn in product tests
- restore logAction spy after each test

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e52d633208329b6d9b974755b382e