### PR TITLE
feat: send WhatsApp appointment notifications

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -7,12 +7,14 @@ import { CommissionsModule } from '../commissions/commissions.module';
 import { Service as SalonService } from '../services/service.entity';
 import { User } from '../users/user.entity';
 import { LogsModule } from '../logs/logs.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([Appointment, SalonService, User]),
         CommissionsModule,
         LogsModule,
+        NotificationsModule,
     ],
     providers: [AppointmentsService],
     controllers: [AppointmentsController],

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -12,6 +12,7 @@ import { Service as SalonService } from '../services/service.entity';
 import { User } from '../users/user.entity';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
+import { WhatsappService } from '../notifications/whatsapp.service';
 
 @Injectable()
 export class AppointmentsService {
@@ -24,6 +25,7 @@ export class AppointmentsService {
         private readonly usersRepository: Repository<User>,
         private readonly commissionsService: CommissionsService,
         private readonly logService: LogService,
+        private readonly whatsappService: WhatsappService,
     ) {}
 
     async create(data: Partial<Appointment>, user: User): Promise<Appointment> {
@@ -109,6 +111,13 @@ export class AppointmentsService {
             );
         } catch (error) {
             console.error('Failed to log appointment creation action', error);
+        }
+        try {
+            await this.whatsappService.sendBookingConfirmation(client.phone, [
+                result.id.toString(),
+            ]);
+        } catch (error) {
+            console.error('Failed to send booking confirmation', error);
         }
         return result;
     }
@@ -214,6 +223,13 @@ export class AppointmentsService {
                     'Failed to log appointment completion action',
                     error,
                 );
+            }
+            try {
+                await this.whatsappService.sendFollowUp(updated.client.phone, [
+                    updated.id.toString(),
+                ]);
+            } catch (error) {
+                console.error('Failed to send follow up message', error);
             }
         }
         return updated;

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -19,6 +19,9 @@ export class User {
     @Column({ type: 'simple-enum', enum: Role, default: Role.Client })
     role: Role;
 
+    @Column({ nullable: true })
+    phone?: string;
+
     @Column('decimal', {
         transformer: new ColumnNumericTransformer(),
         default: 0,


### PR DESCRIPTION
## Summary
- send booking confirmations and follow ups via WhatsApp
- add phone field to User
- test WhatsApp notifications

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1c9d2dc8329b5dd16ee2c9861c1