### PR TITLE
refactor: reuse server variable in chat controller tests

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.controller.spec.ts
+++ b/backend/salonbw-backend/src/chat/chat.controller.spec.ts
@@ -77,7 +77,6 @@ describe('ChatController', () => {
                     provide: getRepositoryToken(Appointment),
                     useValue: mockAppointmentRepo,
                 },
-
             ],
         })
             .overrideGuard(AuthGuard('jwt'))
@@ -113,16 +112,14 @@ describe('ChatController', () => {
 
         await chatService.saveMessage(1, 1, 'hello');
 
-        const res = await request(app.getHttpServer())
+        const res = await request(server)
             .get('/appointments/1/chat')
             .expect(200);
-        expect(res.body).toHaveLength(1);
-        expect(res.body[0].text).toBe('hello');
+        const body = res.body as ChatMessage[];
+        expect(body).toHaveLength(1);
+        expect(body[0].text).toBe('hello');
 
         currentUser = { userId: 3, role: Role.Client };
-        await request(app.getHttpServer())
-            .get('/appointments/1/chat')
-            .expect(403);
-
+        await request(server).get('/appointments/1/chat').expect(403);
     });
 });


### PR DESCRIPTION
## Summary
- reuse typed server variable for all requests in chat controller tests
- cast fetched messages to `ChatMessage[]` and access via `body[0]`

## Testing
- `npm run lint` *(fails: 'Socket' is defined but never used in chat.gateway.spec.ts)*
- `npx eslint src/chat/chat.controller.spec.ts && echo 'Lint OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a19171e5048329aaa3dbd5dbe7892d