### PR TITLE
Ensure log failures don't block core operations

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -201,6 +201,23 @@ describe('AppointmentsService', () => {
         );
     });
 
+    it('should create an appointment even if logging fails', async () => {
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        logActionSpy.mockRejectedValueOnce(new Error('fail'));
+        const result = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
+
+        expect(result.id).toBeDefined();
+        expect(appointments).toHaveLength(1);
+    });
+
     it('should reject overlapping appointments', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
         await service.create(
@@ -254,6 +271,23 @@ describe('AppointmentsService', () => {
                 status: AppointmentStatus.Cancelled,
             }),
         );
+    });
+
+    it('should cancel an appointment even if logging fails', async () => {
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
+
+        logActionSpy.mockRejectedValueOnce(new Error('fail'));
+        const cancelled = await service.cancel(id, users[0]);
+        expect(cancelled?.status).toBe(AppointmentStatus.Cancelled);
     });
 
     it('should not cancel a completed appointment', async () => {
@@ -331,6 +365,23 @@ describe('AppointmentsService', () => {
         );
         const appt = await service.findOne(id);
         expect(appt?.status).toBe(AppointmentStatus.Scheduled);
+    });
+
+    it('should complete an appointment even if logging fails', async () => {
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
+
+        logActionSpy.mockRejectedValueOnce(new Error('fail'));
+        const completed = await service.completeAppointment(id, users[1]);
+        expect(completed?.status).toBe(AppointmentStatus.Completed);
     });
 
     it('should log when completing an appointment', async () => {

--- a/backend/salonbw-backend/src/services/services.service.spec.ts
+++ b/backend/salonbw-backend/src/services/services.service.spec.ts
@@ -90,6 +90,20 @@ describe('ServicesService', () => {
         );
     });
 
+    it('creates a service even if logging fails', async () => {
+        const dto = {
+            name: 'Cut',
+            description: 'Hair cut',
+            duration: 30,
+            price: 10,
+        };
+        jest
+            .spyOn(logService, 'logAction')
+            .mockRejectedValueOnce(new Error('fail'));
+        const user = { id: 1 } as User;
+        await expect(service.create(dto, user)).resolves.toEqual(serviceEntity);
+    });
+
     it('returns all services', async () => {
         const findSpy = jest.spyOn(repo, 'find');
         await expect(service.findAll()).resolves.toEqual([serviceEntity]);
@@ -127,6 +141,15 @@ describe('ServicesService', () => {
         );
     });
 
+    it('updates a service even if logging fails', async () => {
+        const dto: UpdateServiceDto = { name: 'New' };
+        jest
+            .spyOn(logService, 'logAction')
+            .mockRejectedValueOnce(new Error('fail'));
+        const user = { id: 1 } as User;
+        await expect(service.update(1, dto, user)).resolves.toBe(serviceEntity);
+    });
+
     it('removes a service', async () => {
         const deleteSpy = jest.spyOn(repo, 'delete');
         const logSpy = jest.spyOn(logService, 'logAction');
@@ -141,5 +164,13 @@ describe('ServicesService', () => {
                 name: serviceEntity.name,
             }),
         );
+    });
+
+    it('removes a service even if logging fails', async () => {
+        const user = { id: 1 } as User;
+        jest
+            .spyOn(logService, 'logAction')
+            .mockRejectedValueOnce(new Error('fail'));
+        await expect(service.remove(1, user)).resolves.toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary
- add services tests verifying create/update/remove succeed when logging fails
- add appointment tests verifying create/cancel/complete continue despite log errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f0c316c8883299c9a51dcf9053958