### PR TITLE
feat: enforce role-aware dashboard access

### DIFF
--- a/frontend/src/__tests__/login.test.tsx
+++ b/frontend/src/__tests__/login.test.tsx
@@ -21,10 +21,10 @@ describe('LoginPage', () => {
         const login = jest.fn().mockResolvedValue(undefined);
         mockedUseAuth.mockReturnValue(createAuthValue({ login }));
         render(<LoginPage />);
-        fireEvent.change(screen.getByPlaceholderText('email'), {
+        fireEvent.change(screen.getByLabelText(/email/i), {
             target: { value: 'a@b.com' },
         });
-        fireEvent.change(screen.getByPlaceholderText('password'), {
+        fireEvent.change(screen.getByLabelText(/password/i), {
             target: { value: 'secret' },
         });
         fireEvent.click(screen.getByRole('button', { name: /login/i }));
@@ -36,14 +36,14 @@ describe('LoginPage', () => {
         const login = jest.fn();
         mockedUseAuth.mockReturnValue(createAuthValue({ login }));
         render(<LoginPage />);
-        fireEvent.change(screen.getByPlaceholderText('email'), {
-            target: { value: 'bad' },
-        });
-        fireEvent.change(screen.getByPlaceholderText('password'), {
-            target: { value: '' },
-        });
+        const emailInput = screen.getByLabelText(/email/i);
+        const passwordInput = screen.getByLabelText(/password/i);
+        fireEvent.change(emailInput, { target: { value: 'bad' } });
+        fireEvent.blur(emailInput);
+        fireEvent.change(passwordInput, { target: { value: '' } });
+        fireEvent.blur(passwordInput);
         fireEvent.click(screen.getByRole('button', { name: /login/i }));
-        expect(await screen.findByRole('alert')).toBeInTheDocument();
+        expect(await screen.findAllByRole('alert')).not.toHaveLength(0);
         expect(login).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/__tests__/routeGuard.test.tsx
+++ b/frontend/src/__tests__/routeGuard.test.tsx
@@ -51,6 +51,6 @@ describe('RouteGuard', () => {
                 <div>Secret</div>
             </RouteGuard>,
         );
-        expect(replace).toHaveBeenCalledWith('/dashboard');
+        expect(replace).toHaveBeenCalledWith('/dashboard/client');
     });
 });

--- a/frontend/src/components/RouteGuard.tsx
+++ b/frontend/src/components/RouteGuard.tsx
@@ -16,7 +16,7 @@ export default function RouteGuard({ children, roles }: Props) {
         if (!isAuthenticated) {
             void router.replace('/auth/login');
         } else if (roles && role && !roles.includes(role)) {
-            void router.replace('/dashboard');
+            void router.replace(`/dashboard/${role}`);
         }
     }, [isAuthenticated, role, roles, router]);
 

--- a/frontend/src/pages/dashboard/services/index.tsx
+++ b/frontend/src/pages/dashboard/services/index.tsx
@@ -43,7 +43,7 @@ export default function ServicesPage() {
     };
 
     return (
-        <RouteGuard>
+        <RouteGuard roles={['admin']}>
             <DashboardLayout>
                 <div className="mb-2 flex justify-end">
                     <button


### PR DESCRIPTION
## Summary
- direct unauthorized users to their own dashboard based on role
- restrict services dashboard page to admins
- update route guard and login tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac51960e8083298f7147f740fa5750