### PR TITLE
Expose employee commission summary under employees path

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -577,7 +577,7 @@
         ]
       }
     },
-    "/commissions/employees/{id}/commissions/summary": {
+    "/employees/{id}/commissions/summary": {
       "get": {
         "operationId": "CommissionsController_getSummaryForEmployee",
         "parameters": [

--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -1,6 +1,8 @@
 import { CommissionsController } from './commissions.controller';
 import { CommissionsService } from './commissions.service';
 import { Commission } from './commission.entity';
+import { RequestMethod } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
 
 describe('CommissionsController', () => {
     let controller: CommissionsController;
@@ -36,17 +38,27 @@ describe('CommissionsController', () => {
     it('delegates getSummaryForEmployee to service', async () => {
         const sumSpy = jest.spyOn(service, 'sumForUser');
         await expect(
-            controller.getSummaryForEmployee(
-                1,
-                '2024-01-01',
-                '2024-01-31',
-            ),
+            controller.getSummaryForEmployee(1, '2024-01-01', '2024-01-31'),
         ).resolves.toEqual({ amount: 10 });
         expect(sumSpy).toHaveBeenCalledWith(
             1,
             new Date('2024-01-01'),
             new Date('2024-01-31'),
         );
+    });
+
+    it('maps getSummaryForEmployee to GET /employees/:id/commissions/summary', () => {
+        const handler = Object.getOwnPropertyDescriptor(
+            CommissionsController.prototype,
+            'getSummaryForEmployee',
+        )?.value as unknown;
+        const path = Reflect.getMetadata(PATH_METADATA, handler) as string;
+        const method = Reflect.getMetadata(
+            METHOD_METADATA,
+            handler,
+        ) as RequestMethod;
+        expect(path).toBe('employees/:id/commissions/summary');
+        expect(method).toBe(RequestMethod.GET);
     });
 
     it('delegates findAll to service', async () => {

--- a/backend/salonbw-backend/src/commissions/commissions.controller.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.ts
@@ -14,19 +14,19 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
 import { Commission } from './commission.entity';
 
-@Controller('commissions')
+@Controller()
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class CommissionsController {
     constructor(private readonly commissionsService: CommissionsService) {}
 
     @Roles(Role.Employee, Role.Admin)
-    @Get('me')
+    @Get('commissions/me')
     findMine(@CurrentUser() user: { userId: number }): Promise<Commission[]> {
         return this.commissionsService.findForUser(user.userId);
     }
 
     @Roles(Role.Admin)
-    @Get('employees/:id')
+    @Get('commissions/employees/:id')
     findForEmployee(
         @Param('id', ParseIntPipe) id: number,
     ): Promise<Commission[]> {
@@ -46,7 +46,7 @@ export class CommissionsController {
     }
 
     @Roles(Role.Admin)
-    @Get()
+    @Get('commissions')
     findAll(): Promise<Commission[]> {
         return this.commissionsService.findAll();
     }


### PR DESCRIPTION
## Summary
- expose commissions summary for employees at `GET /employees/:id/commissions/summary`
- adjust controller and OpenAPI spec to match new route
- add test ensuring controller method is mapped to new endpoint
- refactor route-mapping test to satisfy lint rules

## Testing
- `npx eslint src/commissions/commissions.controller.spec.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0711185d883298e5d3432b33db168