### PR TITLE
test: use explicit /api routes in Cypress intercepts

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -24,13 +24,13 @@ describe('admin dashboard navigation', () => {
 describe('admin dashboard services crud', () => {
     beforeEach(() => {
         mockAdminLogin();
-        cy.intercept('GET', '**/api/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '/api/services', { fixture: 'services.json' }).as(
             'getSvc',
         );
     });
 
     it('creates a service', () => {
-        cy.intercept('POST', '**/api/services', { id: 3, name: 'Wax' }).as(
+        cy.intercept('POST', '/api/services', { id: 3, name: 'Wax' }).as(
             'createSvc',
         );
         cy.visit('/dashboard/services');

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -23,13 +23,13 @@ describe('client dashboard navigation', () => {
 describe('client dashboard reviews crud', () => {
     beforeEach(() => {
         mockClientLogin();
-        cy.intercept('GET', '**/api/employees/*/reviews', {
+        cy.intercept('GET', '/api/reviews', {
             fixture: 'reviews.json',
         }).as('getReviews');
     });
 
     it('creates a review', () => {
-        cy.intercept('POST', '**/api/appointments/*/review', {
+        cy.intercept('POST', '/api/reviews', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -24,13 +24,13 @@ describe('employee dashboard navigation', () => {
 describe('employee dashboard clients crud', () => {
     beforeEach(() => {
         mockEmployeeLogin();
-        cy.intercept('GET', '**/clients', { fixture: 'clients.json' }).as(
+        cy.intercept('GET', '/api/clients', { fixture: 'clients.json' }).as(
             'getClients',
         );
     });
 
     it('creates a client', () => {
-        cy.intercept('POST', '**/clients', { id: 3, name: 'New' }).as(
+        cy.intercept('POST', '/api/clients', { id: 3, name: 'New' }).as(
             'createClient',
         );
         cy.visit('/clients');

--- a/frontend/cypress/e2e/employees.cy.ts
+++ b/frontend/cypress/e2e/employees.cy.ts
@@ -11,10 +11,10 @@ describe('employees crud', () => {
     });
 
     it('loads and creates employee', () => {
-        cy.intercept('GET', '**/api/employees', { fixture: 'employees.json' }).as(
+        cy.intercept('GET', '/api/employees', { fixture: 'employees.json' }).as(
             'getEmps',
         );
-        cy.intercept('POST', '**/api/employees', { id: 3, name: 'New' }).as(
+        cy.intercept('POST', '/api/employees', { id: 3, name: 'New' }).as(
             'createEmp',
         );
         cy.visit('/employees');

--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -2,7 +2,7 @@ describe('navigation visibility', () => {
     it('shows dashboard navigation for authenticated users on /products', () => {
         localStorage.setItem('jwtToken', 'x');
         localStorage.setItem('role', 'admin');
-        cy.intercept('GET', '**/api/products**', { fixture: 'products.json' }).as(
+        cy.intercept('GET', '/api/products/admin', { fixture: 'products.json' }).as(
             'getProd',
         );
         cy.visit('/products');
@@ -17,7 +17,7 @@ describe('navigation visibility', () => {
     });
 
     it('renders public navigation on public pages', () => {
-        cy.intercept('GET', '**/api/services**', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '/api/services', { fixture: 'services.json' }).as(
             'getServices',
         );
         cy.visit('/services');

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -10,10 +10,10 @@ describe('products crud', () => {
     });
 
     it('loads and creates product', () => {
-        cy.intercept('GET', '**/api/products/admin', {
+        cy.intercept('GET', '/api/products/admin', {
             fixture: 'products.json',
         }).as('getProd');
-        cy.intercept('POST', '**/api/products/admin', {
+        cy.intercept('POST', '/api/products/admin', {
             id: 2,
             name: 'New',
             unitPrice: 1,

--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -10,10 +10,10 @@ describe('reviews crud', () => {
     });
 
     it('loads and creates review', () => {
-        cy.intercept('GET', '**/api/employees/*/reviews', {
+        cy.intercept('GET', '/api/reviews', {
             fixture: 'reviews.json',
         }).as('getRev');
-        cy.intercept('POST', '**/api/appointments/*/review', {
+        cy.intercept('POST', '/api/reviews', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -10,10 +10,10 @@ describe('services crud', () => {
     });
 
     it('loads and creates service', () => {
-        cy.intercept('GET', '**/api/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '/api/services', { fixture: 'services.json' }).as(
             'getSvc',
         );
-        cy.intercept('POST', '**/api/services', { id: 3, name: 'New' }).as(
+        cy.intercept('POST', '/api/services', { id: 3, name: 'New' }).as(
             'createSvc',
         );
         cy.visit('/services');


### PR DESCRIPTION
## Summary
- target `/api` endpoints directly in admin service tests
- unify review routes under `/api/reviews`
- replace wildcard intercepts with explicit `/api/<resource>` paths in Cypress tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acca73799c8329933af8949c2d0439