### PR TITLE
feat(chat): configure jwt module

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.module.ts
+++ b/backend/salonbw-backend/src/chat/chat.module.ts
@@ -3,7 +3,8 @@ import { WebSocketModule } from '@nestjs/websockets';
 import { AppointmentsModule } from '../appointments/appointments.module';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
-import { JwtService } from '@nestjs/jwt';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChatMessage } from './chat-message.entity';
 
@@ -12,8 +13,15 @@ import { ChatMessage } from './chat-message.entity';
         WebSocketModule,
         AppointmentsModule,
         TypeOrmModule.forFeature([ChatMessage]),
+        JwtModule.registerAsync({
+            inject: [ConfigService],
+            useFactory: (config: ConfigService) => ({
+                secret: config.get<string>('JWT_SECRET'),
+                signOptions: { expiresIn: '1h' },
+            }),
+        }),
     ],
-    providers: [ChatGateway, ChatService, JwtService],
+    providers: [ChatGateway, ChatService],
     exports: [ChatService],
 })
 export class ChatModule {}


### PR DESCRIPTION
## Summary
- integrate JwtModule in ChatModule using app-wide secret and expiration
- remove direct JwtService provider from ChatModule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1092243808329bc659ef16fdd2edf