### PR TITLE
Inject ConfigService into ChatGateway

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
@@ -5,6 +5,7 @@ import { io } from 'socket.io-client';
 import { ChatGateway } from './chat.gateway';
 import { AppointmentsService } from '../appointments/appointments.service';
 import { ChatService } from './chat.service';
+import { ConfigService } from '@nestjs/config';
 import { Appointment } from '../appointments/appointment.entity';
 import { User } from '../users/user.entity';
 import { Server } from 'http';
@@ -65,6 +66,16 @@ describe('ChatGateway', () => {
                     useValue: mockAppointmentsService,
                 },
                 { provide: ChatService, useValue: mockChatService },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string) => {
+                            if (key === 'JWT_SECRET') return 'test';
+                            if (key === 'FRONTEND_URL') return true;
+                            return null;
+                        }),
+                    },
+                },
             ],
             imports: [JwtModule.register({ secret: 'test' })],
         }).compile();


### PR DESCRIPTION
## Summary
- inject ConfigService into ChatGateway to drive CORS origin from configuration
- use ConfigService to supply JWT secret when verifying tokens
- adjust ChatGateway tests with mocked ConfigService

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c57a9c108329997b3e310b9ed3ea