### PR TITLE
Refactor WhatsApp service error handling

### DIFF
--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
+import { isAxiosError } from 'axios';
 
 @Injectable()
 export class WhatsappService {
@@ -53,13 +54,10 @@ export class WhatsappService {
                 );
                 return;
             } catch (error: unknown) {
-                if (typeof error === 'object' && error && 'response' in error) {
-                    const response = (
-                        error as { response?: { data?: unknown } }
-                    ).response;
+                if (isAxiosError(error)) {
                     console.error(
                         'Failed to send WhatsApp message',
-                        response?.data,
+                        error.response?.data,
                     );
                 } else {
                     console.error('Failed to send WhatsApp message', error);


### PR DESCRIPTION
## Summary
- handle WhatsApp sendTemplate errors via axios `isAxiosError`
- log raw errors when not from axios

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cd2093548329aaca04c5e7ccd892