### PR TITLE
test(chat): add chat controller and gateway specs

### DIFF
--- a/backend/salonbw-backend/package-lock.json
+++ b/backend/salonbw-backend/package-lock.json
@@ -54,6 +54,7 @@
         "globals": "^16.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
+        "socket.io-client": "^4.8.1",
         "source-map-support": "^0.5.21",
         "sqlite3": "^5.1.7",
         "supertest": "^7.0.0",
@@ -5663,6 +5664,38 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -10915,6 +10948,40 @@
         }
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -13048,6 +13115,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/backend/salonbw-backend/package.json
+++ b/backend/salonbw-backend/package.json
@@ -66,6 +66,7 @@
     "globals": "^16.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
+    "socket.io-client": "^4.8.1",
     "source-map-support": "^0.5.21",
     "sqlite3": "^5.1.7",
     "supertest": "^7.0.0",

--- a/backend/salonbw-backend/src/chat/chat.controller.spec.ts
+++ b/backend/salonbw-backend/src/chat/chat.controller.spec.ts
@@ -1,0 +1,113 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, ExecutionContext } from '@nestjs/common';
+import request from 'supertest';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+import { Appointment } from '../appointments/appointment.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+
+interface ChatMessage {
+    id: number;
+    user: { id: number };
+    appointment: { id: number };
+    text: string;
+    timestamp: Date;
+}
+
+describe('ChatController', () => {
+    let app: INestApplication;
+    let chatService: {
+        findMessages: jest.Mock;
+        saveMessage: jest.Mock;
+    };
+    let currentUser: { userId: number; role: Role };
+    let messages: ChatMessage[];
+    let appointment: Appointment;
+
+    beforeEach(async () => {
+        messages = [];
+        appointment = {
+            id: 1,
+            client: { id: 1, role: Role.Client } as any,
+            employee: { id: 2, role: Role.Employee } as any,
+        } as Appointment;
+
+        chatService = {
+            findMessages: jest
+                .fn<Promise<ChatMessage[]>, [number]>(async (id) =>
+                    messages.filter((m) => m.appointment.id === id),
+                ),
+            saveMessage: jest
+                .fn<Promise<ChatMessage>, [number, number, string]>(
+                    async (userId, appointmentId, text) => {
+                        const msg = {
+                            id: messages.length + 1,
+                            user: { id: userId },
+                            appointment: { id: appointmentId },
+                            text,
+                            timestamp: new Date(),
+                        };
+                        messages.push(msg);
+                        return msg;
+                    },
+                ),
+        };
+
+        const mockAppointmentRepo = {
+            findOne: jest.fn(async ({ where: { id } }) =>
+                id === appointment.id ? appointment : null,
+            ),
+        };
+
+        currentUser = { userId: 1, role: Role.Client };
+
+        const moduleRef = await Test.createTestingModule({
+            controllers: [ChatController],
+            providers: [
+                { provide: ChatService, useValue: chatService },
+                { provide: getRepositoryToken(Appointment), useValue: mockAppointmentRepo },
+            ],
+        })
+            .overrideGuard(AuthGuard('jwt'))
+            .useValue({
+                canActivate: (context: ExecutionContext) => {
+                    const req = context.switchToHttp().getRequest();
+                    req.user = currentUser;
+                    return true;
+                },
+            })
+            .overrideGuard(RolesGuard)
+            .useValue({ canActivate: () => true })
+            .compile();
+
+        app = moduleRef.createNestApplication();
+        await app.init();
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+
+    it('should return messages for authorized user and forbid others', async () => {
+        await request(app.getHttpServer())
+            .get('/appointments/1/chat')
+            .expect(200)
+            .expect([]);
+
+        await chatService.saveMessage(1, 1, 'hello');
+
+        const res = await request(app.getHttpServer())
+            .get('/appointments/1/chat')
+            .expect(200);
+        expect(res.body).toHaveLength(1);
+        expect(res.body[0].text).toBe('hello');
+
+        currentUser = { userId: 3, role: Role.Client };
+        await request(app.getHttpServer())
+            .get('/appointments/1/chat')
+            .expect(403);
+    });
+});

--- a/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
@@ -1,0 +1,140 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { io, Socket } from 'socket.io-client';
+import { ChatGateway } from './chat.gateway';
+import { AppointmentsService } from '../appointments/appointments.service';
+import { ChatService } from './chat.service';
+import { Appointment } from '../appointments/appointment.entity';
+
+interface Message {
+    id: number;
+    user: { id: number };
+    appointment: { id: number };
+    text: string;
+    timestamp: Date;
+}
+
+describe('ChatGateway', () => {
+    let app: INestApplication;
+    let jwtService: JwtService;
+    let baseUrl: string;
+    let mockAppointmentsService: jest.Mocked<AppointmentsService>;
+    let mockChatService: { saveMessage: jest.Mock };
+    let messages: Message[];
+    let appointment: Appointment;
+
+    beforeAll(async () => {
+        messages = [];
+        appointment = {
+            id: 1,
+            client: { id: 1 } as any,
+            employee: { id: 2 } as any,
+        } as Appointment;
+
+        mockAppointmentsService = {
+            findOne: jest.fn().mockResolvedValue(appointment),
+        } as any;
+
+        mockChatService = {
+            saveMessage: jest
+                .fn()
+                .mockImplementation(
+                    async (
+                        userId: number,
+                        appointmentId: number,
+                        text: string,
+                    ) => {
+                        const msg = {
+                            id: messages.length + 1,
+                            user: { id: userId },
+                            appointment: { id: appointmentId },
+                            text,
+                            timestamp: new Date(),
+                        };
+                        messages.push(msg);
+                        return msg;
+                    },
+                ),
+        };
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                ChatGateway,
+                { provide: AppointmentsService, useValue: mockAppointmentsService },
+                { provide: ChatService, useValue: mockChatService },
+            ],
+            imports: [JwtModule.register({ secret: 'test' })],
+        }).compile();
+
+        app = moduleRef.createNestApplication();
+        await app.listen(0);
+        const server = app.getHttpServer();
+        const address = server.address();
+        baseUrl = `http://localhost:${address.port}`;
+        jwtService = moduleRef.get(JwtService);
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    it('should disconnect clients without token', async () => {
+        const socket = io(baseUrl, {
+            transports: ['websocket'],
+            forceNew: true,
+            reconnection: false,
+        });
+        await new Promise((resolve) => socket.on('disconnect', resolve));
+        expect(socket.connected).toBe(false);
+        socket.close();
+    });
+
+    it('should allow authorized clients to exchange messages', async () => {
+        const token1 = await jwtService.signAsync({ sub: 1, role: 'Client' });
+        const token2 = await jwtService.signAsync({ sub: 2, role: 'Employee' });
+
+        const socket1 = io(baseUrl, {
+            transports: ['websocket'],
+            forceNew: true,
+            extraHeaders: { Authorization: `Bearer ${token1}` },
+        });
+        const socket2 = io(baseUrl, {
+            transports: ['websocket'],
+            forceNew: true,
+            extraHeaders: { Authorization: `Bearer ${token2}` },
+        });
+
+        await Promise.all([
+            new Promise((resolve) => socket1.on('connect', resolve)),
+            new Promise((resolve) => socket2.on('connect', resolve)),
+        ]);
+
+        const join1 = await new Promise((resolve) =>
+            socket1.emit('joinRoom', { appointmentId: 1 }, resolve),
+        );
+        const join2 = await new Promise((resolve) =>
+            socket2.emit('joinRoom', { appointmentId: 1 }, resolve),
+        );
+        expect(join1).toEqual({ status: 'ok' });
+        expect(join2).toEqual({ status: 'ok' });
+
+        const received = new Promise<any>((resolve) =>
+            socket2.on('message', resolve),
+        );
+        const sendRes = await new Promise((resolve) =>
+            socket1.emit(
+                'message',
+                { appointmentId: 1, message: 'hello' },
+                resolve,
+            ),
+        );
+        expect(sendRes).toEqual({ status: 'ok' });
+        const msg = await received;
+        expect(msg.text).toBe('hello');
+        expect(msg.userId).toBe(1);
+
+        socket1.close();
+        socket2.close();
+    });
+});


### PR DESCRIPTION
## Summary
- add socket.io-client dev dependency
- add chat.gateway spec covering auth and message flow
- add chat.controller spec to fetch messages and handle authorization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11949ee548329b762829dd18b2d07