### PR TITLE
chore: align frontend prettier with backend

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "tabWidth": 4,
+  "semi": true
 }

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  e2e: {
-    baseUrl: 'http://localhost:3000',
-  },
+    e2e: {
+        baseUrl: 'http://localhost:3000',
+    },
 });

--- a/frontend/cypress/e2e/appointments.cy.ts
+++ b/frontend/cypress/e2e/appointments.cy.ts
@@ -1,6 +1,6 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });

--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -1,6 +1,6 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });

--- a/frontend/cypress/e2e/clients.cy.ts
+++ b/frontend/cypress/e2e/clients.cy.ts
@@ -1,6 +1,6 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });

--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -1,49 +1,57 @@
 describe('admin dashboard navigation', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'admin');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'admin');
+    });
 
-  it('redirects to admin dashboard and shows widgets', () => {
-    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
-    cy.visit('/dashboard');
-    cy.wait('@dash');
-    cy.url().should('include', '/dashboard/admin');
-    cy.contains('Clients');
-    cy.contains('Employees');
-  });
+    it('redirects to admin dashboard and shows widgets', () => {
+        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+            'dash',
+        );
+        cy.visit('/dashboard');
+        cy.wait('@dash');
+        cy.url().should('include', '/dashboard/admin');
+        cy.contains('Clients');
+        cy.contains('Employees');
+    });
 
-  it('navigates to employees via sidebar', () => {
-    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
-    cy.visit('/dashboard/admin');
-    cy.wait('@dash');
-    cy.contains('Employees').click();
-    cy.url().should('include', '/employees');
-  });
+    it('navigates to employees via sidebar', () => {
+        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+            'dash',
+        );
+        cy.visit('/dashboard/admin');
+        cy.wait('@dash');
+        cy.contains('Employees').click();
+        cy.url().should('include', '/employees');
+    });
 });
 
 describe('admin dashboard services crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'admin');
-    cy.intercept('GET', '**/services', { fixture: 'services.json' }).as('getSvc');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'admin');
+        cy.intercept('GET', '**/services', { fixture: 'services.json' }).as(
+            'getSvc',
+        );
+    });
 
-  it('creates a service', () => {
-    cy.intercept('POST', '**/services', { id: 3, name: 'Wax' }).as('createSvc');
-    cy.visit('/dashboard/services');
-    cy.wait('@getSvc');
-    cy.contains('Add Service').click();
-    cy.get('input[placeholder="Name"]').type('Wax');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createSvc');
-    cy.contains('Wax');
-  });
+    it('creates a service', () => {
+        cy.intercept('POST', '**/services', { id: 3, name: 'Wax' }).as(
+            'createSvc',
+        );
+        cy.visit('/dashboard/services');
+        cy.wait('@getSvc');
+        cy.contains('Add Service').click();
+        cy.get('input[placeholder="Name"]').type('Wax');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createSvc');
+        cy.contains('Wax');
+    });
 });
 
 describe('admin dashboard permissions', () => {
-  it('redirects anonymous user', () => {
-    cy.visit('/dashboard/admin');
-    cy.url().should('include', '/auth/login');
-  });
+    it('redirects anonymous user', () => {
+        cy.visit('/dashboard/admin');
+        cy.url().should('include', '/auth/login');
+    });
 });

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -1,53 +1,59 @@
 describe('client dashboard navigation', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'client');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'client');
+    });
 
-  it('redirects to client dashboard and shows widgets', () => {
-    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
-    cy.visit('/dashboard');
-    cy.wait('@dash');
-    cy.url().should('include', '/dashboard/client');
-    cy.contains('Upcoming');
-  });
+    it('redirects to client dashboard and shows widgets', () => {
+        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+            'dash',
+        );
+        cy.visit('/dashboard');
+        cy.wait('@dash');
+        cy.url().should('include', '/dashboard/client');
+        cy.contains('Upcoming');
+    });
 
-  it('navigates to reviews via sidebar', () => {
-    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
-    cy.visit('/dashboard/client');
-    cy.wait('@dash');
-    cy.contains('Reviews').click();
-    cy.url().should('include', '/reviews');
-  });
+    it('navigates to reviews via sidebar', () => {
+        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+            'dash',
+        );
+        cy.visit('/dashboard/client');
+        cy.wait('@dash');
+        cy.contains('Reviews').click();
+        cy.url().should('include', '/reviews');
+    });
 });
 
 describe('client dashboard reviews crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'client');
-    cy.intercept('GET', '**/employees/*/reviews', { fixture: 'reviews.json' }).as('getReviews');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'client');
+        cy.intercept('GET', '**/employees/*/reviews', {
+            fixture: 'reviews.json',
+        }).as('getReviews');
+    });
 
-  it('creates a review', () => {
-    cy.intercept('POST', '**/appointments/*/review', {
-      id: 2,
-      appointmentId: 1,
-      rating: 5,
-    }).as('createReview');
-    cy.visit('/reviews');
-    cy.wait('@getReviews');
-    cy.contains('Add Review').click();
-    cy.get('input[placeholder="Appointment"]').type('1');
-    cy.get('input[placeholder="Rating"]').type('5');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createReview');
-    cy.contains('Review created');
-  });
+    it('creates a review', () => {
+        cy.intercept('POST', '**/appointments/*/review', {
+            id: 2,
+            appointmentId: 1,
+            rating: 5,
+        }).as('createReview');
+        cy.visit('/reviews');
+        cy.wait('@getReviews');
+        cy.contains('Add Review').click();
+        cy.get('input[placeholder="Appointment"]').type('1');
+        cy.get('input[placeholder="Rating"]').type('5');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createReview');
+        cy.contains('Review created');
+    });
 });
 
 describe('client dashboard permissions', () => {
-  it('redirects anonymous user', () => {
-    cy.visit('/dashboard/client');
-    cy.url().should('include', '/auth/login');
-  });
+    it('redirects anonymous user', () => {
+        cy.visit('/dashboard/client');
+        cy.url().should('include', '/auth/login');
+    });
 });

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -1,49 +1,57 @@
 describe('employee dashboard navigation', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'employee');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'employee');
+    });
 
-  it('redirects to employee dashboard and shows widgets', () => {
-    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
-    cy.visit('/dashboard');
-    cy.wait('@dash');
-    cy.url().should('include', '/dashboard/employee');
-    cy.contains('Today Appointments');
-    cy.contains('Clients');
-  });
+    it('redirects to employee dashboard and shows widgets', () => {
+        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+            'dash',
+        );
+        cy.visit('/dashboard');
+        cy.wait('@dash');
+        cy.url().should('include', '/dashboard/employee');
+        cy.contains('Today Appointments');
+        cy.contains('Clients');
+    });
 
-  it('navigates to clients via sidebar', () => {
-    cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as('dash');
-    cy.visit('/dashboard/employee');
-    cy.wait('@dash');
-    cy.contains('Clients').click();
-    cy.url().should('include', '/clients');
-  });
+    it('navigates to clients via sidebar', () => {
+        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+            'dash',
+        );
+        cy.visit('/dashboard/employee');
+        cy.wait('@dash');
+        cy.contains('Clients').click();
+        cy.url().should('include', '/clients');
+    });
 });
 
 describe('employee dashboard clients crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'employee');
-    cy.intercept('GET', '**/clients', { fixture: 'clients.json' }).as('getClients');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'employee');
+        cy.intercept('GET', '**/clients', { fixture: 'clients.json' }).as(
+            'getClients',
+        );
+    });
 
-  it('creates a client', () => {
-    cy.intercept('POST', '**/clients', { id: 3, name: 'New' }).as('createClient');
-    cy.visit('/clients');
-    cy.wait('@getClients');
-    cy.contains('Add Client').click();
-    cy.get('input[placeholder="Name"]').type('New');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createClient');
-    cy.contains('New');
-  });
+    it('creates a client', () => {
+        cy.intercept('POST', '**/clients', { id: 3, name: 'New' }).as(
+            'createClient',
+        );
+        cy.visit('/clients');
+        cy.wait('@getClients');
+        cy.contains('Add Client').click();
+        cy.get('input[placeholder="Name"]').type('New');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createClient');
+        cy.contains('New');
+    });
 });
 
 describe('employee dashboard permissions', () => {
-  it('redirects anonymous user', () => {
-    cy.visit('/dashboard/employee');
-    cy.url().should('include', '/auth/login');
-  });
+    it('redirects anonymous user', () => {
+        cy.visit('/dashboard/employee');
+        cy.url().should('include', '/auth/login');
+    });
 });

--- a/frontend/cypress/e2e/dashboard.cy.ts
+++ b/frontend/cypress/e2e/dashboard.cy.ts
@@ -1,6 +1,6 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });

--- a/frontend/cypress/e2e/employees.cy.ts
+++ b/frontend/cypress/e2e/employees.cy.ts
@@ -1,26 +1,29 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });
 
 describe('employees crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+    });
 
-  it('loads and creates employee', () => {
-    cy.intercept('GET', '**/employees', { fixture: 'employees.json' }).as('getEmps');
-    cy.intercept('POST', '**/employees', { id: 3, name: 'New' }).as('createEmp');
-    cy.visit('/employees');
-    cy.wait('@getEmps');
-    cy.contains('Add Employee').click();
-    cy.get('input[placeholder="Name"]').type('New');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createEmp');
-    cy.contains('New');
-    cy.contains('Employee created');
-  });
+    it('loads and creates employee', () => {
+        cy.intercept('GET', '**/employees', { fixture: 'employees.json' }).as(
+            'getEmps',
+        );
+        cy.intercept('POST', '**/employees', { id: 3, name: 'New' }).as(
+            'createEmp',
+        );
+        cy.visit('/employees');
+        cy.wait('@getEmps');
+        cy.contains('Add Employee').click();
+        cy.get('input[placeholder="Name"]').type('New');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createEmp');
+        cy.contains('New');
+        cy.contains('Employee created');
+    });
 });
-

--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -1,24 +1,28 @@
 describe('navigation visibility', () => {
-  it('shows dashboard navigation for authenticated users on /products', () => {
-    localStorage.setItem('jwtToken', 'x');
-    localStorage.setItem('role', 'admin');
-    cy.intercept('GET', '**/products**', { fixture: 'products.json' }).as('getProd');
-    cy.visit('/products');
-    cy.wait('@getProd');
-    cy.contains('Dashboard');
-    cy.contains('Products');
-  });
+    it('shows dashboard navigation for authenticated users on /products', () => {
+        localStorage.setItem('jwtToken', 'x');
+        localStorage.setItem('role', 'admin');
+        cy.intercept('GET', '**/products**', { fixture: 'products.json' }).as(
+            'getProd',
+        );
+        cy.visit('/products');
+        cy.wait('@getProd');
+        cy.contains('Dashboard');
+        cy.contains('Products');
+    });
 
-  it('redirects unauthenticated users away from /products', () => {
-    cy.visit('/products');
-    cy.url().should('include', '/auth/login');
-  });
+    it('redirects unauthenticated users away from /products', () => {
+        cy.visit('/products');
+        cy.url().should('include', '/auth/login');
+    });
 
-  it('renders public navigation on public pages', () => {
-    cy.intercept('GET', '**/services**', { fixture: 'services.json' }).as('getServices');
-    cy.visit('/services');
-    cy.wait('@getServices');
-    cy.get('nav').contains('Login');
-    cy.get('nav').contains('Services');
-  });
+    it('renders public navigation on public pages', () => {
+        cy.intercept('GET', '**/services**', { fixture: 'services.json' }).as(
+            'getServices',
+        );
+        cy.visit('/services');
+        cy.wait('@getServices');
+        cy.get('nav').contains('Login');
+        cy.get('nav').contains('Services');
+    });
 });

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -1,26 +1,33 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });
 describe('products crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+    });
 
-  it('loads and creates product', () => {
-    cy.intercept('GET', '**/products/admin', { fixture: 'products.json' }).as('getProd');
-    cy.intercept('POST', '**/products/admin', { id: 2, name: 'New', unitPrice: 1, stock: 1 }).as('createProd');
-    cy.visit('/products');
-    cy.wait('@getProd');
-    cy.contains('Add Product').click();
-    cy.get('input[placeholder="Name"]').type('New');
-    cy.get('input[placeholder="Price"]').type('1');
-    cy.get('input[placeholder="Stock"]').type('1');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createProd');
-    cy.contains('New');
-    cy.contains('Product created');
-  });
+    it('loads and creates product', () => {
+        cy.intercept('GET', '**/products/admin', {
+            fixture: 'products.json',
+        }).as('getProd');
+        cy.intercept('POST', '**/products/admin', {
+            id: 2,
+            name: 'New',
+            unitPrice: 1,
+            stock: 1,
+        }).as('createProd');
+        cy.visit('/products');
+        cy.wait('@getProd');
+        cy.contains('Add Product').click();
+        cy.get('input[placeholder="Name"]').type('New');
+        cy.get('input[placeholder="Price"]').type('1');
+        cy.get('input[placeholder="Stock"]').type('1');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createProd');
+        cy.contains('New');
+        cy.contains('Product created');
+    });
 });

--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -1,28 +1,30 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });
 describe('reviews crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+    });
 
-  it('loads and creates review', () => {
-    cy.intercept('GET', '**/employees/*/reviews', { fixture: 'reviews.json' }).as('getRev');
-    cy.intercept('POST', '**/appointments/*/review', {
-      id: 2,
-      appointmentId: 1,
-      rating: 5,
-    }).as('createRev');
-    cy.visit('/reviews');
-    cy.wait('@getRev');
-    cy.contains('Add Review').click();
-    cy.get('input[placeholder="Appointment"]').type('1');
-    cy.get('input[placeholder="Rating"]').type('5');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createRev');
-    cy.contains('Review created');
-  });
+    it('loads and creates review', () => {
+        cy.intercept('GET', '**/employees/*/reviews', {
+            fixture: 'reviews.json',
+        }).as('getRev');
+        cy.intercept('POST', '**/appointments/*/review', {
+            id: 2,
+            appointmentId: 1,
+            rating: 5,
+        }).as('createRev');
+        cy.visit('/reviews');
+        cy.wait('@getRev');
+        cy.contains('Add Review').click();
+        cy.get('input[placeholder="Appointment"]').type('1');
+        cy.get('input[placeholder="Rating"]').type('5');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createRev');
+        cy.contains('Review created');
+    });
 });

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -1,24 +1,28 @@
 describe('basic', () => {
-  it('loads home', () => {
-    cy.visit('/');
-    cy.contains('Home Page');
-  });
+    it('loads home', () => {
+        cy.visit('/');
+        cy.contains('Home Page');
+    });
 });
 describe('services crud', () => {
-  beforeEach(() => {
-    localStorage.setItem('jwtToken', 'x');
-  });
+    beforeEach(() => {
+        localStorage.setItem('jwtToken', 'x');
+    });
 
-  it('loads and creates service', () => {
-    cy.intercept('GET', '**/services', { fixture: 'services.json' }).as('getSvc');
-    cy.intercept('POST', '**/services', { id: 3, name: 'New' }).as('createSvc');
-    cy.visit('/services');
-    cy.wait('@getSvc');
-    cy.contains('Add Service').click();
-    cy.get('input[placeholder="Name"]').type('New');
-    cy.contains('button', 'Save').click();
-    cy.wait('@createSvc');
-    cy.contains('New');
-    cy.contains('Service created');
-  });
+    it('loads and creates service', () => {
+        cy.intercept('GET', '**/services', { fixture: 'services.json' }).as(
+            'getSvc',
+        );
+        cy.intercept('POST', '**/services', { id: 3, name: 'New' }).as(
+            'createSvc',
+        );
+        cy.visit('/services');
+        cy.wait('@getSvc');
+        cy.contains('Add Service').click();
+        cy.get('input[placeholder="Name"]').type('New');
+        cy.contains('button', 'Save').click();
+        cy.wait('@createSvc');
+        cy.contains('New');
+        cy.contains('Service created');
+    });
 });

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,14 +1,17 @@
 module.exports = {
-  preset: 'ts-jest/presets/default-esm',
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
-  extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json', useESM: true }],
-  },
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-  },
-  transformIgnorePatterns: ['/node_modules/(?!(msw)/)'],
+    preset: 'ts-jest/presets/default-esm',
+    testEnvironment: 'jsdom',
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+    testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+    extensionsToTreatAsEsm: ['.ts', '.tsx'],
+    transform: {
+        '^.+\\.(ts|tsx)$': [
+            'ts-jest',
+            { tsconfig: 'tsconfig.jest.json', useESM: true },
+        ],
+    },
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
+    transformIgnorePatterns: ['/node_modules/(?!(msw)/)'],
 };

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,42 +1,46 @@
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
 import { TextEncoder, TextDecoder } from 'util';
-import { ReadableStream, WritableStream, TransformStream } from 'web-streams-polyfill';
+import {
+    ReadableStream,
+    WritableStream,
+    TransformStream,
+} from 'web-streams-polyfill';
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
 
 declare global {
-  interface BroadcastChannel {
-    readonly name: string;
-    postMessage(message: unknown): void;
-    close(): void;
-    addEventListener(
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      options?: boolean | AddEventListenerOptions,
-    ): void;
-    removeEventListener(
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      options?: boolean | EventListenerOptions,
-    ): void;
-  }
+    interface BroadcastChannel {
+        readonly name: string;
+        postMessage(message: unknown): void;
+        close(): void;
+        addEventListener(
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | AddEventListenerOptions,
+        ): void;
+        removeEventListener(
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | EventListenerOptions,
+        ): void;
+    }
 
-  interface GlobalThis {
-    TextEncoder: typeof import('util').TextEncoder;
-    TextDecoder: typeof import('util').TextDecoder;
-    ReadableStream: typeof import('web-streams-polyfill').ReadableStream;
-    WritableStream: typeof import('web-streams-polyfill').WritableStream;
-    TransformStream: typeof import('web-streams-polyfill').TransformStream;
-    BroadcastChannel: {
-      new (name: string): BroadcastChannel;
-    };
-    matchMedia: (query: string) => {
-      media: string;
-      matches: boolean;
-      addEventListener: () => void;
-      removeEventListener: () => void;
-    };
-  }
+    interface GlobalThis {
+        TextEncoder: typeof import('util').TextEncoder;
+        TextDecoder: typeof import('util').TextDecoder;
+        ReadableStream: typeof import('web-streams-polyfill').ReadableStream;
+        WritableStream: typeof import('web-streams-polyfill').WritableStream;
+        TransformStream: typeof import('web-streams-polyfill').TransformStream;
+        BroadcastChannel: {
+            new (name: string): BroadcastChannel;
+        };
+        matchMedia: (query: string) => {
+            media: string;
+            matches: boolean;
+            addEventListener: () => void;
+            removeEventListener: () => void;
+        };
+    }
 }
 
 // polyfill for msw/node
@@ -47,39 +51,39 @@ global.ReadableStream = ReadableStream;
 global.WritableStream = WritableStream;
 global.TransformStream = TransformStream;
 global.BroadcastChannel = class {
-  constructor(public readonly name: string) {}
-  postMessage(_message: unknown) {
-    void _message;
-  }
-  close() {}
-  addEventListener(
-    _type: string,
-    _listener: EventListenerOrEventListenerObject,
-    _options?: boolean | AddEventListenerOptions,
-  ) {
-    void _type;
-    void _listener;
-    void _options;
-  }
-  removeEventListener(
-    _type: string,
-    _listener: EventListenerOrEventListenerObject,
-    _options?: boolean | EventListenerOptions,
-  ) {
-    void _type;
-    void _listener;
-    void _options;
-  }
+    constructor(public readonly name: string) {}
+    postMessage(_message: unknown) {
+        void _message;
+    }
+    close() {}
+    addEventListener(
+        _type: string,
+        _listener: EventListenerOrEventListenerObject,
+        _options?: boolean | AddEventListenerOptions,
+    ) {
+        void _type;
+        void _listener;
+        void _options;
+    }
+    removeEventListener(
+        _type: string,
+        _listener: EventListenerOrEventListenerObject,
+        _options?: boolean | EventListenerOptions,
+    ) {
+        void _type;
+        void _listener;
+        void _options;
+    }
 };
 
 // polyfill window.matchMedia used by react-hot-toast
 global.matchMedia = ((query: string) => ({
-  media: query,
-  matches: false,
-  addEventListener: () => {},
-  removeEventListener: () => {},
+    media: query,
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
 })) as typeof globalThis.matchMedia;
 
 jest.mock('next/router', () => ({
-  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
 }));

--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -1,72 +1,97 @@
 import { ApiClient } from '@/api/apiClient';
 
 describe('ApiClient', () => {
-  const originalFetch = global.fetch;
+    const originalFetch = global.fetch;
 
-  afterEach(() => {
-    if (originalFetch) {
-      global.fetch = originalFetch;
-    }
-    jest.resetAllMocks();
-  });
-
-  it('adds Authorization header when token is present', async () => {
-    const token = 'test-token';
-    const client = new ApiClient(() => token, () => {});
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response('{}', { status: 200 })
-    ) as jest.MockedFunction<typeof fetch>;
-
-    await client.request('/test');
-
-    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
-    const headers = options.headers as Headers;
-    expect(headers.get('Authorization')).toBe(`Bearer ${token}`);
-  });
-
-  it.each([401, 403])('calls logout callback on %i responses', async (status) => {
-    const onLogout = jest.fn();
-    const client = new ApiClient(() => null, onLogout);
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response(null, { status, statusText: 'Unauthorized' })
-    ) as jest.MockedFunction<typeof fetch>;
-
-    await expect(client.request('/test')).rejects.toThrow('Unauthorized');
-    expect(onLogout).toHaveBeenCalled();
-  });
-
-  it('propagates error messages from the server', async () => {
-    const client = new ApiClient(() => null, () => {});
-    const message = 'Bad things happened';
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response(JSON.stringify({ message }), {
-        status: 400,
-        statusText: 'Bad Request',
-        headers: { 'Content-Type': 'application/json' },
-      })
-    ) as jest.MockedFunction<typeof fetch>;
-
-    await expect(client.request('/test')).rejects.toMatchObject({
-      message,
-      status: 400,
+    afterEach(() => {
+        if (originalFetch) {
+            global.fetch = originalFetch;
+        }
+        jest.resetAllMocks();
     });
-  });
 
-  it('returns undefined for 204 responses', async () => {
-    const client = new ApiClient(() => null, () => {});
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response(null, { status: 204, statusText: 'No Content' })
-    ) as jest.MockedFunction<typeof fetch>;
-    const res = await client.request('/test');
-    expect(res).toBeUndefined();
-  });
+    it('adds Authorization header when token is present', async () => {
+        const token = 'test-token';
+        const client = new ApiClient(
+            () => token,
+            () => {},
+        );
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                new Response('{}', { status: 200 }),
+            ) as jest.MockedFunction<typeof fetch>;
 
-  it('returns undefined for empty bodies', async () => {
-    const client = new ApiClient(() => null, () => {});
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response('', { status: 200 })
-    ) as jest.MockedFunction<typeof fetch>;
-    const res = await client.request('/test');
-    expect(res).toBeUndefined();
-  });
+        await client.request('/test');
+
+        const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+        const headers = options.headers as Headers;
+        expect(headers.get('Authorization')).toBe(`Bearer ${token}`);
+    });
+
+    it.each([401, 403])(
+        'calls logout callback on %i responses',
+        async (status) => {
+            const onLogout = jest.fn();
+            const client = new ApiClient(() => null, onLogout);
+            global.fetch = jest
+                .fn()
+                .mockResolvedValue(
+                    new Response(null, { status, statusText: 'Unauthorized' }),
+                ) as jest.MockedFunction<typeof fetch>;
+
+            await expect(client.request('/test')).rejects.toThrow(
+                'Unauthorized',
+            );
+            expect(onLogout).toHaveBeenCalled();
+        },
+    );
+
+    it('propagates error messages from the server', async () => {
+        const client = new ApiClient(
+            () => null,
+            () => {},
+        );
+        const message = 'Bad things happened';
+        global.fetch = jest.fn().mockResolvedValue(
+            new Response(JSON.stringify({ message }), {
+                status: 400,
+                statusText: 'Bad Request',
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        ) as jest.MockedFunction<typeof fetch>;
+
+        await expect(client.request('/test')).rejects.toMatchObject({
+            message,
+            status: 400,
+        });
+    });
+
+    it('returns undefined for 204 responses', async () => {
+        const client = new ApiClient(
+            () => null,
+            () => {},
+        );
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                new Response(null, { status: 204, statusText: 'No Content' }),
+            ) as jest.MockedFunction<typeof fetch>;
+        const res = await client.request('/test');
+        expect(res).toBeUndefined();
+    });
+
+    it('returns undefined for empty bodies', async () => {
+        const client = new ApiClient(
+            () => null,
+            () => {},
+        );
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                new Response('', { status: 200 }),
+            ) as jest.MockedFunction<typeof fetch>;
+        const res = await client.request('/test');
+        expect(res).toBeUndefined();
+    });
 });

--- a/frontend/src/__tests__/appointmentForm.test.tsx
+++ b/frontend/src/__tests__/appointmentForm.test.tsx
@@ -2,19 +2,25 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import AppointmentForm from '@/components/AppointmentForm';
 
-const services = [
-  { id: 1, name: 'S' },
-];
+const services = [{ id: 1, name: 'S' }];
 
 describe('AppointmentForm', () => {
-  it('shows conflict error', async () => {
-    const onSubmit = jest.fn().mockRejectedValue({ status: 409 });
-    render(
-      <AppointmentForm services={services} onSubmit={onSubmit} onCancel={() => {}} />
-    );
-    fireEvent.change(screen.getByDisplayValue('S'), { target: { value: '1' } });
-    fireEvent.change(screen.getByDisplayValue(''), { target: { value: '2024-01-01T10:00' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    await waitFor(() => screen.getByRole('alert'));
-  });
+    it('shows conflict error', async () => {
+        const onSubmit = jest.fn().mockRejectedValue({ status: 409 });
+        render(
+            <AppointmentForm
+                services={services}
+                onSubmit={onSubmit}
+                onCancel={() => {}}
+            />,
+        );
+        fireEvent.change(screen.getByDisplayValue('S'), {
+            target: { value: '1' },
+        });
+        fireEvent.change(screen.getByDisplayValue(''), {
+            target: { value: '2024-01-01T10:00' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+        await waitFor(() => screen.getByRole('alert'));
+    });
 });

--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -5,12 +5,12 @@ import { http, HttpResponse } from 'msw';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 
 const server = setupServer(
-  http.post('http://localhost/auth/login', () =>
-    HttpResponse.json({ access_token: 'abc' })
-  ),
-  http.get('http://localhost/clients', () =>
-    HttpResponse.json([{ id: 1, name: 'John' }])
-  )
+    http.post('http://localhost/auth/login', () =>
+        HttpResponse.json({ access_token: 'abc' }),
+    ),
+    http.get('http://localhost/clients', () =>
+        HttpResponse.json([{ id: 1, name: 'John' }]),
+    ),
 );
 
 beforeAll(() => server.listen());
@@ -18,26 +18,27 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('auth flow', () => {
-  it('login fetches token and fetches clients then logout clears token', async () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) =>
-      React.createElement(AuthProvider, null, children);
-    const { result } = renderHook(() => useAuth(), { wrapper });
+    it('login fetches token and fetches clients then logout clears token', async () => {
+        const wrapper = ({ children }: { children: React.ReactNode }) =>
+            React.createElement(AuthProvider, null, children);
+        const { result } = renderHook(() => useAuth(), { wrapper });
 
-    await act(async () => {
-      await result.current.login('a', 'b');
-    });
-    expect(result.current.token).toBe('abc');
+        await act(async () => {
+            await result.current.login('a', 'b');
+        });
+        expect(result.current.token).toBe('abc');
 
-    await act(async () => {
-      const clients = await result.current.apiFetch<{ id: number; name: string }[]>(
-        '/clients'
-      );
-      expect(clients[0].name).toBe('John');
-    });
+        await act(async () => {
+            const clients =
+                await result.current.apiFetch<{ id: number; name: string }[]>(
+                    '/clients',
+                );
+            expect(clients[0].name).toBe('John');
+        });
 
-    act(() => {
-      result.current.logout();
+        act(() => {
+            result.current.logout();
+        });
+        expect(result.current.token).toBeNull();
     });
-    expect(result.current.token).toBeNull();
-  });
 });

--- a/frontend/src/__tests__/clientApi.test.tsx
+++ b/frontend/src/__tests__/clientApi.test.tsx
@@ -7,37 +7,39 @@ import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
-  Toaster: () => null,
-  toast: { success: jest.fn(), error: jest.fn() },
+    Toaster: () => null,
+    toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const toast = require('react-hot-toast').toast;
 
 describe('useClientApi', () => {
-  it('shows success toast on create', async () => {
-    const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useClientApi(), { wrapper });
-    await act(async () => {
-      await result.current.create({ name: 'A' });
+    it('shows success toast on create', async () => {
+        const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useClientApi(), { wrapper });
+        await act(async () => {
+            await result.current.create({ name: 'A' });
+        });
+        expect(toast.success).toHaveBeenCalled();
     });
-    expect(toast.success).toHaveBeenCalled();
-  });
 
-  it('shows error toast on failure', async () => {
-    const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useClientApi(), { wrapper });
-    await expect(act(async () => {
-      await result.current.create({ name: 'A' });
-    })).rejects.toThrow();
-    expect(toast.error).toHaveBeenCalled();
-  });
+    it('shows error toast on failure', async () => {
+        const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useClientApi(), { wrapper });
+        await expect(
+            act(async () => {
+                await result.current.create({ name: 'A' });
+            }),
+        ).rejects.toThrow();
+        expect(toast.error).toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/clientForm.test.tsx
+++ b/frontend/src/__tests__/clientForm.test.tsx
@@ -2,21 +2,23 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ClientForm from '@/components/ClientForm';
 
 describe('ClientForm', () => {
-  it('validates name', async () => {
-    const onSubmit = jest.fn();
-    render(<ClientForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it('submits valid data', async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(<ClientForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
-      target: { value: 'John' },
+    it('validates name', async () => {
+        const onSubmit = jest.fn();
+        render(<ClientForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(onSubmit).not.toHaveBeenCalled();
     });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'John' }));
-  });
+
+    it('submits valid data', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(undefined);
+        render(<ClientForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText('Name'), {
+            target: { value: 'John' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({ name: 'John' }),
+        );
+    });
 });

--- a/frontend/src/__tests__/contactForm.test.tsx
+++ b/frontend/src/__tests__/contactForm.test.tsx
@@ -4,54 +4,67 @@ import ContactForm from '@/components/ContactForm';
 import { ToastProvider } from '@/contexts/ToastContext';
 
 describe('ContactForm', () => {
-  beforeEach(() => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) }) as jest.MockedFunction<typeof fetch>;
-  });
+    beforeEach(() => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: () => ({}),
+        }) as jest.MockedFunction<typeof fetch>;
+    });
 
-  it('posts form data', async () => {
-    render(
-      <ToastProvider>
-        <ContactForm />
-      </ToastProvider>
-    );
-    fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'John' } });
-    fireEvent.change(screen.getByPlaceholderText('Your email'), { target: { value: 'john@example.com' } });
-    fireEvent.change(screen.getByPlaceholderText('Message'), { target: { value: 'Hello' } });
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    expect(global.fetch).toHaveBeenCalledWith(
-      `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
-      expect.objectContaining({
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          to: 'contact@example.com',
-          subject: 'Contact form',
-          template: '<p>{{message}}</p>',
-          data: { name: 'John', email: 'john@example.com', message: 'Hello' },
-        }),
-      })
-    );
-  });
+    it('posts form data', async () => {
+        render(
+            <ToastProvider>
+                <ContactForm />
+            </ToastProvider>,
+        );
+        fireEvent.change(screen.getByPlaceholderText('Your name'), {
+            target: { value: 'John' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Your email'), {
+            target: { value: 'john@example.com' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Message'), {
+            target: { value: 'Hello' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /send/i }));
+        await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+        expect(global.fetch).toHaveBeenCalledWith(
+            `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
+            expect.objectContaining({
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    to: 'contact@example.com',
+                    subject: 'Contact form',
+                    template: '<p>{{message}}</p>',
+                    data: {
+                        name: 'John',
+                        email: 'john@example.com',
+                        message: 'Hello',
+                    },
+                }),
+            }),
+        );
+    });
 
-  it('shows email validation error', async () => {
-    render(
-      <ToastProvider>
-        <ContactForm />
-      </ToastProvider>
-    );
-    fireEvent.change(screen.getByPlaceholderText('Your name'), {
-      target: { value: 'John' },
+    it('shows email validation error', async () => {
+        render(
+            <ToastProvider>
+                <ContactForm />
+            </ToastProvider>,
+        );
+        fireEvent.change(screen.getByPlaceholderText('Your name'), {
+            target: { value: 'John' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Your email'), {
+            target: { value: 'invalid' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Message'), {
+            target: { value: 'Hello' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /send/i }));
+        expect(
+            await screen.findByText(/nieprawidłowy format adresu email/i),
+        ).toBeInTheDocument();
     });
-    fireEvent.change(screen.getByPlaceholderText('Your email'), {
-      target: { value: 'invalid' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Message'), {
-      target: { value: 'Hello' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
-    expect(
-      await screen.findByText(/nieprawidłowy format adresu email/i)
-    ).toBeInTheDocument();
-  });
 });

--- a/frontend/src/__tests__/dashboardWidget.test.tsx
+++ b/frontend/src/__tests__/dashboardWidget.test.tsx
@@ -2,14 +2,14 @@ import { render, screen } from '@testing-library/react';
 import DashboardWidget from '@/components/DashboardWidget';
 
 describe('DashboardWidget', () => {
-  it('renders value', () => {
-    render(<DashboardWidget label="Test" value={5} />);
-    expect(screen.getByText('Test')).toBeInTheDocument();
-    expect(screen.getByTestId('value').textContent).toBe('5');
-  });
+    it('renders value', () => {
+        render(<DashboardWidget label="Test" value={5} />);
+        expect(screen.getByText('Test')).toBeInTheDocument();
+        expect(screen.getByTestId('value').textContent).toBe('5');
+    });
 
-  it('shows loader', () => {
-    render(<DashboardWidget label="X" value={0} loading />);
-    expect(screen.getByRole('status')).toBeInTheDocument();
-  });
+    it('shows loader', () => {
+        render(<DashboardWidget label="X" value={0} loading />);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/employeeApi.test.tsx
+++ b/frontend/src/__tests__/employeeApi.test.tsx
@@ -7,46 +7,44 @@ import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
-  Toaster: () => null,
-  toast: { success: jest.fn(), error: jest.fn() },
+    Toaster: () => null,
+    toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const toast = require('react-hot-toast').toast;
 
 describe('useEmployeeApi', () => {
-  it('shows success toast on create', async () => {
-    const apiFetch = jest
-      .fn()
-      .mockResolvedValue({
-        id: 1,
-        firstName: 'A',
-        lastName: 'B',
-        fullName: 'A B',
-      });
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useEmployeeApi(), { wrapper });
-    await act(async () => {
-      await result.current.create({ firstName: 'A', lastName: 'B' });
+    it('shows success toast on create', async () => {
+        const apiFetch = jest.fn().mockResolvedValue({
+            id: 1,
+            firstName: 'A',
+            lastName: 'B',
+            fullName: 'A B',
+        });
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useEmployeeApi(), { wrapper });
+        await act(async () => {
+            await result.current.create({ firstName: 'A', lastName: 'B' });
+        });
+        expect(toast.success).toHaveBeenCalled();
     });
-    expect(toast.success).toHaveBeenCalled();
-  });
 
-  it('shows error toast on failure', async () => {
-    const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useEmployeeApi(), { wrapper });
-    await expect(
-      act(async () => {
-        await result.current.create({ firstName: 'A', lastName: 'B' });
-      })
-    ).rejects.toThrow();
-    expect(toast.error).toHaveBeenCalled();
-  });
+    it('shows error toast on failure', async () => {
+        const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useEmployeeApi(), { wrapper });
+        await expect(
+            act(async () => {
+                await result.current.create({ firstName: 'A', lastName: 'B' });
+            }),
+        ).rejects.toThrow();
+        expect(toast.error).toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/employeeForm.test.tsx
+++ b/frontend/src/__tests__/employeeForm.test.tsx
@@ -2,26 +2,29 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import EmployeeForm from '@/components/EmployeeForm';
 
 describe('EmployeeForm', () => {
-  it('validates name', async () => {
-    const onSubmit = jest.fn();
-    render(<EmployeeForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
+    it('validates name', async () => {
+        const onSubmit = jest.fn();
+        render(<EmployeeForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
 
-  it('submits valid data', async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(<EmployeeForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('First name'), {
-      target: { value: 'A' },
+    it('submits valid data', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(undefined);
+        render(<EmployeeForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText('First name'), {
+            target: { value: 'A' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Last name'), {
+            target: { value: 'B' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({
+                firstName: 'A',
+                lastName: 'B',
+            }),
+        );
     });
-    fireEvent.change(screen.getByPlaceholderText('Last name'), {
-      target: { value: 'B' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith({ firstName: 'A', lastName: 'B' })
-    );
-  });
 });

--- a/frontend/src/__tests__/faq.test.tsx
+++ b/frontend/src/__tests__/faq.test.tsx
@@ -8,11 +8,11 @@ jest.mock('@/contexts/AuthContext');
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('FAQ page', () => {
-  it('renders without crashing', () => {
-    mockedUseAuth.mockReturnValue(createAuthValue());
-    render(<FAQPage />);
-    expect(
-      screen.getByText(/Frequently Asked Questions/i)
-    ).toBeInTheDocument();
-  });
+    it('renders without crashing', () => {
+        mockedUseAuth.mockReturnValue(createAuthValue());
+        render(<FAQPage />);
+        expect(
+            screen.getByText(/Frequently Asked Questions/i),
+        ).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/helloWorld.test.tsx
+++ b/frontend/src/__tests__/helloWorld.test.tsx
@@ -2,12 +2,12 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 function HelloWorld() {
-  return <h1>Hello World</h1>;
+    return <h1>Hello World</h1>;
 }
 
 describe('HelloWorld component', () => {
-  it('renders greeting', () => {
-    render(<HelloWorld />);
-    expect(screen.getByText('Hello World')).toBeInTheDocument();
-  });
+    it('renders greeting', () => {
+        render(<HelloWorld />);
+        expect(screen.getByText('Hello World')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/isPublicPage.test.ts
+++ b/frontend/src/__tests__/isPublicPage.test.ts
@@ -1,11 +1,11 @@
 import { isPublicPage } from '@/components/Layout';
 
 describe('isPublicPage', () => {
-  it('does not mark /services-old as public', () => {
-    expect(isPublicPage('/services-old')).toBe(false);
-  });
+    it('does not mark /services-old as public', () => {
+        expect(isPublicPage('/services-old')).toBe(false);
+    });
 
-  it('does not mark /gallery123 as public', () => {
-    expect(isPublicPage('/gallery123')).toBe(false);
-  });
+    it('does not mark /gallery123 as public', () => {
+        expect(isPublicPage('/gallery123')).toBe(false);
+    });
 });

--- a/frontend/src/__tests__/layout.test.tsx
+++ b/frontend/src/__tests__/layout.test.tsx
@@ -12,24 +12,24 @@ const mockedUseRouter = useRouter as jest.Mock;
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('Layout', () => {
-  beforeEach(() => {
-    mockedUseRouter.mockReset();
-    mockedUseAuth.mockReset();
-  });
+    beforeEach(() => {
+        mockedUseRouter.mockReset();
+        mockedUseAuth.mockReset();
+    });
 
-  it('renders PublicNav on public routes', () => {
-    mockedUseRouter.mockReturnValue({ pathname: '/services' });
-    mockedUseAuth.mockReturnValue(createAuthValue());
-    render(<Layout>content</Layout>);
-    expect(screen.getByText('Login')).toBeInTheDocument();
-  });
+    it('renders PublicNav on public routes', () => {
+        mockedUseRouter.mockReturnValue({ pathname: '/services' });
+        mockedUseAuth.mockReturnValue(createAuthValue());
+        render(<Layout>content</Layout>);
+        expect(screen.getByText('Login')).toBeInTheDocument();
+    });
 
-  it('renders dashboard navigation on private routes', () => {
-    mockedUseRouter.mockReturnValue({ pathname: '/products' });
-    mockedUseAuth.mockReturnValue(
-      createAuthValue({ isAuthenticated: true, role: 'admin' })
-    );
-    render(<Layout>content</Layout>);
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-  });
+    it('renders dashboard navigation on private routes', () => {
+        mockedUseRouter.mockReturnValue({ pathname: '/products' });
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ isAuthenticated: true, role: 'admin' }),
+        );
+        render(<Layout>content</Layout>);
+        expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/login.test.tsx
+++ b/frontend/src/__tests__/login.test.tsx
@@ -5,35 +5,45 @@ import { useAuth } from '@/contexts/AuthContext';
 import { createAuthValue } from '../testUtils';
 
 const push = jest.fn();
-jest.mock('next/router', () => ({ useRouter: () => ({ push, replace: jest.fn() }) }));
+jest.mock('next/router', () => ({
+    useRouter: () => ({ push, replace: jest.fn() }),
+}));
 jest.mock('@/contexts/AuthContext');
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('LoginPage', () => {
-  beforeEach(() => {
-    push.mockClear();
-  });
+    beforeEach(() => {
+        push.mockClear();
+    });
 
-  it('submits valid form', async () => {
-    const login = jest.fn().mockResolvedValue(undefined);
-    mockedUseAuth.mockReturnValue(createAuthValue({ login }));
-    render(<LoginPage />);
-    fireEvent.change(screen.getByPlaceholderText('email'), { target: { value: 'a@b.com' } });
-    fireEvent.change(screen.getByPlaceholderText('password'), { target: { value: 'secret' } });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
-    await waitFor(() => expect(login).toHaveBeenCalled());
-    expect(push).toHaveBeenCalledWith('/dashboard');
-  });
+    it('submits valid form', async () => {
+        const login = jest.fn().mockResolvedValue(undefined);
+        mockedUseAuth.mockReturnValue(createAuthValue({ login }));
+        render(<LoginPage />);
+        fireEvent.change(screen.getByPlaceholderText('email'), {
+            target: { value: 'a@b.com' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('password'), {
+            target: { value: 'secret' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /login/i }));
+        await waitFor(() => expect(login).toHaveBeenCalled());
+        expect(push).toHaveBeenCalledWith('/dashboard');
+    });
 
-  it('shows validation error', async () => {
-    const login = jest.fn();
-    mockedUseAuth.mockReturnValue(createAuthValue({ login }));
-    render(<LoginPage />);
-    fireEvent.change(screen.getByPlaceholderText('email'), { target: { value: 'bad' } });
-    fireEvent.change(screen.getByPlaceholderText('password'), { target: { value: '' } });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
-    expect(login).not.toHaveBeenCalled();
-  });
+    it('shows validation error', async () => {
+        const login = jest.fn();
+        mockedUseAuth.mockReturnValue(createAuthValue({ login }));
+        render(<LoginPage />);
+        fireEvent.change(screen.getByPlaceholderText('email'), {
+            target: { value: 'bad' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('password'), {
+            target: { value: '' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /login/i }));
+        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(login).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/paymentsApi.test.tsx
+++ b/frontend/src/__tests__/paymentsApi.test.tsx
@@ -8,12 +8,14 @@ jest.mock('@/contexts/AuthContext');
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('usePaymentsApi', () => {
-  it('creates session and returns url', async () => {
-    const apiFetch = jest.fn().mockResolvedValue({ url: 'u' });
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const { result } = renderHook(() => usePaymentsApi());
-    let url: string | null = null;
-    await act(async () => { url = await result.current.createSession(1); });
-    expect(url).toBe('u');
-  });
+    it('creates session and returns url', async () => {
+        const apiFetch = jest.fn().mockResolvedValue({ url: 'u' });
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const { result } = renderHook(() => usePaymentsApi());
+        let url: string | null = null;
+        await act(async () => {
+            url = await result.current.createSession(1);
+        });
+        expect(url).toBe('u');
+    });
 });

--- a/frontend/src/__tests__/productApi.test.tsx
+++ b/frontend/src/__tests__/productApi.test.tsx
@@ -7,57 +7,55 @@ import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
-  Toaster: () => null,
-  toast: { success: jest.fn(), error: jest.fn() },
+    Toaster: () => null,
+    toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const toast = require('react-hot-toast').toast;
 
 describe('useProductApi', () => {
-  it('shows success toast on create', async () => {
-    const apiFetch = jest
-      .fn()
-      .mockResolvedValue({
-        id: 1,
-        name: 'A',
-        unitPrice: 1,
-        stock: 1,
-        lowStockThreshold: 5,
-      });
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useProductApi(), { wrapper });
-    await act(async () => {
-      await result.current.create({
-        name: 'A',
-        unitPrice: 1,
-        stock: 1,
-        lowStockThreshold: 5,
-      });
-    });
-    expect(toast.success).toHaveBeenCalled();
-  });
-
-  it('shows error toast on failure', async () => {
-    const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useProductApi(), { wrapper });
-    await expect(
-      act(async () => {
-        await result.current.create({
-          name: 'A',
-          unitPrice: 1,
-          stock: 1,
-          lowStockThreshold: 5,
+    it('shows success toast on create', async () => {
+        const apiFetch = jest.fn().mockResolvedValue({
+            id: 1,
+            name: 'A',
+            unitPrice: 1,
+            stock: 1,
+            lowStockThreshold: 5,
         });
-      })
-    ).rejects.toThrow();
-    expect(toast.error).toHaveBeenCalled();
-  });
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useProductApi(), { wrapper });
+        await act(async () => {
+            await result.current.create({
+                name: 'A',
+                unitPrice: 1,
+                stock: 1,
+                lowStockThreshold: 5,
+            });
+        });
+        expect(toast.success).toHaveBeenCalled();
+    });
+
+    it('shows error toast on failure', async () => {
+        const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useProductApi(), { wrapper });
+        await expect(
+            act(async () => {
+                await result.current.create({
+                    name: 'A',
+                    unitPrice: 1,
+                    stock: 1,
+                    lowStockThreshold: 5,
+                });
+            }),
+        ).rejects.toThrow();
+        expect(toast.error).toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/productForm.test.tsx
+++ b/frontend/src/__tests__/productForm.test.tsx
@@ -2,30 +2,36 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProductForm from '@/components/ProductForm';
 
 describe('ProductForm', () => {
-  it('validates fields', async () => {
-    const onSubmit = jest.fn();
-    render(<ProductForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
+    it('validates fields', async () => {
+        const onSubmit = jest.fn();
+        render(<ProductForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
 
-  it('submits valid data', async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(<ProductForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'P' } });
-    fireEvent.change(screen.getByPlaceholderText('Price'), { target: { value: '1' } });
-    fireEvent.change(screen.getByPlaceholderText('Stock'), { target: { value: '2' } });
-    // lowStockThreshold left as default (5)
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith({
-        name: 'P',
-        unitPrice: 1,
-        stock: 2,
-        lowStockThreshold: 5,
-        brand: '',
-      })
-    );
-  });
+    it('submits valid data', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(undefined);
+        render(<ProductForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText('Name'), {
+            target: { value: 'P' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Price'), {
+            target: { value: '1' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Stock'), {
+            target: { value: '2' },
+        });
+        // lowStockThreshold left as default (5)
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'P',
+                unitPrice: 1,
+                stock: 2,
+                lowStockThreshold: 5,
+                brand: '',
+            }),
+        );
+    });
 });

--- a/frontend/src/__tests__/receptionistAppointments.test.tsx
+++ b/frontend/src/__tests__/receptionistAppointments.test.tsx
@@ -3,9 +3,15 @@ import AppointmentsPage from '@/pages/appointments';
 import { useAuth } from '@/contexts/AuthContext';
 import { createAuthValue } from '../testUtils';
 
-jest.mock('@/hooks/useAppointments', () => ({ useAppointments: () => ({ data: [], loading: false, error: null }) }));
-jest.mock('@/hooks/useServices', () => ({ useServices: () => ({ data: [], loading: false }) }));
-jest.mock('@/api/appointments', () => ({ useAppointmentsApi: () => ({ create: jest.fn(), update: jest.fn() }) }));
+jest.mock('@/hooks/useAppointments', () => ({
+    useAppointments: () => ({ data: [], loading: false, error: null }),
+}));
+jest.mock('@/hooks/useServices', () => ({
+    useServices: () => ({ data: [], loading: false }),
+}));
+jest.mock('@/api/appointments', () => ({
+    useAppointmentsApi: () => ({ create: jest.fn(), update: jest.fn() }),
+}));
 // eslint-disable-next-line react/display-name
 jest.mock('@fullcalendar/react', () => () => <div>calendar</div>);
 jest.mock('@fullcalendar/daygrid', () => ({}));
@@ -16,13 +22,13 @@ jest.mock('next/router', () => ({ useRouter: () => ({ pathname: '/' }) }));
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('Receptionist appointments', () => {
-  it('shows all employees message', () => {
-    mockedUseAuth.mockReturnValue(
-      createAuthValue({ role: 'receptionist', isAuthenticated: true })
-    );
-    render(<AppointmentsPage />);
-    expect(
-      screen.getByText(/Viewing appointments for all employees/i)
-    ).toBeInTheDocument();
-  });
+    it('shows all employees message', () => {
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ role: 'receptionist', isAuthenticated: true }),
+        );
+        render(<AppointmentsPage />);
+        expect(
+            screen.getByText(/Viewing appointments for all employees/i),
+        ).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/receptionistNav.test.tsx
+++ b/frontend/src/__tests__/receptionistNav.test.tsx
@@ -10,16 +10,20 @@ const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockedUseRouter = useRouter as jest.Mock;
 
 describe('DashboardNav receptionist', () => {
-  beforeEach(() => {
-    mockedUseAuth.mockReset();
-    mockedUseRouter.mockReset();
-  });
+    beforeEach(() => {
+        mockedUseAuth.mockReset();
+        mockedUseRouter.mockReset();
+    });
 
-  it('shows receptionist links', () => {
-    mockedUseAuth.mockReturnValue(createAuthValue({ role: 'receptionist' }));
-    mockedUseRouter.mockReturnValue({ pathname: '/dashboard/receptionist' });
-    render(<DashboardNav />);
-    expect(screen.getByText('Home')).toBeInTheDocument();
-    expect(screen.getByText('Appointments')).toBeInTheDocument();
-  });
+    it('shows receptionist links', () => {
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ role: 'receptionist' }),
+        );
+        mockedUseRouter.mockReturnValue({
+            pathname: '/dashboard/receptionist',
+        });
+        render(<DashboardNav />);
+        expect(screen.getByText('Home')).toBeInTheDocument();
+        expect(screen.getByText('Appointments')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/reviewApi.test.tsx
+++ b/frontend/src/__tests__/reviewApi.test.tsx
@@ -7,39 +7,39 @@ import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
-  Toaster: () => null,
-  toast: { success: jest.fn(), error: jest.fn() },
+    Toaster: () => null,
+    toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const toast = require('react-hot-toast').toast;
 
 describe('useReviewApi', () => {
-  it('shows success toast on create', async () => {
-    const apiFetch = jest.fn().mockResolvedValue({ id: 1, rating: 5 });
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useReviewApi(), { wrapper });
-    await act(async () => {
-      await result.current.create(1, { rating: 5 });
+    it('shows success toast on create', async () => {
+        const apiFetch = jest.fn().mockResolvedValue({ id: 1, rating: 5 });
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useReviewApi(), { wrapper });
+        await act(async () => {
+            await result.current.create(1, { rating: 5 });
+        });
+        expect(toast.success).toHaveBeenCalled();
     });
-    expect(toast.success).toHaveBeenCalled();
-  });
 
-  it('shows error toast on failure', async () => {
-    const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useReviewApi(), { wrapper });
-    await expect(
-      act(async () => {
-        await result.current.create(1, { rating: 5 });
-      })
-    ).rejects.toThrow();
-    expect(toast.error).toHaveBeenCalled();
-  });
+    it('shows error toast on failure', async () => {
+        const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useReviewApi(), { wrapper });
+        await expect(
+            act(async () => {
+                await result.current.create(1, { rating: 5 });
+            }),
+        ).rejects.toThrow();
+        expect(toast.error).toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/reviewForm.test.tsx
+++ b/frontend/src/__tests__/reviewForm.test.tsx
@@ -2,22 +2,30 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ReviewForm from '@/components/ReviewForm';
 
 describe('ReviewForm', () => {
-  it('validates fields', async () => {
-    const onSubmit = jest.fn();
-    render(<ReviewForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
+    it('validates fields', async () => {
+        const onSubmit = jest.fn();
+        render(<ReviewForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
 
-  it('submits valid data', async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(<ReviewForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('Appointment'), { target: { value: '1' } });
-    fireEvent.change(screen.getByPlaceholderText('Rating'), { target: { value: '5' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith({ appointmentId: 1, rating: 5, comment: '' })
-    );
-  });
+    it('submits valid data', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(undefined);
+        render(<ReviewForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText('Appointment'), {
+            target: { value: '1' },
+        });
+        fireEvent.change(screen.getByPlaceholderText('Rating'), {
+            target: { value: '5' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({
+                appointmentId: 1,
+                rating: 5,
+                comment: '',
+            }),
+        );
+    });
 });

--- a/frontend/src/__tests__/routeGuard.test.tsx
+++ b/frontend/src/__tests__/routeGuard.test.tsx
@@ -5,48 +5,52 @@ import { useAuth } from '@/contexts/AuthContext';
 import { createAuthValue } from '../testUtils';
 
 const replace = jest.fn();
-jest.mock('next/router', () => ({ useRouter: () => ({ replace, push: jest.fn() }) }));
+jest.mock('next/router', () => ({
+    useRouter: () => ({ replace, push: jest.fn() }),
+}));
 jest.mock('@/contexts/AuthContext');
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('RouteGuard', () => {
-  beforeEach(() => {
-    replace.mockClear();
-  });
-  it('redirects when unauthenticated', () => {
-    mockedUseAuth.mockReturnValue(createAuthValue({ isAuthenticated: false }));
-    render(
-      <RouteGuard>
-        <div>Secret</div>
-      </RouteGuard>
-    );
-    expect(replace).toHaveBeenCalledWith('/auth/login');
-    expect(screen.queryByText('Secret')).toBeNull();
-  });
+    beforeEach(() => {
+        replace.mockClear();
+    });
+    it('redirects when unauthenticated', () => {
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ isAuthenticated: false }),
+        );
+        render(
+            <RouteGuard>
+                <div>Secret</div>
+            </RouteGuard>,
+        );
+        expect(replace).toHaveBeenCalledWith('/auth/login');
+        expect(screen.queryByText('Secret')).toBeNull();
+    });
 
-  it('renders children when authenticated and role allowed', () => {
-    mockedUseAuth.mockReturnValue(
-      createAuthValue({ isAuthenticated: true, role: 'receptionist' })
-    );
-    render(
-      <RouteGuard roles={['receptionist']}>
-        <div>Secret</div>
-      </RouteGuard>
-    );
-    expect(replace).not.toHaveBeenCalled();
-    expect(screen.getByText('Secret')).toBeInTheDocument();
-  });
+    it('renders children when authenticated and role allowed', () => {
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ isAuthenticated: true, role: 'receptionist' }),
+        );
+        render(
+            <RouteGuard roles={['receptionist']}>
+                <div>Secret</div>
+            </RouteGuard>,
+        );
+        expect(replace).not.toHaveBeenCalled();
+        expect(screen.getByText('Secret')).toBeInTheDocument();
+    });
 
-  it('redirects when role not permitted', () => {
-    mockedUseAuth.mockReturnValue(
-      createAuthValue({ isAuthenticated: true, role: 'client' })
-    );
-    render(
-      <RouteGuard roles={['admin']}>
-        <div>Secret</div>
-      </RouteGuard>
-    );
-    expect(replace).toHaveBeenCalledWith('/dashboard');
-  });
+    it('redirects when role not permitted', () => {
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ isAuthenticated: true, role: 'client' }),
+        );
+        render(
+            <RouteGuard roles={['admin']}>
+                <div>Secret</div>
+            </RouteGuard>,
+        );
+        expect(replace).toHaveBeenCalledWith('/dashboard');
+    });
 });

--- a/frontend/src/__tests__/sample.test.tsx
+++ b/frontend/src/__tests__/sample.test.tsx
@@ -2,12 +2,12 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 function Sample() {
-  return <div>Hello Jest</div>;
+    return <div>Hello Jest</div>;
 }
 
 describe('Sample component', () => {
-  it('renders text', () => {
-    render(<Sample />);
-    expect(screen.getByText('Hello Jest')).toBeInTheDocument();
-  });
+    it('renders text', () => {
+        render(<Sample />);
+        expect(screen.getByText('Hello Jest')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/__tests__/serviceApi.test.tsx
+++ b/frontend/src/__tests__/serviceApi.test.tsx
@@ -7,39 +7,39 @@ import { createAuthValue } from '../testUtils';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('react-hot-toast', () => ({
-  Toaster: () => null,
-  toast: { success: jest.fn(), error: jest.fn() },
+    Toaster: () => null,
+    toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const toast = require('react-hot-toast').toast;
 
 describe('useServiceApi', () => {
-  it('shows success toast on create', async () => {
-    const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useServiceApi(), { wrapper });
-    await act(async () => {
-      await result.current.create({ name: 'A' });
+    it('shows success toast on create', async () => {
+        const apiFetch = jest.fn().mockResolvedValue({ id: 1, name: 'A' });
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useServiceApi(), { wrapper });
+        await act(async () => {
+            await result.current.create({ name: 'A' });
+        });
+        expect(toast.success).toHaveBeenCalled();
     });
-    expect(toast.success).toHaveBeenCalled();
-  });
 
-  it('shows error toast on failure', async () => {
-    const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
-    mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    );
-    const { result } = renderHook(() => useServiceApi(), { wrapper });
-    await expect(
-      act(async () => {
-        await result.current.create({ name: 'A' });
-      })
-    ).rejects.toThrow();
-    expect(toast.error).toHaveBeenCalled();
-  });
+    it('shows error toast on failure', async () => {
+        const apiFetch = jest.fn().mockRejectedValue(new Error('fail'));
+        mockedUseAuth.mockReturnValue(createAuthValue({ apiFetch }));
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <ToastProvider>{children}</ToastProvider>
+        );
+        const { result } = renderHook(() => useServiceApi(), { wrapper });
+        await expect(
+            act(async () => {
+                await result.current.create({ name: 'A' });
+            }),
+        ).rejects.toThrow();
+        expect(toast.error).toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/serviceForm.test.tsx
+++ b/frontend/src/__tests__/serviceForm.test.tsx
@@ -2,19 +2,23 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ServiceForm from '@/components/ServiceForm';
 
 describe('ServiceForm', () => {
-  it('validates name', async () => {
-    const onSubmit = jest.fn();
-    render(<ServiceForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
+    it('validates name', async () => {
+        const onSubmit = jest.fn();
+        render(<ServiceForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
 
-  it('submits valid data', async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(<ServiceForm onSubmit={onSubmit} onCancel={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'S' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'S' }));
-  });
+    it('submits valid data', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(undefined);
+        render(<ServiceForm onSubmit={onSubmit} onCancel={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText('Name'), {
+            target: { value: 'S' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({ name: 'S' }),
+        );
+    });
 });

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -1,64 +1,69 @@
 export interface ApiError extends Error {
-  status?: number;
+    status?: number;
 }
 
 export class ApiClient {
-  constructor(
-    private getToken: () => string | null,
-    private onLogout: () => void
-  ) {}
+    constructor(
+        private getToken: () => string | null,
+        private onLogout: () => void,
+    ) {}
 
-  async request<T>(endpoint: string, init: RequestInit = {}): Promise<T> {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
-    const headers = new Headers(init.headers);
-    const token = this.getToken();
-    if (token) {
-      headers.set('Authorization', `Bearer ${token}`);
-    }
-    const retries = 3;
-    for (let attempt = 0; attempt < retries; attempt++) {
-      try {
-        const response = await fetch(`${baseUrl}${endpoint}`, {
-          ...init,
-          headers,
-          credentials: 'include',
-        });
+    async request<T>(endpoint: string, init: RequestInit = {}): Promise<T> {
+        const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
+        const headers = new Headers(init.headers);
+        const token = this.getToken();
+        if (token) {
+            headers.set('Authorization', `Bearer ${token}`);
+        }
+        const retries = 3;
+        for (let attempt = 0; attempt < retries; attempt++) {
+            try {
+                const response = await fetch(`${baseUrl}${endpoint}`, {
+                    ...init,
+                    headers,
+                    credentials: 'include',
+                });
 
-        if (!response.ok) {
-          if (response.status === 401 || response.status === 403) {
-            this.onLogout();
-          }
-          let message: string;
-          try {
-            const data = await response.json();
-            message = data.message || response.statusText;
-          } catch {
-            message = response.statusText;
-          }
-          const error: ApiError = new Error(message);
-          error.status = response.status;
-          throw error;
+                if (!response.ok) {
+                    if (response.status === 401 || response.status === 403) {
+                        this.onLogout();
+                    }
+                    let message: string;
+                    try {
+                        const data = await response.json();
+                        message = data.message || response.statusText;
+                    } catch {
+                        message = response.statusText;
+                    }
+                    const error: ApiError = new Error(message);
+                    error.status = response.status;
+                    throw error;
+                }
+                if (response.status === 204) {
+                    return undefined as T;
+                }
+                const text = await response.text();
+                if (!text) {
+                    return undefined as T;
+                }
+                return JSON.parse(text) as T;
+            } catch (error: unknown) {
+                const err = error as ApiError & {
+                    response?: { data?: unknown };
+                };
+                console.error(
+                    'API request failed',
+                    err.response?.data || err.message,
+                );
+                if (
+                    attempt === retries - 1 ||
+                    (typeof err.status === 'number' && err.status < 500)
+                ) {
+                    throw err;
+                }
+                await new Promise((res) => setTimeout(res, 1000));
+            }
         }
-        if (response.status === 204) {
-          return undefined as T;
-        }
-        const text = await response.text();
-        if (!text) {
-          return undefined as T;
-        }
-        return JSON.parse(text) as T;
-      } catch (error: unknown) {
-        const err = error as ApiError & { response?: { data?: unknown } };
-        console.error('API request failed', err.response?.data || err.message);
-        if (
-          attempt === retries - 1 ||
-          (typeof err.status === 'number' && err.status < 500)
-        ) {
-          throw err;
-        }
-        await new Promise((res) => setTimeout(res, 1000));
-      }
+        throw new Error('Request failed');
     }
-    throw new Error('Request failed');
-  }
 }

--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -3,42 +3,45 @@ import { useToast } from '@/contexts/ToastContext';
 import { Appointment } from '@/types';
 
 export function useAppointmentsApi() {
-  const { apiFetch } = useAuth();
-  const toast = useToast();
+    const { apiFetch } = useAuth();
+    const toast = useToast();
 
-  const create = async (data: {
-    employeeId: number;
-    serviceId: number;
-    startTime: string;
-  }) => {
-    try {
-      const res = await apiFetch<Appointment>('/appointments/admin', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Appointment created');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const create = async (data: {
+        employeeId: number;
+        serviceId: number;
+        startTime: string;
+    }) => {
+        try {
+            const res = await apiFetch<Appointment>('/appointments/admin', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Appointment created');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const update = async (id: number, data: { startTime: string }) => {
-    try {
-      const res = await apiFetch<Appointment>(`/appointments/admin/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Appointment updated');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const update = async (id: number, data: { startTime: string }) => {
+        try {
+            const res = await apiFetch<Appointment>(
+                `/appointments/admin/${id}`,
+                {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data),
+                },
+            );
+            toast.success('Appointment updated');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  return { create, update };
+    return { create, update };
 }

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -3,48 +3,48 @@ import { useToast } from '@/contexts/ToastContext';
 import { Client } from '@/types';
 
 export function useClientApi() {
-  const { apiFetch } = useAuth();
-  const toast = useToast();
+    const { apiFetch } = useAuth();
+    const toast = useToast();
 
-  const create = async (data: { name: string }) => {
-    try {
-      const res = await apiFetch<Client>('/clients', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Client created');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const create = async (data: { name: string }) => {
+        try {
+            const res = await apiFetch<Client>('/clients', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Client created');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const update = async (id: number, data: { name: string }) => {
-    try {
-      const res = await apiFetch<Client>(`/clients/${id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Client updated');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const update = async (id: number, data: { name: string }) => {
+        try {
+            const res = await apiFetch<Client>(`/clients/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Client updated');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const remove = async (id: number) => {
-    try {
-      await apiFetch(`/clients/${id}`, { method: 'DELETE' });
-      toast.success('Client deleted');
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const remove = async (id: number) => {
+        try {
+            await apiFetch(`/clients/${id}`, { method: 'DELETE' });
+            toast.success('Client deleted');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  return { create, update, remove };
+    return { create, update, remove };
 }

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -3,48 +3,51 @@ import { useToast } from '@/contexts/ToastContext';
 import { Employee } from '@/types';
 
 export function useEmployeeApi() {
-  const { apiFetch } = useAuth();
-  const toast = useToast();
+    const { apiFetch } = useAuth();
+    const toast = useToast();
 
-  const create = async (data: { firstName: string; lastName: string }) => {
-    try {
-      const res = await apiFetch<Employee>('/employees', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Employee created');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const create = async (data: { firstName: string; lastName: string }) => {
+        try {
+            const res = await apiFetch<Employee>('/employees', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Employee created');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const update = async (id: number, data: { firstName: string; lastName: string }) => {
-    try {
-      const res = await apiFetch<Employee>(`/employees/${id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Employee updated');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const update = async (
+        id: number,
+        data: { firstName: string; lastName: string },
+    ) => {
+        try {
+            const res = await apiFetch<Employee>(`/employees/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Employee updated');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const remove = async (id: number) => {
-    try {
-      await apiFetch(`/employees/${id}`, { method: 'DELETE' });
-      toast.success('Employee deleted');
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const remove = async (id: number) => {
+        try {
+            await apiFetch(`/employees/${id}`, { method: 'DELETE' });
+            toast.success('Employee deleted');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  return { create, update, remove };
+    return { create, update, remove };
 }

--- a/frontend/src/api/payments.ts
+++ b/frontend/src/api/payments.ts
@@ -1,16 +1,19 @@
 import { useAuth } from '@/contexts/AuthContext';
 
 export function usePaymentsApi() {
-  const { apiFetch } = useAuth();
+    const { apiFetch } = useAuth();
 
-  const createSession = async (appointmentId: number) => {
-    const res = await apiFetch<{ url: string }>('/payments/create-session', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ appointmentId }),
-    });
-    return res.url;
-  };
+    const createSession = async (appointmentId: number) => {
+        const res = await apiFetch<{ url: string }>(
+            '/payments/create-session',
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ appointmentId }),
+            },
+        );
+        return res.url;
+    };
 
-  return { createSession };
+    return { createSession };
 }

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -3,84 +3,90 @@ import { useToast } from '@/contexts/ToastContext';
 import { Review } from '@/types';
 
 export function useReviewApi() {
-  const { apiFetch } = useAuth();
-  const toast = useToast();
+    const { apiFetch } = useAuth();
+    const toast = useToast();
 
-  const create = async (
-    appointmentId: number,
-    data: { rating: number; comment?: string },
-  ) => {
-    try {
-      const res = await apiFetch<Review>(
-        `/appointments/${appointmentId}/review`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data),
-        },
-      );
-      toast.success('Review created');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const create = async (
+        appointmentId: number,
+        data: { rating: number; comment?: string },
+    ) => {
+        try {
+            const res = await apiFetch<Review>(
+                `/appointments/${appointmentId}/review`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data),
+                },
+            );
+            toast.success('Review created');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const get = async (appointmentId: number) => {
-    try {
-      return await apiFetch<Review>(
-        `/appointments/${appointmentId}/review`,
-      );
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const get = async (appointmentId: number) => {
+        try {
+            return await apiFetch<Review>(
+                `/appointments/${appointmentId}/review`,
+            );
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const listForEmployee = async (
-    employeeId: number,
-    params: { page?: number; limit?: number; rating?: number } = {},
-  ) => {
-    const query = new URLSearchParams();
-    if (params.page) query.set('page', String(params.page));
-    if (params.limit) query.set('limit', String(params.limit));
-    if (params.rating) query.set('rating', String(params.rating));
-    const qs = query.toString();
-    try {
-      return await apiFetch<{ data: Review[]; total: number; page: number; limit: number }>(
-        `/employees/${employeeId}/reviews${qs ? `?${qs}` : ''}`,
-      );
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const listForEmployee = async (
+        employeeId: number,
+        params: { page?: number; limit?: number; rating?: number } = {},
+    ) => {
+        const query = new URLSearchParams();
+        if (params.page) query.set('page', String(params.page));
+        if (params.limit) query.set('limit', String(params.limit));
+        if (params.rating) query.set('rating', String(params.rating));
+        const qs = query.toString();
+        try {
+            return await apiFetch<{
+                data: Review[];
+                total: number;
+                page: number;
+                limit: number;
+            }>(`/employees/${employeeId}/reviews${qs ? `?${qs}` : ''}`);
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const update = async (id: number, data: { rating?: number; comment?: string }) => {
-    try {
-      const res = await apiFetch<Review>(`/reviews/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Review updated');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const update = async (
+        id: number,
+        data: { rating?: number; comment?: string },
+    ) => {
+        try {
+            const res = await apiFetch<Review>(`/reviews/${id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Review updated');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const remove = async (id: number) => {
-    try {
-      await apiFetch(`/reviews/${id}`, { method: 'DELETE' });
-      toast.success('Review deleted');
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const remove = async (id: number) => {
+        try {
+            await apiFetch(`/reviews/${id}`, { method: 'DELETE' });
+            toast.success('Review deleted');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  return { create, get, listForEmployee, update, remove };
+    return { create, get, listForEmployee, update, remove };
 }

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -3,48 +3,48 @@ import { useToast } from '@/contexts/ToastContext';
 import { Service } from '@/types';
 
 export function useServiceApi() {
-  const { apiFetch } = useAuth();
-  const toast = useToast();
+    const { apiFetch } = useAuth();
+    const toast = useToast();
 
-  const create = async (data: { name: string }) => {
-    try {
-      const res = await apiFetch<Service>('/services', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Service created');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const create = async (data: { name: string }) => {
+        try {
+            const res = await apiFetch<Service>('/services', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Service created');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const update = async (id: number, data: { name: string }) => {
-    try {
-      const res = await apiFetch<Service>(`/services/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      toast.success('Service updated');
-      return res;
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const update = async (id: number, data: { name: string }) => {
+        try {
+            const res = await apiFetch<Service>(`/services/${id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            toast.success('Service updated');
+            return res;
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  const remove = async (id: number) => {
-    try {
-      await apiFetch(`/services/${id}`, { method: 'DELETE' });
-      toast.success('Service deleted');
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-      throw err;
-    }
-  };
+    const remove = async (id: number) => {
+        try {
+            await apiFetch(`/services/${id}`, { method: 'DELETE' });
+            toast.success('Service deleted');
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : 'Error');
+            throw err;
+        }
+    };
 
-  return { create, update, remove };
+    return { create, update, remove };
 }

--- a/frontend/src/components/AppointmentForm.tsx
+++ b/frontend/src/components/AppointmentForm.tsx
@@ -2,66 +2,81 @@ import { FormEvent, useState } from 'react';
 import { Service } from '@/types';
 
 interface Props {
-  services: Service[];
-  initial?: { serviceId?: number; startTime?: string };
-  onSubmit: (data: { serviceId: number; startTime: string }) => Promise<void>;
-  onCancel: () => void;
+    services: Service[];
+    initial?: { serviceId?: number; startTime?: string };
+    onSubmit: (data: { serviceId: number; startTime: string }) => Promise<void>;
+    onCancel: () => void;
 }
 
-export default function AppointmentForm({ services, initial, onSubmit, onCancel }: Props) {
-  const [serviceId, setServiceId] = useState(initial?.serviceId ?? services[0]?.id);
-  const [startTime, setStartTime] = useState(initial?.startTime ?? '');
-  const [error, setError] = useState('');
+export default function AppointmentForm({
+    services,
+    initial,
+    onSubmit,
+    onCancel,
+}: Props) {
+    const [serviceId, setServiceId] = useState(
+        initial?.serviceId ?? services[0]?.id,
+    );
+    const [startTime, setStartTime] = useState(initial?.startTime ?? '');
+    const [error, setError] = useState('');
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    setError('');
-    try {
-      await onSubmit({ serviceId: Number(serviceId), startTime });
-    } catch (err: unknown) {
-      if (
-        typeof err === 'object' &&
-        err !== null &&
-        'status' in err &&
-        (err as { status?: number }).status === 409
-      ) {
-        setError('Conflict');
-      } else if (err instanceof Error) {
-        setError(err.message || 'Error');
-      } else {
-        setError('Error');
-      }
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        setError('');
+        try {
+            await onSubmit({ serviceId: Number(serviceId), startTime });
+        } catch (err: unknown) {
+            if (
+                typeof err === 'object' &&
+                err !== null &&
+                'status' in err &&
+                (err as { status?: number }).status === 409
+            ) {
+                setError('Conflict');
+            } else if (err instanceof Error) {
+                setError(err.message || 'Error');
+            } else {
+                setError('Error');
+            }
+        }
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <select value={serviceId} onChange={(e) => setServiceId(Number(e.target.value))} className="border p-1 w-full">
-        {services.map((s) => (
-          <option key={s.id} value={s.id}>
-            {s.name}
-          </option>
-        ))}
-      </select>
-      <input
-        type="datetime-local"
-        value={startTime}
-        onChange={(e) => setStartTime(e.target.value)}
-        className="border p-1 w-full"
-      />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      <div className="flex gap-2 justify-end">
-        <button type="button" onClick={onCancel} className="border px-2 py-1">
-          Cancel
-        </button>
-        <button type="submit" className="border px-2 py-1">
-          Save
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <select
+                value={serviceId}
+                onChange={(e) => setServiceId(Number(e.target.value))}
+                className="border p-1 w-full"
+            >
+                {services.map((s) => (
+                    <option key={s.id} value={s.id}>
+                        {s.name}
+                    </option>
+                ))}
+            </select>
+            <input
+                type="datetime-local"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className="border p-1 w-full"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/components/ClientForm.tsx
+++ b/frontend/src/components/ClientForm.tsx
@@ -3,51 +3,56 @@ import { z } from 'zod';
 import { Client } from '@/types';
 
 const schema = z.object({
-  name: z.string().min(1, { message: 'Name is required' }),
+    name: z.string().min(1, { message: 'Name is required' }),
 });
 
 interface Props {
-  initial?: Partial<Client>;
-  onSubmit: (data: { name: string }) => Promise<void>;
-  onCancel: () => void;
+    initial?: Partial<Client>;
+    onSubmit: (data: { name: string }) => Promise<void>;
+    onCancel: () => void;
 }
 
 export default function ClientForm({ initial, onSubmit, onCancel }: Props) {
-  const [name, setName] = useState(initial?.name ?? '');
-  const [error, setError] = useState('');
+    const [name, setName] = useState(initial?.name ?? '');
+    const [error, setError] = useState('');
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const data = schema.parse({ name });
-      await onSubmit(data);
-    } catch (err: unknown) {
-      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
-      else setError('Error');
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        try {
+            const data = schema.parse({ name });
+            await onSubmit(data);
+        } catch (err: unknown) {
+            if (err instanceof z.ZodError)
+                setError(err.issues[0]?.message ?? 'Error');
+            else setError('Error');
+        }
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        className="border p-1 w-full"
-        placeholder="Name"
-      />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      <div className="flex gap-2 justify-end">
-        <button type="button" onClick={onCancel} className="border px-2 py-1">
-          Cancel
-        </button>
-        <button type="submit" className="border px-2 py-1">
-          Save
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="border p-1 w-full"
+                placeholder="Name"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -3,146 +3,147 @@ import { z } from 'zod';
 import { useToast } from '@/contexts/ToastContext';
 
 const schema = z.object({
-  name: z.string().min(1, { message: 'Imię jest wymagane' }),
-  email: z
-    .string()
-    .email({ message: 'Nieprawidłowy format adresu email' }),
-  message: z.string().min(1, { message: 'Wiadomość jest wymagana' }),
+    name: z.string().min(1, { message: 'Imię jest wymagane' }),
+    email: z.string().email({ message: 'Nieprawidłowy format adresu email' }),
+    message: z.string().min(1, { message: 'Wiadomość jest wymagana' }),
 });
 
 export default function ContactForm() {
-  const toast = useToast();
-  const [form, setForm] = useState({ name: '', email: '', message: '' });
-  const [error, setError] = useState('');
-  const [emailError, setEmailError] = useState('');
-  const [submitError, setSubmitError] = useState('');
-  const [submitted, setSubmitted] = useState(false);
+    const toast = useToast();
+    const [form, setForm] = useState({ name: '', email: '', message: '' });
+    const [error, setError] = useState('');
+    const [emailError, setEmailError] = useState('');
+    const [submitError, setSubmitError] = useState('');
+    const [submitted, setSubmitted] = useState(false);
 
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = e.target;
-    setForm((f) => ({ ...f, [name]: value }));
-    setSubmitted(false);
-    setSubmitError('');
-    if (name === 'email') {
-      const result = schema.shape.email.safeParse(value);
-      setEmailError(result.success ? '' : result.error.issues[0].message);
-    }
-  };
-
-  const isValid = schema.safeParse(form).success;
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    const result = schema.safeParse(form);
-    if (!result.success) {
-      const issue = result.error.issues[0];
-      if (issue.path[0] === 'email') {
-        setEmailError(issue.message);
-      } else {
-        setError(issue.message);
-      }
-      return;
-    }
-    setError('');
-    setEmailError('');
-    setSubmitError('');
-    const retries = 3;
-    for (let attempt = 0; attempt < retries; attempt++) {
-      try {
-        const res = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              to: 'contact@example.com',
-              subject: 'Contact form',
-              template: '<p>{{message}}</p>',
-              data: form,
-            }),
-          }
-        );
-        if (!res.ok) throw new Error('Failed');
-        toast.success('formularz został wysłany');
-        setSubmitted(true);
-        setForm({ name: '', email: '', message: '' });
-        return;
-      } catch (error: unknown) {
-        const err = error as { response?: { data?: unknown }; message?: string };
-        console.error(
-          'Failed to submit contact form',
-          err.response?.data || err.message,
-        );
-        if (attempt === retries - 1) {
-          setSubmitError('Nie udało się wysłać formularza');
-          toast.error('Nie udało się wysłać formularza');
-        } else {
-          await new Promise((res) => setTimeout(res, 1000));
+    const handleChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+        const { name, value } = e.target;
+        setForm((f) => ({ ...f, [name]: value }));
+        setSubmitted(false);
+        setSubmitError('');
+        if (name === 'email') {
+            const result = schema.shape.email.safeParse(value);
+            setEmailError(result.success ? '' : result.error.issues[0].message);
         }
-      }
-    }
-  };
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input
-        name="name"
-        value={form.name}
-        onChange={handleChange}
-        placeholder="Your name"
-        className="w-full border p-2 rounded"
-      />
-      <input
-        name="email"
-        type="email"
-        value={form.email}
-        onChange={handleChange}
-        placeholder="Your email"
-        className="w-full border p-2 rounded"
-      />
-      {emailError && (
-        <p role="alert" className="text-red-600 text-sm">
-          {emailError}
-        </p>
-      )}
-      <textarea
-        name="message"
-        value={form.message}
-        onChange={handleChange}
-        placeholder="Message"
-        className="w-full border p-2 rounded"
-        rows={4}
-      />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      {submitError && (
-        <p
-          data-testid="form-error-alert"
-          className="text-red-600 text-sm"
-        >
-          {submitError}
-        </p>
-      )}
-      {submitted && (
-        <p
-          data-testid="form-success-message"
-          className="text-green-600 text-sm"
-        >
-          formularz został wysłany
-        </p>
-      )}
-      <button
-        type="submit"
-        disabled={!isValid}
-        className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
-      >
-        Send
-      </button>
-    </form>
-  );
+    const isValid = schema.safeParse(form).success;
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        const result = schema.safeParse(form);
+        if (!result.success) {
+            const issue = result.error.issues[0];
+            if (issue.path[0] === 'email') {
+                setEmailError(issue.message);
+            } else {
+                setError(issue.message);
+            }
+            return;
+        }
+        setError('');
+        setEmailError('');
+        setSubmitError('');
+        const retries = 3;
+        for (let attempt = 0; attempt < retries; attempt++) {
+            try {
+                const res = await fetch(
+                    `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            to: 'contact@example.com',
+                            subject: 'Contact form',
+                            template: '<p>{{message}}</p>',
+                            data: form,
+                        }),
+                    },
+                );
+                if (!res.ok) throw new Error('Failed');
+                toast.success('formularz został wysłany');
+                setSubmitted(true);
+                setForm({ name: '', email: '', message: '' });
+                return;
+            } catch (error: unknown) {
+                const err = error as {
+                    response?: { data?: unknown };
+                    message?: string;
+                };
+                console.error(
+                    'Failed to submit contact form',
+                    err.response?.data || err.message,
+                );
+                if (attempt === retries - 1) {
+                    setSubmitError('Nie udało się wysłać formularza');
+                    toast.error('Nie udało się wysłać formularza');
+                } else {
+                    await new Promise((res) => setTimeout(res, 1000));
+                }
+            }
+        }
+    };
+
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <input
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                placeholder="Your name"
+                className="w-full border p-2 rounded"
+            />
+            <input
+                name="email"
+                type="email"
+                value={form.email}
+                onChange={handleChange}
+                placeholder="Your email"
+                className="w-full border p-2 rounded"
+            />
+            {emailError && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {emailError}
+                </p>
+            )}
+            <textarea
+                name="message"
+                value={form.message}
+                onChange={handleChange}
+                placeholder="Message"
+                className="w-full border p-2 rounded"
+                rows={4}
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            {submitError && (
+                <p
+                    data-testid="form-error-alert"
+                    className="text-red-600 text-sm"
+                >
+                    {submitError}
+                </p>
+            )}
+            {submitted && (
+                <p
+                    data-testid="form-success-message"
+                    className="text-green-600 text-sm"
+                >
+                    formularz został wysłany
+                </p>
+            )}
+            <button
+                type="submit"
+                disabled={!isValid}
+                className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+            >
+                Send
+            </button>
+        </form>
+    );
 }

--- a/frontend/src/components/DashboardWidget.tsx
+++ b/frontend/src/components/DashboardWidget.tsx
@@ -1,22 +1,22 @@
 interface Props {
-  label: string;
-  value: number | null;
-  loading?: boolean;
+    label: string;
+    value: number | null;
+    loading?: boolean;
 }
 
 export default function DashboardWidget({ label, value, loading }: Props) {
-  return (
-    <div className="p-4 bg-white rounded shadow">
-      {loading ? (
-        <div role="status" className="h-6 bg-gray-200 animate-pulse" />
-      ) : (
-        <>
-          <div className="text-sm text-gray-500">{label}</div>
-          <div data-testid="value" className="text-2xl font-bold">
-            {value}
-          </div>
-        </>
-      )}
-    </div>
-  );
+    return (
+        <div className="p-4 bg-white rounded shadow">
+            {loading ? (
+                <div role="status" className="h-6 bg-gray-200 animate-pulse" />
+            ) : (
+                <>
+                    <div className="text-sm text-gray-500">{label}</div>
+                    <div data-testid="value" className="text-2xl font-bold">
+                        {value}
+                    </div>
+                </>
+            )}
+        </div>
+    );
 }

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,116 +1,121 @@
 import React, { useState } from 'react';
 
 export interface Column<T> {
-  header: string;
-  accessor: keyof T;
+    header: string;
+    accessor: keyof T;
 }
 
 interface Props<T> {
-  data: T[];
-  columns: Column<T>[];
-  initialSort?: keyof T;
-  renderActions?: (row: T) => React.ReactNode;
-  pageSize?: number;
+    data: T[];
+    columns: Column<T>[];
+    initialSort?: keyof T;
+    renderActions?: (row: T) => React.ReactNode;
+    pageSize?: number;
 }
 
 export default function DataTable<T>({
-  data,
-  columns,
-  initialSort,
-  renderActions,
-  pageSize = 10,
+    data,
+    columns,
+    initialSort,
+    renderActions,
+    pageSize = 10,
 }: Props<T>) {
-  const [search, setSearch] = useState('');
-  const [sortKey, setSortKey] = useState<keyof T | undefined>(initialSort);
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [page, setPage] = useState(0);
+    const [search, setSearch] = useState('');
+    const [sortKey, setSortKey] = useState<keyof T | undefined>(initialSort);
+    const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+    const [page, setPage] = useState(0);
 
-  const filtered = data.filter((item) =>
-    columns.some((c) =>
-      String(item[c.accessor])
-        .toLowerCase()
-        .includes(search.toLowerCase())
-    )
-  );
+    const filtered = data.filter((item) =>
+        columns.some((c) =>
+            String(item[c.accessor])
+                .toLowerCase()
+                .includes(search.toLowerCase()),
+        ),
+    );
 
-  const sorted = sortKey
-    ? [...filtered].sort((a, b) => {
-        const av = a[sortKey];
-        const bv = b[sortKey];
-        if (av === bv) return 0;
-        if (sortDir === 'asc') return av > bv ? 1 : -1;
-        return av < bv ? 1 : -1;
-      })
-    : filtered;
+    const sorted = sortKey
+        ? [...filtered].sort((a, b) => {
+              const av = a[sortKey];
+              const bv = b[sortKey];
+              if (av === bv) return 0;
+              if (sortDir === 'asc') return av > bv ? 1 : -1;
+              return av < bv ? 1 : -1;
+          })
+        : filtered;
 
-  const paginated = sorted.slice(page * pageSize, (page + 1) * pageSize);
-  const totalPages = Math.ceil(sorted.length / pageSize);
+    const paginated = sorted.slice(page * pageSize, (page + 1) * pageSize);
+    const totalPages = Math.ceil(sorted.length / pageSize);
 
-  const toggleSort = (key: keyof T) => {
-    if (sortKey === key) {
-      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
-    } else {
-      setSortKey(key);
-      setSortDir('asc');
-    }
-  };
+    const toggleSort = (key: keyof T) => {
+        if (sortKey === key) {
+            setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+        } else {
+            setSortKey(key);
+            setSortDir('asc');
+        }
+    };
 
-  return (
-    <div>
-      <input
-        placeholder="Search"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="border p-1 mb-2"
-      />
-      <table className="min-w-full border">
-        <thead>
-          <tr className="bg-gray-50">
-            {columns.map((col) => (
-              <th
-                key={String(col.accessor)}
-                className="p-2 text-left cursor-pointer"
-                onClick={() => toggleSort(col.accessor)}
-              >
-                {col.header}
-                {sortKey === col.accessor && (sortDir === 'asc' ? ' ▲' : ' ▼')}
-              </th>
-            ))}
-            <th className="p-2" />
-          </tr>
-        </thead>
-        <tbody>
-          {paginated.map((row, i) => (
-            <tr key={i} className="border-t">
-              {columns.map((col) => (
-                <td key={String(col.accessor)} className="p-2">
-                  {String(row[col.accessor])}
-                </td>
-              ))}
-              <td className="p-2">{renderActions ? renderActions(row) : null}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <div className="mt-2 flex items-center gap-2">
-        <button
-          disabled={page === 0}
-          onClick={() => setPage((p) => Math.max(p - 1, 0))}
-          className="border px-2 py-1"
-        >
-          Prev
-        </button>
-        <span>
-          {page + 1} / {totalPages || 1}
-        </span>
-        <button
-          disabled={page + 1 >= totalPages}
-          onClick={() => setPage((p) => Math.min(p + 1, totalPages - 1))}
-          className="border px-2 py-1"
-        >
-          Next
-        </button>
-      </div>
-    </div>
-  );
+    return (
+        <div>
+            <input
+                placeholder="Search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="border p-1 mb-2"
+            />
+            <table className="min-w-full border">
+                <thead>
+                    <tr className="bg-gray-50">
+                        {columns.map((col) => (
+                            <th
+                                key={String(col.accessor)}
+                                className="p-2 text-left cursor-pointer"
+                                onClick={() => toggleSort(col.accessor)}
+                            >
+                                {col.header}
+                                {sortKey === col.accessor &&
+                                    (sortDir === 'asc' ? ' ▲' : ' ▼')}
+                            </th>
+                        ))}
+                        <th className="p-2" />
+                    </tr>
+                </thead>
+                <tbody>
+                    {paginated.map((row, i) => (
+                        <tr key={i} className="border-t">
+                            {columns.map((col) => (
+                                <td key={String(col.accessor)} className="p-2">
+                                    {String(row[col.accessor])}
+                                </td>
+                            ))}
+                            <td className="p-2">
+                                {renderActions ? renderActions(row) : null}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <div className="mt-2 flex items-center gap-2">
+                <button
+                    disabled={page === 0}
+                    onClick={() => setPage((p) => Math.max(p - 1, 0))}
+                    className="border px-2 py-1"
+                >
+                    Prev
+                </button>
+                <span>
+                    {page + 1} / {totalPages || 1}
+                </span>
+                <button
+                    disabled={page + 1 >= totalPages}
+                    onClick={() =>
+                        setPage((p) => Math.min(p + 1, totalPages - 1))
+                    }
+                    className="border px-2 py-1"
+                >
+                    Next
+                </button>
+            </div>
+        </div>
+    );
 }

--- a/frontend/src/components/EmployeeForm.tsx
+++ b/frontend/src/components/EmployeeForm.tsx
@@ -3,59 +3,64 @@ import { z } from 'zod';
 import { Employee } from '@/types';
 
 const schema = z.object({
-  firstName: z.string().min(1, { message: 'First name is required' }),
-  lastName: z.string().min(1, { message: 'Last name is required' }),
+    firstName: z.string().min(1, { message: 'First name is required' }),
+    lastName: z.string().min(1, { message: 'Last name is required' }),
 });
 
 interface Props {
-  initial?: Partial<Employee>;
-  onSubmit: (data: { firstName: string; lastName: string }) => Promise<void>;
-  onCancel: () => void;
+    initial?: Partial<Employee>;
+    onSubmit: (data: { firstName: string; lastName: string }) => Promise<void>;
+    onCancel: () => void;
 }
 
 export default function EmployeeForm({ initial, onSubmit, onCancel }: Props) {
-  const [firstName, setFirstName] = useState(initial?.firstName ?? '');
-  const [lastName, setLastName] = useState(initial?.lastName ?? '');
-  const [error, setError] = useState('');
+    const [firstName, setFirstName] = useState(initial?.firstName ?? '');
+    const [lastName, setLastName] = useState(initial?.lastName ?? '');
+    const [error, setError] = useState('');
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const data = schema.parse({ firstName, lastName });
-      await onSubmit(data);
-    } catch (err: unknown) {
-      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
-      else setError('Error');
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        try {
+            const data = schema.parse({ firstName, lastName });
+            await onSubmit(data);
+        } catch (err: unknown) {
+            if (err instanceof z.ZodError)
+                setError(err.issues[0]?.message ?? 'Error');
+            else setError('Error');
+        }
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input
-        value={firstName}
-        onChange={(e) => setFirstName(e.target.value)}
-        className="border p-1 w-full"
-        placeholder="First name"
-      />
-      <input
-        value={lastName}
-        onChange={(e) => setLastName(e.target.value)}
-        className="border p-1 w-full"
-        placeholder="Last name"
-      />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      <div className="flex gap-2 justify-end">
-        <button type="button" onClick={onCancel} className="border px-2 py-1">
-          Cancel
-        </button>
-        <button type="submit" className="border px-2 py-1">
-          Save
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <input
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                className="border p-1 w-full"
+                placeholder="First name"
+            />
+            <input
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                className="border p-1 w-full"
+                placeholder="Last name"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/components/FAQAccordion.tsx
+++ b/frontend/src/components/FAQAccordion.tsx
@@ -2,31 +2,33 @@
 import { useState } from 'react';
 
 export interface FAQItem {
-  question: string;
-  answer: string;
+    question: string;
+    answer: string;
 }
 
 export default function FAQAccordion({ items }: { items: FAQItem[] }) {
-  const [open, setOpen] = useState<number | null>(null);
+    const [open, setOpen] = useState<number | null>(null);
 
-  const toggle = (index: number) => {
-    setOpen(index === open ? null : index);
-  };
+    const toggle = (index: number) => {
+        setOpen(index === open ? null : index);
+    };
 
-  return (
-    <div className="space-y-2">
-      {items.map((item, i) => (
-        <div key={i} className="border rounded">
-          <button
-            type="button"
-            onClick={() => toggle(i)}
-            className="w-full p-2 text-left font-medium"
-          >
-            {item.question}
-          </button>
-          {open === i && <div className="p-2 border-t">{item.answer}</div>}
+    return (
+        <div className="space-y-2">
+            {items.map((item, i) => (
+                <div key={i} className="border rounded">
+                    <button
+                        type="button"
+                        onClick={() => toggle(i)}
+                        className="w-full p-2 text-left font-medium"
+                    >
+                        {item.question}
+                    </button>
+                    {open === i && (
+                        <div className="p-2 border-t">{item.answer}</div>
+                    )}
+                </div>
+            ))}
         </div>
-      ))}
-    </div>
-  );
+    );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,17 +6,19 @@ import DashboardLayout from './DashboardLayout';
 import { publicRoutes } from '@/config/publicRoutes';
 
 export function isPublicPage(pathname: string): boolean {
-  return publicRoutes.some((route) =>
-    route === '/' ? pathname === '/' : pathname.split('/')[1] === route.slice(1)
-  );
+    return publicRoutes.some((route) =>
+        route === '/'
+            ? pathname === '/'
+            : pathname.split('/')[1] === route.slice(1),
+    );
 }
 
 export default function Layout({ children }: { children: ReactNode }) {
-  const router = useRouter();
-  const publicPage = isPublicPage(router.pathname);
-  return publicPage ? (
-    <PublicLayout>{children}</PublicLayout>
-  ) : (
-    <DashboardLayout>{children}</DashboardLayout>
-  );
+    const router = useRouter();
+    const publicPage = isPublicPage(router.pathname);
+    return publicPage ? (
+        <PublicLayout>{children}</PublicLayout>
+    ) : (
+        <DashboardLayout>{children}</DashboardLayout>
+    );
 }

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,27 +1,27 @@
 import { ReactNode, useEffect } from 'react';
 
 interface Props {
-  open: boolean;
-  onClose: () => void;
-  children: ReactNode;
+    open: boolean;
+    onClose: () => void;
+    children: ReactNode;
 }
 
 export default function Modal({ open, onClose, children }: Props) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    if (open) document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        if (open) document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, [open, onClose]);
 
-  if (!open) return null;
+    if (!open) return null;
 
-  return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
-      <div className="bg-white p-4 rounded shadow min-w-[300px]">
-        {children}
-      </div>
-    </div>
-  );
+    return (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
+            <div className="bg-white p-4 rounded shadow min-w-[300px]">
+                {children}
+            </div>
+        </div>
+    );
 }

--- a/frontend/src/components/NotificationList.tsx
+++ b/frontend/src/components/NotificationList.tsx
@@ -1,17 +1,17 @@
 import { useNotifications } from '@/hooks/useNotifications';
 
 export default function NotificationList() {
-  const { data } = useNotifications();
-  return (
-    <ul className="space-y-2">
-      {data.map((n) => (
-        <li key={n.id} className="border p-2">
-          <div>{n.message}</div>
-          <div className="text-xs text-gray-500">
-            {new Date(n.createdAt).toLocaleString()}
-          </div>
-        </li>
-      ))}
-    </ul>
-  );
+    const { data } = useNotifications();
+    return (
+        <ul className="space-y-2">
+            {data.map((n) => (
+                <li key={n.id} className="border p-2">
+                    <div>{n.message}</div>
+                    <div className="text-xs text-gray-500">
+                        {new Date(n.createdAt).toLocaleString()}
+                    </div>
+                </li>
+            ))}
+        </ul>
+    );
 }

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -3,103 +3,108 @@ import { z } from 'zod';
 import { Product } from '@/types';
 
 const schema = z.object({
-  name: z.string().min(1, { message: 'Name is required' }),
-  unitPrice: z.coerce.number().min(0, { message: 'Price must be >= 0' }),
-  stock: z.coerce.number().min(0, { message: 'Stock must be >= 0' }),
-  lowStockThreshold: z.coerce.number().min(0, { message: 'Low stock threshold must be >= 0' }),
-  brand: z.string().optional(),
+    name: z.string().min(1, { message: 'Name is required' }),
+    unitPrice: z.coerce.number().min(0, { message: 'Price must be >= 0' }),
+    stock: z.coerce.number().min(0, { message: 'Stock must be >= 0' }),
+    lowStockThreshold: z.coerce
+        .number()
+        .min(0, { message: 'Low stock threshold must be >= 0' }),
+    brand: z.string().optional(),
 });
 
 interface Props {
-  initial?: Partial<Product>;
-  onSubmit: (
-    data: {
-      name: string;
-      unitPrice: number;
-      stock: number;
-      lowStockThreshold: number;
-      brand?: string;
-    }
-  ) => Promise<void>;
-  onCancel: () => void;
+    initial?: Partial<Product>;
+    onSubmit: (data: {
+        name: string;
+        unitPrice: number;
+        stock: number;
+        lowStockThreshold: number;
+        brand?: string;
+    }) => Promise<void>;
+    onCancel: () => void;
 }
 
 export default function ProductForm({ initial, onSubmit, onCancel }: Props) {
-  const [form, setForm] = useState({
-    name: initial?.name ?? '',
-    unitPrice: initial?.unitPrice ?? 0,
-    stock: initial?.stock ?? 0,
-    lowStockThreshold: initial?.lowStockThreshold ?? 5,
-    brand: initial?.brand ?? '',
-  });
-  const [error, setError] = useState('');
+    const [form, setForm] = useState({
+        name: initial?.name ?? '',
+        unitPrice: initial?.unitPrice ?? 0,
+        stock: initial?.stock ?? 0,
+        lowStockThreshold: initial?.lowStockThreshold ?? 5,
+        brand: initial?.brand ?? '',
+    });
+    const [error, setError] = useState('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setForm((f) => ({ ...f, [name]: value }));
-  };
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setForm((f) => ({ ...f, [name]: value }));
+    };
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const data = schema.parse(form);
-      await onSubmit(data);
-    } catch (err: unknown) {
-      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
-      else setError('Error');
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        try {
+            const data = schema.parse(form);
+            await onSubmit(data);
+        } catch (err: unknown) {
+            if (err instanceof z.ZodError)
+                setError(err.issues[0]?.message ?? 'Error');
+            else setError('Error');
+        }
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input
-        name="name"
-        value={form.name}
-        onChange={handleChange}
-        className="border p-1 w-full"
-        placeholder="Name"
-      />
-      <input
-        name="brand"
-        value={form.brand}
-        onChange={handleChange}
-        className="border p-1 w-full"
-        placeholder="Brand"
-      />
-      <input
-        name="unitPrice"
-        value={form.unitPrice}
-        onChange={handleChange}
-        className="border p-1 w-full"
-        placeholder="Price"
-      />
-      <input
-        name="stock"
-        value={form.stock}
-        onChange={handleChange}
-        className="border p-1 w-full"
-        placeholder="Stock"
-      />
-      <input
-        name="lowStockThreshold"
-        value={form.lowStockThreshold}
-        onChange={handleChange}
-        className="border p-1 w-full"
-        placeholder="Low Stock Threshold"
-      />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      <div className="flex gap-2 justify-end">
-        <button type="button" onClick={onCancel} className="border px-2 py-1">
-          Cancel
-        </button>
-        <button type="submit" className="border px-2 py-1">
-          Save
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <input
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Name"
+            />
+            <input
+                name="brand"
+                value={form.brand}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Brand"
+            />
+            <input
+                name="unitPrice"
+                value={form.unitPrice}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Price"
+            />
+            <input
+                name="stock"
+                value={form.stock}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Stock"
+            />
+            <input
+                name="lowStockThreshold"
+                value={form.lowStockThreshold}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Low Stock Threshold"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/components/PublicLayout.tsx
+++ b/frontend/src/components/PublicLayout.tsx
@@ -3,10 +3,10 @@ import { ReactNode } from 'react';
 import PublicNav from './PublicNav';
 
 export default function PublicLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="min-h-screen flex flex-col">
-      <PublicNav />
-      <main className="flex-1 p-4">{children}</main>
-    </div>
-  );
+    return (
+        <div className="min-h-screen flex flex-col">
+            <PublicNav />
+            <main className="flex-1 p-4">{children}</main>
+        </div>
+    );
 }

--- a/frontend/src/components/PublicNav.tsx
+++ b/frontend/src/components/PublicNav.tsx
@@ -3,82 +3,79 @@ import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function PublicNav() {
-  const { role } = useAuth();
-  const linkClass = 'transition duration-150 hover:text-blue-700';
+    const { role } = useAuth();
+    const linkClass = 'transition duration-150 hover:text-blue-700';
 
-  return (
-    <nav
-      aria-label="Main navigation"
-      className="flex justify-between items-center p-4 bg-gray-100 shadow-md"
-    >
-      <Link
-        href="/"
-        className={`font-bold text-xl mr-4 ${linkClass}`}
-      >
-        Salon Black & White
-      </Link>
-      <ul className="flex space-x-4">
-        <li>
-          <Link href="/" className={linkClass}>
-            Home
-          </Link>
-        </li>
-        <li>
-          <Link href="/services" className={linkClass}>
-            Services
-          </Link>
-        </li>
-        <li>
-          <Link href="/gallery" className={linkClass}>
-            Gallery
-          </Link>
-        </li>
-        <li>
-          <Link href="/faq" className={linkClass}>
-            FAQ
-          </Link>
-        </li>
-        <li>
-          <Link href="/contact" className={linkClass}>
-            Contact
-          </Link>
-        </li>
-        <li>
-          <Link href="/appointments" className={linkClass}>
-            Book Now
-          </Link>
-        </li>
-        {role ? (
-          <li>
-            <Link href={`/dashboard/${role}`} className={linkClass}>
-              Dashboard
+    return (
+        <nav
+            aria-label="Main navigation"
+            className="flex justify-between items-center p-4 bg-gray-100 shadow-md"
+        >
+            <Link href="/" className={`font-bold text-xl mr-4 ${linkClass}`}>
+                Salon Black & White
             </Link>
-          </li>
-        ) : (
-          <>
-            <li>
-              <Link href="/auth/login" className={linkClass}>
-                Login
-              </Link>
-            </li>
-            <li>
-              <Link href="/auth/register" className={linkClass}>
-                Register
-              </Link>
-            </li>
-          </>
-        )}
-        <li>
-          <Link href="/policy" className={linkClass}>
-            Policy
-          </Link>
-        </li>
-        <li>
-          <Link href="/privacy" className={linkClass}>
-            Privacy
-          </Link>
-        </li>
-      </ul>
-    </nav>
-  );
+            <ul className="flex space-x-4">
+                <li>
+                    <Link href="/" className={linkClass}>
+                        Home
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/services" className={linkClass}>
+                        Services
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/gallery" className={linkClass}>
+                        Gallery
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/faq" className={linkClass}>
+                        FAQ
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/contact" className={linkClass}>
+                        Contact
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/appointments" className={linkClass}>
+                        Book Now
+                    </Link>
+                </li>
+                {role ? (
+                    <li>
+                        <Link href={`/dashboard/${role}`} className={linkClass}>
+                            Dashboard
+                        </Link>
+                    </li>
+                ) : (
+                    <>
+                        <li>
+                            <Link href="/auth/login" className={linkClass}>
+                                Login
+                            </Link>
+                        </li>
+                        <li>
+                            <Link href="/auth/register" className={linkClass}>
+                                Register
+                            </Link>
+                        </li>
+                    </>
+                )}
+                <li>
+                    <Link href="/policy" className={linkClass}>
+                        Policy
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/privacy" className={linkClass}>
+                        Privacy
+                    </Link>
+                </li>
+            </ul>
+        </nav>
+    );
 }

--- a/frontend/src/components/ReviewForm.tsx
+++ b/frontend/src/components/ReviewForm.tsx
@@ -3,81 +3,106 @@ import { z } from 'zod';
 import { Review } from '@/types';
 
 const schema = z.object({
-  appointmentId: z.coerce.number().min(1, { message: 'Appointment is required' }),
-  rating: z.coerce.number().min(1).max(5),
-  comment: z.string().optional(),
+    appointmentId: z.coerce
+        .number()
+        .min(1, { message: 'Appointment is required' }),
+    rating: z.coerce.number().min(1).max(5),
+    comment: z.string().optional(),
 });
 
 interface Props {
-  initial?: Partial<Review>;
-  onSubmit: (data: { appointmentId: number; rating: number; comment?: string }) => Promise<void>;
-  onCancel: () => void;
+    initial?: Partial<Review>;
+    onSubmit: (data: {
+        appointmentId: number;
+        rating: number;
+        comment?: string;
+    }) => Promise<void>;
+    onCancel: () => void;
 }
 
 export default function ReviewForm({ initial, onSubmit, onCancel }: Props) {
-  const [form, setForm] = useState({
-    appointmentId: initial?.appointmentId ?? 0,
-    rating: initial?.rating ?? 1,
-    comment: initial?.comment ?? '',
-  });
-  const [error, setError] = useState('');
+    const [form, setForm] = useState({
+        appointmentId: initial?.appointmentId ?? 0,
+        rating: initial?.rating ?? 1,
+        comment: initial?.comment ?? '',
+    });
+    const [error, setError] = useState('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setForm((f) => ({ ...f, [name]: value }));
-  };
+    const handleChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+        const { name, value } = e.target;
+        setForm((f) => ({ ...f, [name]: value }));
+    };
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const data = schema.parse(form);
-      await onSubmit(data);
-    } catch (err: unknown) {
-      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
-      else setError('Error');
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        try {
+            const data = schema.parse(form);
+            await onSubmit(data);
+        } catch (err: unknown) {
+            if (err instanceof z.ZodError)
+                setError(err.issues[0]?.message ?? 'Error');
+            else setError('Error');
+        }
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input
-        name="appointmentId"
-        value={form.appointmentId}
-        onChange={handleChange}
-        className="border p-1 w-full"
-        placeholder="Appointment"
-      />
-      {initial?.employee && (
-        <input
-          value={initial.employee.fullName}
-          readOnly
-          className="border p-1 w-full bg-gray-100"
-          placeholder="Employee"
-        />
-      )}
-      {initial?.author && (
-        <input
-          value={initial.author.name}
-          readOnly
-          className="border p-1 w-full bg-gray-100"
-          placeholder="Author"
-        />
-      )}
-      <input name="rating" value={form.rating} onChange={handleChange} className="border p-1 w-full" placeholder="Rating" />
-      <textarea name="comment" value={form.comment} onChange={handleChange} className="border p-1 w-full" placeholder="Comment" />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      <div className="flex gap-2 justify-end">
-        <button type="button" onClick={onCancel} className="border px-2 py-1">
-          Cancel
-        </button>
-        <button type="submit" className="border px-2 py-1">
-          Save
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <input
+                name="appointmentId"
+                value={form.appointmentId}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Appointment"
+            />
+            {initial?.employee && (
+                <input
+                    value={initial.employee.fullName}
+                    readOnly
+                    className="border p-1 w-full bg-gray-100"
+                    placeholder="Employee"
+                />
+            )}
+            {initial?.author && (
+                <input
+                    value={initial.author.name}
+                    readOnly
+                    className="border p-1 w-full bg-gray-100"
+                    placeholder="Author"
+                />
+            )}
+            <input
+                name="rating"
+                value={form.rating}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Rating"
+            />
+            <textarea
+                name="comment"
+                value={form.comment}
+                onChange={handleChange}
+                className="border p-1 w-full"
+                placeholder="Comment"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/components/RouteGuard.tsx
+++ b/frontend/src/components/RouteGuard.tsx
@@ -4,23 +4,23 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { Role } from '@/types';
 
 interface Props {
-  children: ReactNode;
-  roles?: Role[];
+    children: ReactNode;
+    roles?: Role[];
 }
 
 export default function RouteGuard({ children, roles }: Props) {
-  const { isAuthenticated, role } = useAuth();
-  const router = useRouter();
+    const { isAuthenticated, role } = useAuth();
+    const router = useRouter();
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      void router.replace('/auth/login');
-    } else if (roles && role && !roles.includes(role)) {
-      void router.replace('/dashboard');
-    }
-  }, [isAuthenticated, role, roles, router]);
+    useEffect(() => {
+        if (!isAuthenticated) {
+            void router.replace('/auth/login');
+        } else if (roles && role && !roles.includes(role)) {
+            void router.replace('/dashboard');
+        }
+    }, [isAuthenticated, role, roles, router]);
 
-  if (!isAuthenticated) return null;
-  if (roles && role && !roles.includes(role)) return null;
-  return <>{children}</>;
+    if (!isAuthenticated) return null;
+    if (roles && role && !roles.includes(role)) return null;
+    return <>{children}</>;
 }

--- a/frontend/src/components/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm.tsx
@@ -3,51 +3,56 @@ import { z } from 'zod';
 import { Service } from '@/types';
 
 const schema = z.object({
-  name: z.string().min(1, { message: 'Name is required' }),
+    name: z.string().min(1, { message: 'Name is required' }),
 });
 
 interface Props {
-  initial?: Partial<Service>;
-  onSubmit: (data: { name: string }) => Promise<void>;
-  onCancel: () => void;
+    initial?: Partial<Service>;
+    onSubmit: (data: { name: string }) => Promise<void>;
+    onCancel: () => void;
 }
 
 export default function ServiceForm({ initial, onSubmit, onCancel }: Props) {
-  const [name, setName] = useState(initial?.name ?? '');
-  const [error, setError] = useState('');
+    const [name, setName] = useState(initial?.name ?? '');
+    const [error, setError] = useState('');
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const data = schema.parse({ name });
-      await onSubmit(data);
-    } catch (err: unknown) {
-      if (err instanceof z.ZodError) setError(err.issues[0]?.message ?? 'Error');
-      else setError('Error');
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        try {
+            const data = schema.parse({ name });
+            await onSubmit(data);
+        } catch (err: unknown) {
+            if (err instanceof z.ZodError)
+                setError(err.issues[0]?.message ?? 'Error');
+            else setError('Error');
+        }
+    };
 
-  return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
-      <input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        className="border p-1 w-full"
-        placeholder="Name"
-      />
-      {error && (
-        <p role="alert" className="text-red-600 text-sm">
-          {error}
-        </p>
-      )}
-      <div className="flex gap-2 justify-end">
-        <button type="button" onClick={onCancel} className="border px-2 py-1">
-          Cancel
-        </button>
-        <button type="submit" className="border px-2 py-1">
-          Save
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+            <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="border p-1 w-full"
+                placeholder="Name"
+            />
+            {error && (
+                <p role="alert" className="text-red-600 text-sm">
+                    {error}
+                </p>
+            )}
+            <div className="flex gap-2 justify-end">
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="border px-2 py-1"
+                >
+                    Cancel
+                </button>
+                <button type="submit" className="border px-2 py-1">
+                    Save
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/config/publicRoutes.ts
+++ b/frontend/src/config/publicRoutes.ts
@@ -1,10 +1,10 @@
 export const publicRoutes = [
-  '/',
-  '/services',
-  '/gallery',
-  '/contact',
-  '/faq',
-  '/policy',
-  '/privacy',
-  '/auth',
+    '/',
+    '/services',
+    '/gallery',
+    '/contact',
+    '/faq',
+    '/policy',
+    '/privacy',
+    '/auth',
 ];

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,24 +1,24 @@
 'use client';
 import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
 } from 'react';
 import { useRouter } from 'next/router';
 import { ApiClient } from '@/api/apiClient';
 import type { Role } from '@/types';
 
 interface AuthContextValue {
-  token: string | null;
-  role: Role | null;
-  isAuthenticated: boolean;
-  login: (email: string, password: string) => Promise<void>;
-  logout: () => void;
-  refreshToken: () => Promise<void>;
-  apiFetch: <T>(endpoint: string, init?: RequestInit) => Promise<T>;
+    token: string | null;
+    role: Role | null;
+    isAuthenticated: boolean;
+    login: (email: string, password: string) => Promise<void>;
+    logout: () => void;
+    refreshToken: () => Promise<void>;
+    apiFetch: <T>(endpoint: string, init?: RequestInit) => Promise<T>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -27,94 +27,102 @@ const TOKEN_KEY = 'jwtToken';
 const ROLE_KEY = 'role';
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
-  const [token, setToken] = useState<string | null>(null);
-  const [role, setRole] = useState<Role | null>(null);
+    const router = useRouter();
+    const [token, setToken] = useState<string | null>(null);
+    const [role, setRole] = useState<Role | null>(null);
 
-  useEffect(() => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
-    const storedRole = localStorage.getItem(ROLE_KEY) as Role | null;
-    if (storedToken) setToken(storedToken);
-    if (
-      storedRole === 'client' ||
-      storedRole === 'employee' ||
-      storedRole === 'receptionist' ||
-      storedRole === 'admin'
-    ) {
-      setRole(storedRole);
-    }
-  }, []);
+    useEffect(() => {
+        const storedToken = localStorage.getItem(TOKEN_KEY);
+        const storedRole = localStorage.getItem(ROLE_KEY) as Role | null;
+        if (storedToken) setToken(storedToken);
+        if (
+            storedRole === 'client' ||
+            storedRole === 'employee' ||
+            storedRole === 'receptionist' ||
+            storedRole === 'admin'
+        ) {
+            setRole(storedRole);
+        }
+    }, []);
 
-  const handleLogout = useCallback(() => {
-    setToken(null);
-    setRole(null);
-    localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(ROLE_KEY);
-    void router.push('/auth/login');
-  }, [router]);
+    const handleLogout = useCallback(() => {
+        setToken(null);
+        setRole(null);
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(ROLE_KEY);
+        void router.push('/auth/login');
+    }, [router]);
 
-  const client = useMemo(
-    () => new ApiClient(() => token, handleLogout),
-    [token, handleLogout]
-  );
+    const client = useMemo(
+        () => new ApiClient(() => token, handleLogout),
+        [token, handleLogout],
+    );
 
-  const decodeRole = (jwt: string): Role | null => {
-    try {
-      const payload = JSON.parse(atob(jwt.split('.')[1]));
-      const r = payload.role as Role | undefined;
-      if (
-        r === 'client' ||
-        r === 'employee' ||
-        r === 'receptionist' ||
-        r === 'admin'
-      ) {
-        return r;
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  };
+    const decodeRole = (jwt: string): Role | null => {
+        try {
+            const payload = JSON.parse(atob(jwt.split('.')[1]));
+            const r = payload.role as Role | undefined;
+            if (
+                r === 'client' ||
+                r === 'employee' ||
+                r === 'receptionist' ||
+                r === 'admin'
+            ) {
+                return r;
+            }
+            return null;
+        } catch {
+            return null;
+        }
+    };
 
-  const login = async (email: string, password: string) => {
-    const data = await client.request<{ access_token: string }>('/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-    setToken(data.access_token);
-    localStorage.setItem(TOKEN_KEY, data.access_token);
-    const r = decodeRole(data.access_token);
-    setRole(r);
-    if (r) localStorage.setItem(ROLE_KEY, r);
-  };
+    const login = async (email: string, password: string) => {
+        const data = await client.request<{ access_token: string }>(
+            '/auth/login',
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, password }),
+            },
+        );
+        setToken(data.access_token);
+        localStorage.setItem(TOKEN_KEY, data.access_token);
+        const r = decodeRole(data.access_token);
+        setRole(r);
+        if (r) localStorage.setItem(ROLE_KEY, r);
+    };
 
-  const refreshToken = async () => {
-    const data = await client.request<{ access_token: string }>('/auth/refresh', {
-      method: 'POST',
-    });
-    setToken(data.access_token);
-    localStorage.setItem(TOKEN_KEY, data.access_token);
-    const r = decodeRole(data.access_token);
-    setRole(r);
-    if (r) localStorage.setItem(ROLE_KEY, r);
-  };
+    const refreshToken = async () => {
+        const data = await client.request<{ access_token: string }>(
+            '/auth/refresh',
+            {
+                method: 'POST',
+            },
+        );
+        setToken(data.access_token);
+        localStorage.setItem(TOKEN_KEY, data.access_token);
+        const r = decodeRole(data.access_token);
+        setRole(r);
+        if (r) localStorage.setItem(ROLE_KEY, r);
+    };
 
-  const value: AuthContextValue = {
-    token,
-    role,
-    isAuthenticated: Boolean(token),
-    login,
-    logout: handleLogout,
-    refreshToken,
-    apiFetch: client.request.bind(client),
-  };
+    const value: AuthContextValue = {
+        token,
+        role,
+        isAuthenticated: Boolean(token),
+        login,
+        logout: handleLogout,
+        refreshToken,
+        apiFetch: client.request.bind(client),
+    };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+    return (
+        <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    );
 }
 
 export function useAuth() {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
-  return ctx;
+    const ctx = useContext(AuthContext);
+    if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+    return ctx;
 }

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -2,24 +2,26 @@ import { createContext, useContext } from 'react';
 import { Toaster, toast } from 'react-hot-toast';
 
 interface ToastContextValue {
-  success: (msg: string) => void;
-  error: (msg: string) => void;
+    success: (msg: string) => void;
+    error: (msg: string) => void;
 }
 
 const ToastContext = createContext<ToastContextValue>({
-  success: () => {},
-  error: () => {},
+    success: () => {},
+    error: () => {},
 });
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
-  return (
-    <ToastContext.Provider value={{ success: toast.success, error: toast.error }}>
-      {children}
-      <Toaster position="top-right" />
-    </ToastContext.Provider>
-  );
+    return (
+        <ToastContext.Provider
+            value={{ success: toast.success, error: toast.error }}
+        >
+            {children}
+            <Toaster position="top-right" />
+        </ToastContext.Provider>
+    );
 }
 
 export function useToast() {
-  return useContext(ToastContext);
+    return useContext(ToastContext);
 }

--- a/frontend/src/hooks/useAppointments.ts
+++ b/frontend/src/hooks/useAppointments.ts
@@ -2,5 +2,5 @@ import { useList } from './useList';
 import { Appointment } from '@/types';
 
 export function useAppointments() {
-  return useList<Appointment>('/appointments');
+    return useList<Appointment>('/appointments');
 }

--- a/frontend/src/hooks/useClients.ts
+++ b/frontend/src/hooks/useClients.ts
@@ -2,5 +2,5 @@ import { useList } from './useList';
 import { Client } from '@/types';
 
 export function useClients() {
-  return useList<Client>('/clients');
+    return useList<Client>('/clients');
 }

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -5,25 +5,25 @@ import { DashboardResponse } from '@/types';
 export interface DashboardData extends DashboardResponse {}
 
 export function useDashboard() {
-  const { apiFetch } = useAuth();
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(true);
+    const { apiFetch } = useAuth();
+    const [data, setData] = useState<DashboardData | null>(null);
+    const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    let mounted = true;
-    const getDashboardData = async () => {
-      try {
-        const d = await apiFetch<DashboardData>('/dashboard');
-        if (mounted) setData(d);
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    };
-    void getDashboardData();
-    return () => {
-      mounted = false;
-    };
-  }, [apiFetch]);
+    useEffect(() => {
+        let mounted = true;
+        const getDashboardData = async () => {
+            try {
+                const d = await apiFetch<DashboardData>('/dashboard');
+                if (mounted) setData(d);
+            } finally {
+                if (mounted) setLoading(false);
+            }
+        };
+        void getDashboardData();
+        return () => {
+            mounted = false;
+        };
+    }, [apiFetch]);
 
-  return { data, loading };
+    return { data, loading };
 }

--- a/frontend/src/hooks/useEmails.ts
+++ b/frontend/src/hooks/useEmails.ts
@@ -17,7 +17,9 @@ export function useEmails() {
                 }
             } catch (err: unknown) {
                 if (active) {
-                    setError(err instanceof Error ? err : new Error(String(err)));
+                    setError(
+                        err instanceof Error ? err : new Error(String(err)),
+                    );
                 }
             }
         };

--- a/frontend/src/hooks/useEmployees.ts
+++ b/frontend/src/hooks/useEmployees.ts
@@ -2,5 +2,5 @@ import { useList } from './useList';
 import { Employee } from '@/types';
 
 export function useEmployees() {
-  return useList<Employee>('/employees');
+    return useList<Employee>('/employees');
 }

--- a/frontend/src/hooks/useList.ts
+++ b/frontend/src/hooks/useList.ts
@@ -2,28 +2,31 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 
 export function useList<T>(endpoint: string) {
-  const { apiFetch } = useAuth();
-  const [data, setData] = useState<T[] | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-  const [loading, setLoading] = useState(true);
+    const { apiFetch } = useAuth();
+    const [data, setData] = useState<T[] | null>(null);
+    const [error, setError] = useState<Error | null>(null);
+    const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    let mounted = true;
-    setLoading(true);
-    apiFetch<T[]>(endpoint)
-      .then((res) => {
-        if (mounted) setData(res);
-      })
-      .catch((err: unknown) => {
-        if (mounted) setError(err instanceof Error ? err : new Error(String(err)));
-      })
-      .finally(() => {
-        if (mounted) setLoading(false);
-      });
-    return () => {
-      mounted = false;
-    };
-  }, [endpoint, apiFetch]);
+    useEffect(() => {
+        let mounted = true;
+        setLoading(true);
+        apiFetch<T[]>(endpoint)
+            .then((res) => {
+                if (mounted) setData(res);
+            })
+            .catch((err: unknown) => {
+                if (mounted)
+                    setError(
+                        err instanceof Error ? err : new Error(String(err)),
+                    );
+            })
+            .finally(() => {
+                if (mounted) setLoading(false);
+            });
+        return () => {
+            mounted = false;
+        };
+    }, [endpoint, apiFetch]);
 
-  return { data, error, loading };
+    return { data, error, loading };
 }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -3,33 +3,35 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Notification } from '@/types';
 
 export function useNotifications() {
-  const { apiFetch } = useAuth();
-  const [data, setData] = useState<Notification[]>([]);
-  const [error, setError] = useState<Error | null>(null);
+    const { apiFetch } = useAuth();
+    const [data, setData] = useState<Notification[]>([]);
+    const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    let active = true;
-    const fetchData = async () => {
-      try {
-        const d = await apiFetch<Notification[]>('/notifications');
-        if (active) {
-          setData(d);
-        }
-      } catch (err: unknown) {
-        if (active) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      }
-    };
-    void fetchData();
-    const id = setInterval(() => {
-      void fetchData();
-    }, 30000);
-    return () => {
-      active = false;
-      clearInterval(id);
-    };
-  }, [apiFetch]);
+    useEffect(() => {
+        let active = true;
+        const fetchData = async () => {
+            try {
+                const d = await apiFetch<Notification[]>('/notifications');
+                if (active) {
+                    setData(d);
+                }
+            } catch (err: unknown) {
+                if (active) {
+                    setError(
+                        err instanceof Error ? err : new Error(String(err)),
+                    );
+                }
+            }
+        };
+        void fetchData();
+        const id = setInterval(() => {
+            void fetchData();
+        }, 30000);
+        return () => {
+            active = false;
+            clearInterval(id);
+        };
+    }, [apiFetch]);
 
-  return { data, error };
+    return { data, error };
 }

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -3,45 +3,58 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Review } from '@/types';
 
 interface Options {
-  employeeId?: number;
-  clientId?: number;
+    employeeId?: number;
+    clientId?: number;
 }
 
 export function useReviews(options: Options = {}) {
-  const { apiFetch } = useAuth();
-  const [data, setData] = useState<Review[]>([]);
-  const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(10);
-  const [rating, setRating] = useState<number | undefined>();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+    const { apiFetch } = useAuth();
+    const [data, setData] = useState<Review[]>([]);
+    const [total, setTotal] = useState(0);
+    const [page, setPage] = useState(1);
+    const [limit, setLimit] = useState(10);
+    const [rating, setRating] = useState<number | undefined>();
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    const endpoint = options.employeeId
-      ? `/employees/${options.employeeId}/reviews`
-      : options.clientId
-      ? `/clients/${options.clientId}/reviews`
-      : '/reviews';
-    const params = new URLSearchParams();
-    params.set('page', String(page));
-    params.set('limit', String(limit));
-    if (rating) params.set('rating', String(rating));
-    const qs = params.toString();
-    setLoading(true);
-    apiFetch<{ data: Review[]; total: number; page: number; limit: number }>(
-      `${endpoint}${qs ? `?${qs}` : ''}`,
-    )
-      .then((res) => {
-        setData(res.data);
-        setTotal(res.total);
-        setLimit(res.limit);
-      })
-      .catch((err: unknown) =>
-        setError(err instanceof Error ? err : new Error(String(err)))
-      )
-      .finally(() => setLoading(false));
-  }, [options.employeeId, options.clientId, page, limit, rating, apiFetch]);
+    useEffect(() => {
+        const endpoint = options.employeeId
+            ? `/employees/${options.employeeId}/reviews`
+            : options.clientId
+              ? `/clients/${options.clientId}/reviews`
+              : '/reviews';
+        const params = new URLSearchParams();
+        params.set('page', String(page));
+        params.set('limit', String(limit));
+        if (rating) params.set('rating', String(rating));
+        const qs = params.toString();
+        setLoading(true);
+        apiFetch<{
+            data: Review[];
+            total: number;
+            page: number;
+            limit: number;
+        }>(`${endpoint}${qs ? `?${qs}` : ''}`)
+            .then((res) => {
+                setData(res.data);
+                setTotal(res.total);
+                setLimit(res.limit);
+            })
+            .catch((err: unknown) =>
+                setError(err instanceof Error ? err : new Error(String(err))),
+            )
+            .finally(() => setLoading(false));
+    }, [options.employeeId, options.clientId, page, limit, rating, apiFetch]);
 
-  return { data, total, page, limit, rating, setPage, setRating, loading, error };
+    return {
+        data,
+        total,
+        page,
+        limit,
+        rating,
+        setPage,
+        setRating,
+        loading,
+        error,
+    };
 }

--- a/frontend/src/hooks/useServices.ts
+++ b/frontend/src/hooks/useServices.ts
@@ -2,5 +2,5 @@ import { useList } from './useList';
 import { Service } from '@/types';
 
 export function useServices() {
-  return useList<Service>('/services');
+    return useList<Service>('/services');
 }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -4,11 +4,11 @@ import { ToastProvider } from '@/contexts/ToastContext';
 import '@/styles/globals.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <AuthProvider>
-      <ToastProvider>
-        <Component {...pageProps} />
-      </ToastProvider>
-    </AuthProvider>
-  );
+    return (
+        <AuthProvider>
+            <ToastProvider>
+                <Component {...pageProps} />
+            </ToastProvider>
+        </AuthProvider>
+    );
 }

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -5,55 +5,55 @@ import { useAuth } from '@/contexts/AuthContext';
 import PublicLayout from '@/components/PublicLayout';
 
 export default function LoginPage() {
-  const { login } = useAuth();
-  const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+    const { login } = useAuth();
+    const router = useRouter();
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
 
-  const schema = z.object({
-    email: z.string().email({ message: 'Invalid email' }),
-    password: z.string().min(1, { message: 'Password is required' }),
-  });
+    const schema = z.object({
+        email: z.string().email({ message: 'Invalid email' }),
+        password: z.string().min(1, { message: 'Password is required' }),
+    });
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    try {
-      const creds = schema.parse({ email, password });
-      await login(creds.email, creds.password);
-      void router.push('/dashboard');
-    } catch (err: unknown) {
-      if (err instanceof z.ZodError) {
-        setError(err.issues[0]?.message ?? 'Login failed');
-      } else if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError('Login failed');
-      }
-    }
-  };
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        try {
+            const creds = schema.parse({ email, password });
+            await login(creds.email, creds.password);
+            void router.push('/dashboard');
+        } catch (err: unknown) {
+            if (err instanceof z.ZodError) {
+                setError(err.issues[0]?.message ?? 'Login failed');
+            } else if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('Login failed');
+            }
+        }
+    };
 
-  return (
-    <PublicLayout>
-      <form onSubmit={(e) => void handleSubmit(e)}>
-        <input
-          placeholder="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          placeholder="password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button type="submit">Login</button>
-        {error && (
-          <p role="alert" style={{ color: 'red' }}>
-            {error}
-          </p>
-        )}
-      </form>
-    </PublicLayout>
-  );
+    return (
+        <PublicLayout>
+            <form onSubmit={(e) => void handleSubmit(e)}>
+                <input
+                    placeholder="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                />
+                <input
+                    placeholder="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+                <button type="submit">Login</button>
+                {error && (
+                    <p role="alert" style={{ color: 'red' }}>
+                        {error}
+                    </p>
+                )}
+            </form>
+        </PublicLayout>
+    );
 }

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -3,72 +3,77 @@ import { useRouter } from 'next/router';
 import PublicLayout from '@/components/PublicLayout';
 
 export default function RegisterPage() {
-  const router = useRouter();
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [phone, setPhone] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+    const router = useRouter();
+    const [name, setName] = useState('');
+    const [email, setEmail] = useState('');
+    const [phone, setPhone] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    setError('');
-    try {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/auth/register`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, email, phone, password }),
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        setError('');
+        try {
+            const res = await fetch(
+                `${process.env.NEXT_PUBLIC_API_URL}/auth/register`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name, email, phone, password }),
+                },
+            );
+            if (!res.ok) throw new Error('Registration failed');
+            void router.push('/auth/login');
+        } catch (err: unknown) {
+            setError(
+                err instanceof Error ? err.message : 'Registration failed',
+            );
         }
-      );
-      if (!res.ok) throw new Error('Registration failed');
-      void router.push('/auth/login');
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Registration failed');
-    }
-  };
+    };
 
-  return (
-    <PublicLayout>
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2 p-4">
-        <h1 className="text-2xl font-bold">Register</h1>
-        <input
-          className="border p-1 w-full"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <input
-          className="border p-1 w-full"
-          placeholder="Email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          className="border p-1 w-full"
-          placeholder="Phone"
-          type="tel"
-          value={phone}
-          onChange={(e) => setPhone(e.target.value)}
-        />
-        <input
-          className="border p-1 w-full"
-          placeholder="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button className="border px-2 py-1" type="submit">
-          Register
-        </button>
-        {error && (
-          <p role="alert" className="text-red-600">
-            {error}
-          </p>
-        )}
-      </form>
-    </PublicLayout>
-  );
+    return (
+        <PublicLayout>
+            <form
+                onSubmit={(e) => void handleSubmit(e)}
+                className="space-y-2 p-4"
+            >
+                <h1 className="text-2xl font-bold">Register</h1>
+                <input
+                    className="border p-1 w-full"
+                    placeholder="Name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+                <input
+                    className="border p-1 w-full"
+                    placeholder="Email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                />
+                <input
+                    className="border p-1 w-full"
+                    placeholder="Phone"
+                    type="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                />
+                <input
+                    className="border p-1 w-full"
+                    placeholder="Password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+                <button className="border px-2 py-1" type="submit">
+                    Register
+                </button>
+                {error && (
+                    <p role="alert" className="text-red-600">
+                        {error}
+                    </p>
+                )}
+            </form>
+        </PublicLayout>
+    );
 }

--- a/frontend/src/pages/clients/[id]/reviews.tsx
+++ b/frontend/src/pages/clients/[id]/reviews.tsx
@@ -6,57 +6,69 @@ import DataTable, { Column } from '@/components/DataTable';
 import { Review } from '@/types';
 
 export default function ClientReviewsPage() {
-  const router = useRouter();
-  const id = Number(router.query.id);
-  const opts = isNaN(id) ? {} : { clientId: id };
-  const { data, page, total, limit, setPage, rating, setRating } = useReviews(opts);
-  type Row = Review & { employeeName?: string };
-  const rows: Row[] = data.map((r) => ({ ...r, employeeName: r.employee?.fullName }));
-  const columns: Column<Row>[] = [
-    { header: 'Appointment', accessor: 'appointmentId' },
-    { header: 'Employee', accessor: 'employeeName' },
-    { header: 'Rating', accessor: 'rating' },
-    { header: 'Comment', accessor: 'comment' },
-  ];
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <div className="mb-2 flex justify-between">
-          <div className="flex items-center gap-2">
-            <label>
-              Rating
-              <input
-                className="border ml-1 p-1 w-16"
-                value={rating ?? ''}
-                onChange={(e) =>
-                  setRating(e.target.value ? Number(e.target.value) : undefined)
-                }
-                placeholder="All"
-              />
-            </label>
-          </div>
-        </div>
-        <DataTable data={rows} columns={columns} pageSize={rows.length || 1} />
-        <div className="mt-2 flex justify-end gap-2">
-          <button
-            className="border px-2 py-1"
-            disabled={page <= 1}
-            onClick={() => setPage(page - 1)}
-          >
-            Prev
-          </button>
-          <span>
-            {page} / {Math.ceil(total / limit) || 1}
-          </span>
-          <button
-            className="border px-2 py-1"
-            disabled={page * limit >= total}
-            onClick={() => setPage(page + 1)}
-          >
-            Next
-          </button>
-        </div>
-      </DashboardLayout>
-    </RouteGuard>
-  );
+    const router = useRouter();
+    const id = Number(router.query.id);
+    const opts = isNaN(id) ? {} : { clientId: id };
+    const { data, page, total, limit, setPage, rating, setRating } =
+        useReviews(opts);
+    type Row = Review & { employeeName?: string };
+    const rows: Row[] = data.map((r) => ({
+        ...r,
+        employeeName: r.employee?.fullName,
+    }));
+    const columns: Column<Row>[] = [
+        { header: 'Appointment', accessor: 'appointmentId' },
+        { header: 'Employee', accessor: 'employeeName' },
+        { header: 'Rating', accessor: 'rating' },
+        { header: 'Comment', accessor: 'comment' },
+    ];
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <div className="mb-2 flex justify-between">
+                    <div className="flex items-center gap-2">
+                        <label>
+                            Rating
+                            <input
+                                className="border ml-1 p-1 w-16"
+                                value={rating ?? ''}
+                                onChange={(e) =>
+                                    setRating(
+                                        e.target.value
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                    )
+                                }
+                                placeholder="All"
+                            />
+                        </label>
+                    </div>
+                </div>
+                <DataTable
+                    data={rows}
+                    columns={columns}
+                    pageSize={rows.length || 1}
+                />
+                <div className="mt-2 flex justify-end gap-2">
+                    <button
+                        className="border px-2 py-1"
+                        disabled={page <= 1}
+                        onClick={() => setPage(page - 1)}
+                    >
+                        Prev
+                    </button>
+                    <span>
+                        {page} / {Math.ceil(total / limit) || 1}
+                    </span>
+                    <button
+                        className="border px-2 py-1"
+                        disabled={page * limit >= total}
+                        onClick={() => setPage(page + 1)}
+                    >
+                        Next
+                    </button>
+                </div>
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/clients/index.tsx
+++ b/frontend/src/pages/clients/index.tsx
@@ -9,97 +9,97 @@ import { useClientApi } from '@/api/clients';
 import { Client } from '@/types';
 
 export default function ClientsPage() {
-  const { data } = useClients();
-  const api = useClientApi();
-  const [clients, setClients] = useState<Client[]>([]);
-  const [openForm, setOpenForm] = useState(false);
-  const [editing, setEditing] = useState<Client | null>(null);
+    const { data } = useClients();
+    const api = useClientApi();
+    const [clients, setClients] = useState<Client[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [editing, setEditing] = useState<Client | null>(null);
 
-  // sync once data loads
-  if (data && clients.length === 0) setClients(data);
+    // sync once data loads
+    if (data && clients.length === 0) setClients(data);
 
-  const columns: Column<Client>[] = [
-    { header: 'ID', accessor: 'id' },
-    { header: 'Name', accessor: 'name' },
-  ];
+    const columns: Column<Client>[] = [
+        { header: 'ID', accessor: 'id' },
+        { header: 'Name', accessor: 'name' },
+    ];
 
-  const handleCreate = async (values: { name: string }) => {
-    const created = await api.create(values);
-    setClients((c) => [...c, created]);
-    setOpenForm(false);
-  };
+    const handleCreate = async (values: { name: string }) => {
+        const created = await api.create(values);
+        setClients((c) => [...c, created]);
+        setOpenForm(false);
+    };
 
-  const handleUpdate = async (values: { name: string }) => {
-    if (!editing) return;
-    const updated = await api.update(editing.id, values);
-    setClients((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
-    setEditing(null);
-    setOpenForm(false);
-  };
+    const handleUpdate = async (values: { name: string }) => {
+        if (!editing) return;
+        const updated = await api.update(editing.id, values);
+        setClients((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
+        setEditing(null);
+        setOpenForm(false);
+    };
 
-  const handleDelete = async (client: Client) => {
-    if (!confirm(`Delete ${client.name}?`)) return;
-    await api.remove(client.id);
-    setClients((c) => c.filter((cl) => cl.id !== client.id));
-  };
+    const handleDelete = async (client: Client) => {
+        if (!confirm(`Delete ${client.name}?`)) return;
+        await api.remove(client.id);
+        setClients((c) => c.filter((cl) => cl.id !== client.id));
+    };
 
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <div className="mb-2 flex justify-end">
-          <button
-            className="border px-2 py-1"
-            onClick={() => {
-              setEditing(null);
-              setOpenForm(true);
-            }}
-          >
-            Add Client
-          </button>
-        </div>
-        {clients && (
-          <DataTable
-            data={clients}
-            columns={columns}
-            initialSort="id"
-            renderActions={(c) => (
-              <span className="space-x-2">
-                <button
-                  className="border px-2 py-1"
-                  onClick={() => {
-                    setEditing(c);
-                    setOpenForm(true);
-                  }}
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <div className="mb-2 flex justify-end">
+                    <button
+                        className="border px-2 py-1"
+                        onClick={() => {
+                            setEditing(null);
+                            setOpenForm(true);
+                        }}
+                    >
+                        Add Client
+                    </button>
+                </div>
+                {clients && (
+                    <DataTable
+                        data={clients}
+                        columns={columns}
+                        initialSort="id"
+                        renderActions={(c) => (
+                            <span className="space-x-2">
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => {
+                                        setEditing(c);
+                                        setOpenForm(true);
+                                    }}
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => void handleDelete(c)}
+                                >
+                                    Delete
+                                </button>
+                            </span>
+                        )}
+                    />
+                )}
+                <Modal
+                    open={openForm || Boolean(editing)}
+                    onClose={() => {
+                        setOpenForm(false);
+                        setEditing(null);
+                    }}
                 >
-                  Edit
-                </button>
-                <button
-                  className="border px-2 py-1"
-                  onClick={() => void handleDelete(c)}
-                >
-                  Delete
-                </button>
-              </span>
-            )}
-          />
-        )}
-        <Modal
-          open={openForm || Boolean(editing)}
-          onClose={() => {
-            setOpenForm(false);
-            setEditing(null);
-          }}
-        >
-          <ClientForm
-            initial={editing ?? undefined}
-            onCancel={() => {
-              setOpenForm(false);
-              setEditing(null);
-            }}
-            onSubmit={editing ? handleUpdate : handleCreate}
-          />
-        </Modal>
-      </DashboardLayout>
-    </RouteGuard>
-  );
+                    <ClientForm
+                        initial={editing ?? undefined}
+                        onCancel={() => {
+                            setOpenForm(false);
+                            setEditing(null);
+                        }}
+                        onSubmit={editing ? handleUpdate : handleCreate}
+                    />
+                </Modal>
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -4,17 +4,17 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { Role } from '@/types';
 
 export default function DashboardRedirect() {
-  const router = useRouter();
-  const { role } = useAuth();
-  useEffect(() => {
-    const current: Role =
-      role === 'client' ||
-      role === 'employee' ||
-      role === 'receptionist' ||
-      role === 'admin'
-        ? role
-        : 'client';
-    void router.replace(`/dashboard/${current}`).catch(() => {});
-  }, [router, role]);
-  return null;
+    const router = useRouter();
+    const { role } = useAuth();
+    useEffect(() => {
+        const current: Role =
+            role === 'client' ||
+            role === 'employee' ||
+            role === 'receptionist' ||
+            role === 'admin'
+                ? role
+                : 'client';
+        void router.replace(`/dashboard/${current}`).catch(() => {});
+    }, [router, role]);
+    return null;
 }

--- a/frontend/src/pages/dashboard/services/index.tsx
+++ b/frontend/src/pages/dashboard/services/index.tsx
@@ -9,93 +9,96 @@ import { useServiceApi } from '@/api/services';
 import { Service } from '@/types';
 
 export default function ServicesPage() {
-  const { data } = useServices();
-  const api = useServiceApi();
-  const [rows, setRows] = useState<Service[]>([]);
-  const [openForm, setOpenForm] = useState(false);
-  const [editing, setEditing] = useState<Service | null>(null);
+    const { data } = useServices();
+    const api = useServiceApi();
+    const [rows, setRows] = useState<Service[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [editing, setEditing] = useState<Service | null>(null);
 
-  if (data && rows.length === 0) setRows(data);
+    if (data && rows.length === 0) setRows(data);
 
-  const columns: Column<Service>[] = [
-    { header: 'ID', accessor: 'id' },
-    { header: 'Name', accessor: 'name' },
-  ];
+    const columns: Column<Service>[] = [
+        { header: 'ID', accessor: 'id' },
+        { header: 'Name', accessor: 'name' },
+    ];
 
-  const handleCreate = async (values: { name: string }) => {
-    const created = await api.create(values);
-    setRows((c) => [...c, created]);
-    setOpenForm(false);
-  };
+    const handleCreate = async (values: { name: string }) => {
+        const created = await api.create(values);
+        setRows((c) => [...c, created]);
+        setOpenForm(false);
+    };
 
-  const handleUpdate = async (values: { name: string }) => {
-    if (!editing) return;
-    const updated = await api.update(editing.id, values);
-    setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
-    setEditing(null);
-    setOpenForm(false);
-  };
+    const handleUpdate = async (values: { name: string }) => {
+        if (!editing) return;
+        const updated = await api.update(editing.id, values);
+        setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
+        setEditing(null);
+        setOpenForm(false);
+    };
 
-  const handleDelete = async (row: Service) => {
-    if (!confirm(`Delete ${row.name}?`)) return;
-    await api.remove(row.id);
-    setRows((c) => c.filter((cl) => cl.id !== row.id));
-  };
+    const handleDelete = async (row: Service) => {
+        if (!confirm(`Delete ${row.name}?`)) return;
+        await api.remove(row.id);
+        setRows((c) => c.filter((cl) => cl.id !== row.id));
+    };
 
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <div className="mb-2 flex justify-end">
-            <button
-              className="border px-2 py-1"
-              onClick={() => {
-                setEditing(null);
-                setOpenForm(true);
-              }}
-            >
-              Add Service
-            </button>
-          </div>
-          {rows && (
-            <DataTable
-              data={rows}
-              columns={columns}
-              initialSort="id"
-              renderActions={(r) => (
-                <span className="space-x-2">
-                  <button
-                    className="border px-2 py-1"
-                    onClick={() => {
-                      setEditing(r);
-                      setOpenForm(true);
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <div className="mb-2 flex justify-end">
+                    <button
+                        className="border px-2 py-1"
+                        onClick={() => {
+                            setEditing(null);
+                            setOpenForm(true);
+                        }}
+                    >
+                        Add Service
+                    </button>
+                </div>
+                {rows && (
+                    <DataTable
+                        data={rows}
+                        columns={columns}
+                        initialSort="id"
+                        renderActions={(r) => (
+                            <span className="space-x-2">
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => {
+                                        setEditing(r);
+                                        setOpenForm(true);
+                                    }}
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => void handleDelete(r)}
+                                >
+                                    Delete
+                                </button>
+                            </span>
+                        )}
+                    />
+                )}
+                <Modal
+                    open={openForm || Boolean(editing)}
+                    onClose={() => {
+                        setOpenForm(false);
+                        setEditing(null);
                     }}
-                  >
-                    Edit
-                  </button>
-                  <button className="border px-2 py-1" onClick={() => void handleDelete(r)}>
-                    Delete
-                  </button>
-                </span>
-              )}
-            />
-          )}
-          <Modal
-            open={openForm || Boolean(editing)}
-            onClose={() => {
-              setOpenForm(false);
-              setEditing(null);
-            }}
-          >
-            <ServiceForm
-              initial={editing ?? undefined}
-              onCancel={() => {
-                setOpenForm(false);
-                setEditing(null);
-              }}
-              onSubmit={editing ? handleUpdate : handleCreate}
-            />
-          </Modal>
-      </DashboardLayout>
-    </RouteGuard>
-  );
+                >
+                    <ServiceForm
+                        initial={editing ?? undefined}
+                        onCancel={() => {
+                            setOpenForm(false);
+                            setEditing(null);
+                        }}
+                        onSubmit={editing ? handleUpdate : handleCreate}
+                    />
+                </Modal>
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/employees/[id]/reviews.tsx
+++ b/frontend/src/pages/employees/[id]/reviews.tsx
@@ -6,57 +6,66 @@ import DataTable, { Column } from '@/components/DataTable';
 import { Review } from '@/types';
 
 export default function EmployeeReviewsPage() {
-  const router = useRouter();
-  const id = Number(router.query.id);
-  const opts = isNaN(id) ? {} : { employeeId: id };
-  const { data, page, total, limit, setPage, rating, setRating } = useReviews(opts);
-  type Row = Review & { authorName?: string };
-  const rows: Row[] = data.map((r) => ({ ...r, authorName: r.author?.name }));
-  const columns: Column<Row>[] = [
-    { header: 'Appointment', accessor: 'appointmentId' },
-    { header: 'Author', accessor: 'authorName' },
-    { header: 'Rating', accessor: 'rating' },
-    { header: 'Comment', accessor: 'comment' },
-  ];
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <div className="mb-2 flex justify-between">
-          <div className="flex items-center gap-2">
-            <label>
-              Rating
-              <input
-                className="border ml-1 p-1 w-16"
-                value={rating ?? ''}
-                onChange={(e) =>
-                  setRating(e.target.value ? Number(e.target.value) : undefined)
-                }
-                placeholder="All"
-              />
-            </label>
-          </div>
-        </div>
-        <DataTable data={rows} columns={columns} pageSize={rows.length || 1} />
-        <div className="mt-2 flex justify-end gap-2">
-          <button
-            className="border px-2 py-1"
-            disabled={page <= 1}
-            onClick={() => setPage(page - 1)}
-          >
-            Prev
-          </button>
-          <span>
-            {page} / {Math.ceil(total / limit) || 1}
-          </span>
-          <button
-            className="border px-2 py-1"
-            disabled={page * limit >= total}
-            onClick={() => setPage(page + 1)}
-          >
-            Next
-          </button>
-        </div>
-      </DashboardLayout>
-    </RouteGuard>
-  );
+    const router = useRouter();
+    const id = Number(router.query.id);
+    const opts = isNaN(id) ? {} : { employeeId: id };
+    const { data, page, total, limit, setPage, rating, setRating } =
+        useReviews(opts);
+    type Row = Review & { authorName?: string };
+    const rows: Row[] = data.map((r) => ({ ...r, authorName: r.author?.name }));
+    const columns: Column<Row>[] = [
+        { header: 'Appointment', accessor: 'appointmentId' },
+        { header: 'Author', accessor: 'authorName' },
+        { header: 'Rating', accessor: 'rating' },
+        { header: 'Comment', accessor: 'comment' },
+    ];
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <div className="mb-2 flex justify-between">
+                    <div className="flex items-center gap-2">
+                        <label>
+                            Rating
+                            <input
+                                className="border ml-1 p-1 w-16"
+                                value={rating ?? ''}
+                                onChange={(e) =>
+                                    setRating(
+                                        e.target.value
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                    )
+                                }
+                                placeholder="All"
+                            />
+                        </label>
+                    </div>
+                </div>
+                <DataTable
+                    data={rows}
+                    columns={columns}
+                    pageSize={rows.length || 1}
+                />
+                <div className="mt-2 flex justify-end gap-2">
+                    <button
+                        className="border px-2 py-1"
+                        disabled={page <= 1}
+                        onClick={() => setPage(page - 1)}
+                    >
+                        Prev
+                    </button>
+                    <span>
+                        {page} / {Math.ceil(total / limit) || 1}
+                    </span>
+                    <button
+                        className="border px-2 py-1"
+                        disabled={page * limit >= total}
+                        onClick={() => setPage(page + 1)}
+                    >
+                        Next
+                    </button>
+                </div>
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/employees/index.tsx
+++ b/frontend/src/pages/employees/index.tsx
@@ -9,93 +9,102 @@ import { useEmployeeApi } from '@/api/employees';
 import { Employee } from '@/types';
 
 export default function EmployeesPage() {
-  const { data } = useEmployees();
-  const api = useEmployeeApi();
-  const [rows, setRows] = useState<Employee[]>([]);
-  const [openForm, setOpenForm] = useState(false);
-  const [editing, setEditing] = useState<Employee | null>(null);
+    const { data } = useEmployees();
+    const api = useEmployeeApi();
+    const [rows, setRows] = useState<Employee[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [editing, setEditing] = useState<Employee | null>(null);
 
-  if (data && rows.length === 0) setRows(data);
+    if (data && rows.length === 0) setRows(data);
 
-  const columns: Column<Employee>[] = [
-    { header: 'ID', accessor: 'id' },
-    { header: 'Name', accessor: 'fullName' },
-  ];
+    const columns: Column<Employee>[] = [
+        { header: 'ID', accessor: 'id' },
+        { header: 'Name', accessor: 'fullName' },
+    ];
 
-  const handleCreate = async (values: { firstName: string; lastName: string }) => {
-    const created = await api.create(values);
-    setRows((c) => [...c, created]);
-    setOpenForm(false);
-  };
+    const handleCreate = async (values: {
+        firstName: string;
+        lastName: string;
+    }) => {
+        const created = await api.create(values);
+        setRows((c) => [...c, created]);
+        setOpenForm(false);
+    };
 
-  const handleUpdate = async (values: { firstName: string; lastName: string }) => {
-    if (!editing) return;
-    const updated = await api.update(editing.id, values);
-    setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
-    setEditing(null);
-    setOpenForm(false);
-  };
+    const handleUpdate = async (values: {
+        firstName: string;
+        lastName: string;
+    }) => {
+        if (!editing) return;
+        const updated = await api.update(editing.id, values);
+        setRows((c) => c.map((cl) => (cl.id === editing.id ? updated : cl)));
+        setEditing(null);
+        setOpenForm(false);
+    };
 
-  const handleDelete = async (row: Employee) => {
-    if (!confirm(`Delete ${row.fullName}?`)) return;
-    await api.remove(row.id);
-    setRows((c) => c.filter((cl) => cl.id !== row.id));
-  };
+    const handleDelete = async (row: Employee) => {
+        if (!confirm(`Delete ${row.fullName}?`)) return;
+        await api.remove(row.id);
+        setRows((c) => c.filter((cl) => cl.id !== row.id));
+    };
 
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <div className="mb-2 flex justify-end">
-          <button
-            className="border px-2 py-1"
-            onClick={() => {
-              setEditing(null);
-              setOpenForm(true);
-            }}
-          >
-            Add Employee
-          </button>
-        </div>
-        {rows && (
-          <DataTable
-            data={rows}
-            columns={columns}
-            initialSort="id"
-            renderActions={(r) => (
-              <span className="space-x-2">
-                <button
-                  className="border px-2 py-1"
-                  onClick={() => {
-                    setEditing(r);
-                    setOpenForm(true);
-                  }}
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <div className="mb-2 flex justify-end">
+                    <button
+                        className="border px-2 py-1"
+                        onClick={() => {
+                            setEditing(null);
+                            setOpenForm(true);
+                        }}
+                    >
+                        Add Employee
+                    </button>
+                </div>
+                {rows && (
+                    <DataTable
+                        data={rows}
+                        columns={columns}
+                        initialSort="id"
+                        renderActions={(r) => (
+                            <span className="space-x-2">
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => {
+                                        setEditing(r);
+                                        setOpenForm(true);
+                                    }}
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => void handleDelete(r)}
+                                >
+                                    Delete
+                                </button>
+                            </span>
+                        )}
+                    />
+                )}
+                <Modal
+                    open={openForm || Boolean(editing)}
+                    onClose={() => {
+                        setOpenForm(false);
+                        setEditing(null);
+                    }}
                 >
-                  Edit
-                </button>
-                <button className="border px-2 py-1" onClick={() => void handleDelete(r)}>
-                  Delete
-                </button>
-              </span>
-            )}
-          />
-        )}
-        <Modal
-          open={openForm || Boolean(editing)}
-          onClose={() => {
-            setOpenForm(false);
-            setEditing(null);
-          }}
-        >
-          <EmployeeForm
-            initial={editing ?? undefined}
-            onCancel={() => {
-              setOpenForm(false);
-              setEditing(null);
-            }}
-            onSubmit={editing ? handleUpdate : handleCreate}
-          />
-        </Modal>
-      </DashboardLayout>
-    </RouteGuard>
-  );
+                    <EmployeeForm
+                        initial={editing ?? undefined}
+                        onCancel={() => {
+                            setOpenForm(false);
+                            setEditing(null);
+                        }}
+                        onSubmit={editing ? handleUpdate : handleCreate}
+                    />
+                </Modal>
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/gallery.tsx
+++ b/frontend/src/pages/gallery.tsx
@@ -53,7 +53,9 @@ export default function GalleryPage({ items }: GalleryPageProps) {
     );
 }
 
-export const getServerSideProps: GetServerSideProps<GalleryPageProps> = async () => {
+export const getServerSideProps: GetServerSideProps<
+    GalleryPageProps
+> = async () => {
     const token = process.env.INSTAGRAM_ACCESS_TOKEN;
     if (!token) {
         return { props: { items: [] } };

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -86,7 +86,9 @@ export default function HomePage() {
                             alt="Salon highlight"
                             fill
                             className={`object-cover transition-opacity duration-700 ${
-                                index === currentSlide ? 'opacity-100' : 'opacity-0'
+                                index === currentSlide
+                                    ? 'opacity-100'
+                                    : 'opacity-0'
                             }`}
                             priority={index === 0}
                         />
@@ -104,7 +106,9 @@ export default function HomePage() {
                                 key={service.title}
                                 className="p-4 border rounded text-center"
                             >
-                                <h3 className="font-semibold">{service.title}</h3>
+                                <h3 className="font-semibold">
+                                    {service.title}
+                                </h3>
                                 <p className="text-sm text-gray-600">
                                     {service.description}
                                 </p>
@@ -159,7 +163,9 @@ export default function HomePage() {
 
                 {/* Contact Section with Map */}
                 <section className="p-4 space-y-4">
-                    <h2 className="text-xl font-bold text-center">Contact Us</h2>
+                    <h2 className="text-xl font-bold text-center">
+                        Contact Us
+                    </h2>
                     <div className="flex flex-col items-center space-y-2">
                         <p>123 Salon Street, Beauty City</p>
                         <iframe
@@ -175,4 +181,3 @@ export default function HomePage() {
         </PublicLayout>
     );
 }
-

--- a/frontend/src/pages/notifications/index.tsx
+++ b/frontend/src/pages/notifications/index.tsx
@@ -3,11 +3,11 @@ import DashboardLayout from '@/components/DashboardLayout';
 import NotificationList from '@/components/NotificationList';
 
 export default function NotificationsPage() {
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <NotificationList />
-      </DashboardLayout>
-    </RouteGuard>
-  );
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <NotificationList />
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/policy.tsx
+++ b/frontend/src/pages/policy.tsx
@@ -2,19 +2,19 @@ import Head from 'next/head';
 import PublicLayout from '@/components/PublicLayout';
 
 export default function PolicyPage() {
-  return (
-    <PublicLayout>
-      <Head>
-        <title>Policy | Salon Black & White</title>
-        <meta
-          name="description"
-          content="Policies for using Salon Black & White."
-        />
-      </Head>
-      <div className="p-4 space-y-4 max-w-md">
-        <h1 className="text-2xl font-bold">Policy</h1>
-        <p>Placeholder for the salon&apos;s policy information.</p>
-      </div>
-    </PublicLayout>
-  );
+    return (
+        <PublicLayout>
+            <Head>
+                <title>Policy | Salon Black & White</title>
+                <meta
+                    name="description"
+                    content="Policies for using Salon Black & White."
+                />
+            </Head>
+            <div className="p-4 space-y-4 max-w-md">
+                <h1 className="text-2xl font-bold">Policy</h1>
+                <p>Placeholder for the salon&apos;s policy information.</p>
+            </div>
+        </PublicLayout>
+    );
 }

--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -2,19 +2,19 @@ import Head from 'next/head';
 import PublicLayout from '@/components/PublicLayout';
 
 export default function PrivacyPage() {
-  return (
-    <PublicLayout>
-      <Head>
-        <title>Privacy Policy | Salon Black & White</title>
-        <meta
-          name="description"
-          content="Privacy policy for Salon Black & White."
-        />
-      </Head>
-      <div className="p-4 space-y-4 max-w-md">
-        <h1 className="text-2xl font-bold">Privacy Policy</h1>
-        <p>Placeholder for the privacy policy content.</p>
-      </div>
-    </PublicLayout>
-  );
+    return (
+        <PublicLayout>
+            <Head>
+                <title>Privacy Policy | Salon Black & White</title>
+                <meta
+                    name="description"
+                    content="Privacy policy for Salon Black & White."
+                />
+            </Head>
+            <div className="p-4 space-y-4 max-w-md">
+                <h1 className="text-2xl font-bold">Privacy Policy</h1>
+                <p>Placeholder for the privacy policy content.</p>
+            </div>
+        </PublicLayout>
+    );
 }

--- a/frontend/src/pages/reviews/index.tsx
+++ b/frontend/src/pages/reviews/index.tsx
@@ -9,154 +9,190 @@ import { useReviewApi } from '@/api/reviews';
 import { Review } from '@/types';
 
 export default function ReviewsPage() {
-  const [employeeId, setEmployeeId] = useState(1);
-  const { data, page, total, limit, setPage, rating, setRating } = useReviews({ employeeId });
-  const api = useReviewApi();
-  type Row = Review & { employeeName?: string; authorName?: string };
-  const [rows, setRows] = useState<Row[]>([]);
-  const [openForm, setOpenForm] = useState(false);
-  const [editing, setEditing] = useState<Row | null>(null);
-
-  useEffect(() => {
-    setRows(data.map((r) => ({ ...r, employeeName: r.employee?.fullName, authorName: r.author?.name })));
-  }, [data]);
-
-  const columns: Column<Row>[] = [
-    { header: 'ID', accessor: 'id' },
-    { header: 'Appointment', accessor: 'appointmentId' },
-    { header: 'Employee', accessor: 'employeeName' },
-    { header: 'Author', accessor: 'authorName' },
-    { header: 'Rating', accessor: 'rating' },
-    { header: 'Comment', accessor: 'comment' },
-  ];
-
-  const handleCreate = async (values: { appointmentId: number; rating: number; comment?: string }) => {
-    const created = await api.create(values.appointmentId, {
-      rating: values.rating,
-      comment: values.comment,
-    });
-    setRows((c) => [...c, { ...created, employeeName: created.employee?.fullName, authorName: created.author?.name }]);
-    setOpenForm(false);
-  };
-
-  const handleUpdate = async (values: { appointmentId: number; rating: number; comment?: string }) => {
-    if (!editing) return;
-    const updated = await api.update(editing.id, {
-      rating: values.rating,
-      comment: values.comment,
-    });
-    setRows((c) =>
-      c.map((cl) =>
-        cl.id === editing.id
-          ? { ...updated, employeeName: updated.employee?.fullName, authorName: updated.author?.name }
-          : cl,
-      ),
+    const [employeeId, setEmployeeId] = useState(1);
+    const { data, page, total, limit, setPage, rating, setRating } = useReviews(
+        { employeeId },
     );
-    setEditing(null);
-    setOpenForm(false);
-  };
+    const api = useReviewApi();
+    type Row = Review & { employeeName?: string; authorName?: string };
+    const [rows, setRows] = useState<Row[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [editing, setEditing] = useState<Row | null>(null);
 
-  const handleDelete = async (row: Row) => {
-    if (!confirm(`Delete review ${row.id}?`)) return;
-    await api.remove(row.id);
-    setRows((c) => c.filter((cl) => cl.id !== row.id));
-  };
+    useEffect(() => {
+        setRows(
+            data.map((r) => ({
+                ...r,
+                employeeName: r.employee?.fullName,
+                authorName: r.author?.name,
+            })),
+        );
+    }, [data]);
 
-  return (
-    <RouteGuard>
-      <DashboardLayout>
-        <div className="mb-2 flex justify-between">
-          <div className="flex items-center gap-2">
-            <label>
-              Employee
-              <input
-                className="border ml-1 p-1 w-16"
-                value={employeeId}
-                onChange={(e) => setEmployeeId(Number(e.target.value) || 1)}
-              />
-            </label>
-            <label>
-              Rating
-              <input
-                className="border ml-1 p-1 w-16"
-                value={rating ?? ''}
-                onChange={(e) =>
-                  setRating(e.target.value ? Number(e.target.value) : undefined)
-                }
-                placeholder="All"
-              />
-            </label>
-          </div>
-          <button
-            className="border px-2 py-1"
-            onClick={() => {
-              setEditing(null);
-              setOpenForm(true);
-            }}
-          >
-            Add Review
-          </button>
-        </div>
-        {rows && (
-          <DataTable
-            data={rows}
-            columns={columns}
-            initialSort="id"
-            pageSize={rows.length || 1}
-            renderActions={(r) => (
-              <span className="space-x-2">
-                <button
-                  className="border px-2 py-1"
-                  onClick={() => {
-                    setEditing(r);
-                    setOpenForm(true);
-                  }}
+    const columns: Column<Row>[] = [
+        { header: 'ID', accessor: 'id' },
+        { header: 'Appointment', accessor: 'appointmentId' },
+        { header: 'Employee', accessor: 'employeeName' },
+        { header: 'Author', accessor: 'authorName' },
+        { header: 'Rating', accessor: 'rating' },
+        { header: 'Comment', accessor: 'comment' },
+    ];
+
+    const handleCreate = async (values: {
+        appointmentId: number;
+        rating: number;
+        comment?: string;
+    }) => {
+        const created = await api.create(values.appointmentId, {
+            rating: values.rating,
+            comment: values.comment,
+        });
+        setRows((c) => [
+            ...c,
+            {
+                ...created,
+                employeeName: created.employee?.fullName,
+                authorName: created.author?.name,
+            },
+        ]);
+        setOpenForm(false);
+    };
+
+    const handleUpdate = async (values: {
+        appointmentId: number;
+        rating: number;
+        comment?: string;
+    }) => {
+        if (!editing) return;
+        const updated = await api.update(editing.id, {
+            rating: values.rating,
+            comment: values.comment,
+        });
+        setRows((c) =>
+            c.map((cl) =>
+                cl.id === editing.id
+                    ? {
+                          ...updated,
+                          employeeName: updated.employee?.fullName,
+                          authorName: updated.author?.name,
+                      }
+                    : cl,
+            ),
+        );
+        setEditing(null);
+        setOpenForm(false);
+    };
+
+    const handleDelete = async (row: Row) => {
+        if (!confirm(`Delete review ${row.id}?`)) return;
+        await api.remove(row.id);
+        setRows((c) => c.filter((cl) => cl.id !== row.id));
+    };
+
+    return (
+        <RouteGuard>
+            <DashboardLayout>
+                <div className="mb-2 flex justify-between">
+                    <div className="flex items-center gap-2">
+                        <label>
+                            Employee
+                            <input
+                                className="border ml-1 p-1 w-16"
+                                value={employeeId}
+                                onChange={(e) =>
+                                    setEmployeeId(Number(e.target.value) || 1)
+                                }
+                            />
+                        </label>
+                        <label>
+                            Rating
+                            <input
+                                className="border ml-1 p-1 w-16"
+                                value={rating ?? ''}
+                                onChange={(e) =>
+                                    setRating(
+                                        e.target.value
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                    )
+                                }
+                                placeholder="All"
+                            />
+                        </label>
+                    </div>
+                    <button
+                        className="border px-2 py-1"
+                        onClick={() => {
+                            setEditing(null);
+                            setOpenForm(true);
+                        }}
+                    >
+                        Add Review
+                    </button>
+                </div>
+                {rows && (
+                    <DataTable
+                        data={rows}
+                        columns={columns}
+                        initialSort="id"
+                        pageSize={rows.length || 1}
+                        renderActions={(r) => (
+                            <span className="space-x-2">
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => {
+                                        setEditing(r);
+                                        setOpenForm(true);
+                                    }}
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    className="border px-2 py-1"
+                                    onClick={() => void handleDelete(r)}
+                                >
+                                    Delete
+                                </button>
+                            </span>
+                        )}
+                    />
+                )}
+                <div className="mt-2 flex justify-end gap-2">
+                    <button
+                        className="border px-2 py-1"
+                        disabled={page <= 1}
+                        onClick={() => setPage(page - 1)}
+                    >
+                        Prev
+                    </button>
+                    <span>
+                        {page} / {Math.ceil(total / limit) || 1}
+                    </span>
+                    <button
+                        className="border px-2 py-1"
+                        disabled={page * limit >= total}
+                        onClick={() => setPage(page + 1)}
+                    >
+                        Next
+                    </button>
+                </div>
+                <Modal
+                    open={openForm || Boolean(editing)}
+                    onClose={() => {
+                        setOpenForm(false);
+                        setEditing(null);
+                    }}
                 >
-                  Edit
-                </button>
-                <button className="border px-2 py-1" onClick={() => void handleDelete(r)}>
-                  Delete
-                </button>
-              </span>
-            )}
-          />
-        )}
-        <div className="mt-2 flex justify-end gap-2">
-          <button
-            className="border px-2 py-1"
-            disabled={page <= 1}
-            onClick={() => setPage(page - 1)}
-          >
-            Prev
-          </button>
-          <span>
-            {page} / {Math.ceil(total / limit) || 1}
-          </span>
-          <button
-            className="border px-2 py-1"
-            disabled={page * limit >= total}
-            onClick={() => setPage(page + 1)}
-          >
-            Next
-          </button>
-        </div>
-        <Modal
-          open={openForm || Boolean(editing)}
-          onClose={() => {
-            setOpenForm(false);
-            setEditing(null);
-          }}
-        >
-          <ReviewForm
-            initial={editing ?? undefined}
-            onCancel={() => {
-              setOpenForm(false);
-              setEditing(null);
-            }}
-            onSubmit={editing ? handleUpdate : handleCreate}
-          />
-        </Modal>
-      </DashboardLayout>
-    </RouteGuard>
-  );
+                    <ReviewForm
+                        initial={editing ?? undefined}
+                        onCancel={() => {
+                            setOpenForm(false);
+                            setEditing(null);
+                        }}
+                        onSubmit={editing ? handleUpdate : handleCreate}
+                    />
+                </Modal>
+            </DashboardLayout>
+        </RouteGuard>
+    );
 }

--- a/frontend/src/pages/services.tsx
+++ b/frontend/src/pages/services.tsx
@@ -30,7 +30,10 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                         <h2 className="text-xl font-semibold">{cat.name}</h2>
                         <ul className="space-y-1">
                             {cat.services.map((s) => (
-                                <li key={s.id} className="flex justify-between border-b pb-1">
+                                <li
+                                    key={s.id}
+                                    className="flex justify-between border-b pb-1"
+                                >
                                     <span>{s.name}</span>
                                     <span className="text-sm text-gray-600">
                                         {s.duration} min - {s.price} zł
@@ -45,7 +48,9 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
     );
 }
 
-export const getServerSideProps: GetServerSideProps<ServicesPageProps> = async () => {
+export const getServerSideProps: GetServerSideProps<
+    ServicesPageProps
+> = async () => {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
     try {
         const res = await fetch(`${apiUrl}/services`);

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -1,14 +1,14 @@
 import type { useAuth } from '@/contexts/AuthContext';
 
 export const createAuthValue = (
-  overrides: Partial<ReturnType<typeof useAuth>> = {}
+    overrides: Partial<ReturnType<typeof useAuth>> = {},
 ): ReturnType<typeof useAuth> => ({
-  token: null,
-  role: null,
-  isAuthenticated: false,
-  login: jest.fn(),
-  logout: jest.fn(),
-  refreshToken: jest.fn(),
-  apiFetch: jest.fn(),
-  ...overrides,
+    token: null,
+    role: null,
+    isAuthenticated: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+    refreshToken: jest.fn(),
+    apiFetch: jest.fn(),
+    ...overrides,
 });


### PR DESCRIPTION
## Summary
- add `tabWidth` and `semi` settings to frontend Prettier config
- format frontend files with new Prettier rules

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa143a71ac8329ab5dce9967b8af8e