### PR TITLE
refactor: simplify whatsapp mock in appointment tests

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -220,8 +220,9 @@ describe('AppointmentsService', () => {
 
         const date = start.toISOString().split('T')[0];
         const time = start.toISOString().split('T')[1].slice(0, 5);
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockWhatsappService.sendBookingConfirmation).toHaveBeenCalledWith(
+        const sendBookingConfirmationMock =
+            mockWhatsappService.sendBookingConfirmation as jest.Mock;
+        expect(sendBookingConfirmationMock).toHaveBeenCalledWith(
             users[0].phone,
             date,
             time,
@@ -229,8 +230,7 @@ describe('AppointmentsService', () => {
         expect(
             mockAppointmentsRepo.save.mock.invocationCallOrder[0],
         ).toBeLessThan(
-            mockWhatsappService.sendBookingConfirmation.mock
-                .invocationCallOrder[0],
+            sendBookingConfirmationMock.mock.invocationCallOrder[0],
         );
     });
 
@@ -247,8 +247,9 @@ describe('AppointmentsService', () => {
             users[0],
         );
 
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockWhatsappService.sendBookingConfirmation).not.toHaveBeenCalled();
+        const sendBookingConfirmationMock =
+            mockWhatsappService.sendBookingConfirmation as jest.Mock;
+        expect(sendBookingConfirmationMock).not.toHaveBeenCalled();
     });
 
     it('should create an appointment even if logging fails', async () => {


### PR DESCRIPTION
## Summary
- use a reusable `sendBookingConfirmationMock` to assert WhatsApp messaging in appointment tests
- remove redundant ESLint suppressions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75fb0a3708329b489f3afb49d6df6