### PR TITLE
chore: remove unused Socket import in chat test

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { JwtModule, JwtService } from '@nestjs/jwt';
-import { io, Socket } from 'socket.io-client';
+import { io } from 'socket.io-client';
 import { ChatGateway } from './chat.gateway';
 import { AppointmentsService } from '../appointments/appointments.service';
 import { ChatService } from './chat.service';


### PR DESCRIPTION
## Summary
- remove unused `Socket` import from chat gateway test

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1b00aa258832982a7becaad1214ef