### PR TITLE
Add Swagger documentation to controllers

### DIFF
--- a/backend/salonbw-backend/src/app.controller.ts
+++ b/backend/salonbw-backend/src/app.controller.ts
@@ -1,11 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AppService } from './app.service';
 
+@ApiTags('app')
 @Controller()
 export class AppController {
     constructor(private readonly appService: AppService) {}
 
     @Get()
+    @ApiOperation({ summary: 'Root endpoint' })
+    @ApiResponse({ status: 200, description: 'Hello world message' })
     getHello(): string {
         return this.appService.getHello();
     }

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -11,7 +11,7 @@ import {
     NotFoundException,
     ParseIntPipe,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
@@ -31,6 +31,7 @@ export class AppointmentsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Post()
+    @ApiBearerAuth()
     @ApiOperation({
         summary: 'Create appointment',
         description:
@@ -74,6 +75,9 @@ export class AppointmentsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get('me')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get appointments for current user' })
+    @ApiResponse({ status: 200, type: Appointment, isArray: true })
     findMine(@CurrentUser() user: { userId: number }): Promise<Appointment[]> {
         return this.appointmentsService.findForUser(user.userId);
     }
@@ -81,6 +85,11 @@ export class AppointmentsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Patch(':id/cancel')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Cancel appointment' })
+    @ApiResponse({ status: 200, description: 'Appointment cancelled', type: Appointment })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Appointment not found' })
     async cancel(
         @Param('id', ParseIntPipe) id: number,
         @CurrentUser() user: { userId: number; role: Role },
@@ -102,6 +111,11 @@ export class AppointmentsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Employee, Role.Admin)
     @Patch(':id/complete')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Complete appointment' })
+    @ApiResponse({ status: 200, description: 'Appointment completed', type: Appointment })
+    @ApiResponse({ status: 403, description: 'Forbidden' })
+    @ApiResponse({ status: 404, description: 'Appointment not found' })
     async complete(
         @Param('id', ParseIntPipe) id: number,
         @CurrentUser() user: { userId: number; role: Role },

--- a/backend/salonbw-backend/src/chat/chat.controller.ts
+++ b/backend/salonbw-backend/src/chat/chat.controller.ts
@@ -8,7 +8,7 @@ import {
     ParseIntPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -31,11 +31,13 @@ export class ChatController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get(':id/chat')
+    @ApiBearerAuth()
     @ApiOperation({ summary: 'Get chat messages for an appointment' })
     @ApiResponse({
         status: 200,
         description: 'List of chat messages',
-        type: [ChatMessage],
+        type: ChatMessage,
+        isArray: true,
     })
     @ApiResponse({ status: 403, description: 'Forbidden' })
     @ApiResponse({ status: 404, description: 'Appointment not found' })

--- a/backend/salonbw-backend/src/commissions/commissions.controller.ts
+++ b/backend/salonbw-backend/src/commissions/commissions.controller.ts
@@ -7,6 +7,7 @@ import {
     Query,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CommissionsService } from './commissions.service';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
@@ -15,6 +16,7 @@ import { Role } from '../users/role.enum';
 import { Commission } from './commission.entity';
 import { GetSummaryDto } from './dto/get-summary.dto';
 
+@ApiTags('commissions')
 @Controller()
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class CommissionsController {
@@ -22,12 +24,18 @@ export class CommissionsController {
 
     @Roles(Role.Employee, Role.Admin)
     @Get('commissions/me')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get commissions for current user' })
+    @ApiResponse({ status: 200, type: Commission, isArray: true })
     findMine(@CurrentUser() user: { userId: number }): Promise<Commission[]> {
         return this.commissionsService.findForUser(user.userId);
     }
 
     @Roles(Role.Admin)
     @Get('commissions/employees/:id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get commissions for employee' })
+    @ApiResponse({ status: 200, type: Commission, isArray: true })
     findForEmployee(
         @Param('id', ParseIntPipe) id: number,
     ): Promise<Commission[]> {
@@ -36,6 +44,9 @@ export class CommissionsController {
 
     @Roles(Role.Admin)
     @Get('employees/:id/commissions/summary')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get commission summary for employee' })
+    @ApiResponse({ status: 200, description: 'Summary amount', schema: { example: { amount: 0 } } })
     getSummaryForEmployee(
         @Param('id', ParseIntPipe) id: number,
         @Query() { from, to }: GetSummaryDto,
@@ -47,6 +58,9 @@ export class CommissionsController {
 
     @Roles(Role.Admin)
     @Get('commissions')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get all commissions' })
+    @ApiResponse({ status: 200, type: Commission, isArray: true })
     findAll(): Promise<Commission[]> {
         return this.commissionsService.findAll();
     }

--- a/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/appointment-formulas.controller.ts
@@ -7,6 +7,7 @@ import {
     ParseIntPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
@@ -15,6 +16,7 @@ import { FormulasService } from './formulas.service';
 import { Formula } from './formula.entity';
 import { CreateFormulaDto } from './dto/create-formula.dto';
 
+@ApiTags('formulas')
 @Controller('appointments/:appointmentId/formulas')
 export class AppointmentFormulasController {
     constructor(private readonly formulasService: FormulasService) {}
@@ -22,6 +24,9 @@ export class AppointmentFormulasController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Employee, Role.Admin)
     @Post()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Add formula to appointment' })
+    @ApiResponse({ status: 201, type: Formula })
     addFormula(
         @Param('appointmentId', ParseIntPipe) appointmentId: number,
         @Body() body: CreateFormulaDto,

--- a/backend/salonbw-backend/src/formulas/client-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/client-formulas.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param, UseGuards, ParseIntPipe } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
@@ -7,6 +8,7 @@ import { Role } from '../users/role.enum';
 import { FormulasService } from './formulas.service';
 import { Formula } from './formula.entity';
 
+@ApiTags('formulas')
 @Controller('clients')
 export class ClientFormulasController {
     constructor(private readonly formulasService: FormulasService) {}
@@ -14,6 +16,9 @@ export class ClientFormulasController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Admin)
     @Get('me/formulas')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get formulas for current user' })
+    @ApiResponse({ status: 200, type: Formula, isArray: true })
     findMine(@CurrentUser() user: { userId: number }): Promise<Formula[]> {
         return this.formulasService.findForClient(user.userId);
     }
@@ -21,6 +26,9 @@ export class ClientFormulasController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Employee, Role.Admin)
     @Get(':id/formulas')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get formulas for client' })
+    @ApiResponse({ status: 200, type: Formula, isArray: true })
     findForClient(
         @Param('id', ParseIntPipe) id: number,
     ): Promise<Formula[]> {

--- a/backend/salonbw-backend/src/health.controller.ts
+++ b/backend/salonbw-backend/src/health.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('health')
 @Controller('health')
 export class HealthController {
     @Get()
+    @ApiOperation({ summary: 'Health check' })
+    @ApiResponse({ status: 200, description: 'Service is up' })
     getHealth() {
         return { status: 'ok' };
     }

--- a/backend/salonbw-backend/src/logs/logs.controller.ts
+++ b/backend/salonbw-backend/src/logs/logs.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get, Query, UseGuards, ValidationPipe } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
 import { LogService } from './log.service';
 import { GetLogsDto } from './dto/get-logs.dto';
 
+@ApiTags('logs')
 @Controller('logs')
 export class LogsController {
     constructor(private readonly logService: LogService) {}
@@ -13,6 +15,9 @@ export class LogsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Get()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get logs' })
+    @ApiResponse({ status: 200, description: 'List of logs' })
     getLogs(
         @Query(new ValidationPipe({ transform: true })) dto: GetLogsDto,
     ) {

--- a/backend/salonbw-backend/src/products/products.controller.ts
+++ b/backend/salonbw-backend/src/products/products.controller.ts
@@ -10,6 +10,7 @@ import {
     ParseIntPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
@@ -20,6 +21,7 @@ import { UpdateProductDto } from './dto/update-product.dto';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { User } from '../users/user.entity';
 
+@ApiTags('products')
 @Controller('products')
 export class ProductsController {
     constructor(private readonly productsService: ProductsService) {}
@@ -27,6 +29,9 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin, Role.Employee)
     @Get()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get all products' })
+    @ApiResponse({ status: 200, type: Product, isArray: true })
     findAll(): Promise<Product[]> {
         return this.productsService.findAll();
     }
@@ -34,6 +39,9 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin, Role.Employee)
     @Get(':id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get product by id' })
+    @ApiResponse({ status: 200, type: Product })
     findOne(@Param('id', ParseIntPipe) id: number): Promise<Product> {
         return this.productsService.findOne(id);
     }
@@ -41,6 +49,9 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Create product' })
+    @ApiResponse({ status: 201, type: Product })
     create(
         @Body() body: CreateProductDto,
         @CurrentUser() user: { userId: number },
@@ -51,6 +62,9 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Patch(':id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Update product' })
+    @ApiResponse({ status: 200, type: Product })
     update(
         @Param('id', ParseIntPipe) id: number,
         @Body() body: UpdateProductDto,
@@ -62,6 +76,9 @@ export class ProductsController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Remove product' })
+    @ApiResponse({ status: 200, description: 'Product removed' })
     remove(
         @Param('id', ParseIntPipe) id: number,
         @CurrentUser() user: { userId: number },

--- a/backend/salonbw-backend/src/services/services.controller.ts
+++ b/backend/salonbw-backend/src/services/services.controller.ts
@@ -10,6 +10,7 @@ import {
     ParseIntPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
@@ -20,6 +21,7 @@ import { UpdateServiceDto } from './dto/update-service.dto';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { User } from '../users/user.entity';
 
+@ApiTags('services')
 @Controller('services')
 export class ServicesController {
     constructor(private readonly servicesService: ServicesService) {}
@@ -27,6 +29,9 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get all services' })
+    @ApiResponse({ status: 200, type: Service, isArray: true })
     findAll(): Promise<Service[]> {
         return this.servicesService.findAll();
     }
@@ -34,6 +39,9 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get(':id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get service by id' })
+    @ApiResponse({ status: 200, type: Service })
     findOne(@Param('id', ParseIntPipe) id: number): Promise<Service> {
         return this.servicesService.findOne(id);
     }
@@ -41,6 +49,9 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Create service' })
+    @ApiResponse({ status: 201, type: Service })
     create(
         @Body() createServiceDto: CreateServiceDto,
         @CurrentUser() user: { userId: number },
@@ -53,6 +64,9 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Patch(':id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Update service' })
+    @ApiResponse({ status: 200, type: Service })
     update(
         @Param('id', ParseIntPipe) id: number,
         @Body() updateServiceDto: UpdateServiceDto,
@@ -66,6 +80,9 @@ export class ServicesController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Delete(':id')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Remove service' })
+    @ApiResponse({ status: 200, description: 'Service removed' })
     remove(
         @Param('id', ParseIntPipe) id: number,
         @CurrentUser() user: { userId: number },

--- a/backend/salonbw-backend/src/users/users.controller.ts
+++ b/backend/salonbw-backend/src/users/users.controller.ts
@@ -1,5 +1,10 @@
 import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOkResponse } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Roles } from '../auth/roles.decorator';
@@ -9,6 +14,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UserDto } from './dto/user.dto';
 import { Role } from './role.enum';
 
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
     constructor(private readonly usersService: UsersService) {}
@@ -16,6 +22,9 @@ export class UsersController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Employee, Role.Admin)
     @Get('profile')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get current user profile' })
+    @ApiResponse({ status: 200, description: 'Current user profile' })
     getProfile(@CurrentUser() user: { userId: number; role: string }) {
         return user;
     }
@@ -24,7 +33,8 @@ export class UsersController {
     @Roles(Role.Admin)
     @Get()
     @ApiBearerAuth()
-    @ApiOkResponse({ type: UserDto, isArray: true })
+    @ApiOperation({ summary: 'List users' })
+    @ApiResponse({ status: 200, type: UserDto, isArray: true })
     async findAll(): Promise<UserDto[]> {
         const users = await this.usersService.findAll();
         return users.map(({ password: _password, ...rest }) => {
@@ -36,6 +46,9 @@ export class UsersController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin)
     @Post()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Create user' })
+    @ApiResponse({ status: 201, description: 'User created', type: UserDto })
     async create(@Body() createUserDto: CreateUserDto) {
         const user = await this.usersService.createUser(createUserDto);
         const { password: _password, ...result } = user;


### PR DESCRIPTION
## Summary
- document user endpoints with tags, operations, responses and JWT auth markers
- add Swagger metadata to appointments, chat, logs, products, services, formulas, commissions, health and root controllers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87fa37f2c8329b647f017e24c973b