### PR TITLE
refactor cypress auth helpers

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -3,6 +3,9 @@ import { mockAdminLogin } from '../support/mockLogin';
 describe('admin dashboard navigation', () => {
     beforeEach(() => {
         mockAdminLogin();
+        cy.intercept('GET', '/api/dashboard', { fixture: 'dashboard.json' }).as(
+            'dashboard',
+        );
     });
 
     it('redirects to admin dashboard and shows widgets', () => {

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -3,6 +3,9 @@ import { mockClientLogin } from '../support/mockLogin';
 describe('client dashboard navigation', () => {
     beforeEach(() => {
         mockClientLogin();
+        cy.intercept('GET', '/api/dashboard', { fixture: 'dashboard.json' }).as(
+            'dashboard',
+        );
     });
 
     it('redirects to client dashboard and shows widgets', () => {

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -3,6 +3,9 @@ import { mockEmployeeLogin } from '../support/mockLogin';
 describe('employee dashboard navigation', () => {
     beforeEach(() => {
         mockEmployeeLogin();
+        cy.intercept('GET', '/api/dashboard', { fixture: 'dashboard.json' }).as(
+            'dashboard',
+        );
     });
 
     it('redirects to employee dashboard and shows widgets', () => {

--- a/frontend/cypress/e2e/employees.cy.ts
+++ b/frontend/cypress/e2e/employees.cy.ts
@@ -1,3 +1,5 @@
+import { mockAdminLogin } from '../support/mockLogin';
+
 describe('basic', () => {
     it('loads home', () => {
         cy.visit('/');
@@ -7,7 +9,7 @@ describe('basic', () => {
 
 describe('employees crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
+        mockAdminLogin();
     });
 
     it('loads and creates employee', () => {

--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -1,14 +1,20 @@
+import { mockAdminLogin } from '../support/mockLogin';
+
 describe('navigation visibility', () => {
-    it('shows dashboard navigation for authenticated users on /products', () => {
-        localStorage.setItem('jwtToken', 'x');
-        localStorage.setItem('role', 'admin');
-        cy.intercept('GET', '/api/products/admin', { fixture: 'products.json' }).as(
-            'getProd',
-        );
-        cy.visit('/products');
-        cy.wait('@getProd');
-        cy.contains('Dashboard');
-        cy.contains('Products');
+    describe('authenticated admin', () => {
+        beforeEach(() => {
+            mockAdminLogin();
+            cy.intercept('GET', '/api/products/admin', {
+                fixture: 'products.json',
+            }).as('getProd');
+        });
+
+        it('shows dashboard navigation for authenticated users on /products', () => {
+            cy.visit('/products');
+            cy.wait('@getProd');
+            cy.contains('Dashboard');
+            cy.contains('Products');
+        });
     });
 
     it('redirects unauthenticated users away from /products', () => {

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -1,12 +1,15 @@
+import { mockAdminLogin } from '../support/mockLogin';
+
 describe('basic', () => {
     it('loads home', () => {
         cy.visit('/');
         cy.contains('Featured Services');
     });
 });
+
 describe('products crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
+        mockAdminLogin();
     });
 
     it('loads and creates product', () => {

--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -1,12 +1,15 @@
+import { mockClientLogin } from '../support/mockLogin';
+
 describe('basic', () => {
     it('loads home', () => {
         cy.visit('/');
         cy.contains('Featured Services');
     });
 });
+
 describe('reviews crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
+        mockClientLogin();
     });
 
     it('loads and creates review', () => {

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -1,12 +1,15 @@
+import { mockAdminLogin } from '../support/mockLogin';
+
 describe('basic', () => {
     it('loads home', () => {
         cy.visit('/');
         cy.contains('Featured Services');
     });
 });
+
 describe('services crud', () => {
     beforeEach(() => {
-        localStorage.setItem('jwtToken', 'x');
+        mockAdminLogin();
     });
 
     it('loads and creates service', () => {

--- a/frontend/cypress/support/mockLogin.ts
+++ b/frontend/cypress/support/mockLogin.ts
@@ -1,65 +1,37 @@
 const buildToken = (role: string) =>
     `header.${Buffer.from(JSON.stringify({ role })).toString('base64')}.sig`;
 
-export function mockAdminLogin() {
-    const token = buildToken('admin');
+function applyMockLogin(role: 'admin' | 'client' | 'employee', name: string) {
+    const token = buildToken(role);
+
     cy.intercept('POST', '/api/auth/login', {
         accessToken: token,
         refreshToken: 'refresh',
     }).as('login');
+
     cy.intercept('GET', '/api/profile', {
         id: 1,
-        name: 'Admin User',
-        role: 'admin',
+        name,
+        role,
     }).as('profile');
-    cy.intercept('GET', '/api/dashboard', {
-        fixture: 'dashboard.json',
-    }).as('dashboard');
-    cy.visit('/auth/login');
-    cy.get('input[name=email]').type('admin@example.com');
-    cy.get('input[name=password]').type('secret');
-    cy.get('button[type=submit]').click();
-    cy.wait(['@login', '@profile', '@dashboard']);
+
+    cy.setCookie('jwtToken', token);
+    cy.setCookie('refreshToken', 'refresh');
+
+    localStorage.setItem('jwtToken', token);
+    localStorage.setItem('refreshToken', 'refresh');
+    localStorage.setItem('role', role);
+}
+
+export function mockAdminLogin() {
+    applyMockLogin('admin', 'Admin User');
 }
 
 export function mockClientLogin() {
-    const token = buildToken('client');
-    cy.intercept('POST', '/api/auth/login', {
-        accessToken: token,
-        refreshToken: 'refresh',
-    }).as('login');
-    cy.intercept('GET', '/api/profile', {
-        id: 1,
-        name: 'Test Client',
-        role: 'client',
-    }).as('profile');
-    cy.intercept('GET', '/api/dashboard', {
-        fixture: 'dashboard.json',
-    }).as('dashboard');
-    cy.visit('/auth/login');
-    cy.get('input[name=email]').type('client@example.com');
-    cy.get('input[name=password]').type('secret');
-    cy.get('button[type=submit]').click();
-    cy.wait(['@login', '@profile', '@dashboard']);
+    applyMockLogin('client', 'Test Client');
 }
 
 export function mockEmployeeLogin() {
-    const token = buildToken('employee');
-    cy.intercept('POST', '/api/auth/login', {
-        accessToken: token,
-        refreshToken: 'refresh',
-    }).as('login');
-    cy.intercept('GET', '/api/profile', {
-        id: 1,
-        name: 'Employee User',
-        role: 'employee',
-    }).as('profile');
-    cy.intercept('GET', '/api/dashboard', {
-        fixture: 'dashboard.json',
-    }).as('dashboard');
-    cy.visit('/auth/login');
-    cy.get('input[name=email]').type('employee@example.com');
-    cy.get('input[name=password]').type('secret');
-    cy.get('button[type=submit]').click();
-    cy.wait(['@login', '@profile', '@dashboard']);
+    applyMockLogin('employee', 'Employee User');
 }
+


### PR DESCRIPTION
## Summary
- add cookie-based mock login helpers for admin, client, and employee
- use new helpers instead of direct localStorage edits in e2e specs
- intercept dashboard requests in dashboard tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68accf603d508329b1df44b0fca8c435