### PR TITLE
docs: document API swagger endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ frontend/
 The NestJS backend lives in `backend/` with typical controllers,
 services and entities under `src/`.
 
+## API documentation
+
+In development, the API is documented with Swagger and available at `/api/docs`.
+Make sure to secure or disable Swagger in production.
+
 ## Prerequisites
 
 Install [Node.js](https://nodejs.org/) and npm. The project uses Node.js 20 (see


### PR DESCRIPTION
## Summary
- add section about API documentation at `/api/docs`
- note to secure or disable Swagger for production deployments

## Testing
- `cd backend/salonbw-backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a888676e2c83299adaedafa3d13e59