### PR TITLE
test: increase timeout for dashboard review wait

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -56,7 +56,7 @@ describe('client dashboard reviews crud', () => {
         cy.get('input[placeholder="Appointment"]').type('1');
         cy.get('input[placeholder="Rating"]').type('5');
         cy.contains('button', 'Save').click();
-        cy.wait('@createReview');
+        cy.wait('@createReview', { timeout: 10000 });
         cy.contains('Review created');
     });
 });


### PR DESCRIPTION
## Summary
- extend `cy.wait` timeout for create review request in client dashboard E2E test

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1dd834c48329a8208ae39a6b7d73