### PR TITLE
feat: add base entity migrations

### DIFF
--- a/backend/salonbw-backend/src/migrations/1710000100000-CreateServicesTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000100000-CreateServicesTable.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateServicesTable1710000100000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'services',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'name',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'description',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'duration',
+                        type: 'int',
+                    },
+                    {
+                        name: 'price',
+                        type: 'decimal',
+                    },
+                    {
+                        name: 'category',
+                        type: 'varchar',
+                        isNullable: true,
+                    },
+                    {
+                        name: 'commissionPercent',
+                        type: 'decimal',
+                        isNullable: true,
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('services');
+    }
+}

--- a/backend/salonbw-backend/src/migrations/1710000200000-CreateProductsTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000200000-CreateProductsTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateProductsTable1710000200000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'products',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'name',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'brand',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'unitPrice',
+                        type: 'decimal',
+                    },
+                    {
+                        name: 'stock',
+                        type: 'int',
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('products');
+    }
+}

--- a/backend/salonbw-backend/src/migrations/1710000300000-CreateAppointmentsTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000300000-CreateAppointmentsTable.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateAppointmentsTable1710000300000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'appointments',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'clientId',
+                        type: 'int',
+                    },
+                    {
+                        name: 'employeeId',
+                        type: 'int',
+                    },
+                    {
+                        name: 'serviceId',
+                        type: 'int',
+                    },
+                    {
+                        name: 'startTime',
+                        type: 'timestamp',
+                    },
+                    {
+                        name: 'endTime',
+                        type: 'timestamp',
+                    },
+                    {
+                        name: 'status',
+                        type: 'enum',
+                        enum: ['scheduled', 'cancelled', 'completed'],
+                        default: `'scheduled'`,
+                    },
+                    {
+                        name: 'notes',
+                        type: 'varchar',
+                        isNullable: true,
+                    },
+                ],
+                foreignKeys: [
+                    {
+                        columnNames: ['clientId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                    },
+                    {
+                        columnNames: ['employeeId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                    },
+                    {
+                        columnNames: ['serviceId'],
+                        referencedTableName: 'services',
+                        referencedColumnNames: ['id'],
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('appointments');
+    }
+}

--- a/backend/salonbw-backend/src/migrations/1710000400000-CreateFormulasTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000400000-CreateFormulasTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateFormulasTable1710000400000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'formulas',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'description',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'date',
+                        type: 'timestamp',
+                    },
+                    {
+                        name: 'clientId',
+                        type: 'int',
+                    },
+                    {
+                        name: 'appointmentId',
+                        type: 'int',
+                        isNullable: true,
+                    },
+                ],
+                foreignKeys: [
+                    {
+                        columnNames: ['clientId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                    },
+                    {
+                        columnNames: ['appointmentId'],
+                        referencedTableName: 'appointments',
+                        referencedColumnNames: ['id'],
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('formulas');
+    }
+}

--- a/backend/salonbw-backend/src/migrations/1710000500000-CreateLogsTable.ts
+++ b/backend/salonbw-backend/src/migrations/1710000500000-CreateLogsTable.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateLogsTable1710000500000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'logs',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'userId',
+                        type: 'int',
+                        isNullable: true,
+                    },
+                    {
+                        name: 'action',
+                        type: 'enum',
+                        enum: [
+                            'USER_LOGIN',
+                            'LOGIN_FAIL',
+                            'USER_REGISTERED',
+                            'AUTHORIZATION_FAILURE',
+                            'PRODUCT_CREATED',
+                            'PRODUCT_UPDATED',
+                            'PRODUCT_DELETED',
+                            'SERVICE_CREATED',
+                            'SERVICE_UPDATED',
+                            'SERVICE_DELETED',
+                            'APPOINTMENT_CREATED',
+                            'APPOINTMENT_CANCELLED',
+                            'APPOINTMENT_COMPLETED',
+                            'COMMISSION_CREATED',
+                        ],
+                    },
+                    {
+                        name: 'description',
+                        type: 'text',
+                        isNullable: true,
+                    },
+                    {
+                        name: 'timestamp',
+                        type: 'timestamp',
+                        default: 'now()',
+                    },
+                ],
+                foreignKeys: [
+                    {
+                        columnNames: ['userId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                    },
+                ],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('logs');
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations for services, products, appointments, formulas, and logs tables

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a389ff462c8329959eed99c9c41aba