### PR TITLE
test: add cypress api intercept helpers

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -1,5 +1,5 @@
 import { mockClientLogin } from '../support/mockLogin';
-import { interceptCreateReview } from '../support/api';
+import { interceptAppointmentsList, interceptCreateReview } from '../support/api';
 
 describe('client dashboard navigation', () => {
     beforeEach(() => {
@@ -32,34 +32,51 @@ describe('client dashboard navigation', () => {
 describe('client dashboard reviews crud', () => {
     beforeEach(() => {
         mockClientLogin();
+        cy.intercept('GET', '/api/dashboard', { fixture: 'dashboard.json' }).as(
+            'dashboard',
+        );
         cy.fixture('reviews.json').then((reviews) => {
             cy.intercept('GET', '/api/employees/*/reviews*', reviews).as(
                 'getReviews',
             );
         });
+        interceptAppointmentsList();
+        interceptCreateReview();
     });
 
     it('creates a review', () => {
-        interceptCreateReview();
-        cy.intercept(
-            'POST',
-            /\/(api\/)?appointments\/\d+\/review(?:\/)?(?:\?.*)?$/,
-            {
-                statusCode: 201,
-                body: { id: 1000, appointmentId: 1, rating: 5, comment: 'Great' },
-            },
-        ).as('createReview');
-        cy.visit('/reviews');
+        cy.visit('/dashboard/client');
         cy.wait('@profile');
-        cy.wait('@getReviews');
-        cy.contains('Add Review', { timeout: 10000 })
-            .should('be.visible')
-            .click();
-        cy.get('input[placeholder="Appointment"]').type('1');
-        cy.get('input[placeholder="Rating"]').type('5');
+        cy.wait('@dashboard');
+        cy.contains('Reviews', { timeout: 10000 }).click();
+        cy.wait('@getAppointments');
+
+        cy.contains('Add Review', { timeout: 10000 }).click();
+
+        cy.get('input[placeholder="Rating"], input[name="rating"]').first().clear().type('5');
+
+        cy.get('textarea[placeholder="Comment"], textarea[name="comment"]').first().then(($el) => {
+            if ($el.length) cy.wrap($el).type('Great');
+        });
+
+        cy.get('input[placeholder*="Appointment"], input[name="appointmentId"]').then(($in) => {
+            if ($in.length) {
+                cy.wrap($in[0]).clear().type('1');
+            } else {
+                cy.get('select[name="appointmentId"]').then(($sel) => {
+                    if ($sel.length) {
+                        cy.wrap($sel[0]).select('1');
+                    } else {
+                        cy.get('[data-testid="appointment-select-trigger"], [role="combobox"]').first().click();
+                        cy.get('[data-radix-select-collection-item], [role="option"]').first().click();
+                    }
+                });
+            }
+        });
+
         cy.contains('button', 'Save').click();
         cy.wait('@createReview', { timeout: 10000 });
-        cy.contains('Review created');
+        cy.contains('Review created', { timeout: 10000 });
     });
 });
 

--- a/frontend/cypress/support/api.ts
+++ b/frontend/cypress/support/api.ts
@@ -1,16 +1,37 @@
+export function interceptAppointmentsList() {
+  cy.intercept('GET', /\/(api\/)?appointments(?:\/)?(?:\?.*)?$/, {
+    statusCode: 200,
+    body: [
+      {
+        id: 1,
+        date: '2025-01-01T10:00:00.000Z',
+        status: 'COMPLETED',
+        customerId: 1,
+        employeeId: 1,
+        serviceId: 1,
+      },
+    ],
+  }).as('getAppointments');
+}
+
 export function interceptCreateReview() {
+  // Match both /appointments/:id/review and /reviews with optional /api prefix and query params
   cy.intercept(
-    { method: 'POST', url: /\/(api\/)?appointments\/\d+\/review(?:\/)?(?:\?.*)?$/ },
+    {
+      method: 'POST',
+      url: /\/(api\/)?(appointments\/\d+\/review|reviews)(?:\/)?(?:\?.*)?$/,
+    },
     {
       statusCode: 201,
       body: {
-        id: 2,
+        id: 1001,
         appointmentId: 1,
         rating: 5,
         comment: 'Great',
         employee: { id: 1, fullName: 'John Doe' },
         author: { id: 1, name: 'Test Client' },
       },
-    }
+    },
   ).as('createReview');
 }
+


### PR DESCRIPTION
## Summary
- add `interceptAppointmentsList` and expand `interceptCreateReview` to support multiple routes
- refactor reviews E2E test to use intercept helpers and defensively fill form fields
- reuse intercept helpers in dashboard client review test and wait for appointments before submitting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae2d99b1d483298f661bb216a238b1