### PR TITLE
feat(chat): persist messages via TypeORM

### DIFF
--- a/backend/salonbw-backend/src/chat/chat-message.entity.ts
+++ b/backend/salonbw-backend/src/chat/chat-message.entity.ts
@@ -1,0 +1,27 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    CreateDateColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Appointment } from '../appointments/appointment.entity';
+
+@Entity('chat_messages')
+export class ChatMessage {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => User, { eager: true })
+    user: User;
+
+    @ManyToOne(() => Appointment, { eager: true })
+    appointment: Appointment;
+
+    @Column()
+    content: string;
+
+    @CreateDateColumn()
+    timestamp: Date;
+}

--- a/backend/salonbw-backend/src/chat/chat.gateway.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.ts
@@ -90,7 +90,13 @@ export class ChatGateway implements OnGatewayConnection {
             payload.appointmentId,
             payload.message,
         );
-        this.server.to(roomName).emit('message', saved);
+        this.server.to(roomName).emit('message', {
+            id: saved.id,
+            userId: saved.user.id,
+            appointmentId: saved.appointment.id,
+            content: saved.content,
+            timestamp: saved.timestamp,
+        });
         return { status: 'ok' };
     }
 }

--- a/backend/salonbw-backend/src/chat/chat.module.ts
+++ b/backend/salonbw-backend/src/chat/chat.module.ts
@@ -4,9 +4,15 @@ import { AppointmentsModule } from '../appointments/appointments.module';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { JwtService } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChatMessage } from './chat-message.entity';
 
 @Module({
-    imports: [WebSocketModule, AppointmentsModule],
+    imports: [
+        WebSocketModule,
+        AppointmentsModule,
+        TypeOrmModule.forFeature([ChatMessage]),
+    ],
     providers: [ChatGateway, ChatService, JwtService],
     exports: [ChatService],
 })

--- a/backend/salonbw-backend/src/chat/chat.service.ts
+++ b/backend/salonbw-backend/src/chat/chat.service.ts
@@ -1,21 +1,30 @@
 import { Injectable } from '@nestjs/common';
-
-export interface ChatMessage {
-    userId: number;
-    appointmentId: number;
-    content: string;
-}
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChatMessage } from './chat-message.entity';
+import { User } from '../users/user.entity';
+import { Appointment } from '../appointments/appointment.entity';
 
 @Injectable()
 export class ChatService {
+    constructor(
+        @InjectRepository(ChatMessage)
+        private readonly chatMessageRepository: Repository<ChatMessage>,
+    ) {}
+
     async createMessage(
         userId: number,
         appointmentId: number,
         content: string,
     ): Promise<ChatMessage> {
-        // Persist message in storage or database
-        const message = { userId, appointmentId, content };
-        await Promise.resolve();
-        return message;
+        const message = this.chatMessageRepository.create({
+            user: { id: userId } as User,
+            appointment: { id: appointmentId } as Appointment,
+            content,
+        });
+        const saved = await this.chatMessageRepository.save(message);
+        return this.chatMessageRepository.findOneOrFail({
+            where: { id: saved.id },
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add ChatMessage entity linking users and appointments
- persist chat messages through TypeORM repository
- broadcast stored message details from chat gateway

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e0742b48832999ad4028387c8161