### PR TITLE
refactor: move socket.io-client to dev deps

### DIFF
--- a/backend/salonbw-backend/package-lock.json
+++ b/backend/salonbw-backend/package-lock.json
@@ -31,7 +31,6 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1",
         "ts-node": "^10.9.2",
         "typeorm": "^0.3.25"
       },
@@ -56,6 +55,7 @@
         "globals": "^16.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
+        "socket.io-client": "^4.8.1",
         "source-map-support": "^0.5.21",
         "sqlite3": "^5.1.7",
         "supertest": "^7.0.0",
@@ -5680,6 +5680,7 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
       "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -5693,6 +5694,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10962,6 +10964,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
       "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -10977,6 +10980,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -13129,6 +13133,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }

--- a/backend/salonbw-backend/package.json
+++ b/backend/salonbw-backend/package.json
@@ -43,7 +43,6 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
-    "socket.io-client": "^4.8.1",
     "ts-node": "^10.9.2",
     "typeorm": "^0.3.25"
   },
@@ -68,6 +67,7 @@
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
     "@types/socket.io-client": "^3.0.0",
+    "socket.io-client": "^4.8.1",
     "source-map-support": "^0.5.21",
     "sqlite3": "^5.1.7",
     "supertest": "^7.0.0",


### PR DESCRIPTION
## Summary
- move socket.io-client to devDependencies
- update lockfile

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b515e7c483299fa43493cc139d9f