### PR TITLE
Wait for profile before dashboard tests interact

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -10,6 +10,7 @@ describe('admin dashboard navigation', () => {
 
     it('redirects to admin dashboard and shows widgets', () => {
         cy.visit('/dashboard');
+        cy.wait('@profile');
         cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/admin');
         cy.contains('Clients');
@@ -18,6 +19,7 @@ describe('admin dashboard navigation', () => {
 
     it('navigates to employees via sidebar', () => {
         cy.visit('/dashboard/admin');
+        cy.wait('@profile');
         cy.wait('@dashboard');
         cy.contains('Employees').click();
         cy.url().should('include', '/employees');
@@ -37,6 +39,7 @@ describe('admin dashboard services crud', () => {
             'createSvc',
         );
         cy.visit('/dashboard/services');
+        cy.wait('@profile');
         cy.wait('@getSvc');
         cy.contains('Add Service').click();
         cy.get('input[placeholder="Name"]').type('Wax');

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -10,6 +10,7 @@ describe('employee dashboard navigation', () => {
 
     it('redirects to employee dashboard and shows widgets', () => {
         cy.visit('/dashboard');
+        cy.wait('@profile');
         cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/employee');
         cy.contains('Today Appointments');
@@ -18,6 +19,7 @@ describe('employee dashboard navigation', () => {
 
     it('navigates to clients via sidebar', () => {
         cy.visit('/dashboard/employee');
+        cy.wait('@profile');
         cy.wait('@dashboard');
         cy.contains('Clients').click();
         cy.url().should('include', '/clients');
@@ -37,6 +39,7 @@ describe('employee dashboard clients crud', () => {
             'createClient',
         );
         cy.visit('/clients');
+        cy.wait('@profile');
         cy.wait('@getClients');
         cy.contains('Add Client').click();
         cy.get('input[placeholder="Name"]').type('New');

--- a/frontend/cypress/e2e/employees.cy.ts
+++ b/frontend/cypress/e2e/employees.cy.ts
@@ -20,6 +20,7 @@ describe('employees crud', () => {
             'createEmp',
         );
         cy.visit('/employees');
+        cy.wait('@profile');
         cy.wait('@getEmps');
         cy.contains('Add Employee').click();
         cy.get('input[placeholder="Name"]').type('New');


### PR DESCRIPTION
## Summary
- wait for `@profile` after visiting admin dashboard pages
- wait for `@profile` in employee dashboard navigation and CRUD specs
- ensure employees CRUD waits for profile before loading data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acdd2e0d048329aa298a0be80e1ad9