### PR TITLE
test: add double completion commission test

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -408,4 +408,29 @@ describe('AppointmentsService', () => {
             }),
         );
     });
+
+    it('should not create duplicate commissions when completing twice', async () => {
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
+
+        await service.completeAppointment(id, users[1]);
+        const calls =
+            mockCommissionsService.createFromAppointment.mock.calls.length;
+
+        try {
+            await service.completeAppointment(id, users[1]);
+        } catch {}
+
+        expect(
+            mockCommissionsService.createFromAppointment.mock.calls.length,
+        ).toBe(calls);
+    });
 });


### PR DESCRIPTION
## Summary
- add a regression test ensuring `completeAppointment` isn't called twice to create extra commission entries

## Testing
- `npm test` *(fails: 1 failed, 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe963ddc8329b3c3cbcfe3a66d3a