### PR TITLE
Stabilize Cypress Add button clicks

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -54,7 +54,9 @@ describe('admin dashboard services crud', () => {
         cy.visit('/dashboard/services');
         cy.wait('@profile');
         cy.wait('@getSvc');
-        cy.contains('Add Service').click();
+        cy.contains('Add Service', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Name"]').type('Wax');
         cy.contains('button', 'Save').click();
         cy.wait('@createSvc');

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -42,7 +42,9 @@ describe('client dashboard reviews crud', () => {
         cy.visit('/reviews');
         cy.wait('@profile');
         cy.wait('@getReviews');
-        cy.contains('Add Review').click();
+        cy.contains('Add Review', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Appointment"]').type('1');
         cy.get('input[placeholder="Rating"]').type('5');
         cy.contains('button', 'Save').click();

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -47,7 +47,9 @@ describe('employee dashboard clients crud', () => {
         cy.visit('/clients');
         cy.wait('@profile');
         cy.wait('@getClients');
-        cy.contains('Add Client').click();
+        cy.contains('Add Client', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Name"]').type('New');
         cy.contains('button', 'Save').click();
         cy.wait('@createClient');

--- a/frontend/cypress/e2e/employees.cy.ts
+++ b/frontend/cypress/e2e/employees.cy.ts
@@ -22,7 +22,9 @@ describe('employees crud', () => {
         cy.visit('/employees');
         cy.wait('@profile');
         cy.wait('@getEmps');
-        cy.contains('Add Employee').click();
+        cy.contains('Add Employee', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Name"]').type('New');
         cy.contains('button', 'Save').click();
         cy.wait('@createEmp');

--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -25,7 +25,9 @@ describe('products crud', () => {
         cy.visit('/products');
         cy.wait('@profile');
         cy.wait('@getProd');
-        cy.contains('Add Product').click();
+        cy.contains('Add Product', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Name"]').type('New');
         cy.get('input[placeholder="Price"]').type('1');
         cy.get('input[placeholder="Stock"]').type('1');

--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -23,7 +23,9 @@ describe('reviews crud', () => {
         }).as('createReview');
         cy.visit('/reviews');
         cy.wait('@getReviews');
-        cy.contains('Add Review').click();
+        cy.contains('Add Review', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Appointment"]').type('1');
         cy.get('input[placeholder="Rating"]').type('5');
         cy.contains('button', 'Save').click();

--- a/frontend/cypress/e2e/services.cy.ts
+++ b/frontend/cypress/e2e/services.cy.ts
@@ -23,7 +23,9 @@ describe('services crud', () => {
         cy.wait('@profile');
         cy.wait('@getSvc');
         cy.contains('Cut');
-        cy.contains('Add Service').click();
+        cy.contains('Add Service', { timeout: 10000 })
+            .should('be.visible')
+            .click();
         cy.get('input[placeholder="Name"]').type('New');
         cy.contains('button', 'Save').click();
         cy.wait('@createSvc');


### PR DESCRIPTION
## Summary
- Ensure all CRUD and dashboard specs wait for "Add" buttons to be visible before clicking
- Confirm GET intercepts are set up before visiting pages for reliable waits

## Testing
- `npm run e2e -- --spec "cypress/e2e/services.cy.ts,cypress/e2e/products.cy.ts,cypress/e2e/employees.cy.ts,cypress/e2e/reviews.cy.ts,cypress/e2e/dashboard-client.cy.ts,cypress/e2e/dashboard-admin.cy.ts,cypress/e2e/dashboard-employee.cy.ts"` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68ad726ee3948329bd0626a73fb66a04