### PR TITLE
test: update review intercepts

### DIFF
--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -13,21 +13,21 @@ describe('reviews crud', () => {
     });
 
     it('loads and creates review', () => {
-        cy.intercept('GET', '/api/reviews', {
+        cy.intercept('GET', '/api/employees/*/reviews*', {
             fixture: 'reviews.json',
-        }).as('getRev');
-        cy.intercept('POST', '/api/reviews', {
+        }).as('getReviews');
+        cy.intercept('POST', '/api/employees/*/reviews*', {
             id: 2,
             appointmentId: 1,
             rating: 5,
-        }).as('createRev');
+        }).as('createReview');
         cy.visit('/reviews');
-        cy.wait('@getRev');
+        cy.wait('@getReviews');
         cy.contains('Add Review').click();
         cy.get('input[placeholder="Appointment"]').type('1');
         cy.get('input[placeholder="Rating"]').type('5');
         cy.contains('button', 'Save').click();
-        cy.wait('@createRev');
+        cy.wait('@createReview');
         cy.contains('Review created');
     });
 });


### PR DESCRIPTION
## Summary
- mock employee-specific review API calls in Cypress tests
- wait for employee review fetch before interacting with the page

## Testing
- `npm test`
- `npx cypress run --spec cypress/e2e/reviews.cy.ts` *(fails: your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68acf50f544c8329b2aa947b53bf0425