### PR TITLE
test: update product creation intercept

### DIFF
--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -17,11 +17,16 @@ describe('products crud', () => {
             fixture: 'products.json',
         }).as('getProd');
         cy.intercept('POST', '/api/products/admin', {
-            id: 2,
-            name: 'New',
-            unitPrice: 1,
-            stock: 1,
-        }).as('createProdAdmin');
+            statusCode: 201,
+            body: {
+                id: 999,
+                name: 'New',
+                brand: 'B',
+                unitPrice: 1,
+                stock: 1,
+                lowStockThreshold: 5,
+            },
+        }).as('createProd');
         cy.visit('/products');
         cy.wait('@profile');
         cy.wait('@getProd');
@@ -32,7 +37,7 @@ describe('products crud', () => {
         cy.get('input[placeholder="Price"]').type('1');
         cy.get('input[placeholder="Stock"]').type('1');
         cy.contains('button', 'Save').click();
-        cy.wait('@createProdAdmin');
+        cy.wait('@createProd');
         cy.contains('New');
         cy.contains('Product created');
     });


### PR DESCRIPTION
## Summary
- expand product creation intercept with detailed response and status code
- align product creation test wait alias

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae21911d0c8329a6e2ac72b0bc9cb1