### PR TITLE
Add validation and auth e2e tests

### DIFF
--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -1,6 +1,61 @@
-describe('basic', () => {
-    it('loads home', () => {
-        cy.visit('/');
-        cy.contains('Home Page');
+const clientToken = `header.${Buffer.from(JSON.stringify({ role: 'client' })).toString('base64')}.sig`;
+
+function mockLogin() {
+    cy.intercept('POST', '/api/auth/login', {
+        accessToken: clientToken,
+        refreshToken: 'refresh',
+    }).as('login');
+    cy.intercept('GET', '/api/profile', {
+        id: 1,
+        name: 'Test Client',
+        role: 'client',
+    }).as('profile');
+    cy.intercept('GET', '/api/dashboard', {
+        todayCount: 0,
+        clientCount: 0,
+    }).as('dashboard');
+}
+
+describe('authentication flow', () => {
+    it('successful login redirects to /dashboard and shows user-specific feedback', () => {
+        mockLogin();
+        cy.visit('/auth/login');
+        cy.get('input[name=email]').type('client@example.com');
+        cy.get('input[name=password]').type('secret');
+        cy.get('button[type=submit]').click();
+        cy.wait(['@login', '@profile', '@dashboard']);
+        cy.url().should('include', '/dashboard/client');
+        cy.contains('Upcoming');
+    });
+
+    it('logout returns to /auth/login and clears session', () => {
+        mockLogin();
+        cy.visit('/auth/login');
+        cy.get('input[name=email]').type('client@example.com');
+        cy.get('input[name=password]').type('secret');
+        cy.get('button[type=submit]').click();
+        cy.wait(['@login', '@profile', '@dashboard']);
+        cy.contains('Logout').click();
+        cy.url().should('include', '/auth/login');
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('jwtToken')).to.be.null;
+            expect(win.localStorage.getItem('refreshToken')).to.be.null;
+        });
+    });
+
+    it('direct navigation to /dashboard when logged out redirects to /auth/login', () => {
+        cy.visit('/dashboard');
+        cy.url().should('include', '/auth/login');
+    });
+
+    it('client visiting /dashboard/employee is redirected to /dashboard/client', () => {
+        mockLogin();
+        cy.visit('/auth/login');
+        cy.get('input[name=email]').type('client@example.com');
+        cy.get('input[name=password]').type('secret');
+        cy.get('button[type=submit]').click();
+        cy.wait(['@login', '@profile', '@dashboard']);
+        cy.visit('/dashboard/employee');
+        cy.url().should('include', '/dashboard/client');
     });
 });

--- a/frontend/src/__tests__/loginSchema.test.ts
+++ b/frontend/src/__tests__/loginSchema.test.ts
@@ -1,0 +1,33 @@
+import { loginValidationSchema } from '@/pages/auth/login';
+
+describe('loginValidationSchema', () => {
+    it('requires email and password', async () => {
+        await expect(
+            loginValidationSchema.validateAt('email', {
+                email: '',
+                password: '',
+            }),
+        ).rejects.toThrow('Email is required');
+        await expect(
+            loginValidationSchema.validateAt('password', {
+                email: 'a@b.com',
+                password: '',
+            }),
+        ).rejects.toThrow('Password is required');
+    });
+
+    it('validates email format', async () => {
+        await expect(
+            loginValidationSchema.validate(
+                { email: 'bad', password: 'secret' },
+                { abortEarly: false },
+            ),
+        ).rejects.toThrow('Invalid email');
+        await expect(
+            loginValidationSchema.isValid({
+                email: 'user@example.com',
+                password: 'secret',
+            }),
+        ).resolves.toBe(true);
+    });
+});

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -5,22 +5,20 @@ import { useRouter } from 'next/router';
 import { useAuth } from '@/contexts/AuthContext';
 import PublicLayout from '@/components/PublicLayout';
 
+export const loginValidationSchema = Yup.object({
+    email: Yup.string().email('Invalid email').required('Email is required'),
+    password: Yup.string().required('Password is required'),
+});
+
 export default function LoginPage() {
     const { login } = useAuth();
     const router = useRouter();
-
-    const validationSchema = Yup.object({
-        email: Yup.string()
-            .email('Invalid email')
-            .required('Email is required'),
-        password: Yup.string().required('Password is required'),
-    });
 
     return (
         <PublicLayout>
             <Formik
                 initialValues={{ email: '', password: '' }}
-                validationSchema={validationSchema}
+                validationSchema={loginValidationSchema}
                 onSubmit={async (
                     values,
                     { setSubmitting, setStatus, setFieldValue },


### PR DESCRIPTION
## Summary
- export and test login form Yup validation rules
- add Cypress tests for login, logout, redirects and role-based access

## Testing
- `npm test`
- `npm run e2e` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac53fbb1d88329935cab4004dcf560