### PR TITLE
Add nav data-testid attributes and update Cypress navigation tests

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -8,21 +8,32 @@ describe('admin dashboard navigation', () => {
         );
     });
 
-    it('redirects to admin dashboard and shows widgets', () => {
+    it('redirects to admin dashboard and navigates to employees', () => {
         cy.visit('/dashboard');
         cy.wait('@profile');
         cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/admin');
         cy.contains('Clients');
-        cy.contains('Employees');
+        cy.intercept('GET', '/api/employees*', {
+            fixture: 'employees.json',
+        }).as('getEmployees');
+        cy.get('[data-testid="nav-employees"]').click();
+        cy.wait('@getEmployees');
+        cy.url().should('include', '/employees');
+        cy.get('table').should('be.visible');
     });
 
     it('navigates to employees via sidebar', () => {
         cy.visit('/dashboard/admin');
         cy.wait('@profile');
         cy.wait('@dashboard');
-        cy.contains('Employees').click();
+        cy.intercept('GET', '/api/employees*', {
+            fixture: 'employees.json',
+        }).as('getEmployees');
+        cy.get('[data-testid="nav-employees"]').click();
+        cy.wait('@getEmployees');
         cy.url().should('include', '/employees');
+        cy.get('table').should('be.visible');
     });
 });
 

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -21,8 +21,13 @@ describe('employee dashboard navigation', () => {
         cy.visit('/dashboard/employee');
         cy.wait('@profile');
         cy.wait('@dashboard');
-        cy.contains('Clients').click();
+        cy.intercept('GET', '/api/clients', {
+            fixture: 'clients.json',
+        }).as('getClients');
+        cy.get('[data-testid="nav-clients"]').click();
+        cy.wait('@getClients');
         cy.url().should('include', '/clients');
+        cy.get('table').should('be.visible');
     });
 });
 

--- a/frontend/src/components/DashboardNav.tsx
+++ b/frontend/src/components/DashboardNav.tsx
@@ -53,6 +53,7 @@ export default function DashboardNav() {
                             href={l.href}
                             aria-current={isActive ? 'page' : undefined}
                             className={`block px-2 py-1 transition duration-150 hover:text-blue-700 ${isActive ? 'font-bold text-blue-600 border-l-4 border-blue-500 pl-2 bg-white' : ''}`}
+                            data-testid={`nav-${l.label.toLowerCase().replace(/\s+/g, '-')}`}
                         >
                             {l.label}
                         </Link>

--- a/frontend/src/components/SidebarMenu.tsx
+++ b/frontend/src/components/SidebarMenu.tsx
@@ -51,6 +51,7 @@ export default function SidebarMenu({ open, onClose }: Props) {
                     key={l.href}
                     href={l.href}
                     className="block rounded px-2 py-1 hover:bg-gray-700"
+                    data-testid={`nav-${l.label.toLowerCase().replace(/\s+/g, '-')}`}
                 >
                     {l.label}
                 </Link>


### PR DESCRIPTION
## Summary
- add `data-testid` attributes for navigation links
- use the new test ids in dashboard navigation Cypress tests with URL and list checks

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e -- --spec "cypress/e2e/dashboard-admin.cy.ts,cypress/e2e/dashboard-employee.cy.ts"` *(fails: missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ace001e9fc8329a62fea360bdcd71c