### PR TITLE
feat: add commission rule entity

### DIFF
--- a/backend/salonbw-backend/src/commissions/commission-rule.entity.ts
+++ b/backend/salonbw-backend/src/commissions/commission-rule.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { ColumnNumericTransformer } from '../column-numeric.transformer';
+import { User } from '../users/user.entity';
+import { Service } from '../services/service.entity';
+
+@Entity('commission_rules')
+export class CommissionRule {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => User, { eager: true })
+    employee: User;
+
+    @ManyToOne(() => Service, { nullable: true, eager: true })
+    service?: Service | null;
+
+    @Column({ nullable: true })
+    category?: string | null;
+
+    @Column('decimal', { transformer: new ColumnNumericTransformer() })
+    commissionPercent: number;
+}

--- a/backend/salonbw-backend/src/commissions/commissions.module.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Commission } from './commission.entity';
+import { CommissionRule } from './commission-rule.entity';
 import { CommissionsService } from './commissions.service';
 import { CommissionsController } from './commissions.controller';
 import { LogsModule } from '../logs/logs.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Commission]), LogsModule],
+    imports: [
+        TypeOrmModule.forFeature([Commission, CommissionRule]),
+        LogsModule,
+    ],
     providers: [CommissionsService],
     controllers: [CommissionsController],
     exports: [CommissionsService],

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CommissionsService } from './commissions.service';
 import { Commission } from './commission.entity';
+import { CommissionRule } from './commission-rule.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
@@ -33,6 +34,10 @@ describe('CommissionsService', () => {
                 {
                     provide: getRepositoryToken(Commission),
                     useValue: mockRepository(),
+                },
+                {
+                    provide: getRepositoryToken(CommissionRule),
+                    useValue: {},
                 },
                 {
                     provide: LogService,

--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Commission } from './commission.entity';
+import { CommissionRule } from './commission-rule.entity';
 import { Appointment } from '../appointments/appointment.entity';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
@@ -12,6 +13,8 @@ export class CommissionsService {
     constructor(
         @InjectRepository(Commission)
         private readonly commissionsRepository: Repository<Commission>,
+        @InjectRepository(CommissionRule)
+        private readonly commissionRulesRepository: Repository<CommissionRule>,
         private readonly logService: LogService,
     ) {}
 
@@ -19,12 +22,16 @@ export class CommissionsService {
         const commission = this.commissionsRepository.create(data);
         const saved = await this.commissionsRepository.save(commission);
         try {
-            await this.logService.logAction(user, LogAction.COMMISSION_CREATED, {
-                commissionId: saved.id,
-                appointmentId: saved.appointment?.id,
-                employeeId: saved.employee?.id,
-                amount: saved.amount,
-            });
+            await this.logService.logAction(
+                user,
+                LogAction.COMMISSION_CREATED,
+                {
+                    commissionId: saved.id,
+                    appointmentId: saved.appointment?.id,
+                    employeeId: saved.employee?.id,
+                    amount: saved.amount,
+                },
+            );
         } catch (error) {
             console.error('Failed to log commission creation action', error);
         }


### PR DESCRIPTION
## Summary
- add CommissionRule entity for employee commission percentages
- register CommissionRule in CommissionsModule and service
- update commission service tests for new repository

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f31fdbbdc83299c7b4ccbdc89515e