### PR TITLE
feat(chat): limit message length

### DIFF
--- a/backend/salonbw-backend/src/chat/chat.gateway.ts
+++ b/backend/salonbw-backend/src/chat/chat.gateway.ts
@@ -27,7 +27,11 @@ interface ChatSocket extends Socket {
 }
 
 @WebSocketGateway()
-@UsePipes(new ValidationPipe())
+@UsePipes(
+    new ValidationPipe({
+        transform: true,
+    }),
+)
 export class ChatGateway implements OnGatewayConnection, OnGatewayInit {
     @WebSocketServer()
     server: Server;

--- a/backend/salonbw-backend/src/chat/dto/message.dto.ts
+++ b/backend/salonbw-backend/src/chat/dto/message.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class MessageDto {
@@ -9,5 +9,6 @@ export class MessageDto {
 
     @IsString()
     @IsNotEmpty()
+    @MaxLength(500)
     message: string;
 }


### PR DESCRIPTION
## Summary
- cap chat messages at 500 characters
- ensure ChatGateway transforms payloads for validation
- add websocket test for oversize message rejection
- type exception listener in chat gateway test to satisfy lint rules

## Testing
- `cd backend/salonbw-backend && npm run lint`
- `cd backend/salonbw-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed043824832998efcc62e7d17cb8