### PR TITLE
test: remove cy.wait usage in server data tests

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -6,12 +6,12 @@ describe('navigation visibility', () => {
             mockAdminLogin();
             cy.intercept('GET', '/api/products*', {
                 fixture: 'products.json',
-            }).as('getProd');
+            });
         });
 
         it('shows dashboard navigation for authenticated users on /products', () => {
             cy.visit('/products');
-            cy.wait('@getProd');
+            cy.contains('Shampoo');
             cy.contains('Dashboard');
             cy.contains('Products');
         });
@@ -23,11 +23,9 @@ describe('navigation visibility', () => {
     });
 
     it('renders public navigation on public pages', () => {
-        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
-            'getServices',
-        );
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' });
         cy.visit('/services');
-        cy.wait('@getServices');
+        cy.contains('Cut');
         cy.get('nav').contains('Login');
         cy.get('nav').contains('Services');
     });

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -13,19 +13,14 @@ describe('services crud', () => {
     });
 
     it('loads and creates service', () => {
-        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
-            'getSvc',
-        );
-        cy.intercept('POST', '/api/services', { id: 3, name: 'New' }).as(
-            'createSvc',
-        );
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' });
+        cy.intercept('POST', '/api/services', { id: 3, name: 'New' });
         cy.visit('/services');
-        cy.wait('@getSvc');
+        cy.contains('Cut');
         cy.contains('Add Service').click();
         cy.get('input[placeholder="Name"]').type('New');
         cy.contains('button', 'Save').click();
-        cy.wait('@createSvc');
-        cy.contains('New');
         cy.contains('Service created');
+        cy.contains('New');
     });
 });


### PR DESCRIPTION
## Summary
- assert service and product data directly instead of relying on `cy.wait`
- stub service creation without waiting on request
- check navigation on public pages with service list rendered

## Testing
- `npm test`
- `npm run lint` *(fails: produced no output)*
- `npm run e2e -- --spec "cypress/e2e/services.cy.ts,cypress/e2e/navigation.cy.ts"` *(fails: missing Xvfb dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68acdaaa8a48832988731de3b2e5e45b