### PR TITLE
feat: use service commission percent before employee base

### DIFF
--- a/backend/salonbw-backend/src/commissions/commissions.service.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.service.ts
@@ -71,6 +71,9 @@ export class CommissionsService {
                 return Number(ruleForCategory.commissionPercent);
             }
         }
+        if (service.commissionPercent != null) {
+            return Number(service.commissionPercent);
+        }
         return Number(employee.commissionBase ?? 0);
     }
 


### PR DESCRIPTION
## Summary
- fall back to a service's commissionPercent before employee base when resolving commission rates
- test commission calculations when only a service percent is present
- verify resolveCommissionPercent uses service percent or employee base appropriately

## Testing
- `cd backend/salonbw-backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a066982e98832995a4d77c9706aa6d