### PR TITLE
feat: load WhatsApp config from env

### DIFF
--- a/backend/salonbw-backend/.env.example
+++ b/backend/salonbw-backend/.env.example
@@ -4,3 +4,9 @@ FRONTEND_URL=http://localhost:3000
 JWT_SECRET=example_jwt_secret
 JWT_REFRESH_SECRET=example_refresh_secret
 PORT=3000
+# Token for authenticating with the WhatsApp Cloud API
+WHATSAPP_TOKEN=your_whatsapp_api_token
+# Phone number ID for the WhatsApp Business account
+WHATSAPP_PHONE_ID=1234567890
+# Hours before an appointment to send reminder messages
+REMINDER_HOURS_BEFORE=24

--- a/backend/salonbw-backend/src/notifications/reminder.service.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.ts
@@ -16,7 +16,11 @@ export class ReminderService {
         private readonly whatsapp: WhatsappService,
         private readonly config: ConfigService,
     ) {
-        this.hoursBefore = this.config.get<number>('REMINDER_HOURS_BEFORE', 24);
+        this.hoursBefore = this.config.get<number>(
+            'REMINDER_HOURS_BEFORE',
+            24,
+            { infer: true },
+        );
     }
 
     @Cron('0 7 * * *')

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
@@ -23,10 +23,10 @@ describe('WhatsappService', () => {
                 {
                     provide: ConfigService,
                     useValue: {
-                        get: (key: string) => {
+                        getOrThrow: (key: string) => {
                             if (key === 'WHATSAPP_TOKEN') return 'token';
                             if (key === 'WHATSAPP_PHONE_ID') return '123456';
-                            return null;
+                            throw new Error(`Missing env ${key}`);
                         },
                     },
                 },

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -12,8 +12,8 @@ export class WhatsappService {
         private readonly http: HttpService,
         private readonly config: ConfigService,
     ) {
-        this.token = this.config.get<string>('WHATSAPP_TOKEN')!;
-        this.phoneId = this.config.get<string>('WHATSAPP_PHONE_ID')!;
+        this.token = this.config.getOrThrow<string>('WHATSAPP_TOKEN');
+        this.phoneId = this.config.getOrThrow<string>('WHATSAPP_PHONE_ID');
     }
 
     async sendTemplate(


### PR DESCRIPTION
## Summary
- document WhatsApp and reminder env vars
- load WhatsApp credentials and reminder window via ConfigService
- adjust tests for new config access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a49e0a24c883299bc871370f1fe80e