### PR TITLE
Send appointment datetime in WhatsApp notifications

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -175,13 +175,15 @@ describe('AppointmentsService', () => {
         } as Partial<LogService> as jest.Mocked<LogService>;
 
         mockWhatsappService = {
-            sendBookingConfirmation: jest.fn<Promise<void>, [string, string[]]>(
-                () => Promise.resolve(),
-            ),
-            sendReminder: jest.fn(),
-            sendFollowUp: jest.fn<Promise<void>, [string, string[]]>(() =>
-                Promise.resolve(),
-            ),
+            sendBookingConfirmation: jest.fn<
+                Promise<void>,
+                [string, string, string]
+            >(() => Promise.resolve()),
+            sendReminder: jest.fn<Promise<void>, [string, string, string]>(),
+            sendFollowUp: jest.fn<
+                Promise<void>,
+                [string, string, string]
+            >(() => Promise.resolve()),
         } as Partial<WhatsappService> as jest.Mocked<WhatsappService>;
 
         service = new AppointmentsService(
@@ -216,10 +218,12 @@ describe('AppointmentsService', () => {
             expect.objectContaining({ id: result.id }),
         );
 
+        const date = start.toISOString().split('T')[0];
+        const time = start.toISOString().split('T')[1].slice(0, 5);
         expect(
             // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation,
-        ).toHaveBeenCalledWith(users[0].phone, [result.id.toString()]);
+        ).toHaveBeenCalledWith(users[0].phone, date, time);
     });
 
     it('should not send booking confirmation if client has no phone', async () => {
@@ -446,10 +450,12 @@ describe('AppointmentsService', () => {
                 status: AppointmentStatus.Completed,
             }),
         );
+        const date = start.toISOString().split('T')[0];
+        const time = start.toISOString().split('T')[1].slice(0, 5);
         expect(
             // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendFollowUp,
-        ).toHaveBeenCalledWith(users[0].phone, [id.toString()]);
+        ).toHaveBeenCalledWith(users[0].phone, date, time);
     });
 
     it('should not send follow up if client has no phone', async () => {

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -113,10 +113,13 @@ export class AppointmentsService {
             console.error('Failed to log appointment creation action', error);
         }
         if (client.phone) {
+            const date = result.startTime.toISOString().split('T')[0];
+            const time = result.startTime.toISOString().split('T')[1].slice(0, 5);
             try {
                 await this.whatsappService.sendBookingConfirmation(
                     client.phone,
-                    [result.id.toString()],
+                    date,
+                    time,
                 );
             } catch (error) {
                 console.error('Failed to send booking confirmation', error);
@@ -232,10 +235,18 @@ export class AppointmentsService {
                 );
             }
             if (updated.client.phone) {
+                const date = updated.startTime
+                    .toISOString()
+                    .split('T')[0];
+                const time = updated.startTime
+                    .toISOString()
+                    .split('T')[1]
+                    .slice(0, 5);
                 try {
                     await this.whatsappService.sendFollowUp(
                         updated.client.phone,
-                        [updated.id.toString()],
+                        date,
+                        time,
                     );
                 } catch (error) {
                     console.error('Failed to send follow up message', error);

--- a/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
@@ -16,7 +16,9 @@ describe('ReminderService', () => {
     beforeEach(async () => {
         repo = { find: jest.fn() };
         const whatsappMock = {
-            sendReminder: jest.fn().mockResolvedValue(undefined),
+            sendReminder: jest
+                .fn<Promise<void>, [string, string, string]>()
+                .mockResolvedValue(undefined),
         };
 
         const module: TestingModule = await Test.createTestingModule({
@@ -52,6 +54,8 @@ describe('ReminderService', () => {
 
         await service.handleCron();
 
-        expect(sendReminder).toHaveBeenCalledWith('1234567890', ['1']);
+        const date = appointment.startTime.toISOString().split('T')[0];
+        const time = appointment.startTime.toISOString().split('T')[1].slice(0, 5);
+        expect(sendReminder).toHaveBeenCalledWith('1234567890', date, time);
     });
 });

--- a/backend/salonbw-backend/src/notifications/reminder.service.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.ts
@@ -36,9 +36,14 @@ export class ReminderService {
                 continue;
             }
             try {
-                await this.whatsapp.sendReminder(phone, [
-                    appointment.id.toString(),
-                ]);
+                const date = appointment.startTime
+                    .toISOString()
+                    .split('T')[0];
+                const time = appointment.startTime
+                    .toISOString()
+                    .split('T')[1]
+                    .slice(0, 5);
+                await this.whatsapp.sendReminder(phone, date, time);
             } catch (error) {
                 console.error('Failed to send reminder', error);
             }

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -71,15 +71,19 @@ export class WhatsappService {
         }
     }
 
-    async sendBookingConfirmation(to: string, params: string[]): Promise<void> {
-        await this.sendTemplate(to, 'booking_confirmation', params);
+    async sendBookingConfirmation(
+        to: string,
+        date: string,
+        time: string,
+    ): Promise<void> {
+        await this.sendTemplate(to, 'booking_confirmation', [date, time]);
     }
 
-    async sendReminder(to: string, params: string[]): Promise<void> {
-        await this.sendTemplate(to, 'appointment_reminder', params);
+    async sendReminder(to: string, date: string, time: string): Promise<void> {
+        await this.sendTemplate(to, 'appointment_reminder', [date, time]);
     }
 
-    async sendFollowUp(to: string, params: string[]): Promise<void> {
-        await this.sendTemplate(to, 'follow_up', params);
+    async sendFollowUp(to: string, date: string, time: string): Promise<void> {
+        await this.sendTemplate(to, 'follow_up', [date, time]);
     }
 }


### PR DESCRIPTION
## Summary
- Include appointment date and time when sending booking confirmations, reminders and follow-ups via WhatsApp
- Extend WhatsApp service methods to accept structured date and time parameters
- Adjust unit tests for new WhatsApp service signatures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b3979fe48329ac6c1f271ca7c700