### PR TITLE
test: verify WhatsApp notifications order

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -224,6 +224,12 @@ describe('AppointmentsService', () => {
             // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation,
         ).toHaveBeenCalledWith(users[0].phone, date, time);
+        expect(
+            mockAppointmentsRepo.save.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+            mockWhatsappService.sendBookingConfirmation.mock
+                .invocationCallOrder[0],
+        );
     });
 
     it('should not send booking confirmation if client has no phone', async () => {
@@ -451,11 +457,17 @@ describe('AppointmentsService', () => {
             }),
         );
         const date = start.toISOString().split('T')[0];
-        const time = start.toISOString().split('T')[1].slice(0, 5);
+       const time = start.toISOString().split('T')[1].slice(0, 5);
+       expect(
+           // eslint-disable-next-line @typescript-eslint/unbound-method
+           mockWhatsappService.sendFollowUp,
+       ).toHaveBeenCalledWith(users[0].phone, date, time);
         expect(
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            mockWhatsappService.sendFollowUp,
-        ).toHaveBeenCalledWith(users[0].phone, date, time);
+            mockAppointmentsRepo.manager.transaction.mock
+                .invocationCallOrder[0],
+        ).toBeLessThan(
+            mockWhatsappService.sendFollowUp.mock.invocationCallOrder[0],
+        );
     });
 
     it('should not send follow up if client has no phone', async () => {


### PR DESCRIPTION
## Summary
- ensure booking confirmations are sent after appointments are saved
- confirm follow-up messages happen after completing appointments

## Testing
- `npm test src/appointments/appointments.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a634fe0e7083299419a688bf522524