### PR TITLE
refactor: relocate eslint comments

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -194,17 +194,18 @@ describe('AppointmentsService', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         Object.assign(sendFollowUpMock, mockWhatsappService.sendFollowUp);
 
-        transactionMock = mockAppointmentsRepo.manager.transaction.bind(
-            mockAppointmentsRepo.manager,
-        ) as jest.Mock;
-        // eslint-disable-next-line @typescript-eslint/unbound-method
+        transactionMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            mockAppointmentsRepo.manager.transaction.bind(
+                mockAppointmentsRepo.manager,
+            ) as jest.Mock;
         Object.assign(transactionMock, mockAppointmentsRepo.manager.transaction);
 
         createFromAppointmentMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockCommissionsService.createFromAppointment.bind(
                 mockCommissionsService,
             ) as jest.Mock;
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         Object.assign(createFromAppointmentMock, mockCommissionsService.createFromAppointment);
 
         service = new AppointmentsService(
@@ -231,10 +232,10 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         Object.assign(sendBookingConfirmationMock, mockWhatsappService.sendBookingConfirmation);
 
         expect(result.id).toBeDefined();
@@ -272,10 +273,10 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         Object.assign(sendBookingConfirmationMock, mockWhatsappService.sendBookingConfirmation);
         expect(sendBookingConfirmationMock).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- move ESLint unbound-method comments above bind calls in appointments service tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8474450ec8329a47ea672dc7d13a7