### PR TITLE
feat(chat): add DTO validation for websocket payloads

### DIFF
--- a/backend/salonbw-backend/src/chat/dto/join-room.dto.ts
+++ b/backend/salonbw-backend/src/chat/dto/join-room.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class JoinRoomDto {
+    @Type(() => Number)
+    @IsInt()
+    @IsNotEmpty()
+    appointmentId: number;
+}

--- a/backend/salonbw-backend/src/chat/dto/message.dto.ts
+++ b/backend/salonbw-backend/src/chat/dto/message.dto.ts
@@ -1,0 +1,13 @@
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class MessageDto {
+    @Type(() => Number)
+    @IsInt()
+    @IsNotEmpty()
+    appointmentId: number;
+
+    @IsString()
+    @IsNotEmpty()
+    message: string;
+}


### PR DESCRIPTION
## Summary
- validate WebSocket payloads using DTOs
- ensure chat gateway uses ValidationPipe for runtime checks

## Testing
- `npx eslint "src/chat/**/*.ts"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec5888d0832995112e1c0b720c88