### PR TITLE
Add Content-Type header for WhatsApp template

### DIFF
--- a/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.spec.ts
@@ -46,6 +46,7 @@ describe('WhatsappService', () => {
 
     it('should post template with correct body', async () => {
         const scope = nock('https://graph.facebook.com')
+            .matchHeader('content-type', 'application/json')
             .post('/v17.0/123456/messages', (body: WhatsAppTemplateRequest) => {
                 expect(body.to).toBe('987654321');
                 expect(body.template.name).toBe('test_template');
@@ -69,6 +70,7 @@ describe('WhatsappService', () => {
             .spyOn(console, 'error')
             .mockImplementation(() => {});
         const scope = nock('https://graph.facebook.com')
+            .matchHeader('content-type', 'application/json')
             .post('/v17.0/123456/messages')
             .reply(401, {});
 
@@ -85,6 +87,7 @@ describe('WhatsappService', () => {
             .mockImplementation(() => {});
         let attempts = 0;
         const scope = nock('https://graph.facebook.com')
+            .matchHeader('content-type', 'application/json')
             .post('/v17.0/123456/messages')
             .times(3)
             .reply(() => {

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -49,7 +49,10 @@ export class WhatsappService {
             try {
                 await firstValueFrom(
                     this.http.post(url, body, {
-                        headers: { Authorization: `Bearer ${this.token}` },
+                        headers: {
+                            Authorization: `Bearer ${this.token}`,
+                            'Content-Type': 'application/json',
+                        },
                     }),
                 );
                 return;


### PR DESCRIPTION
## Summary
- send WhatsApp template requests with explicit JSON content-type header
- verify content-type header in WhatsappService tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a864da08b0832988c6469662491596