### PR TITLE
test: use spy for sendReminder

### DIFF
--- a/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
@@ -13,8 +13,7 @@ describe('ReminderService', () => {
 
     beforeEach(async () => {
         repo = { find: jest.fn() };
-        const whatsappMock = { sendReminder: jest.fn() };
-        jest.spyOn(whatsappMock, 'sendReminder').mockResolvedValue();
+        const whatsappMock = { sendReminder: jest.fn().mockResolvedValue(undefined) };
 
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -27,7 +26,7 @@ describe('ReminderService', () => {
 
         service = module.get<ReminderService>(ReminderService);
         whatsapp = module.get<WhatsappService>(WhatsappService);
-        sendReminder = whatsapp.sendReminder as jest.Mock;
+        sendReminder = jest.spyOn(whatsapp, 'sendReminder');
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Summary
- spy on `WhatsappService.sendReminder` rather than accessing property directly in `ReminderService` spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57f1f25d08329b3fea5336140f348