### PR TITLE
feat: document user DTOs and hide passwords

### DIFF
--- a/backend/salonbw-backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/salonbw-backend/src/auth/dto/refresh-token.dto.ts
@@ -1,6 +1,8 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class RefreshTokenDto {
+    @ApiProperty({ description: 'JWT refresh token', example: 'eyJhbGci...' })
     @IsString()
     refreshToken: string;
 }

--- a/backend/salonbw-backend/src/auth/dto/register.dto.ts
+++ b/backend/salonbw-backend/src/auth/dto/register.dto.ts
@@ -1,13 +1,20 @@
 import { IsEmail, IsString, MinLength } from 'class-validator';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 
 export class RegisterDto {
+    @ApiProperty({
+        description: 'User email address',
+        example: 'user@example.com',
+    })
     @IsEmail()
     email: string;
 
+    @ApiHideProperty()
     @IsString()
     @MinLength(8)
     password: string;
 
+    @ApiProperty({ description: 'User full name', example: 'John Doe' })
     @IsString()
     name: string;
 }

--- a/backend/salonbw-backend/src/users/dto/create-user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/create-user.dto.ts
@@ -7,18 +7,30 @@ import {
     Matches,
     IsBoolean,
 } from 'class-validator';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
+    @ApiProperty({
+        description: 'User email address',
+        example: 'user@example.com',
+    })
     @IsEmail()
     email: string;
 
+    @ApiHideProperty()
     @IsString()
     @MinLength(8)
     password: string;
 
+    @ApiProperty({ description: 'User full name', example: 'John Doe' })
     @IsString()
     name: string;
 
+    @ApiProperty({
+        required: false,
+        description: 'International phone number',
+        example: '+123456789',
+    })
     @IsOptional()
     @IsString()
     @Matches(/^\+?[1-9]\d{1,14}$/, {
@@ -26,10 +38,20 @@ export class CreateUserDto {
     })
     phone?: string;
 
+    @ApiProperty({
+        required: false,
+        description: 'Commission base for the user',
+        example: 0,
+    })
     @IsOptional()
     @Min(0)
     commissionBase?: number;
 
+    @ApiProperty({
+        required: false,
+        description: 'Whether the user receives notifications',
+        example: true,
+    })
     @IsOptional()
     @IsBoolean()
     receiveNotifications?: boolean;

--- a/backend/salonbw-backend/src/users/dto/user.dto.ts
+++ b/backend/salonbw-backend/src/users/dto/user.dto.ts
@@ -1,11 +1,35 @@
 import { Role } from '../role.enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserDto {
+    @ApiProperty({ description: 'Unique identifier', example: 1 })
     id: number;
+
+    @ApiProperty({
+        description: 'User email address',
+        example: 'user@example.com',
+    })
     email: string;
+
+    @ApiProperty({ description: 'User full name', example: 'John Doe' })
     name: string;
+
+    @ApiProperty({ description: 'User role', enum: Role, example: Role.Client })
     role: Role;
+
+    @ApiProperty({
+        description: 'International phone number',
+        example: '+123456789',
+        nullable: true,
+    })
     phone: string | null;
+
+    @ApiProperty({ description: 'Commission base for the user', example: 0 })
     commissionBase: number;
+
+    @ApiProperty({
+        description: 'Whether the user receives notifications',
+        example: true,
+    })
     receiveNotifications: boolean;
 }

--- a/backend/salonbw-backend/src/users/user.entity.ts
+++ b/backend/salonbw-backend/src/users/user.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { Role } from './role.enum';
 import { ColumnNumericTransformer } from '../column-numeric.transformer';
+import { ApiHideProperty } from '@nestjs/swagger';
 
 @Entity('users')
 export class User {
@@ -10,6 +11,7 @@ export class User {
     @Column({ unique: true })
     email: string;
 
+    @ApiHideProperty()
     @Column({ select: false })
     password: string;
 


### PR DESCRIPTION
## Summary
- add swagger ApiProperty decorators with examples to user and auth DTOs
- hide password fields from swagger docs via ApiHideProperty

## Testing
- `npx eslint src/auth/dto/refresh-token.dto.ts src/auth/dto/register.dto.ts src/users/dto/create-user.dto.ts src/users/dto/user.dto.ts src/users/user.entity.ts --fix`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a880d82c048329aa54d241380b3164