### PR TITLE
Handle refresh token failures by logging out

### DIFF
--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -41,4 +41,27 @@ describe('auth flow', () => {
         });
         expect(result.current.token).toBeNull();
     });
+
+    it('logs out when refresh token fails', async () => {
+        const wrapper = ({ children }: { children: React.ReactNode }) =>
+            React.createElement(AuthProvider, null, children);
+        const { result } = renderHook(() => useAuth(), { wrapper });
+
+        await act(async () => {
+            await result.current.login('a', 'b');
+        });
+        expect(result.current.token).toBe('abc');
+
+        server.use(
+            http.post('http://localhost/auth/refresh', () =>
+                HttpResponse.json({}, { status: 401 }),
+            ),
+        );
+
+        await act(async () => {
+            await expect(result.current.refreshToken()).rejects.toThrow();
+        });
+
+        expect(result.current.token).toBeNull();
+    });
 });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,9 +1,15 @@
 import { ApiClient } from './apiClient';
 import { User } from '@/types';
 
+let logoutCallback: () => void = () => {};
+
+export function setLogoutCallback(cb: () => void) {
+    logoutCallback = cb;
+}
+
 const client = new ApiClient(
     () => null,
-    () => {},
+    () => logoutCallback(),
 );
 
 export interface LoginCredentials {


### PR DESCRIPTION
## Summary
- Allow auth API client to register a logout callback
- Clear auth state when refresh token fails by catching errors and invoking logout
- Test refresh token failure handling

## Testing
- `cd frontend && npm test src/__tests__/auth.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab6acb1c708329a3ef0f6598e360f9