### PR TITLE
chore: configure eslint with prettier

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { FlatCompat } from '@eslint/eslintrc';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat.extends('next/core-web-vitals'),
+  ...compat.extends('plugin:prettier/recommended'),
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint src",
     "format": "prettier --write '**/*.{ts,tsx,js,jsx,css,md}'",
     "test": "jest",
     "e2e": "NEXT_PUBLIC_API_URL=/api npm run build && NEXT_PUBLIC_API_URL=/api start-server-and-test start http://localhost:3000 'cypress run'",


### PR DESCRIPTION
## Summary
- set up ESLint config extending `next/core-web-vitals` and Prettier
- run `lint` script on the `src` directory

## Testing
- `npm run lint` *(fails: formatting errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa13997f208329a41b126afa2d9195