### PR TITLE
feat: add commissions summary endpoint

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -577,6 +577,45 @@
         ]
       }
     },
+    "/commissions/employees/{id}/commissions/summary": {
+      "get": {
+        "operationId": "CommissionsController_getSummaryForEmployee",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "from",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Commissions"
+        ]
+      }
+    },
     "/commissions": {
       "get": {
         "operationId": "CommissionsController_findAll",

--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -14,6 +14,7 @@ describe('CommissionsController', () => {
         service = {
             findForUser: jest.fn().mockResolvedValue([mine]),
             findAll: jest.fn().mockResolvedValue([all]),
+            sumForUser: jest.fn().mockResolvedValue(10),
         } as jest.Mocked<CommissionsService>;
         controller = new CommissionsController(service);
     });
@@ -30,6 +31,22 @@ describe('CommissionsController', () => {
         const findForUserSpy = jest.spyOn(service, 'findForUser');
         await expect(controller.findForEmployee(2)).resolves.toEqual([mine]);
         expect(findForUserSpy).toHaveBeenCalledWith(2);
+    });
+
+    it('delegates getSummaryForEmployee to service', async () => {
+        const sumSpy = jest.spyOn(service, 'sumForUser');
+        await expect(
+            controller.getSummaryForEmployee(
+                1,
+                '2024-01-01',
+                '2024-01-31',
+            ),
+        ).resolves.toEqual({ amount: 10 });
+        expect(sumSpy).toHaveBeenCalledWith(
+            1,
+            new Date('2024-01-01'),
+            new Date('2024-01-31'),
+        );
     });
 
     it('delegates findAll to service', async () => {

--- a/backend/salonbw-backend/src/commissions/commissions.controller.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Param,
+    ParseIntPipe,
+    UseGuards,
+    Query,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CommissionsService } from './commissions.service';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -24,6 +31,18 @@ export class CommissionsController {
         @Param('id', ParseIntPipe) id: number,
     ): Promise<Commission[]> {
         return this.commissionsService.findForUser(id);
+    }
+
+    @Roles(Role.Admin)
+    @Get('employees/:id/commissions/summary')
+    getSummaryForEmployee(
+        @Param('id', ParseIntPipe) id: number,
+        @Query('from') from: string,
+        @Query('to') to: string,
+    ): Promise<{ amount: number }> {
+        return this.commissionsService
+            .sumForUser(id, new Date(from), new Date(to))
+            .then((amount) => ({ amount }));
     }
 
     @Roles(Role.Admin)

--- a/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.spec.ts
@@ -28,6 +28,7 @@ describe('CommissionsService', () => {
                 ),
             find: jest.fn<Promise<Commission[]>, []>().mockResolvedValue([]),
             findOne: jest.fn(),
+            createQueryBuilder: jest.fn(),
         }) as jest.Mocked<Repository<Commission>>;
 
     const mockRulesRepository = (): jest.Mocked<Repository<CommissionRule>> =>
@@ -210,5 +211,26 @@ describe('CommissionsService', () => {
         expect(findSpy).toHaveBeenCalledWith({
             order: { createdAt: 'DESC' },
         });
+    });
+
+    it('sums commissions for user in date range', async () => {
+        const qb: any = {
+            select: jest.fn().mockReturnThis(),
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            getRawOne: jest.fn().mockResolvedValue({ total: '100' }),
+        };
+        repo.createQueryBuilder.mockReturnValue(qb);
+        const result = await service.sumForUser(
+            1,
+            new Date('2024-01-01'),
+            new Date('2024-01-31'),
+        );
+        expect(repo.createQueryBuilder).toHaveBeenCalledWith('commission');
+        expect(qb.select).toHaveBeenCalledWith(
+            'COALESCE(SUM(commission.amount), 0)',
+            'total',
+        );
+        expect(result).toBe(100);
     });
 });

--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -128,6 +128,23 @@ export class CommissionsService {
         });
     }
 
+    async sumForUser(
+        userId: number,
+        from: Date,
+        to: Date,
+    ): Promise<number> {
+        const result = await this.commissionsRepository
+            .createQueryBuilder('commission')
+            .select('COALESCE(SUM(commission.amount), 0)', 'total')
+            .where('commission.employeeId = :userId', { userId })
+            .andWhere('commission.createdAt BETWEEN :from AND :to', {
+                from,
+                to,
+            })
+            .getRawOne<{ total: string }>();
+        return Number(result?.total ?? 0);
+    }
+
     findAll(): Promise<Commission[]> {
         return this.commissionsRepository.find({
             order: { createdAt: 'DESC' },


### PR DESCRIPTION
## Summary
- support summing commissions for an employee within a date range
- expose admin endpoint to retrieve commission summary

## Testing
- `npm test`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_689f69a477488329a1ef9ae408cab2f8