### PR TITLE
feat: add commission base to users

### DIFF
--- a/backend/salonbw-backend/src/migrations/1710000000000-CreateUsersTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000000000-CreateUsersTable.ts
@@ -32,6 +32,11 @@ export class CreateUsersTable1710000000000 implements MigrationInterface {
                         enum: ['client', 'employee', 'admin'],
                         default: `'client'`,
                     },
+                    {
+                        name: 'commissionBase',
+                        type: 'decimal',
+                        default: 0,
+                    },
                 ],
             }),
         );

--- a/backend/salonbw-backend/src/users/dto/create-user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsOptional, Min } from 'class-validator';
 
 export class CreateUserDto {
     @IsEmail()
@@ -10,4 +10,8 @@ export class CreateUserDto {
 
     @IsString()
     name: string;
+
+    @IsOptional()
+    @Min(0)
+    commissionBase?: number;
 }

--- a/backend/salonbw-backend/src/users/dto/user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/user.dto.ts
@@ -5,4 +5,5 @@ export class UserDto {
     email: string;
     name: string;
     role: Role;
+    commissionBase: number;
 }

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { Role } from './role.enum';
+import { ColumnNumericTransformer } from '../column-numeric.transformer';
 
 @Entity('users')
 export class User {
@@ -17,4 +18,10 @@ export class User {
 
     @Column({ type: 'simple-enum', enum: Role, default: Role.Client })
     role: Role;
+
+    @Column('decimal', {
+        transformer: new ColumnNumericTransformer(),
+        default: 0,
+    })
+    commissionBase: number;
 }

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -63,11 +63,12 @@ describe('UsersService', () => {
     });
 
     describe('createUser', () => {
-        it('hashes the password, sets default role and saves user', async () => {
+        it('hashes the password, sets default role and saves user with commissionBase', async () => {
             const dto: CreateUserDto = {
                 email: 'test@example.com',
                 name: 'Test User',
                 password: 'plainPass',
+                commissionBase: 10,
             };
             qb.getOne.mockResolvedValue(null);
             bcryptMock.hash.mockResolvedValue('hashedPass');
@@ -76,6 +77,7 @@ describe('UsersService', () => {
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
+                commissionBase: dto.commissionBase,
             };
             const createSpy = jest
                 .spyOn(repo, 'create')
@@ -92,10 +94,48 @@ describe('UsersService', () => {
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
+                commissionBase: dto.commissionBase,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.role).toBe(Role.Client);
             expect(result.password).toBe('hashedPass');
+            expect(result.commissionBase).toBe(dto.commissionBase);
+        });
+
+        it('defaults commissionBase to zero when not provided', async () => {
+            const dto: CreateUserDto = {
+                email: 'test2@example.com',
+                name: 'Test User2',
+                password: 'plainPass',
+            };
+            qb.getOne.mockResolvedValue(null);
+            bcryptMock.hash.mockResolvedValue('hashedPass');
+            const created = {
+                email: dto.email,
+                name: dto.name,
+                password: 'hashedPass',
+                role: Role.Client,
+                commissionBase: 0,
+            };
+            const createSpy = jest
+                .spyOn(repo, 'create')
+                .mockReturnValue(created);
+            const saveSpy = jest
+                .spyOn(repo, 'save')
+                .mockResolvedValue({ ...created, id: 2 });
+
+            const result = await service.createUser(dto);
+
+            expect(bcryptMock.hash).toHaveBeenCalledWith(dto.password, 10);
+            expect(createSpy).toHaveBeenCalledWith({
+                email: dto.email,
+                name: dto.name,
+                password: 'hashedPass',
+                role: Role.Client,
+                commissionBase: 0,
+            });
+            expect(saveSpy).toHaveBeenCalledWith(created);
+            expect(result.commissionBase).toBe(0);
         });
     });
 

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -45,6 +45,7 @@ export class UsersService {
             name: dto.name,
             password: hashedPassword,
             role: Role.Client,
+            commissionBase: dto.commissionBase ?? 0,
         });
 
         return await this.usersRepository.save(user);


### PR DESCRIPTION
## Summary
- add commission base field to User entity and migrations
- allow setting commissionBase when creating users
- cover commissionBase handling with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f1f2f8d6c832990550e25c3c5e797