### PR TITLE
test: handle optional API prefix in review intercept

### DIFF
--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -18,11 +18,19 @@ describe('reviews crud', () => {
                 'getReviews',
             );
         });
-        cy.intercept('POST', '**/appointments/*/review', {
-            id: 2,
-            appointmentId: 1,
-            rating: 5,
-        }).as('createReview');
+        cy.intercept(
+            'POST',
+            /\/(api\/)?appointments\/\d+\/review$/,
+            {
+                statusCode: 201,
+                body: {
+                    id: 2,
+                    appointmentId: 1,
+                    rating: 5,
+                    comment: 'Great',
+                },
+            },
+        ).as('createReview');
         cy.visit('/reviews');
         cy.wait('@getReviews');
         cy.contains('Add Review', { timeout: 10000 })


### PR DESCRIPTION
## Summary
- expand review creation intercept to match optional `/api` prefix using regex

## Testing
- `cd frontend && npm run e2e` *(fails: dashboard-client.cy.ts, reviews.cy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68add172a1fc8329bae58ff888fd3ecd