### PR TITLE
Protect services endpoints with JWT roles

### DIFF
--- a/backend/salonbw-backend/src/commissions/commission-rule.entity.ts
+++ b/backend/salonbw-backend/src/commissions/commission-rule.entity.ts
@@ -14,7 +14,7 @@ export class CommissionRule {
     @ManyToOne(() => Service, { nullable: true, eager: true })
     service?: Service | null;
 
-    @Column({ nullable: true })
+    @Column('text', { nullable: true })
     category?: string | null;
 
     @Column('decimal', { transformer: new ColumnNumericTransformer() })

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -24,11 +24,15 @@ import { User } from '../users/user.entity';
 export class ServicesController {
     constructor(private readonly servicesService: ServicesService) {}
 
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get()
     findAll(): Promise<Service[]> {
         return this.servicesService.findAll();
     }
 
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get(':id')
     findOne(@Param('id', ParseIntPipe) id: number): Promise<Service> {
         return this.servicesService.findOne(id);
@@ -41,7 +45,9 @@ export class ServicesController {
         @Body() createServiceDto: CreateServiceDto,
         @CurrentUser() user: { userId: number },
     ): Promise<Service> {
-        return this.servicesService.create(createServiceDto, { id: user.userId } as User);
+        return this.servicesService.create(createServiceDto, {
+            id: user.userId,
+        } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -52,7 +58,9 @@ export class ServicesController {
         @Body() updateServiceDto: UpdateServiceDto,
         @CurrentUser() user: { userId: number },
     ): Promise<Service> {
-        return this.servicesService.update(id, updateServiceDto, { id: user.userId } as User);
+        return this.servicesService.update(id, updateServiceDto, {
+            id: user.userId,
+        } as User);
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)

--- a/backend/salonbw-backend/test/appointments.e2e-spec.ts
+++ b/backend/salonbw-backend/test/appointments.e2e-spec.ts
@@ -17,6 +17,7 @@ import { User } from '../src/users/user.entity';
 import { Service } from '../src/services/service.entity';
 import { Appointment } from '../src/appointments/appointment.entity';
 import { Commission } from '../src/commissions/commission.entity';
+import { CommissionRule } from '../src/commissions/commission-rule.entity';
 import { Formula } from '../src/formulas/formula.entity';
 import { Product } from '../src/products/product.entity';
 import { Log } from '../src/logs/log.entity';
@@ -62,6 +63,7 @@ describe('Appointments integration', () => {
                         Appointment,
                         Service,
                         Commission,
+                        CommissionRule,
                         Formula,
                         Product,
                         Log,
@@ -99,24 +101,28 @@ describe('Appointments integration', () => {
             password: 'pass',
             name: 'Client',
             role: 'client',
+            commissionBase: 0,
         });
         employee = await userRepo.save({
             email: 'emp@example.com',
             password: 'pass',
             name: 'Emp',
             role: 'employee',
+            commissionBase: 0,
         });
         const otherEmployee = await userRepo.save({
             email: 'emp2@example.com',
             password: 'pass',
             name: 'Emp2',
             role: 'employee',
+            commissionBase: 0,
         });
         const admin = await userRepo.save({
             email: 'admin@example.com',
             password: 'pass',
             name: 'Admin',
             role: 'admin',
+            commissionBase: 0,
         });
 
         service = await serviceRepo.save({
@@ -405,7 +411,10 @@ describe('Appointments integration', () => {
     });
 
     it('rejects non-numeric service id', async () => {
-        await request(server).get('/services/abc').expect(400);
+        await request(server)
+            .get('/services/abc')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .expect(400);
     });
 
     it('rejects non-numeric product id', async () => {

--- a/backend/salonbw-backend/test/auth.e2e-spec.ts
+++ b/backend/salonbw-backend/test/auth.e2e-spec.ts
@@ -63,6 +63,7 @@ describe('Auth & Users (e2e)', () => {
             password: adminPassword,
             name: 'Admin',
             role: 'admin',
+            commissionBase: 0,
         });
         server = app.getHttpServer() as Parameters<typeof request>[0];
     });

--- a/backend/salonbw-backend/test/logs.e2e-spec.ts
+++ b/backend/salonbw-backend/test/logs.e2e-spec.ts
@@ -62,12 +62,14 @@ describe('LogsController (e2e)', () => {
             password: 'pass',
             name: 'Admin',
             role: 'admin',
+            commissionBase: 0,
         });
         user = await userRepo.save({
             email: 'user@example.com',
             password: 'pass',
             name: 'User',
             role: 'client',
+            commissionBase: 0,
         });
 
         try {

--- a/backend/salonbw-backend/test/services.e2e-spec.ts
+++ b/backend/salonbw-backend/test/services.e2e-spec.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+import jwt from 'jsonwebtoken';
+import { Repository } from 'typeorm';
+
+import { AuthModule } from '../src/auth/auth.module';
+import { ServicesModule } from '../src/services/services.module';
+import { User } from '../src/users/user.entity';
+import { Service } from '../src/services/service.entity';
+
+describe('ServicesController (e2e)', () => {
+    let app: INestApplication;
+    let server: Parameters<typeof request>[0];
+    let userRepo: Repository<User>;
+    let serviceRepo: Repository<Service>;
+    let token: string;
+    let service: Service;
+
+    beforeAll(async () => {
+        process.env.JWT_SECRET = 'test-secret';
+        process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({ isGlobal: true }),
+                TypeOrmModule.forRoot({
+                    type: 'sqlite',
+                    database: ':memory:',
+                    dropSchema: true,
+                    entities: [User, Service],
+                    synchronize: true,
+                }),
+                AuthModule,
+                ServicesModule,
+            ],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.use(cookieParser());
+        await app.init();
+        server = app.getHttpServer() as Parameters<typeof request>[0];
+
+        userRepo = moduleFixture.get<Repository<User>>(
+            getRepositoryToken(User),
+        );
+        serviceRepo = moduleFixture.get<Repository<Service>>(
+            getRepositoryToken(Service),
+        );
+
+        const user = await userRepo.save({
+            email: 'client@example.com',
+            password: 'pass',
+            name: 'Client',
+            role: 'client',
+            commissionBase: 0,
+        });
+        service = await serviceRepo.save({
+            name: 'Cut',
+            description: 'Hair cut',
+            duration: 60,
+            price: 100,
+            commissionPercent: 10,
+        });
+
+        token = jwt.sign(
+            { sub: user.id, role: 'client' },
+            process.env.JWT_SECRET ?? '',
+        );
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    it('rejects unauthenticated access', async () => {
+        await request(server).get('/services').expect(401);
+    });
+
+    it('returns all services for authenticated users', async () => {
+        const res = await request(server)
+            .get('/services')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+        expect(res.body).toHaveLength(1);
+        expect(res.body[0].id).toBe(service.id);
+    });
+
+    it('returns a service by id for authenticated users', async () => {
+        const res = await request(server)
+            .get(`/services/${service.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .expect(200);
+        expect(res.body.id).toBe(service.id);
+    });
+});


### PR DESCRIPTION
## Summary
- require JWT authentication and roles for listing and fetching services
- specify type for commission rule category and add e2e tests with authentication

## Testing
- `npx eslint backend/salonbw-backend/src/services/services.controller.ts backend/salonbw-backend/src/commissions/commission-rule.entity.ts backend/salonbw-backend/test/appointments.e2e-spec.ts backend/salonbw-backend/test/auth.e2e-spec.ts backend/salonbw-backend/test/logs.e2e-spec.ts backend/salonbw-backend/test/services.e2e-spec.ts`
- `cd backend/salonbw-backend && npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68a380dd3fd08329a6ade5f668674ee7