### PR TITLE
test: wait for profile request in navigation spec

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -11,6 +11,7 @@ describe('navigation visibility', () => {
 
         it('shows dashboard navigation for authenticated users on /products', () => {
             cy.visit('/products');
+            cy.wait('@profile');
             cy.wait('@getProd');
             cy.contains('Shampoo');
             cy.contains('Dashboard');


### PR DESCRIPTION
## Summary
- ensure navigation spec waits for profile data before products

## Testing
- `NEXT_PUBLIC_API_URL=/api npx start-server-and-test "npm run start" http://localhost:3000 "cypress run --spec cypress/e2e/navigation.cy.ts"` *(fails: `cy.wait()` timed out waiting for `@profile` request)*

------
https://chatgpt.com/codex/tasks/task_e_68adaf9e892483298ac7cc279f127535