### PR TITLE
Send reminders for next day's appointments

### DIFF
--- a/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ReminderService } from './reminder.service';
 import { WhatsappService } from './whatsapp.service';
-import { Appointment, AppointmentStatus } from '../appointments/appointment.entity';
+import {
+    Appointment,
+    AppointmentStatus,
+} from '../appointments/appointment.entity';
 
 describe('ReminderService', () => {
     let service: ReminderService;
@@ -13,14 +15,15 @@ describe('ReminderService', () => {
 
     beforeEach(async () => {
         repo = { find: jest.fn() };
-        const whatsappMock = { sendReminder: jest.fn().mockResolvedValue(undefined) };
+        const whatsappMock = {
+            sendReminder: jest.fn().mockResolvedValue(undefined),
+        };
 
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 ReminderService,
                 { provide: getRepositoryToken(Appointment), useValue: repo },
                 { provide: WhatsappService, useValue: whatsappMock },
-                { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('24') } },
             ],
         }).compile();
 
@@ -34,14 +37,14 @@ describe('ReminderService', () => {
         jest.clearAllMocks();
     });
 
-    it('sends reminders for appointments 24 hours ahead', async () => {
+    it('sends reminders for appointments scheduled the next day', async () => {
         const now = new Date('2024-01-01T07:00:00Z');
         jest.useFakeTimers().setSystemTime(now);
 
         const appointment = {
             id: 1,
-            startTime: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-            endTime: new Date(now.getTime() + 25 * 60 * 60 * 1000),
+            startTime: new Date('2024-01-02T10:00:00Z'),
+            endTime: new Date('2024-01-02T11:00:00Z'),
             status: AppointmentStatus.Scheduled,
             client: { phone: '1234567890' },
         } as unknown as Appointment;
@@ -52,4 +55,3 @@ describe('ReminderService', () => {
         expect(sendReminder).toHaveBeenCalledWith('1234567890', ['1']);
     });
 });
-


### PR DESCRIPTION
## Summary
- Notify clients about appointments scheduled for the following day
- Update reminder service test for next-day schedule

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59a367a348329b55f33b297682ad0