### PR TITLE
test: wait for product and service data in nav tests

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -6,11 +6,13 @@ describe('navigation visibility', () => {
             mockAdminLogin();
             cy.intercept('GET', '/api/products*', {
                 fixture: 'products.json',
-            });
+            }).as('getProd');
         });
 
         it('shows dashboard navigation for authenticated users on /products', () => {
             cy.visit('/products');
+            cy.wait('@profile');
+            cy.wait('@getProd');
             cy.contains('Shampoo');
             cy.contains('Dashboard');
             cy.contains('Products');
@@ -25,10 +27,13 @@ describe('navigation visibility', () => {
     });
 
     it('renders public navigation on public pages', () => {
-        cy.intercept('GET', '/api/services*', { fixture: 'services.json' });
+        cy.intercept('GET', '/api/services*', { fixture: 'services.json' }).as(
+            'getSvc',
+        );
         cy.visit('/services');
+        cy.wait('@getSvc');
         cy.contains('Cut');
-        cy.get('nav').contains('Login');
-        cy.get('nav').contains('Services');
+        cy.get('nav').contains('Login').should('be.visible');
+        cy.get('nav').contains('Services').should('be.visible');
     });
 });


### PR DESCRIPTION
## Summary
- alias product and service API requests in navigation tests
- wait for API responses before asserting navigation
- verify public menu items are visible after data load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf60d88688329b91118ccc9fe90fe