### PR TITLE
feat: allow configuring WhatsApp language

### DIFF
--- a/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
@@ -8,6 +8,7 @@ interface WhatsAppTemplateRequest {
     to: string;
     template: {
         name: string;
+        language: { code: string };
         components: { parameters: { text: string }[] }[];
     };
 }
@@ -28,6 +29,8 @@ describe('WhatsappService', () => {
                             if (key === 'WHATSAPP_PHONE_ID') return '123456';
                             throw new Error(`Missing env ${key}`);
                         },
+                        get: (key: string, defaultValue?: string) =>
+                            key === 'WHATSAPP_LANG' ? 'pl' : defaultValue,
                     },
                 },
             ],
@@ -46,6 +49,7 @@ describe('WhatsappService', () => {
             .post('/v17.0/123456/messages', (body: WhatsAppTemplateRequest) => {
                 expect(body.to).toBe('987654321');
                 expect(body.template.name).toBe('test_template');
+                expect(body.template.language.code).toBe('pl');
                 expect(
                     body.template.components[0].parameters.map((p) => p.text),
                 ).toEqual(['one', 'two']);
@@ -53,7 +57,10 @@ describe('WhatsappService', () => {
             })
             .reply(200, {});
 
-        await service.sendTemplate('987654321', 'test_template', ['one', 'two']);
+        await service.sendTemplate('987654321', 'test_template', [
+            'one',
+            'two',
+        ]);
         expect(scope.isDone()).toBe(true);
     });
 

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -7,6 +7,7 @@ import { firstValueFrom } from 'rxjs';
 export class WhatsappService {
     private readonly token: string;
     private readonly phoneId: string;
+    private readonly lang: string;
 
     constructor(
         private readonly http: HttpService,
@@ -14,6 +15,7 @@ export class WhatsappService {
     ) {
         this.token = this.config.getOrThrow<string>('WHATSAPP_TOKEN');
         this.phoneId = this.config.getOrThrow<string>('WHATSAPP_PHONE_ID');
+        this.lang = this.config.get<string>('WHATSAPP_LANG', 'pl');
     }
 
     async sendTemplate(
@@ -28,7 +30,7 @@ export class WhatsappService {
             type: 'template',
             template: {
                 name: templateName,
-                language: { code: 'en_US' },
+                language: { code: this.lang },
                 components: [
                     {
                         type: 'body',
@@ -52,8 +54,9 @@ export class WhatsappService {
                 return;
             } catch (error: unknown) {
                 if (typeof error === 'object' && error && 'response' in error) {
-                    const response = (error as { response?: { data?: unknown } })
-                        .response;
+                    const response = (
+                        error as { response?: { data?: unknown } }
+                    ).response;
                     console.error(
                         'Failed to send WhatsApp message',
                         response?.data,


### PR DESCRIPTION
## Summary
- read `WHATSAPP_LANG` from `ConfigService` with a default of `pl`
- apply the configured language to WhatsApp template messages
- extend unit tests to verify language configuration

## Testing
- `npx eslint src/notifications/whatsapp.service.ts src/notifications/whatsapp.service.spec.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59cf3eb648329ad9142bb2ba1498f