### PR TITLE
chore: prefix cypress intercepts with API base

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -5,7 +5,7 @@ describe('admin dashboard navigation', () => {
     });
 
     it('redirects to admin dashboard and shows widgets', () => {
-        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
             'dash',
         );
         cy.visit('/dashboard');
@@ -16,7 +16,7 @@ describe('admin dashboard navigation', () => {
     });
 
     it('navigates to employees via sidebar', () => {
-        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
             'dash',
         );
         cy.visit('/dashboard/admin');
@@ -30,13 +30,13 @@ describe('admin dashboard services crud', () => {
     beforeEach(() => {
         localStorage.setItem('jwtToken', 'x');
         localStorage.setItem('role', 'admin');
-        cy.intercept('GET', '**/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '**/api/services', { fixture: 'services.json' }).as(
             'getSvc',
         );
     });
 
     it('creates a service', () => {
-        cy.intercept('POST', '**/services', { id: 3, name: 'Wax' }).as(
+        cy.intercept('POST', '**/api/services', { id: 3, name: 'Wax' }).as(
             'createSvc',
         );
         cy.visit('/dashboard/services');

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -5,7 +5,7 @@ describe('client dashboard navigation', () => {
     });
 
     it('redirects to client dashboard and shows widgets', () => {
-        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
             'dash',
         );
         cy.visit('/dashboard');
@@ -15,7 +15,7 @@ describe('client dashboard navigation', () => {
     });
 
     it('navigates to reviews via sidebar', () => {
-        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
+        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
             'dash',
         );
         cy.visit('/dashboard/client');
@@ -29,13 +29,13 @@ describe('client dashboard reviews crud', () => {
     beforeEach(() => {
         localStorage.setItem('jwtToken', 'x');
         localStorage.setItem('role', 'client');
-        cy.intercept('GET', '**/employees/*/reviews', {
+        cy.intercept('GET', '**/api/employees/*/reviews', {
             fixture: 'reviews.json',
         }).as('getReviews');
     });
 
     it('creates a review', () => {
-        cy.intercept('POST', '**/appointments/*/review', {
+        cy.intercept('POST', '**/api/appointments/*/review', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/e2e/employees.cy.ts
+++ b/frontend/cypress/e2e/employees.cy.ts
@@ -11,10 +11,10 @@ describe('employees crud', () => {
     });
 
     it('loads and creates employee', () => {
-        cy.intercept('GET', '**/employees', { fixture: 'employees.json' }).as(
+        cy.intercept('GET', '**/api/employees', { fixture: 'employees.json' }).as(
             'getEmps',
         );
-        cy.intercept('POST', '**/employees', { id: 3, name: 'New' }).as(
+        cy.intercept('POST', '**/api/employees', { id: 3, name: 'New' }).as(
             'createEmp',
         );
         cy.visit('/employees');

--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -2,7 +2,7 @@ describe('navigation visibility', () => {
     it('shows dashboard navigation for authenticated users on /products', () => {
         localStorage.setItem('jwtToken', 'x');
         localStorage.setItem('role', 'admin');
-        cy.intercept('GET', '**/products**', { fixture: 'products.json' }).as(
+        cy.intercept('GET', '**/api/products**', { fixture: 'products.json' }).as(
             'getProd',
         );
         cy.visit('/products');
@@ -17,7 +17,7 @@ describe('navigation visibility', () => {
     });
 
     it('renders public navigation on public pages', () => {
-        cy.intercept('GET', '**/services**', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '**/api/services**', { fixture: 'services.json' }).as(
             'getServices',
         );
         cy.visit('/services');

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -10,10 +10,10 @@ describe('products crud', () => {
     });
 
     it('loads and creates product', () => {
-        cy.intercept('GET', '**/products/admin', {
+        cy.intercept('GET', '**/api/products/admin', {
             fixture: 'products.json',
         }).as('getProd');
-        cy.intercept('POST', '**/products/admin', {
+        cy.intercept('POST', '**/api/products/admin', {
             id: 2,
             name: 'New',
             unitPrice: 1,

--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -10,10 +10,10 @@ describe('reviews crud', () => {
     });
 
     it('loads and creates review', () => {
-        cy.intercept('GET', '**/employees/*/reviews', {
+        cy.intercept('GET', '**/api/employees/*/reviews', {
             fixture: 'reviews.json',
         }).as('getRev');
-        cy.intercept('POST', '**/appointments/*/review', {
+        cy.intercept('POST', '**/api/appointments/*/review', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -10,10 +10,10 @@ describe('services crud', () => {
     });
 
     it('loads and creates service', () => {
-        cy.intercept('GET', '**/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '**/api/services', { fixture: 'services.json' }).as(
             'getSvc',
         );
-        cy.intercept('POST', '**/services', { id: 3, name: 'New' }).as(
+        cy.intercept('POST', '**/api/services', { id: 3, name: 'New' }).as(
             'createSvc',
         );
         cy.visit('/services');


### PR DESCRIPTION
## Summary
- ensure Cypress tests hit API endpoints by prefixing intercepts with `/api`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acc50f21f083299b7f72b866f6f230