### PR TITLE
chore(test): silence unbound method lint

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -194,19 +194,26 @@ describe('AppointmentsService', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         Object.assign(sendFollowUpMock, mockWhatsappService.sendFollowUp);
 
-        transactionMock =
+        transactionMock = mockAppointmentsRepo.manager.transaction.bind(
+            mockAppointmentsRepo.manager,
+        ) as jest.Mock;
+
+        Object.assign(
+            transactionMock,
             // eslint-disable-next-line @typescript-eslint/unbound-method
-            mockAppointmentsRepo.manager.transaction.bind(
-                mockAppointmentsRepo.manager,
-            ) as jest.Mock;
-        Object.assign(transactionMock, mockAppointmentsRepo.manager.transaction);
+            mockAppointmentsRepo.manager.transaction,
+        );
 
         createFromAppointmentMock =
-            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockCommissionsService.createFromAppointment.bind(
                 mockCommissionsService,
             ) as jest.Mock;
-        Object.assign(createFromAppointmentMock, mockCommissionsService.createFromAppointment);
+
+        Object.assign(
+            createFromAppointmentMock,
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            mockCommissionsService.createFromAppointment,
+        );
 
         service = new AppointmentsService(
             mockAppointmentsRepo,
@@ -232,11 +239,15 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
-            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
-        Object.assign(sendBookingConfirmationMock, mockWhatsappService.sendBookingConfirmation);
+
+        Object.assign(
+            sendBookingConfirmationMock,
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            mockWhatsappService.sendBookingConfirmation,
+        );
 
         expect(result.id).toBeDefined();
         expect(result.endTime.getTime()).toBe(start.getTime() + 30 * 60 * 1000);
@@ -273,11 +284,15 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
-            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
-        Object.assign(sendBookingConfirmationMock, mockWhatsappService.sendBookingConfirmation);
+
+        Object.assign(
+            sendBookingConfirmationMock,
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            mockWhatsappService.sendBookingConfirmation,
+        );
         expect(sendBookingConfirmationMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- ensure unbound-method eslint directives sit above bind calls in appointment tests
- suppress unbound-method warnings inside related Object.assign calls

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a851dd3efc83298c16e6faab61d40d