### PR TITLE
chore: install cypress deps in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,14 @@ jobs:
             echo "OpenAPI generation produced warnings"
             exit 1
           fi
+      - name: Install Cypress dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libatk1.0-0 libgtk-3-0 libnss3 libxss1 libasound2
+      - name: E2E tests
+        run: |
+          cd frontend
+          npm run e2e
       - name: Deploy
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: echo "Deploying..."


### PR DESCRIPTION
## Summary
- install necessary system libraries before running Cypress E2E tests
- run `npm run e2e` in CI

## Testing
- `npm run e2e` *(fails: 11 of 12 failed; confirms Cypress start)*

------
https://chatgpt.com/codex/tasks/task_e_68ac73fb93448329be006656f55beca1