### PR TITLE
test: suppress unbound method warnings in appointment tests

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -462,8 +462,10 @@ describe('AppointmentsService', () => {
            // eslint-disable-next-line @typescript-eslint/unbound-method
            mockWhatsappService.sendFollowUp,
        ).toHaveBeenCalledWith(users[0].phone, date, time);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         const transactionMock =
             mockAppointmentsRepo.manager.transaction as jest.Mock;
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         const sendFollowUpMock =
             mockWhatsappService.sendFollowUp as jest.Mock;
         expect(transactionMock.mock.invocationCallOrder[0]).toBeLessThan(


### PR DESCRIPTION
## Summary
- silence `@typescript-eslint/unbound-method` warnings for mock transaction and WhatsApp follow-up methods in appointment service tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e51edfb883298fe36d4aeb164fb5