### PR TITLE
Add nock tests for WhatsApp service

### DIFF
--- a/backend/salonbw-backend/package-lock.json
+++ b/backend/salonbw-backend/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^16.0.0",
         "jest": "^30.0.0",
+        "nock": "^14.0.10",
         "prettier": "^3.4.2",
         "socket.io-client": "^4.8.1",
         "source-map-support": "^0.5.21",
@@ -2073,6 +2074,24 @@
       "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "license": "MIT"
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2745,6 +2764,31 @@
         "node": "^14.18.0 || >=16.10.0",
         "npm": ">=5.10.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
@@ -7446,6 +7490,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8454,6 +8505,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9384,6 +9442,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "14.0.10",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.10.tgz",
+      "integrity": "sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.39.5",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.75.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
@@ -9686,6 +9759,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -10281,6 +10361,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -11373,6 +11463,13 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/backend/salonbw-backend/package.json
+++ b/backend/salonbw-backend/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",
     "jest": "^30.0.0",
+    "nock": "^14.0.10",
     "prettier": "^3.4.2",
     "socket.io-client": "^4.8.1",
     "source-map-support": "^0.5.21",

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import nock from 'nock';
+import { WhatsappService } from './whatsapp.service';
+
+describe('WhatsappService', () => {
+    let service: WhatsappService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            imports: [HttpModule.register({ proxy: false })],
+            providers: [
+                WhatsappService,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: (key: string) => {
+                            if (key === 'WHATSAPP_TOKEN') return 'token';
+                            if (key === 'WHATSAPP_PHONE_ID') return '123456';
+                            return null;
+                        },
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<WhatsappService>(WhatsappService);
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+        jest.restoreAllMocks();
+    });
+
+    it('should post template with correct body', async () => {
+        const scope = nock('https://graph.facebook.com')
+            .post('/v17.0/123456/messages', (body) => {
+                expect(body.to).toBe('987654321');
+                expect(body.template.name).toBe('test_template');
+                expect(
+                    body.template.components[0].parameters.map((p: any) => p.text),
+                ).toEqual(['one', 'two']);
+                return true;
+            })
+            .reply(200, {});
+
+        await service.sendTemplate('987654321', 'test_template', ['one', 'two']);
+        expect(scope.isDone()).toBe(true);
+    });
+
+    it('should log error on 401 and not throw', async () => {
+        const consoleSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        const scope = nock('https://graph.facebook.com')
+            .post('/v17.0/123456/messages')
+            .reply(401, {});
+
+        await expect(
+            service.sendTemplate('987654321', 'test_template', ['x']),
+        ).resolves.toBeUndefined();
+        expect(consoleSpy).toHaveBeenCalled();
+        expect(scope.isDone()).toBe(true);
+    });
+});

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -40,11 +40,15 @@ export class WhatsappService {
                 ],
             },
         };
-        await firstValueFrom(
-            this.http.post(url, body, {
-                headers: { Authorization: `Bearer ${this.token}` },
-            }),
-        );
+        try {
+            await firstValueFrom(
+                this.http.post(url, body, {
+                    headers: { Authorization: `Bearer ${this.token}` },
+                }),
+            );
+        } catch (error) {
+            console.error('Failed to send WhatsApp message', error);
+        }
     }
 
     async sendBookingConfirmation(to: string, params: string[]): Promise<void> {


### PR DESCRIPTION
## Summary
- install nock for backend tests
- log failures in WhatsappService instead of throwing
- add WhatsappService tests using nock to validate request body and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4679e2e708329acab6fbdd1d291f9