### PR TITLE
test: cast mocks before checking invocation order

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -463,10 +463,13 @@ describe('AppointmentsService', () => {
            mockWhatsappService.sendFollowUp,
        ).toHaveBeenCalledWith(users[0].phone, date, time);
         expect(
-            mockAppointmentsRepo.manager.transaction.mock
-                .invocationCallOrder[0],
+            (
+                mockAppointmentsRepo.manager.transaction as jest.Mock
+            ).mock.invocationCallOrder[0],
         ).toBeLessThan(
-            mockWhatsappService.sendFollowUp.mock.invocationCallOrder[0],
+            (
+                mockWhatsappService.sendFollowUp as jest.Mock
+            ).mock.invocationCallOrder[0],
         );
     });
 


### PR DESCRIPTION
## Summary
- cast transaction and sendFollowUp mocks to `jest.Mock` before accessing invocation order

## Testing
- `npx -y @upstash/context7-mcp`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a639c46c088329835cb53a2479e50e