### PR TITLE
docs: document WhatsApp env variables

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,6 +16,14 @@
    ```
    Expected output: `{"status":"ok"}` with HTTP status `200`.
 
+## Environment variables
+
+Set the following values in your `.env` based on `.env.example`:
+
+- `WHATSAPP_TOKEN` – token for authenticating with the WhatsApp Cloud API.
+- `WHATSAPP_PHONE_ID` – phone number ID for the WhatsApp Business account.
+- `REMINDER_HOURS_BEFORE` – hours before an appointment to send reminder messages.
+
 ## Notes
 
 - TypeORM synchronization is enabled only for development. In production environments set `NODE_ENV=production` and run migrations instead of relying on synchronization.


### PR DESCRIPTION
## Summary
- explain required WhatsApp Cloud API settings in backend README
- note REMINDER_HOURS_BEFORE env variable for appointment reminders

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5b7050e14832994f23abfccf56db5