### PR TITLE
ci: add npm registry auth and retry installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_REGISTRY_URL: https://registry.npmjs.org
     services:
       postgres:
         image: postgres:15
@@ -21,10 +24,15 @@ jobs:
           cache-dependency-path: |
             frontend/package-lock.json
             backend/salonbw-backend/package-lock.json
+      - name: Configure npm registry
+        run: |
+          REGISTRY_HOST=$(echo "$NPM_REGISTRY_URL" | sed -e 's#^https://##' -e 's#^http://##')
+          echo "registry=${NPM_REGISTRY_URL}" > ~/.npmrc
+          echo "//${REGISTRY_HOST}/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
       - name: Install frontend deps
         run: |
           cd frontend
-          npm ci --prefer-offline
+          ../scripts/npm-ci-retry.sh
       - name: Lint frontend
         run: |
           cd frontend
@@ -40,7 +48,7 @@ jobs:
       - name: Install backend deps
         run: |
           cd backend/salonbw-backend
-          npm ci --prefer-offline
+          ../../scripts/npm-ci-retry.sh
       - name: Lint backend
         run: |
           cd backend/salonbw-backend

--- a/scripts/npm-ci-retry.sh
+++ b/scripts/npm-ci-retry.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RETRIES=${NPM_RETRIES:-3}
+DELAY=${NPM_RETRY_DELAY:-60}
+
+for attempt in $(seq 1 "$RETRIES"); do
+  if npm ci; then
+    exit 0
+  fi
+
+  if [ "$attempt" -lt "$RETRIES" ]; then
+    echo "npm ci failed (attempt $attempt/$RETRIES). Possible rate limit. Waiting ${DELAY}s before retrying..." >&2
+    sleep "$DELAY"
+  else
+    echo "npm ci failed after $RETRIES attempts" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- configure npm registry via NPM_TOKEN and NPM_REGISTRY_URL
- add helper script to retry `npm ci` when rate limited
- use retry script in CI for frontend and backend installs

## Testing
- `../scripts/npm-ci-retry.sh` (frontend) followed by `npm test -- --coverage`
- `../../scripts/npm-ci-retry.sh` (backend) followed by `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68adb9525160832992be7a0093a0c86b