### PR TITLE
fix: use libasound2t64 in cypress deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Cypress dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libatk1.0-0 libgtk-3-0 libnss3 libxss1 libasound2
+          sudo apt-get install -y libatk1.0-0 libgtk-3-0 libnss3 libxss1 libasound2t64
       - name: E2E tests
         run: |
           cd frontend


### PR DESCRIPTION
## Summary
- use `libasound2t64` for Cypress dependencies on Ubuntu 24.04

## Testing
- `sudo apt-get install -y libatk1.0-0 libgtk-3-0 libnss3 libxss1 libasound2t64`


------
https://chatgpt.com/codex/tasks/task_e_68acb80ec8d083298808203536c86c56