### PR TITLE
test: verify service creation in admin view

### DIFF
--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -19,7 +19,7 @@ describe('services crud', () => {
         cy.intercept('POST', '/api/services', { id: 3, name: 'New' }).as(
             'createSvc',
         );
-        cy.visit('/services');
+        cy.visit('/dashboard/services');
         cy.wait('@profile');
         cy.wait('@getSvc');
         cy.contains('Cut');
@@ -28,6 +28,6 @@ describe('services crud', () => {
         cy.contains('button', 'Save').click();
         cy.wait('@createSvc');
         cy.contains('Service created');
-        cy.contains('New');
+        cy.get('table').should('contain', 'New');
     });
 });


### PR DESCRIPTION
## Summary
- test service creation via dashboard services page
- ensure service appears in table and shows success toast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf6ab433c83299b7d4bb3d03d1b55