### PR TITLE
chore: optimize npm installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/salonbw-backend/package-lock.json
       - name: Install frontend deps
         run: |
           cd frontend
-          npm ci
+          npm ci --prefer-offline
       - name: Lint frontend
         run: |
           cd frontend
@@ -36,7 +40,7 @@ jobs:
       - name: Install backend deps
         run: |
           cd backend/salonbw-backend
-          npm ci
+          npm ci --prefer-offline
       - name: Lint backend
         run: |
           cd backend/salonbw-backend

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- configure .npmrc with NPM_TOKEN and registry
- cache npm dependencies in CI and favor offline installs

## Testing
- `npm ci --prefer-offline --no-audit --no-progress` (frontend)
- `npm test -- --runInBand` (frontend)
- `npm ci --prefer-offline --no-audit --no-progress` (backend)
- `npm test -- --runInBand` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68ac7fd073688329acdc40c3c29396c2