### PR TITLE
Initialize auth tokens before mount and gate RouteGuard on init

### DIFF
--- a/frontend/src/__tests__/routeGuard.test.tsx
+++ b/frontend/src/__tests__/routeGuard.test.tsx
@@ -29,6 +29,19 @@ describe('RouteGuard', () => {
         expect(screen.queryByText('Secret')).toBeNull();
     });
 
+    it('does not redirect before initialization', () => {
+        mockedUseAuth.mockReturnValue(
+            createAuthValue({ isAuthenticated: false, initialized: false }),
+        );
+        render(
+            <RouteGuard>
+                <div>Secret</div>
+            </RouteGuard>,
+        );
+        expect(replace).not.toHaveBeenCalled();
+        expect(screen.queryByText('Secret')).toBeNull();
+    });
+
     it('renders children when authenticated and role allowed', () => {
         mockedUseAuth.mockReturnValue(
             createAuthValue({ isAuthenticated: true, role: 'receptionist' }),

--- a/frontend/src/components/RouteGuard.tsx
+++ b/frontend/src/components/RouteGuard.tsx
@@ -9,17 +9,19 @@ interface Props {
 }
 
 export default function RouteGuard({ children, roles }: Props) {
-    const { isAuthenticated, role } = useAuth();
+    const { isAuthenticated, role, initialized } = useAuth();
     const router = useRouter();
 
     useEffect(() => {
+        if (!initialized) return;
         if (!isAuthenticated) {
             void router.replace('/auth/login');
         } else if (roles && role && !roles.includes(role)) {
             void router.replace(`/dashboard/${role}`);
         }
-    }, [isAuthenticated, role, roles, router]);
+    }, [initialized, isAuthenticated, role, roles, router]);
 
+    if (!initialized) return null;
     if (!isAuthenticated) return null;
     if (roles && role && !roles.includes(role)) return null;
     return <>{children}</>;

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -8,6 +8,7 @@ export const createAuthValue = (
     accessToken: null,
     refreshToken: null,
     role: null,
+    initialized: true,
     isAuthenticated: false,
     login: jest.fn(),
     register: jest.fn(),


### PR DESCRIPTION
## Summary
- initialize tokens and role from localStorage before React mount
- expose `initialized` flag in auth context and wait for profile checks
- defer RouteGuard redirects until auth is initialized
- add test ensuring RouteGuard skips redirects before initialization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad7ffa0a748329830a1e81a8a727d8