### PR TITLE
chore: silence unbound-method in appointment tests

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -194,30 +194,33 @@ describe('AppointmentsService', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         Object.assign(sendFollowUpMock, mockWhatsappService.sendFollowUp);
 
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         transactionMock = mockAppointmentsRepo.manager.transaction.bind(
             mockAppointmentsRepo.manager,
         ) as jest.Mock;
 
         Object.assign(
             transactionMock,
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockAppointmentsRepo.manager.transaction.bind(
                 mockAppointmentsRepo.manager,
-            ) as jest.Mock
+            ) as jest.Mock,
         );
         Object.assign(
             transactionMock,
             // eslint-disable-next-line @typescript-eslint/unbound-method
-            mockAppointmentsRepo.manager.transaction
+            mockAppointmentsRepo.manager.transaction,
         );
 
         createFromAppointmentMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockCommissionsService.createFromAppointment.bind(
                 mockCommissionsService,
             ) as jest.Mock;
         Object.assign(
             createFromAppointmentMock,
             // eslint-disable-next-line @typescript-eslint/unbound-method
-            mockCommissionsService.createFromAppointment
+            mockCommissionsService.createFromAppointment,
         );
 
         service = new AppointmentsService(
@@ -244,6 +247,7 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
@@ -251,7 +255,7 @@ describe('AppointmentsService', () => {
         Object.assign(
             sendBookingConfirmationMock,
             // eslint-disable-next-line @typescript-eslint/unbound-method
-            mockWhatsappService.sendBookingConfirmation
+            mockWhatsappService.sendBookingConfirmation,
         );
 
         expect(result.id).toBeDefined();
@@ -289,6 +293,7 @@ describe('AppointmentsService', () => {
         );
 
         const sendBookingConfirmationMock =
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockWhatsappService.sendBookingConfirmation.bind(
                 mockWhatsappService,
             ) as jest.Mock;
@@ -296,7 +301,7 @@ describe('AppointmentsService', () => {
         Object.assign(
             sendBookingConfirmationMock,
             // eslint-disable-next-line @typescript-eslint/unbound-method
-            mockWhatsappService.sendBookingConfirmation
+            mockWhatsappService.sendBookingConfirmation,
         );
         expect(sendBookingConfirmationMock).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- suppress unbound-method rule for mocked transaction/commission bindings
- silence @typescript-eslint/unbound-method for booking confirmation test mocks

## Testing
- `npm run lint -- --no-fix`


------
https://chatgpt.com/codex/tasks/task_e_68a85e0313a483299d2c7e2caead0110