### PR TITLE
refactor: type axios mock for token refresh test

### DIFF
--- a/frontend/src/__tests__/authRefresh.test.ts
+++ b/frontend/src/__tests__/authRefresh.test.ts
@@ -1,26 +1,51 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { ApiClient } from '@/api/apiClient';
 
+interface MockAxiosInstance extends AxiosInstance {
+    __requestHandlers: ((config: AxiosRequestConfig) => AxiosRequestConfig)[];
+    __responseError: ((error: unknown) => unknown) | null;
+    __impl: (
+        config: AxiosRequestConfig,
+        respErr: ((error: unknown) => unknown) | null,
+    ) => Promise<unknown>;
+    post: jest.Mock;
+}
+
 jest.mock('axios', () => {
-    const instance: any = (config: any) => instance.request(config);
+    const instance = ((config: AxiosRequestConfig) =>
+        instance.request(config)) as unknown as MockAxiosInstance;
     instance.__requestHandlers = [];
     instance.__responseError = null;
     instance.interceptors = {
-        request: { use: (fn: any) => instance.__requestHandlers.push(fn) },
-        response: { use: (_: any, err: any) => (instance.__responseError = err) },
+        request: {
+            use: (fn: (config: AxiosRequestConfig) => AxiosRequestConfig) =>
+                instance.__requestHandlers.push(fn),
+        },
+        response: {
+            use: (_: unknown, err: (error: unknown) => unknown) => {
+                instance.__responseError = err;
+            },
+        },
     };
-    instance.request = jest.fn(async (config: any) => {
+    instance.request = jest.fn(async (config: AxiosRequestConfig) => {
         for (const fn of instance.__requestHandlers) {
             config = fn(config);
         }
         return instance.__impl(config, instance.__responseError);
     });
     instance.post = jest.fn();
-    const axiosMock: any = { create: jest.fn(() => instance), __instance: instance };
+    interface AxiosMock {
+        create: jest.Mock<MockAxiosInstance, []>;
+        __instance: MockAxiosInstance;
+    }
+    const axiosMock: AxiosMock = {
+        create: jest.fn(() => instance),
+        __instance: instance,
+    };
     return axiosMock;
 });
 
-const mockedAxios = axios as any;
+const mockedAxios = axios as unknown as { __instance: MockAxiosInstance };
 
 beforeEach(() => {
     localStorage.clear();
@@ -36,11 +61,14 @@ describe('ApiClient token refresh', () => {
         const instance = mockedAxios.__instance;
         let call = 0;
         const authHeaders: string[] = [];
-        instance.__impl = async (config: AxiosRequestConfig, respErr: any) => {
+        instance.__impl = async (
+            config: AxiosRequestConfig,
+            respErr: ((error: unknown) => unknown) | null,
+        ) => {
             authHeaders.push(config.headers?.Authorization as string);
             if (call++ === 0) {
                 const error = { response: { status: 401 }, config };
-                return respErr(error);
+                return respErr!(error);
             }
             return { status: 200, data: { ok: true } };
         };


### PR DESCRIPTION
## Summary
- define `MockAxiosInstance` interface and apply explicit types
- format axios mock and interceptors for prettier compliance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac24362ef48329ae483ed34ff61a0d