### PR TITLE
test: cover auth token refresh and storage

### DIFF
--- a/frontend/src/__tests__/authRefresh.test.ts
+++ b/frontend/src/__tests__/authRefresh.test.ts
@@ -1,0 +1,67 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { ApiClient } from '@/api/apiClient';
+
+jest.mock('axios', () => {
+    const instance: any = (config: any) => instance.request(config);
+    instance.__requestHandlers = [];
+    instance.__responseError = null;
+    instance.interceptors = {
+        request: { use: (fn: any) => instance.__requestHandlers.push(fn) },
+        response: { use: (_: any, err: any) => (instance.__responseError = err) },
+    };
+    instance.request = jest.fn(async (config: any) => {
+        for (const fn of instance.__requestHandlers) {
+            config = fn(config);
+        }
+        return instance.__impl(config, instance.__responseError);
+    });
+    instance.post = jest.fn();
+    const axiosMock: any = { create: jest.fn(() => instance), __instance: instance };
+    return axiosMock;
+});
+
+const mockedAxios = axios as any;
+
+beforeEach(() => {
+    localStorage.clear();
+    const instance = mockedAxios.__instance;
+    instance.__requestHandlers = [];
+    instance.__responseError = null;
+    instance.request.mockClear();
+    instance.post.mockClear();
+});
+
+describe('ApiClient token refresh', () => {
+    it('retries request with refreshed token on 401', async () => {
+        const instance = mockedAxios.__instance;
+        let call = 0;
+        const authHeaders: string[] = [];
+        instance.__impl = async (config: AxiosRequestConfig, respErr: any) => {
+            authHeaders.push(config.headers?.Authorization as string);
+            if (call++ === 0) {
+                const error = { response: { status: 401 }, config };
+                return respErr(error);
+            }
+            return { status: 200, data: { ok: true } };
+        };
+        instance.post.mockResolvedValueOnce({
+            data: { accessToken: 'new', refreshToken: 'ref' },
+        });
+
+        localStorage.setItem('refreshToken', 'old');
+        let token = 'oldToken';
+        const client = new ApiClient(
+            () => token,
+            jest.fn(),
+            (t) => {
+                token = t.accessToken;
+                localStorage.setItem('refreshToken', t.refreshToken);
+            },
+        );
+
+        const res = await client.request<{ ok: boolean }>('/protected');
+        expect(res).toEqual({ ok: true });
+        expect(authHeaders).toEqual(['Bearer oldToken', 'Bearer new']);
+        expect(localStorage.getItem('refreshToken')).toBe('ref');
+    });
+});

--- a/frontend/src/__tests__/authStorage.test.tsx
+++ b/frontend/src/__tests__/authStorage.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/api/auth', () => ({
+    login: jest.fn().mockResolvedValue({ accessToken: 'a', refreshToken: 'r' }),
+    register: jest.fn(),
+    refreshToken: jest.fn(),
+    REFRESH_TOKEN_KEY: 'refreshToken',
+    setLogoutCallback: jest.fn(),
+}));
+
+const profile = { id: 1, name: 'Jane', role: 'admin' };
+const requestMock = jest.fn().mockResolvedValue(profile);
+jest.mock('@/api/apiClient', () => ({
+    ApiClient: jest.fn().mockImplementation(() => ({ request: requestMock })),
+}));
+
+describe('AuthContext localStorage', () => {
+    it('login stores tokens and user, logout clears them', async () => {
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <AuthProvider>{children}</AuthProvider>
+        );
+        const { result } = renderHook(() => useAuth(), { wrapper });
+
+        await act(async () => {
+            await result.current.login('e', 'p');
+        });
+        await waitFor(() => expect(result.current.user).toEqual(profile));
+        expect(localStorage.getItem('jwtToken')).toBe('a');
+        expect(localStorage.getItem('refreshToken')).toBe('r');
+
+        act(() => {
+            result.current.logout();
+        });
+        expect(localStorage.getItem('jwtToken')).toBeNull();
+        expect(localStorage.getItem('refreshToken')).toBeNull();
+        expect(result.current.user).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- add ApiClient refresh test mocking axios and verifying token retry
- ensure AuthContext login stores tokens and logout clears them

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac1a8039bc83298877c65cb41ffbb7