### PR TITLE
Bind sendBookingConfirmation mock in appointment tests

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -209,6 +209,15 @@ describe('AppointmentsService', () => {
             users[0],
         );
 
+        const sendBookingConfirmationMock =
+            mockWhatsappService.sendBookingConfirmation.bind(
+                mockWhatsappService,
+            ) as jest.Mock;
+        Object.assign(
+            sendBookingConfirmationMock,
+            mockWhatsappService.sendBookingConfirmation,
+        );
+
         expect(result.id).toBeDefined();
         expect(result.endTime.getTime()).toBe(start.getTime() + 30 * 60 * 1000);
         expect(appointments).toHaveLength(1);
@@ -220,8 +229,6 @@ describe('AppointmentsService', () => {
 
         const date = start.toISOString().split('T')[0];
         const time = start.toISOString().split('T')[1].slice(0, 5);
-        const sendBookingConfirmationMock =
-            mockWhatsappService.sendBookingConfirmation as jest.Mock;
         expect(sendBookingConfirmationMock).toHaveBeenCalledWith(
             users[0].phone,
             date,
@@ -248,7 +255,13 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
-            mockWhatsappService.sendBookingConfirmation as jest.Mock;
+            mockWhatsappService.sendBookingConfirmation.bind(
+                mockWhatsappService,
+            ) as jest.Mock;
+        Object.assign(
+            sendBookingConfirmationMock,
+            mockWhatsappService.sendBookingConfirmation,
+        );
         expect(sendBookingConfirmationMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- Bind `sendBookingConfirmation` mock to `mockWhatsappService`
- Reuse bound mock in tests to check calls and invocation order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78671488483299530afbfacf84bb3