### PR TITLE
test: assert duplicate commission not created on repeat completion

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -425,9 +425,9 @@ describe('AppointmentsService', () => {
         const calls =
             mockCommissionsService.createFromAppointment.mock.calls.length;
 
-        try {
-            await service.completeAppointment(id, users[1]);
-        } catch {}
+        await expect(
+            service.completeAppointment(id, users[1]),
+        ).rejects.toThrow();
 
         expect(
             mockCommissionsService.createFromAppointment.mock.calls.length,


### PR DESCRIPTION
## Summary
- assert appointment completion throws and avoids duplicate commission creation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a054b628108329b21958beb28c2380