### PR TITLE
Add timeout to Cypress product creation wait

### DIFF
--- a/frontend/cypress/e2e/products.cy.ts
+++ b/frontend/cypress/e2e/products.cy.ts
@@ -37,7 +37,7 @@ describe('products crud', () => {
         cy.get('input[placeholder="Price"]').type('1');
         cy.get('input[placeholder="Stock"]').type('1');
         cy.contains('button', 'Save').click();
-        cy.wait('@createProd');
+        cy.wait('@createProd', { timeout: 10000 });
         cy.contains('New');
         cy.contains('Product created');
     });


### PR DESCRIPTION
## Summary
- ensure product creation request wait uses explicit 10s timeout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae227bb8748329b0fa9aabf7600620