### PR TITLE
Default WebSocket CORS to any origin when FRONTEND_URL unset

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,6 +3,7 @@
 ## Verification
 
 1. Copy `.env.example` to `.env` and ensure it contains `DATABASE_URL` (e.g., `postgres://user:password@localhost:5432/database`).
+   `FRONTEND_URL` is optional; when omitted, WebSocket CORS allows requests from any origin.
 2. Start PostgreSQL using those credentials. One way is:
    - `sudo service postgresql start`
    - `sudo -u postgres psql -c "CREATE USER \"user\" WITH PASSWORD 'password';"`

--- a/backend/salonbw-backend/.env.example
+++ b/backend/salonbw-backend/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://user:password@localhost:5432/database
+# Optional: when unset, WebSocket CORS allows requests from any origin
 FRONTEND_URL=http://localhost:3000

--- a/backend/salonbw-backend/src/chat/chat.gateway.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.ts
@@ -7,6 +7,7 @@ import {
 import { UsePipes, ValidationPipe } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { AppointmentsService } from '../appointments/appointments.service';
 import { ChatService } from './chat.service';
 import { JoinRoomDto } from './dto/join-room.dto';
@@ -24,7 +25,8 @@ interface ChatSocket extends Socket {
     };
 }
 
-const FRONTEND_URL = process.env.FRONTEND_URL;
+const FRONTEND_URL =
+    new ConfigService().get<string>('FRONTEND_URL') ?? true;
 
 @WebSocketGateway({ cors: { origin: FRONTEND_URL } })
 @UsePipes(new ValidationPipe())


### PR DESCRIPTION
## Summary
- Use NestJS ConfigService to set WebSocketGateway CORS origin and fall back to allowing all origins when FRONTEND_URL is missing
- Document the optional FRONTEND_URL and its default behavior in backend config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a100e75c308329ab7ad88e82175381