### PR TITLE
Increase review creation wait timeout

### DIFF
--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -39,7 +39,7 @@ describe('reviews crud', () => {
         cy.get('input[placeholder="Appointment"]').type('1');
         cy.get('input[placeholder="Rating"]').type('5');
         cy.contains('button', 'Save').click();
-        cy.wait('@createReview');
+        cy.wait('@createReview', { timeout: 10000 });
         cy.contains('Review created');
     });
 });


### PR DESCRIPTION
## Summary
- extend Cypress `cy.wait` timeout for review creation

## Testing
- `cd frontend && npm run e2e` *(fails: `cy.wait()` timed out waiting for `createReview` request in dashboard-client.cy.ts and reviews.cy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11805a288329b47ed8a3f2f3dadd