### PR TITLE
feat: secure swagger docs and generator

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -635,13 +635,20 @@
   },
   "info": {
     "title": "SalonBW API",
-    "description": "",
+    "description": "The SalonBW API description",
     "version": "1.0",
     "contact": {}
   },
   "tags": [],
   "servers": [],
   "components": {
+    "securitySchemes": {
+      "bearer": {
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "type": "http"
+      }
+    },
     "schemas": {
       "UserDto": {
         "type": "object",

--- a/backend/salonbw-backend/src/main.ts
+++ b/backend/salonbw-backend/src/main.ts
@@ -16,12 +16,16 @@ async function bootstrap() {
     );
     app.use(cookieParser());
     const config = app.get(ConfigService);
-    const swaggerConfig = new DocumentBuilder()
-        .setTitle('SalonBW API')
-        .setVersion('1.0')
-        .build();
-    const document = SwaggerModule.createDocument(app, swaggerConfig);
-    SwaggerModule.setup('api', app, document);
+    if (process.env.NODE_ENV !== 'production') {
+        const swaggerConfig = new DocumentBuilder()
+            .setTitle('SalonBW API')
+            .setDescription('The SalonBW API description')
+            .setVersion('1.0')
+            .addBearerAuth()
+            .build();
+        const document = SwaggerModule.createDocument(app, swaggerConfig);
+        SwaggerModule.setup('api/docs', app, document);
+    }
     app.enableCors({
         origin: config.get<string>('FRONTEND_URL'),
         credentials: true,

--- a/backend/salonbw-backend/swagger.ts
+++ b/backend/salonbw-backend/swagger.ts
@@ -111,7 +111,9 @@ async function generate() {
   const app = await NestFactory.create(SwaggerAppModule, { logger: false });
   const config = new DocumentBuilder()
     .setTitle('SalonBW API')
+    .setDescription('The SalonBW API description')
     .setVersion('1.0')
+    .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);
   writeFileSync('openapi.json', JSON.stringify(document, null, 2) + '\n');


### PR DESCRIPTION
## Summary
- add description and bearer auth to Swagger docs in main bootstrap
- serve Swagger UI at /api/docs only in non-production
- update swagger.ts and regenerate openapi.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87e5737c08329b2e742ac50bc06bd