### PR TITLE
Ensure atomic commission creation for completed appointments

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -160,9 +160,10 @@ describe('AppointmentsService', () => {
         >;
 
         mockCommissionsService = {
-            createFromAppointment: jest.fn<Promise<void>, [Appointment]>(() =>
-                Promise.resolve(),
-            ),
+            createFromAppointment: jest.fn<
+                Promise<unknown>,
+                [Appointment, User, unknown]
+            >(() => Promise.resolve({})),
         } as Partial<CommissionsService> as jest.Mocked<CommissionsService>;
 
         mockLogService = {
@@ -339,9 +340,9 @@ describe('AppointmentsService', () => {
         );
 
         await service.cancel(id, users[0]);
-        await expect(service.completeAppointment(id, users[1])).rejects.toBeInstanceOf(
-            BadRequestException,
-        );
+        await expect(
+            service.completeAppointment(id, users[1]),
+        ).rejects.toBeInstanceOf(BadRequestException);
     });
 
     it('should revert completion if commission creation fails', async () => {


### PR DESCRIPTION
## Summary
- Avoid duplicate commission entries by checking existing records before saving
- Wrap appointment completion and commission creation in a single transaction for atomic updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f54ddff9c8329938cd9a6c61f72f3