### PR TITLE
docs: add jwt and port examples to env template

### DIFF
--- a/backend/salonbw-backend/.env.example
+++ b/backend/salonbw-backend/.env.example
@@ -1,3 +1,6 @@
 DATABASE_URL=postgres://user:password@localhost:5432/database
 # Optional: when unset, WebSocket CORS allows requests from any origin
 FRONTEND_URL=http://localhost:3000
+JWT_SECRET=example_jwt_secret
+JWT_REFRESH_SECRET=example_refresh_secret
+PORT=3000


### PR DESCRIPTION
## Summary
- add example JWT secret and refresh secret to backend env template
- include explicit port example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37d542bfc8329b781b2e9e47068fd