### PR TITLE
feat(chat): limit message length

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.spec.ts
@@ -151,4 +151,44 @@ describe('ChatGateway', () => {
         socket1.close();
         socket2.close();
     });
+
+    it('should reject messages exceeding maximum length', async () => {
+        const token1 = await jwtService.signAsync({ sub: 1, role: 'Client' });
+        const token2 = await jwtService.signAsync({ sub: 2, role: 'Employee' });
+
+        const socket1 = io(baseUrl, {
+            transports: ['websocket'],
+            forceNew: true,
+            extraHeaders: { Authorization: `Bearer ${token1}` },
+        });
+        const socket2 = io(baseUrl, {
+            transports: ['websocket'],
+            forceNew: true,
+            extraHeaders: { Authorization: `Bearer ${token2}` },
+        });
+
+        await Promise.all([
+            new Promise((resolve) => socket1.on('connect', resolve)),
+            new Promise((resolve) => socket2.on('connect', resolve)),
+        ]);
+
+        await new Promise((resolve) =>
+            socket1.emit('joinRoom', { appointmentId: 1 }, resolve),
+        );
+        await new Promise((resolve) =>
+            socket2.emit('joinRoom', { appointmentId: 1 }, resolve),
+        );
+
+        const longText = 'a'.repeat(501);
+        const errorPromise = new Promise<any>((resolve) =>
+            socket1.on('exception', resolve),
+        );
+        socket1.emit('message', { appointmentId: 1, message: longText });
+        const error = await errorPromise;
+
+        expect(error).toBeDefined();
+
+        socket1.close();
+        socket2.close();
+    });
 });

--- a/backend/salonbw-backend/src/chat/chat.gateway.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.ts
@@ -27,7 +27,11 @@ interface ChatSocket extends Socket {
 }
 
 @WebSocketGateway()
-@UsePipes(new ValidationPipe())
+@UsePipes(
+    new ValidationPipe({
+        transform: true,
+    }),
+)
 export class ChatGateway implements OnGatewayConnection, OnGatewayInit {
     @WebSocketServer()
     server: Server;

--- a/backend/salonbw-backend/src/chat/dto/message.dto.ts
+++ b/backend/salonbw-backend/src/chat/dto/message.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class MessageDto {
@@ -9,5 +9,6 @@ export class MessageDto {
 
     @IsString()
     @IsNotEmpty()
+    @MaxLength(500)
     message: string;
 }


### PR DESCRIPTION
## Summary
- cap chat messages at 500 characters
- ensure ChatGateway transforms payloads for validation
- add websocket test for oversize message rejection

## Testing
- `cd backend/salonbw-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed043824832998efcc62e7d17cb8