### PR TITLE
style: fix Prettier formatting in auth files

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,7 +1,10 @@
 import { ApiClient } from './apiClient';
 import { User } from '@/types';
 
-const client = new ApiClient(() => null, () => {});
+const client = new ApiClient(
+    () => null,
+    () => {},
+);
 
 export interface LoginCredentials {
     email: string;
@@ -22,7 +25,9 @@ export interface AuthTokens {
 
 export const REFRESH_TOKEN_KEY = 'refreshToken';
 
-export async function login(credentials: LoginCredentials): Promise<AuthTokens> {
+export async function login(
+    credentials: LoginCredentials,
+): Promise<AuthTokens> {
     try {
         return await client.request<AuthTokens>('/auth/login', {
             method: 'POST',
@@ -30,9 +35,7 @@ export async function login(credentials: LoginCredentials): Promise<AuthTokens> 
             body: JSON.stringify(credentials),
         });
     } catch (err: unknown) {
-        throw new Error(
-            err instanceof Error ? err.message : 'Login failed',
-        );
+        throw new Error(err instanceof Error ? err.message : 'Login failed');
     }
 }
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -9,7 +9,11 @@ import {
 } from 'react';
 import { useRouter } from 'next/router';
 import { ApiClient } from '@/api/apiClient';
-import { login as apiLogin, refreshToken as apiRefreshToken, REFRESH_TOKEN_KEY } from '@/api/auth';
+import {
+    login as apiLogin,
+    refreshToken as apiRefreshToken,
+    REFRESH_TOKEN_KEY,
+} from '@/api/auth';
 import type { Role } from '@/types';
 
 interface AuthContextValue {

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -18,7 +18,9 @@ export default function RegisterPage() {
             await registerUser({ name, email, phone, password });
             void router.push('/auth/login');
         } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : 'Registration failed');
+            setError(
+                err instanceof Error ? err.message : 'Registration failed',
+            );
         }
     };
 


### PR DESCRIPTION
## Summary
- format ApiClient usage and login helper with Prettier
- expand auth context imports with trailing commas
- break long registration error handler for Prettier compliance

## Testing
- `npm run lint -- --fix`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab68909dd08329b7de7a03cc6768cb