### PR TITLE
feat: enhance auth context with tokens and user

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -11,59 +11,39 @@ import { useRouter } from 'next/router';
 import { ApiClient } from '@/api/apiClient';
 import {
     login as apiLogin,
+    register as apiRegister,
     refreshToken as apiRefreshToken,
     REFRESH_TOKEN_KEY,
     setLogoutCallback,
     type AuthTokens,
+    type RegisterData,
 } from '@/api/auth';
-import type { Role } from '@/types';
+import type { Role, User } from '@/types';
 
 interface AuthContextValue {
-    token: string | null;
+    user: User | null;
+    accessToken: string | null;
+    refreshToken: string | null;
     role: Role | null;
     isAuthenticated: boolean;
     login: (email: string, password: string) => Promise<void>;
+    register: (data: RegisterData) => Promise<void>;
     logout: () => void;
-    refreshToken: () => Promise<void>;
+    refresh: () => Promise<void>;
     apiFetch: <T>(endpoint: string, init?: RequestInit) => Promise<T>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-const TOKEN_KEY = 'jwtToken';
+const ACCESS_TOKEN_KEY = 'jwtToken';
 const ROLE_KEY = 'role';
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
     const router = useRouter();
-    const [token, setToken] = useState<string | null>(null);
+    const [accessToken, setAccessToken] = useState<string | null>(null);
+    const [refreshToken, setRefreshToken] = useState<string | null>(null);
+    const [user, setUser] = useState<User | null>(null);
     const [role, setRole] = useState<Role | null>(null);
-
-    useEffect(() => {
-        const storedToken = localStorage.getItem(TOKEN_KEY);
-        const storedRole = localStorage.getItem(ROLE_KEY) as Role | null;
-        if (storedToken) setToken(storedToken);
-        if (
-            storedRole === 'client' ||
-            storedRole === 'employee' ||
-            storedRole === 'receptionist' ||
-            storedRole === 'admin'
-        ) {
-            setRole(storedRole);
-        }
-    }, []);
-
-    const handleLogout = useCallback(() => {
-        setToken(null);
-        setRole(null);
-        localStorage.removeItem(TOKEN_KEY);
-        localStorage.removeItem(ROLE_KEY);
-        localStorage.removeItem(REFRESH_TOKEN_KEY);
-        void router.push('/auth/login');
-    }, [router]);
-
-    useEffect(() => {
-        setLogoutCallback(handleLogout);
-    }, [handleLogout]);
 
     const decodeRole = useCallback((jwt: string): Role | null => {
         try {
@@ -83,10 +63,46 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
     }, []);
 
+    useEffect(() => {
+        const storedAccess = localStorage.getItem(ACCESS_TOKEN_KEY);
+        const storedRefresh = localStorage.getItem(REFRESH_TOKEN_KEY);
+        const storedRole = localStorage.getItem(ROLE_KEY) as Role | null;
+        if (storedAccess) {
+            setAccessToken(storedAccess);
+            const r = decodeRole(storedAccess);
+            setRole(r);
+        }
+        if (storedRefresh) setRefreshToken(storedRefresh);
+        if (
+            storedRole === 'client' ||
+            storedRole === 'employee' ||
+            storedRole === 'receptionist' ||
+            storedRole === 'admin'
+        ) {
+            setRole(storedRole);
+        }
+    }, [decodeRole]);
+
+    const handleLogout = useCallback(() => {
+        setAccessToken(null);
+        setRefreshToken(null);
+        setUser(null);
+        setRole(null);
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        localStorage.removeItem(ROLE_KEY);
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+        void router.push('/auth/login');
+    }, [router]);
+
+    useEffect(() => {
+        setLogoutCallback(handleLogout);
+    }, [handleLogout]);
+
     const applyTokens = useCallback(
         (data: AuthTokens) => {
-            setToken(data.accessToken);
-            localStorage.setItem(TOKEN_KEY, data.accessToken);
+            setAccessToken(data.accessToken);
+            setRefreshToken(data.refreshToken);
+            localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
             localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken);
             const r = decodeRole(data.accessToken);
             setRole(r);
@@ -96,16 +112,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     );
 
     const client = useMemo(
-        () => new ApiClient(() => token, handleLogout, applyTokens),
-        [token, handleLogout, applyTokens],
+        () => new ApiClient(() => accessToken, handleLogout, applyTokens),
+        [accessToken, handleLogout, applyTokens],
     );
+
+    const fetchProfile = useCallback(async () => {
+        const u = await client.request<User>('/profile');
+        setUser(u);
+        setRole(u.role);
+    }, [client]);
+
+    useEffect(() => {
+        if (accessToken) {
+            void fetchProfile().catch(handleLogout);
+        }
+    }, [accessToken, fetchProfile, handleLogout]);
 
     const login = async (email: string, password: string) => {
         const data = await apiLogin({ email, password });
         applyTokens(data);
     };
 
-    const refreshToken = async () => {
+    const register = async (data: RegisterData) => {
+        await apiRegister(data);
+        await login(data.email, data.password);
+    };
+
+    const refresh = async () => {
         try {
             const data = await apiRefreshToken();
             applyTokens(data);
@@ -116,12 +149,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     const value: AuthContextValue = {
-        token,
-        role,
-        isAuthenticated: Boolean(token),
-        login,
-        logout: handleLogout,
+        user,
+        accessToken,
         refreshToken,
+        role,
+        isAuthenticated: Boolean(accessToken),
+        login,
+        register,
+        logout: handleLogout,
+        refresh,
         apiFetch: client.request.bind(client),
     };
 

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -3,12 +3,15 @@ import type { useAuth } from '@/contexts/AuthContext';
 export const createAuthValue = (
     overrides: Partial<ReturnType<typeof useAuth>> = {},
 ): ReturnType<typeof useAuth> => ({
-    token: null,
+    user: null,
+    accessToken: null,
+    refreshToken: null,
     role: null,
     isAuthenticated: false,
     login: jest.fn(),
+    register: jest.fn(),
     logout: jest.fn(),
-    refreshToken: jest.fn(),
+    refresh: jest.fn(),
     apiFetch: jest.fn(),
     ...overrides,
 });


### PR DESCRIPTION
## Summary
- track authenticated user, access and refresh tokens in AuthContext
- load stored tokens, fetch profile on startup, and clear on logout
- update tests for expanded auth context and registration flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab868f86e88329a71864c095c6a7a2