### PR TITLE
feat: add phone field to registration

### DIFF
--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -6,6 +6,7 @@ export default function RegisterPage() {
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
@@ -18,7 +19,7 @@ export default function RegisterPage() {
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, email, password }),
+          body: JSON.stringify({ name, email, phone, password }),
         }
       );
       if (!res.ok) throw new Error('Registration failed');
@@ -44,6 +45,13 @@ export default function RegisterPage() {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-1 w-full"
+          placeholder="Phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
         />
         <input
           className="border p-1 w-full"


### PR DESCRIPTION
## Summary
- add phone field to registration form
- send phone to API when registering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6318ad3d88329a2d0f16392c451b5