### PR TITLE
feat: guard whatsapp notifications

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -222,6 +222,25 @@ describe('AppointmentsService', () => {
         ).toHaveBeenCalledWith(users[0].phone, [result.id.toString()]);
     });
 
+    it('should not send booking confirmation if client has no phone', async () => {
+        users[0].phone = undefined;
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
+
+        expect(
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            mockWhatsappService.sendBookingConfirmation,
+        ).not.toHaveBeenCalled();
+    });
+
     it('should create an appointment even if logging fails', async () => {
         const start = new Date(Date.now() + 60 * 60 * 1000);
         logActionSpy.mockRejectedValueOnce(new Error('fail'));
@@ -431,6 +450,27 @@ describe('AppointmentsService', () => {
             // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendFollowUp,
         ).toHaveBeenCalledWith(users[0].phone, [id.toString()]);
+    });
+
+    it('should not send follow up if client has no phone', async () => {
+        users[0].phone = undefined;
+        const start = new Date(Date.now() + 60 * 60 * 1000);
+        const { id } = await service.create(
+            {
+                client: users[0],
+                employee: users[1],
+                service: services[0],
+                startTime: start,
+            },
+            users[0],
+        );
+
+        await service.completeAppointment(id, users[1]);
+
+        expect(
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            mockWhatsappService.sendFollowUp,
+        ).not.toHaveBeenCalled();
     });
 
     it('should not create duplicate commissions when completing twice', async () => {

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -112,12 +112,19 @@ export class AppointmentsService {
         } catch (error) {
             console.error('Failed to log appointment creation action', error);
         }
-        try {
-            await this.whatsappService.sendBookingConfirmation(client.phone, [
-                result.id.toString(),
-            ]);
-        } catch (error) {
-            console.error('Failed to send booking confirmation', error);
+        if (client.phone) {
+            try {
+                await this.whatsappService.sendBookingConfirmation(
+                    client.phone,
+                    [result.id.toString()],
+                );
+            } catch (error) {
+                console.error('Failed to send booking confirmation', error);
+            }
+        } else {
+            console.warn(
+                'Client has no phone number; skipping booking confirmation',
+            );
         }
         return result;
     }
@@ -224,12 +231,19 @@ export class AppointmentsService {
                     error,
                 );
             }
-            try {
-                await this.whatsappService.sendFollowUp(updated.client.phone, [
-                    updated.id.toString(),
-                ]);
-            } catch (error) {
-                console.error('Failed to send follow up message', error);
+            if (updated.client.phone) {
+                try {
+                    await this.whatsappService.sendFollowUp(
+                        updated.client.phone,
+                        [updated.id.toString()],
+                    );
+                } catch (error) {
+                    console.error('Failed to send follow up message', error);
+                }
+            } else {
+                console.warn(
+                    'Client has no phone number; skipping follow up message',
+                );
             }
         }
         return updated;

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -12,8 +12,8 @@ export class WhatsappService {
         private readonly http: HttpService,
         private readonly config: ConfigService,
     ) {
-        this.token = this.config.get<string>('WHATSAPP_TOKEN');
-        this.phoneId = this.config.get<string>('WHATSAPP_PHONE_ID');
+        this.token = this.config.get<string>('WHATSAPP_TOKEN')!;
+        this.phoneId = this.config.get<string>('WHATSAPP_PHONE_ID')!;
     }
 
     async sendTemplate(


### PR DESCRIPTION
## Summary
- skip WhatsApp booking confirmations when client has no phone
- skip follow-up messages when client phone missing
- assert WhatsApp config values as non-null

## Testing
- `npm test`
- `npm run swagger:generate`


------
https://chatgpt.com/codex/tasks/task_e_68a3a6f2efd48329b68f7d7e710e382b