### PR TITLE
fix: align Cypress intercepts with API hooks

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -27,7 +27,7 @@ describe('admin dashboard navigation', () => {
 describe('admin dashboard services crud', () => {
     beforeEach(() => {
         mockAdminLogin();
-        cy.intercept('GET', '/api/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
             'getSvc',
         );
     });

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -26,13 +26,13 @@ describe('client dashboard navigation', () => {
 describe('client dashboard reviews crud', () => {
     beforeEach(() => {
         mockClientLogin();
-        cy.intercept('GET', '/api/employees/*/reviews', {
+        cy.intercept('GET', '/api/employees/*/reviews*', {
             fixture: 'reviews.json',
         }).as('getReviews');
     });
 
     it('creates a review', () => {
-        cy.intercept('POST', '/api/employees/*/reviews', {
+        cy.intercept('POST', '/api/employees/*/reviews*', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -4,7 +4,7 @@ describe('navigation visibility', () => {
     describe('authenticated admin', () => {
         beforeEach(() => {
             mockAdminLogin();
-            cy.intercept('GET', '/api/products/admin', {
+            cy.intercept('GET', '/api/products*', {
                 fixture: 'products.json',
             }).as('getProd');
         });
@@ -23,7 +23,7 @@ describe('navigation visibility', () => {
     });
 
     it('renders public navigation on public pages', () => {
-        cy.intercept('GET', '/api/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
             'getServices',
         );
         cy.visit('/services');

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -13,10 +13,10 @@ describe('products crud', () => {
     });
 
     it('loads and creates product', () => {
-        cy.intercept('GET', '/api/products/admin', {
+        cy.intercept('GET', '/api/products*', {
             fixture: 'products.json',
         }).as('getProd');
-        cy.intercept('POST', '/api/products/admin', {
+        cy.intercept('POST', '/api/products', {
             id: 2,
             name: 'New',
             unitPrice: 1,

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -13,7 +13,7 @@ describe('services crud', () => {
     });
 
     it('loads and creates service', () => {
-        cy.intercept('GET', '/api/services', { fixture: 'services.json' }).as(
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
             'getSvc',
         );
         cy.intercept('POST', '/api/services', { id: 3, name: 'New' }).as(


### PR DESCRIPTION
## Summary
- match Cypress intercepts to actual API endpoints
- allow query params with trailing wildcards in e2e tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acd7abc24c832994b63a45c0bf8a8e