### PR TITLE
refactor: rename PublicNav to Navbar

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,7 +35,7 @@ using the configuration in `tailwind.config.ts` and the global styles in
 - **Marketing pages** under `src/pages` (`index`, `services`, `gallery`, `contact`).
 - **Authentication** routes in `src/pages/auth` with login and registration forms.
 - **Role-based dashboard** pages under `src/pages/dashboard` for clients, employees and admins.
-- Navigation components in `src/components` (`PublicNav` and `DashboardNav`) rendered via the global `Layout`.
+- Navigation components in `src/components` (`Navbar` and `DashboardNav`) rendered via the global `Layout`.
 - Configure the backend API URL via `NEXT_PUBLIC_API_URL` in `.env.local` (copied from `.env.local.example`).
 
 ## Manual Testing

--- a/frontend/src/__tests__/layout.test.tsx
+++ b/frontend/src/__tests__/layout.test.tsx
@@ -17,7 +17,7 @@ describe('Layout', () => {
         mockedUseAuth.mockReset();
     });
 
-    it('renders PublicNav on public routes', () => {
+    it('renders Navbar on public routes', () => {
         mockedUseRouter.mockReturnValue({ pathname: '/services' });
         mockedUseAuth.mockReturnValue(createAuthValue());
         render(<Layout>content</Layout>);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,7 +2,7 @@
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 
-export default function PublicNav() {
+export default function Navbar() {
     const { role } = useAuth();
     const linkClass = 'transition duration-150 hover:text-blue-700';
 

--- a/frontend/src/components/PublicLayout.tsx
+++ b/frontend/src/components/PublicLayout.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { ReactNode } from 'react';
-import PublicNav from './PublicNav';
+import Navbar from './Navbar';
 import Footer from './Footer';
 
 export default function PublicLayout({ children }: { children: ReactNode }) {
     return (
         <div className="min-h-screen flex flex-col">
-            <PublicNav />
+            <Navbar />
             <main className="flex-1 p-4">{children}</main>
             <Footer />
         </div>


### PR DESCRIPTION
## Summary
- rename `PublicNav` component to `Navbar`
- update layout, tests, and docs for new component name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2468056c8329b3d623d3b528c3ba