### PR TITLE
fix: align unbound method suppression comments in appointments tests

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -462,11 +462,11 @@ describe('AppointmentsService', () => {
            // eslint-disable-next-line @typescript-eslint/unbound-method
            mockWhatsappService.sendFollowUp,
        ).toHaveBeenCalledWith(users[0].phone, date, time);
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         const transactionMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockAppointmentsRepo.manager.transaction as jest.Mock;
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         const sendFollowUpMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendFollowUp as jest.Mock;
         expect(transactionMock.mock.invocationCallOrder[0]).toBeLessThan(
             sendFollowUpMock.mock.invocationCallOrder[0],


### PR DESCRIPTION
## Summary
- ensure unbound method suppression comments in appointments service tests precede the exact method lines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70bdae6788329a06d254f790c72c3