### PR TITLE
test: cast mocks before invocation order check

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -462,14 +462,12 @@ describe('AppointmentsService', () => {
            // eslint-disable-next-line @typescript-eslint/unbound-method
            mockWhatsappService.sendFollowUp,
        ).toHaveBeenCalledWith(users[0].phone, date, time);
-        expect(
-            (
-                mockAppointmentsRepo.manager.transaction as jest.Mock
-            ).mock.invocationCallOrder[0],
-        ).toBeLessThan(
-            (
-                mockWhatsappService.sendFollowUp as jest.Mock
-            ).mock.invocationCallOrder[0],
+        const transactionMock =
+            mockAppointmentsRepo.manager.transaction as jest.Mock;
+        const sendFollowUpMock =
+            mockWhatsappService.sendFollowUp as jest.Mock;
+        expect(transactionMock.mock.invocationCallOrder[0]).toBeLessThan(
+            sendFollowUpMock.mock.invocationCallOrder[0],
         );
     });
 


### PR DESCRIPTION
## Summary
- ensure mocked transaction and WhatsApp follow-up calls are typed as `jest.Mock`
- compare invocation order using typed mocks for clarity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d61d46ec8329ab9def500629987c