### PR TITLE
feat: allow clients to opt out of notifications

### DIFF
--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -112,7 +112,7 @@ export class AppointmentsService {
         } catch (error) {
             console.error('Failed to log appointment creation action', error);
         }
-        if (client.phone) {
+        if (client.phone && client.receiveNotifications) {
             const date = result.startTime.toISOString().split('T')[0];
             const time = result.startTime.toISOString().split('T')[1].slice(0, 5);
             try {
@@ -126,7 +126,7 @@ export class AppointmentsService {
             }
         } else {
             console.warn(
-                'Client has no phone number; skipping booking confirmation',
+                'Client has no phone number or notifications disabled; skipping booking confirmation',
             );
         }
         return result;
@@ -234,7 +234,7 @@ export class AppointmentsService {
                     error,
                 );
             }
-            if (updated.client.phone) {
+            if (updated.client.phone && updated.client.receiveNotifications) {
                 const date = updated.startTime
                     .toISOString()
                     .split('T')[0];
@@ -253,7 +253,7 @@ export class AppointmentsService {
                 }
             } else {
                 console.warn(
-                    'Client has no phone number; skipping follow up message',
+                    'Client has no phone number or notifications disabled; skipping follow up message',
                 );
             }
         }

--- a/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.spec.ts
@@ -52,7 +52,7 @@ describe('ReminderService', () => {
             startTime: new Date('2024-01-02T07:30:00Z'),
             endTime: new Date('2024-01-02T08:30:00Z'),
             status: AppointmentStatus.Scheduled,
-            client: { phone: '1234567890' },
+            client: { phone: '1234567890', receiveNotifications: true },
         } as unknown as Appointment;
         repo.find.mockResolvedValue([appointment]);
 
@@ -61,5 +61,23 @@ describe('ReminderService', () => {
         const date = appointment.startTime.toISOString().split('T')[0];
         const time = appointment.startTime.toISOString().split('T')[1].slice(0, 5);
         expect(sendReminder).toHaveBeenCalledWith('1234567890', date, time);
+    });
+
+    it('does not send reminders if client disabled notifications', async () => {
+        const now = new Date('2024-01-01T07:00:00Z');
+        jest.useFakeTimers().setSystemTime(now);
+
+        const appointment = {
+            id: 2,
+            startTime: new Date('2024-01-02T07:30:00Z'),
+            endTime: new Date('2024-01-02T08:30:00Z'),
+            status: AppointmentStatus.Scheduled,
+            client: { phone: '1234567890', receiveNotifications: false },
+        } as unknown as Appointment;
+        repo.find.mockResolvedValue([appointment]);
+
+        await service.handleCron();
+
+        expect(sendReminder).not.toHaveBeenCalled();
     });
 });

--- a/backend/salonbw-backend/src/notifications/reminder.service.ts
+++ b/backend/salonbw-backend/src/notifications/reminder.service.ts
@@ -36,7 +36,7 @@ export class ReminderService {
         });
         for (const appointment of appointments) {
             const phone = appointment.client?.phone;
-            if (!phone) {
+            if (!phone || appointment.client?.receiveNotifications === false) {
                 continue;
             }
             try {

--- a/backend/salonbw-backend/src/users/dto/create-user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/create-user.dto.ts
@@ -5,6 +5,7 @@ import {
     IsOptional,
     Min,
     Matches,
+    IsBoolean,
 } from 'class-validator';
 
 export class CreateUserDto {
@@ -28,4 +29,8 @@ export class CreateUserDto {
     @IsOptional()
     @Min(0)
     commissionBase?: number;
+
+    @IsOptional()
+    @IsBoolean()
+    receiveNotifications?: boolean;
 }

--- a/backend/salonbw-backend/src/users/dto/user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/user.dto.ts
@@ -7,4 +7,5 @@ export class UserDto {
     role: Role;
     phone: string | null;
     commissionBase: number;
+    receiveNotifications: boolean;
 }

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -22,6 +22,9 @@ export class User {
     @Column({ type: 'varchar', nullable: true })
     phone: string | null;
 
+    @Column({ default: true })
+    receiveNotifications: boolean;
+
     @Column('decimal', {
         transformer: new ColumnNumericTransformer(),
         default: 0,

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -70,6 +70,7 @@ describe('UsersService', () => {
                 password: 'plainPass',
                 phone: '+15551234567',
                 commissionBase: 10,
+                receiveNotifications: true,
             };
             qb.getOne.mockResolvedValue(null);
             bcryptMock.hash.mockResolvedValue('hashedPass');
@@ -80,6 +81,7 @@ describe('UsersService', () => {
                 role: Role.Client,
                 phone: dto.phone,
                 commissionBase: dto.commissionBase,
+                receiveNotifications: dto.receiveNotifications,
             };
             const createSpy = jest
                 .spyOn(repo, 'create')
@@ -98,12 +100,14 @@ describe('UsersService', () => {
                 role: Role.Client,
                 phone: dto.phone,
                 commissionBase: dto.commissionBase,
+                receiveNotifications: dto.receiveNotifications,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.role).toBe(Role.Client);
             expect(result.password).toBe('hashedPass');
             expect(result.commissionBase).toBe(dto.commissionBase);
             expect(result.phone).toBe(dto.phone);
+            expect(result.receiveNotifications).toBe(true);
         });
 
         it('defaults commissionBase to zero when not provided', async () => {
@@ -121,6 +125,7 @@ describe('UsersService', () => {
                 role: Role.Client,
                 phone: null,
                 commissionBase: 0,
+                receiveNotifications: true,
             };
             const createSpy = jest
                 .spyOn(repo, 'create')
@@ -139,10 +144,12 @@ describe('UsersService', () => {
                 role: Role.Client,
                 phone: null,
                 commissionBase: 0,
+                receiveNotifications: true,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.commissionBase).toBe(0);
             expect(result.phone).toBeNull();
+            expect(result.receiveNotifications).toBe(true);
         });
     });
 

--- a/backend/salonbw-backend/src/users/users.service.ts
+++ b/backend/salonbw-backend/src/users/users.service.ts
@@ -47,6 +47,7 @@ export class UsersService {
             role: Role.Client,
             phone: dto.phone ?? null,
             commissionBase: dto.commissionBase ?? 0,
+            receiveNotifications: dto.receiveNotifications ?? true,
         });
 
         return await this.usersRepository.save(user);


### PR DESCRIPTION
## Summary
- add `receiveNotifications` flag to users with default `true`
- expose flag in DTOs and respect it when sending WhatsApp messages
- cover notification opt-out cases with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87b7d57f883299882410e5a3924bc