### PR TITLE
Use specific employee review routes in client dashboard tests

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -23,13 +23,13 @@ describe('client dashboard navigation', () => {
 describe('client dashboard reviews crud', () => {
     beforeEach(() => {
         mockClientLogin();
-        cy.intercept('GET', '/api/reviews', {
+        cy.intercept('GET', '/api/employees/*/reviews', {
             fixture: 'reviews.json',
         }).as('getReviews');
     });
 
     it('creates a review', () => {
-        cy.intercept('POST', '/api/reviews', {
+        cy.intercept('POST', '/api/employees/*/reviews', {
             id: 2,
             appointmentId: 1,
             rating: 5,


### PR DESCRIPTION
## Summary
- target employee review calls in client dashboard tests to `/api/employees/*/reviews`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acce69af9c832996e2f4eea604e438