### PR TITLE
Ensure review intercept matches optional query strings

### DIFF
--- a/frontend/cypress/e2e/reviews.cy.ts
+++ b/frontend/cypress/e2e/reviews.cy.ts
@@ -19,8 +19,10 @@ describe('reviews crud', () => {
             );
         });
         cy.intercept(
-            'POST',
-            /\/(api\/)?appointments\/\d+\/review$/,
+            {
+                method: 'POST',
+                url: /\/(api\/)?appointments\/\d+\/review(?:\/)?(?:\?.*)?$/,
+            },
             {
                 statusCode: 201,
                 body: {
@@ -28,6 +30,8 @@ describe('reviews crud', () => {
                     appointmentId: 1,
                     rating: 5,
                     comment: 'Great',
+                    employee: { id: 1, fullName: 'John Doe' },
+                    author: { id: 1, name: 'Test Client' },
                 },
             },
         ).as('createReview');


### PR DESCRIPTION
## Summary
- expand review creation intercept to match optional `/api` prefix and query strings
- stub employee and author fields in intercepted response

## Testing
- `npm run e2e` *(fails: creating optimized build... process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68adcfb835c88329b660ac0a4b9410fa