### PR TITLE
Refactor reviews fixture to include metadata

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -31,13 +31,15 @@ describe('client dashboard navigation', () => {
 describe('client dashboard reviews crud', () => {
     beforeEach(() => {
         mockClientLogin();
-        cy.intercept('GET', '/api/employees/*/reviews*', {
-            fixture: 'reviews.json',
-        }).as('getReviews');
+        cy.fixture('reviews.json').then((reviews) => {
+            cy.intercept('GET', '/api/employees/*/reviews*', reviews).as(
+                'getReviews',
+            );
+        });
     });
 
     it('creates a review', () => {
-        cy.intercept('POST', '/api/employees/*/reviews*', {
+        cy.intercept('POST', '**/appointments/*/review', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -13,10 +13,12 @@ describe('reviews crud', () => {
     });
 
     it('loads and creates review', () => {
-        cy.intercept('GET', '/api/employees/*/reviews*', {
-            fixture: 'reviews.json',
-        }).as('getReviews');
-        cy.intercept('POST', '/api/employees/*/reviews*', {
+        cy.fixture('reviews.json').then((reviews) => {
+            cy.intercept('GET', '/api/employees/*/reviews*', reviews).as(
+                'getReviews',
+            );
+        });
+        cy.intercept('POST', '**/appointments/*/review', {
             id: 2,
             appointmentId: 1,
             rating: 5,

--- a/frontend/cypress/fixtures/reviews.json
+++ b/frontend/cypress/fixtures/reviews.json
@@ -1,10 +1,15 @@
-[
-  {
-    "id": 1,
-    "appointmentId": 1,
-    "rating": 5,
-    "comment": "Great",
-    "employee": { "id": 1, "fullName": "John Doe" },
-    "author": { "id": 2, "name": "Jane" }
-  }
-]
+{
+  "data": [
+    {
+      "id": 1,
+      "appointmentId": 1,
+      "rating": 5,
+      "comment": "Great",
+      "employee": { "id": 1, "fullName": "John Doe" },
+      "author": { "id": 2, "name": "Jane" }
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "limit": 10
+}


### PR DESCRIPTION
## Summary
- wrap `reviews.json` fixture in `{data, total, page, limit}`
- load updated fixture in review e2e specs
- adjust review POST interceptions for new endpoint

## Testing
- `npx cypress run --spec "cypress/e2e/dashboard-client.cy.ts,cypress/e2e/reviews.cy.ts"` *(fails: timed out waiting for `createReview` route)*

------
https://chatgpt.com/codex/tasks/task_e_68adc2c5aa8883298b68cc6db5c58787