### PR TITLE
feat: configurable reminder interval

### DIFF
--- a/backend/salonbw-backend/.env.example
+++ b/backend/salonbw-backend/.env.example
@@ -8,5 +8,5 @@ PORT=3000
 WHATSAPP_TOKEN=your_whatsapp_api_token
 # Phone number ID for the WhatsApp Business account
 WHATSAPP_PHONE_ID=1234567890
-# Hours before an appointment to send reminder messages
+# Hours before an appointment to send reminder messages (default: 24)
 REMINDER_HOURS_BEFORE=24

--- a/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ReminderService } from './reminder.service';
 import { WhatsappService } from './whatsapp.service';
+import { ConfigService } from '@nestjs/config';
 import {
     Appointment,
     AppointmentStatus,
@@ -12,9 +13,11 @@ describe('ReminderService', () => {
     let whatsapp: WhatsappService;
     let repo: { find: jest.Mock };
     let sendReminder: jest.Mock;
+    let config: { get: jest.Mock };
 
     beforeEach(async () => {
         repo = { find: jest.fn() };
+        config = { get: jest.fn().mockReturnValue(24) };
         const whatsappMock = {
             sendReminder: jest
                 .fn<Promise<void>, [string, string, string]>()
@@ -26,6 +29,7 @@ describe('ReminderService', () => {
                 ReminderService,
                 { provide: getRepositoryToken(Appointment), useValue: repo },
                 { provide: WhatsappService, useValue: whatsappMock },
+                { provide: ConfigService, useValue: config },
             ],
         }).compile();
 
@@ -39,14 +43,14 @@ describe('ReminderService', () => {
         jest.clearAllMocks();
     });
 
-    it('sends reminders for appointments scheduled the next day', async () => {
+    it('sends reminders for appointments within the configured window', async () => {
         const now = new Date('2024-01-01T07:00:00Z');
         jest.useFakeTimers().setSystemTime(now);
 
         const appointment = {
             id: 1,
-            startTime: new Date('2024-01-02T10:00:00Z'),
-            endTime: new Date('2024-01-02T11:00:00Z'),
+            startTime: new Date('2024-01-02T07:30:00Z'),
+            endTime: new Date('2024-01-02T08:30:00Z'),
             status: AppointmentStatus.Scheduled,
             client: { phone: '1234567890' },
         } as unknown as Appointment;


### PR DESCRIPTION
## Summary
- add `REMINDER_HOURS_BEFORE` env example variable to configure reminder timing
- compute reminder window using configured hours instead of fixed 7:00 cron
- update reminder service unit test for new logic

## Testing
- `cd backend/salonbw-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87637b9a08329b2ea1ab6218296b4