### PR TITLE
feat(frontend): add basic footer component

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function Footer() {
+    return <footer className="bg-gray-100 p-4 text-center">Footer</footer>;
+}

--- a/frontend/src/components/PublicLayout.tsx
+++ b/frontend/src/components/PublicLayout.tsx
@@ -1,12 +1,14 @@
 'use client';
 import { ReactNode } from 'react';
 import PublicNav from './PublicNav';
+import Footer from './Footer';
 
 export default function PublicLayout({ children }: { children: ReactNode }) {
     return (
         <div className="min-h-screen flex flex-col">
             <PublicNav />
             <main className="flex-1 p-4">{children}</main>
+            <Footer />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add simple `Footer` component
- include `Footer` in `PublicLayout` for shared layout structure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa1d507f1483298c354467ea21c06b