### PR TITLE
feat: add unique commission appointment index

### DIFF
--- a/backend/salonbw-backend/src/commissions/commission.entity.ts
+++ b/backend/salonbw-backend/src/commissions/commission.entity.ts
@@ -4,6 +4,7 @@ import {
     ManyToOne,
     Column,
     CreateDateColumn,
+    Index,
 } from 'typeorm';
 import { ColumnNumericTransformer } from '../column-numeric.transformer';
 import { User } from '../users/user.entity';
@@ -18,6 +19,7 @@ export class Commission {
     @ManyToOne(() => User, { eager: true })
     employee: User;
 
+    @Index({ unique: true, where: 'appointmentId IS NOT NULL' })
     @ManyToOne(() => Appointment, { nullable: true, eager: true })
     appointment?: Appointment | null;
 

--- a/backend/salonbw-backend/src/migrations/1710003000000-AddUniqueAppointmentIdIndexOnCommissions.ts
+++ b/backend/salonbw-backend/src/migrations/1710003000000-AddUniqueAppointmentIdIndexOnCommissions.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueAppointmentIdIndexOnCommissions1710003000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE UNIQUE INDEX "IDX_commissions_appointmentId_unique" ON "commissions" ("appointmentId") WHERE "appointmentId" IS NOT NULL`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DROP INDEX "IDX_commissions_appointmentId_unique"`
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add migration creating unique index on commissions.appointmentId when not null
- enforce uniqueness through TypeORM entity index

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a555b55883299a921ccf9914f68b