### PR TITLE
fix: ensure mock login sets storage after visiting root

### DIFF
--- a/frontend/cypress/support/mockLogin.ts
+++ b/frontend/cypress/support/mockLogin.ts
@@ -15,12 +15,16 @@ function applyMockLogin(role: 'admin' | 'client' | 'employee', name: string) {
         role,
     }).as('profile');
 
+    cy.visit('/');
+
     cy.setCookie('jwtToken', token);
     cy.setCookie('refreshToken', 'refresh');
 
-    localStorage.setItem('jwtToken', token);
-    localStorage.setItem('refreshToken', 'refresh');
-    localStorage.setItem('role', role);
+    cy.window().then((win) => {
+        win.localStorage.setItem('jwtToken', token);
+        win.localStorage.setItem('refreshToken', 'refresh');
+        win.localStorage.setItem('role', role);
+    });
 }
 
 export function mockAdminLogin() {


### PR DESCRIPTION
## Summary
- visit the app before setting auth tokens
- move localStorage writes into a cy.window callback

## Testing
- `npm run e2e -- --spec "cypress/e2e/services.cy.ts,cypress/e2e/clients.cy.ts,cypress/e2e/products.cy.ts,cypress/e2e/reviews.cy.ts,cypress/e2e/employees.cy.ts"` *(fails: Expected to find element: `[data-testid="nav-employees"]`, but never found it)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6bd919d0832994483c155e7b622f