### PR TITLE
chore: add timeouts to dashboard navigation tests

### DIFF
--- a/frontend/cypress/e2e/dashboard-admin.cy.ts
+++ b/frontend/cypress/e2e/dashboard-admin.cy.ts
@@ -17,7 +17,9 @@ describe('admin dashboard navigation', () => {
         cy.intercept('GET', '/api/employees*', {
             fixture: 'employees.json',
         }).as('getEmployees');
-        cy.get('[data-testid="nav-employees"]').as('navEmployees');
+        cy.get('[data-testid="nav-employees"]', { timeout: 10000 }).as(
+            'navEmployees',
+        );
         cy.get('@navEmployees').click();
         cy.wait('@getEmployees');
         cy.url().should('include', '/employees');
@@ -31,7 +33,9 @@ describe('admin dashboard navigation', () => {
         cy.intercept('GET', '/api/employees*', {
             fixture: 'employees.json',
         }).as('getEmployees');
-        cy.get('[data-testid="nav-employees"]').as('navEmployees');
+        cy.get('[data-testid="nav-employees"]', { timeout: 10000 }).as(
+            'navEmployees',
+        );
         cy.get('@navEmployees').click();
         cy.wait('@getEmployees');
         cy.url().should('include', '/employees');

--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -20,7 +20,10 @@ describe('client dashboard navigation', () => {
         cy.visit('/dashboard/client');
         cy.wait('@profile');
         cy.wait('@dashboard');
-        cy.contains('Reviews').click();
+        cy.get('[data-testid="nav-reviews"]', { timeout: 10000 }).as(
+            'navReviews',
+        );
+        cy.get('@navReviews').click();
         cy.url().should('include', '/reviews');
     });
 });

--- a/frontend/cypress/e2e/dashboard-employee.cy.ts
+++ b/frontend/cypress/e2e/dashboard-employee.cy.ts
@@ -24,7 +24,9 @@ describe('employee dashboard navigation', () => {
         cy.intercept('GET', '/api/clients', {
             fixture: 'clients.json',
         }).as('getClients');
-        cy.get('[data-testid="nav-clients"]').as('navClients');
+        cy.get('[data-testid="nav-clients"]', { timeout: 10000 }).as(
+            'navClients',
+        );
         cy.get('@navClients').click();
         cy.wait('@getClients');
         cy.url().should('include', '/clients');


### PR DESCRIPTION
## Summary
- add 10s timeout alias to dashboard sidebar navigation tests
- use data-testid selectors for client review navigation

## Testing
- `NEXT_PUBLIC_API_URL=/api npx start-server-and-test start http://localhost:3000 "cypress run --spec cypress/e2e/dashboard-admin.cy.ts,cypress/e2e/dashboard-client.cy.ts,cypress/e2e/dashboard-employee.cy.ts"` *(fails: Expected to find content 'Add Review')*


------
https://chatgpt.com/codex/tasks/task_e_68ada1772c0c8329b88f828d4ba2f10a