### PR TITLE
test: wait for profile in CRUD tests

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -10,6 +10,7 @@ describe('client dashboard navigation', () => {
 
     it('redirects to client dashboard and shows widgets', () => {
         cy.visit('/dashboard');
+        cy.wait('@profile');
         cy.wait('@dashboard');
         cy.url().should('include', '/dashboard/client');
         cy.contains('Upcoming');
@@ -17,6 +18,7 @@ describe('client dashboard navigation', () => {
 
     it('navigates to reviews via sidebar', () => {
         cy.visit('/dashboard/client');
+        cy.wait('@profile');
         cy.wait('@dashboard');
         cy.contains('Reviews').click();
         cy.url().should('include', '/reviews');
@@ -38,6 +40,7 @@ describe('client dashboard reviews crud', () => {
             rating: 5,
         }).as('createReview');
         cy.visit('/reviews');
+        cy.wait('@profile');
         cy.wait('@getReviews');
         cy.contains('Add Review').click();
         cy.get('input[placeholder="Appointment"]').type('1');

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -23,6 +23,7 @@ describe('products crud', () => {
             stock: 1,
         }).as('createProd');
         cy.visit('/products');
+        cy.wait('@profile');
         cy.wait('@getProd');
         cy.contains('Add Product').click();
         cy.get('input[placeholder="Name"]').type('New');

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -13,13 +13,20 @@ describe('services crud', () => {
     });
 
     it('loads and creates service', () => {
-        cy.intercept('GET', '/api/services*', { fixture: 'services.json' });
-        cy.intercept('POST', '/api/services', { id: 3, name: 'New' });
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
+            'getSvc',
+        );
+        cy.intercept('POST', '/api/services', { id: 3, name: 'New' }).as(
+            'createSvc',
+        );
         cy.visit('/services');
+        cy.wait('@profile');
+        cy.wait('@getSvc');
         cy.contains('Cut');
         cy.contains('Add Service').click();
         cy.get('input[placeholder="Name"]').type('New');
         cy.contains('button', 'Save').click();
+        cy.wait('@createSvc');
         cy.contains('Service created');
         cy.contains('New');
     });


### PR DESCRIPTION
## Summary
- ensure profile requests resolve before interacting with product, service, and dashboard client pages
- alias GET service requests and wait for them before DOM assertions
- add profile waits to dashboard client navigation tests

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ace1b622b483299d697a81482c0c90