### PR TITLE
Adjust review intercept in client dashboard test

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -39,11 +39,14 @@ describe('client dashboard reviews crud', () => {
     });
 
     it('creates a review', () => {
-        cy.intercept('POST', '**/appointments/*/review', {
-            id: 2,
-            appointmentId: 1,
-            rating: 5,
-        }).as('createReview');
+        cy.intercept(
+            'POST',
+            /\/(api\/)?appointments\/\d+\/review$/,
+            {
+                statusCode: 201,
+                body: { id: 1000, appointmentId: 1, rating: 5, comment: 'Great' },
+            },
+        ).as('createReview');
         cy.visit('/reviews');
         cy.wait('@profile');
         cy.wait('@getReviews');


### PR DESCRIPTION
## Summary
- refine review creation intercept to use regex and return structured response

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae173ccc90832980b81851e82531f8