### PR TITLE
feat: add phone field to users

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -223,7 +223,7 @@ describe('AppointmentsService', () => {
     });
 
     it('should not send booking confirmation if client has no phone', async () => {
-        users[0].phone = undefined;
+        users[0].phone = null;
         const start = new Date(Date.now() + 60 * 60 * 1000);
         await service.create(
             {
@@ -453,7 +453,7 @@ describe('AppointmentsService', () => {
     });
 
     it('should not send follow up if client has no phone', async () => {
-        users[0].phone = undefined;
+        users[0].phone = null;
         const start = new Date(Date.now() + 60 * 60 * 1000);
         const { id } = await service.create(
             {

--- a/backend/salonbw-backend/src/migrations/1710005000000-AddPhoneToUsers.ts
+++ b/backend/salonbw-backend/src/migrations/1710005000000-AddPhoneToUsers.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddPhoneToUsers1710005000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'users',
+            new TableColumn({
+                name: 'phone',
+                type: 'varchar',
+                isNullable: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('users', 'phone');
+    }
+}

--- a/backend/salonbw-backend/src/users/dto/create-user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/create-user.dto.ts
@@ -1,4 +1,11 @@
-import { IsEmail, IsString, MinLength, IsOptional, Min } from 'class-validator';
+import {
+    IsEmail,
+    IsString,
+    MinLength,
+    IsOptional,
+    Min,
+    Matches,
+} from 'class-validator';
 
 export class CreateUserDto {
     @IsEmail()
@@ -10,6 +17,13 @@ export class CreateUserDto {
 
     @IsString()
     name: string;
+
+    @IsOptional()
+    @IsString()
+    @Matches(/^\+?[1-9]\d{1,14}$/, {
+        message: 'phone must be a valid international number',
+    })
+    phone?: string;
 
     @IsOptional()
     @Min(0)

--- a/backend/salonbw-backend/src/users/dto/user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/user.dto.ts
@@ -5,5 +5,6 @@ export class UserDto {
     email: string;
     name: string;
     role: Role;
+    phone: string | null;
     commissionBase: number;
 }

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -19,8 +19,8 @@ export class User {
     @Column({ type: 'simple-enum', enum: Role, default: Role.Client })
     role: Role;
 
-    @Column({ nullable: true })
-    phone?: string;
+    @Column({ type: 'varchar', nullable: true })
+    phone: string | null;
 
     @Column('decimal', {
         transformer: new ColumnNumericTransformer(),

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -68,6 +68,7 @@ describe('UsersService', () => {
                 email: 'test@example.com',
                 name: 'Test User',
                 password: 'plainPass',
+                phone: '+15551234567',
                 commissionBase: 10,
             };
             qb.getOne.mockResolvedValue(null);
@@ -77,6 +78,7 @@ describe('UsersService', () => {
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
+                phone: dto.phone,
                 commissionBase: dto.commissionBase,
             };
             const createSpy = jest
@@ -94,12 +96,14 @@ describe('UsersService', () => {
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
+                phone: dto.phone,
                 commissionBase: dto.commissionBase,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.role).toBe(Role.Client);
             expect(result.password).toBe('hashedPass');
             expect(result.commissionBase).toBe(dto.commissionBase);
+            expect(result.phone).toBe(dto.phone);
         });
 
         it('defaults commissionBase to zero when not provided', async () => {
@@ -115,6 +119,7 @@ describe('UsersService', () => {
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
+                phone: null,
                 commissionBase: 0,
             };
             const createSpy = jest
@@ -132,10 +137,12 @@ describe('UsersService', () => {
                 name: dto.name,
                 password: 'hashedPass',
                 role: Role.Client,
+                phone: null,
                 commissionBase: 0,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.commissionBase).toBe(0);
+            expect(result.phone).toBeNull();
         });
     });
 

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -45,6 +45,7 @@ export class UsersService {
             name: dto.name,
             password: hashedPassword,
             role: Role.Client,
+            phone: dto.phone ?? null,
             commissionBase: dto.commissionBase ?? 0,
         });
 


### PR DESCRIPTION
## Summary
- add nullable `phone` column to users
- validate optional international-format phone on user creation
- persist phone numbers and expose via User DTO
- create migration for new phone column

## Testing
- `npx typeorm-ts-node-commonjs migration:run -d src/data-source.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a442ccfb4c832998bc7d5dfe39b1e8