### PR TITLE
chore(test): silence unbound method lint

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -199,14 +199,22 @@ describe('AppointmentsService', () => {
             mockAppointmentsRepo.manager.transaction.bind(
                 mockAppointmentsRepo.manager,
             ) as jest.Mock;
-        Object.assign(transactionMock, mockAppointmentsRepo.manager.transaction);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        Object.assign(
+            transactionMock,
+            mockAppointmentsRepo.manager.transaction,
+        );
 
         createFromAppointmentMock =
             // eslint-disable-next-line @typescript-eslint/unbound-method
             mockCommissionsService.createFromAppointment.bind(
                 mockCommissionsService,
             ) as jest.Mock;
-        Object.assign(createFromAppointmentMock, mockCommissionsService.createFromAppointment);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        Object.assign(
+            createFromAppointmentMock,
+            mockCommissionsService.createFromAppointment,
+        );
 
         service = new AppointmentsService(
             mockAppointmentsRepo,
@@ -236,7 +244,11 @@ describe('AppointmentsService', () => {
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
-        Object.assign(sendBookingConfirmationMock, mockWhatsappService.sendBookingConfirmation);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        Object.assign(
+            sendBookingConfirmationMock,
+            mockWhatsappService.sendBookingConfirmation,
+        );
 
         expect(result.id).toBeDefined();
         expect(result.endTime.getTime()).toBe(start.getTime() + 30 * 60 * 1000);
@@ -277,7 +289,11 @@ describe('AppointmentsService', () => {
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
-        Object.assign(sendBookingConfirmationMock, mockWhatsappService.sendBookingConfirmation);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        Object.assign(
+            sendBookingConfirmationMock,
+            mockWhatsappService.sendBookingConfirmation,
+        );
         expect(sendBookingConfirmationMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- ensure unbound-method eslint directives sit above bind calls in appointment tests
- duplicate directives for transaction, commission, and booking confirmation mocks

## Testing
- `cd backend/salonbw-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a851dd3efc83298c16e6faab61d40d