### PR TITLE
refactor cypress login mocks

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -1,26 +1,21 @@
+import { mockAdminLogin } from '../support/mockLogin';
+
 describe('admin dashboard navigation', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'admin');
+        mockAdminLogin();
     });
 
     it('redirects to admin dashboard and shows widgets', () => {
-        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
-            'dash',
-        );
         cy.visit('/dashboard');
-        cy.wait('@dash');
+        cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/admin');
         cy.contains('Clients');
         cy.contains('Employees');
     });
 
     it('navigates to employees via sidebar', () => {
-        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
-            'dash',
-        );
         cy.visit('/dashboard/admin');
-        cy.wait('@dash');
+        cy.wait('@dashboard');
         cy.contains('Employees').click();
         cy.url().should('include', '/employees');
     });
@@ -28,8 +23,7 @@ describe('admin dashboard navigation', () => {
 
 describe('admin dashboard services crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'admin');
+        mockAdminLogin();
         cy.intercept('GET', '**/api/services', { fixture: 'services.json' }).as(
             'getSvc',
         );

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -1,25 +1,20 @@
+import { mockClientLogin } from '../support/mockLogin';
+
 describe('client dashboard navigation', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'client');
+        mockClientLogin();
     });
 
     it('redirects to client dashboard and shows widgets', () => {
-        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
-            'dash',
-        );
         cy.visit('/dashboard');
-        cy.wait('@dash');
+        cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/client');
         cy.contains('Upcoming');
     });
 
     it('navigates to reviews via sidebar', () => {
-        cy.intercept('GET', '**/api/dashboard', { fixture: 'dashboard.json' }).as(
-            'dash',
-        );
         cy.visit('/dashboard/client');
-        cy.wait('@dash');
+        cy.wait('@dashboard');
         cy.contains('Reviews').click();
         cy.url().should('include', '/reviews');
     });
@@ -27,8 +22,7 @@ describe('client dashboard navigation', () => {
 
 describe('client dashboard reviews crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'client');
+        mockClientLogin();
         cy.intercept('GET', '**/api/employees/*/reviews', {
             fixture: 'reviews.json',
         }).as('getReviews');

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -1,26 +1,21 @@
+import { mockEmployeeLogin } from '../support/mockLogin';
+
 describe('employee dashboard navigation', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'employee');
+        mockEmployeeLogin();
     });
 
     it('redirects to employee dashboard and shows widgets', () => {
-        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
-            'dash',
-        );
         cy.visit('/dashboard');
-        cy.wait('@dash');
+        cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/employee');
         cy.contains('Today Appointments');
         cy.contains('Clients');
     });
 
     it('navigates to clients via sidebar', () => {
-        cy.intercept('GET', '**/dashboard', { fixture: 'dashboard.json' }).as(
-            'dash',
-        );
         cy.visit('/dashboard/employee');
-        cy.wait('@dash');
+        cy.wait('@dashboard');
         cy.contains('Clients').click();
         cy.url().should('include', '/clients');
     });
@@ -28,8 +23,7 @@ describe('employee dashboard navigation', () => {
 
 describe('employee dashboard clients crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'employee');
+        mockEmployeeLogin();
         cy.intercept('GET', '**/clients', { fixture: 'clients.json' }).as(
             'getClients',
         );

--- a/frontend/cypress/support/mockLogin.ts
+++ b/frontend/cypress/support/mockLogin.ts
@@ -1,0 +1,65 @@
+const buildToken = (role: string) =>
+    `header.${Buffer.from(JSON.stringify({ role })).toString('base64')}.sig`;
+
+export function mockAdminLogin() {
+    const token = buildToken('admin');
+    cy.intercept('POST', '/api/auth/login', {
+        accessToken: token,
+        refreshToken: 'refresh',
+    }).as('login');
+    cy.intercept('GET', '/api/profile', {
+        id: 1,
+        name: 'Admin User',
+        role: 'admin',
+    }).as('profile');
+    cy.intercept('GET', '/api/dashboard', {
+        fixture: 'dashboard.json',
+    }).as('dashboard');
+    cy.visit('/auth/login');
+    cy.get('input[name=email]').type('admin@example.com');
+    cy.get('input[name=password]').type('secret');
+    cy.get('button[type=submit]').click();
+    cy.wait(['@login', '@profile', '@dashboard']);
+}
+
+export function mockClientLogin() {
+    const token = buildToken('client');
+    cy.intercept('POST', '/api/auth/login', {
+        accessToken: token,
+        refreshToken: 'refresh',
+    }).as('login');
+    cy.intercept('GET', '/api/profile', {
+        id: 1,
+        name: 'Test Client',
+        role: 'client',
+    }).as('profile');
+    cy.intercept('GET', '/api/dashboard', {
+        fixture: 'dashboard.json',
+    }).as('dashboard');
+    cy.visit('/auth/login');
+    cy.get('input[name=email]').type('client@example.com');
+    cy.get('input[name=password]').type('secret');
+    cy.get('button[type=submit]').click();
+    cy.wait(['@login', '@profile', '@dashboard']);
+}
+
+export function mockEmployeeLogin() {
+    const token = buildToken('employee');
+    cy.intercept('POST', '/api/auth/login', {
+        accessToken: token,
+        refreshToken: 'refresh',
+    }).as('login');
+    cy.intercept('GET', '/api/profile', {
+        id: 1,
+        name: 'Employee User',
+        role: 'employee',
+    }).as('profile');
+    cy.intercept('GET', '/api/dashboard', {
+        fixture: 'dashboard.json',
+    }).as('dashboard');
+    cy.visit('/auth/login');
+    cy.get('input[name=email]').type('employee@example.com');
+    cy.get('input[name=password]').type('secret');
+    cy.get('button[type=submit]').click();
+    cy.wait(['@login', '@profile', '@dashboard']);
+}


### PR DESCRIPTION
## Summary
- add reusable Cypress helpers for admin, client, and employee logins
- update dashboard e2e tests to use role-based login helpers
- intercept auth, profile, and dashboard calls for stable navigation tests

## Testing
- `npm test`
- `npm run e2e -- --spec cypress/e2e/dashboard-admin.cy.ts,cypress/e2e/dashboard-client.cy.ts,cypress/e2e/dashboard-employee.cy.ts` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8af331883298c537d21ad464539