### PR TITLE
feat: add appointment chat endpoint

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.controller.ts
+++ b/backend/salonbw-backend/src/chat/chat.controller.ts
@@ -1,0 +1,62 @@
+import {
+    Controller,
+    Get,
+    Param,
+    UseGuards,
+    ForbiddenException,
+    NotFoundException,
+    ParseIntPipe,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { Appointment } from '../appointments/appointment.entity';
+import { ChatService } from './chat.service';
+import { ChatMessage } from './chat-message.entity';
+
+@ApiTags('appointments')
+@Controller('appointments')
+export class ChatController {
+    constructor(
+        private readonly chatService: ChatService,
+        @InjectRepository(Appointment)
+        private readonly appointmentRepository: Repository<Appointment>,
+    ) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
+    @Get(':id/chat')
+    @ApiOperation({ summary: 'Get chat messages for an appointment' })
+    @ApiResponse({
+        status: 200,
+        description: 'List of chat messages',
+        type: [ChatMessage],
+    })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Appointment not found' })
+    async getChat(
+        @Param('id', ParseIntPipe) id: number,
+        @CurrentUser() user: { userId: number; role: Role },
+    ): Promise<ChatMessage[]> {
+        const appointment = await this.appointmentRepository.findOne({
+            where: { id },
+            relations: ['client', 'employee'],
+        });
+        if (!appointment) {
+            throw new NotFoundException();
+        }
+        if (
+            user.role !== Role.Admin &&
+            appointment.client.id !== user.userId &&
+            appointment.employee.id !== user.userId
+        ) {
+            throw new ForbiddenException();
+        }
+        return this.chatService.findMessages(id);
+    }
+}

--- a/backend/salonbw-backend/src/chat/chat.module.ts
+++ b/backend/salonbw-backend/src/chat/chat.module.ts
@@ -3,6 +3,7 @@ import { WebSocketModule } from '@nestjs/websockets';
 import { AppointmentsModule } from '../appointments/appointments.module';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
+import { ChatController } from './chat.controller';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -23,6 +24,7 @@ import { User } from '../users/user.entity';
             }),
         }),
     ],
+    controllers: [ChatController],
     providers: [ChatGateway, ChatService],
     exports: [ChatService],
 })


### PR DESCRIPTION
## Summary
- add GET /appointments/:id/chat endpoint to retrieve chat messages for appointments
- wire chat controller into module

## Testing
- `npx eslint src/chat/chat.controller.ts src/chat/chat.module.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1124cb5a483298efe2426a8aa88f2