### PR TITLE
feat: add chat message entity and service methods

### DIFF
--- a/backend/salonbw-backend/src/chat/chat-message.entity.ts
+++ b/backend/salonbw-backend/src/chat/chat-message.entity.ts
@@ -5,23 +5,23 @@ import {
     ManyToOne,
     CreateDateColumn,
 } from 'typeorm';
-import { User } from '../users/user.entity';
 import { Appointment } from '../appointments/appointment.entity';
+import { User } from '../users/user.entity';
 
 @Entity('chat_messages')
 export class ChatMessage {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => User, { eager: true })
-    user: User;
-
-    @ManyToOne(() => Appointment, { eager: true })
-    appointment: Appointment;
-
     @Column()
-    content: string;
+    text: string;
 
     @CreateDateColumn()
     timestamp: Date;
+
+    @ManyToOne(() => Appointment)
+    appointment: Appointment;
+
+    @ManyToOne(() => User, { eager: true })
+    user: User;
 }

--- a/backend/salonbw-backend/src/chat/chat.gateway.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.ts
@@ -93,7 +93,7 @@ export class ChatGateway implements OnGatewayConnection {
         if (!client.rooms.has(roomName)) {
             return { status: 'error' };
         }
-        const saved = await this.chatService.createMessage(
+        const saved = await this.chatService.saveMessage(
             client.data.userId,
             payload.appointmentId,
             payload.message,
@@ -102,7 +102,7 @@ export class ChatGateway implements OnGatewayConnection {
             id: saved.id,
             userId: saved.user.id,
             appointmentId: saved.appointment.id,
-            content: saved.content,
+            text: saved.text,
             timestamp: saved.timestamp,
         });
         return { status: 'ok' };

--- a/backend/salonbw-backend/src/chat/chat.module.ts
+++ b/backend/salonbw-backend/src/chat/chat.module.ts
@@ -7,12 +7,14 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChatMessage } from './chat-message.entity';
+import { Appointment } from '../appointments/appointment.entity';
+import { User } from '../users/user.entity';
 
 @Module({
     imports: [
         WebSocketModule,
         AppointmentsModule,
-        TypeOrmModule.forFeature([ChatMessage]),
+        TypeOrmModule.forFeature([ChatMessage, Appointment, User]),
         JwtModule.registerAsync({
             inject: [ConfigService],
             useFactory: (config: ConfigService) => ({

--- a/backend/salonbw-backend/src/chat/chat.service.ts
+++ b/backend/salonbw-backend/src/chat/chat.service.ts
@@ -12,19 +12,26 @@ export class ChatService {
         private readonly chatMessageRepository: Repository<ChatMessage>,
     ) {}
 
-    async createMessage(
+    async saveMessage(
         userId: number,
         appointmentId: number,
-        content: string,
+        text: string,
     ): Promise<ChatMessage> {
         const message = this.chatMessageRepository.create({
             user: { id: userId } as User,
             appointment: { id: appointmentId } as Appointment,
-            content,
+            text,
         });
         const saved = await this.chatMessageRepository.save(message);
         return this.chatMessageRepository.findOneOrFail({
             where: { id: saved.id },
+        });
+    }
+
+    async findMessages(appointmentId: number): Promise<ChatMessage[]> {
+        return this.chatMessageRepository.find({
+            where: { appointment: { id: appointmentId } },
+            order: { timestamp: 'ASC' },
         });
     }
 }

--- a/backend/salonbw-backend/src/migrations/1710004000000-CreateChatMessagesTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710004000000-CreateChatMessagesTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateChatMessagesTable1710004000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'chat_messages',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'text',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'timestamp',
+                        type: 'timestamp',
+                        default: 'now()',
+                    },
+                    {
+                        name: 'appointmentId',
+                        type: 'int',
+                    },
+                    {
+                        name: 'userId',
+                        type: 'int',
+                    },
+                ],
+                foreignKeys: [
+                    {
+                        columnNames: ['appointmentId'],
+                        referencedTableName: 'appointments',
+                        referencedColumnNames: ['id'],
+                    },
+                    {
+                        columnNames: ['userId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('chat_messages');
+    }
+}


### PR DESCRIPTION
## Summary
- define ChatMessage entity with text, timestamp, and user/appointment relations
- register ChatMessage, Appointment, and User entities in ChatModule
- add migration for chat_messages table and implement ChatService methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1104d5e208329aa4523b44d12a2bb