### PR TITLE
refactor: capture sendReminder mock

### DIFF
--- a/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
@@ -9,6 +9,7 @@ describe('ReminderService', () => {
     let service: ReminderService;
     let whatsapp: WhatsappService;
     let repo: { find: jest.Mock };
+    let sendReminder: jest.Mock;
 
     beforeEach(async () => {
         repo = { find: jest.fn() };
@@ -26,6 +27,7 @@ describe('ReminderService', () => {
 
         service = module.get<ReminderService>(ReminderService);
         whatsapp = module.get<WhatsappService>(WhatsappService);
+        sendReminder = whatsapp.sendReminder as jest.Mock;
     });
 
     afterEach(() => {
@@ -48,7 +50,7 @@ describe('ReminderService', () => {
 
         await service.handleCron();
 
-        expect(whatsapp.sendReminder).toHaveBeenCalledWith('1234567890', ['1']);
+        expect(sendReminder).toHaveBeenCalledWith('1234567890', ['1']);
     });
 });
 


### PR DESCRIPTION
## Summary
- capture `sendReminder` mocked method in ReminderService test to avoid unbound method lint issue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e6d95ac083299901e52aa49e1f29