### PR TITLE
feat: annotate commission summary dates for swagger

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -594,6 +594,7 @@
             "required": true,
             "in": "query",
             "schema": {
+              "format": "date-time",
               "type": "string"
             }
           },
@@ -602,6 +603,7 @@
             "required": true,
             "in": "query",
             "schema": {
+              "format": "date-time",
               "type": "string"
             }
           }

--- a/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.spec.ts
@@ -38,7 +38,10 @@ describe('CommissionsController', () => {
     it('delegates getSummaryForEmployee to service', async () => {
         const sumSpy = jest.spyOn(service, 'sumForUser');
         await expect(
-            controller.getSummaryForEmployee(1, '2024-01-01', '2024-01-31'),
+            controller.getSummaryForEmployee(1, {
+                from: '2024-01-01',
+                to: '2024-01-31',
+            }),
         ).resolves.toEqual({ amount: 10 });
         expect(sumSpy).toHaveBeenCalledWith(
             1,

--- a/backend/salonbw-backend/src/commissions/commissions.controller.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.ts
@@ -13,6 +13,7 @@ import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
 import { Commission } from './commission.entity';
+import { GetSummaryDto } from './dto/get-summary.dto';
 
 @Controller()
 @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -37,8 +38,7 @@ export class CommissionsController {
     @Get('employees/:id/commissions/summary')
     getSummaryForEmployee(
         @Param('id', ParseIntPipe) id: number,
-        @Query('from') from: string,
-        @Query('to') to: string,
+        @Query() { from, to }: GetSummaryDto,
     ): Promise<{ amount: number }> {
         return this.commissionsService
             .sumForUser(id, new Date(from), new Date(to))

--- a/backend/salonbw-backend/src/commissions/dto/get-summary.dto.ts
+++ b/backend/salonbw-backend/src/commissions/dto/get-summary.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsISO8601 } from 'class-validator';
+
+export class GetSummaryDto {
+    @ApiProperty({ required: true, type: String, format: 'date-time' })
+    @IsISO8601()
+    from: string;
+
+    @ApiProperty({ required: true, type: String, format: 'date-time' })
+    @IsISO8601()
+    to: string;
+}


### PR DESCRIPTION
## Summary
- expose `from`/`to` date range for commission summaries in Swagger
- use `GetSummaryDto` in commissions controller and tests
- regenerate OpenAPI spec

## Testing
- `npm run lint`
- `npm test`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_68a082b096f08329a5d26b64c150a51e