### PR TITLE
test(e2e): add shared Cypress intercept helpers for appointments/reviews

### DIFF
--- a/frontend/cypress/support/api.ts
+++ b/frontend/cypress/support/api.ts
@@ -1,21 +1,42 @@
 export function interceptAppointmentsList() {
-  cy.intercept('GET', /\/(api\/)?appointments(?:\/)?(?:\?.*)?$/, {
-    statusCode: 200,
-    body: [
-      {
-        id: 1,
-        date: '2025-01-01T10:00:00.000Z',
-        status: 'COMPLETED',
-        customerId: 1,
-        employeeId: 1,
-        serviceId: 1,
-      },
-    ],
-  }).as('getAppointments');
+  cy.intercept(
+    { method: 'GET', url: /\/(api\/)?appointments(?:\/)?(?:\?.*)?$/ },
+    {
+      statusCode: 200,
+      body: [
+        {
+          id: 1,
+          date: '2025-01-01T10:00:00.000Z',
+          status: 'COMPLETED',
+          customerId: 1,
+          employeeId: 1,
+          serviceId: 1,
+        },
+      ],
+    },
+  ).as('getAppointments');
+}
+
+export function interceptReviewsList() {
+  cy.intercept(
+    { method: 'GET', url: /\/(api\/)?reviews(?:\/)?(?:\?.*)?$/ },
+    {
+      statusCode: 200,
+      body: [
+        {
+          id: 500,
+          appointmentId: 1,
+          rating: 5,
+          comment: 'Sample review',
+          employee: { id: 1, fullName: 'John Doe' },
+          author: { id: 1, name: 'Test Client' },
+        },
+      ],
+    },
+  ).as('getReviews');
 }
 
 export function interceptCreateReview() {
-  // Match both /appointments/:id/review and /reviews with optional /api prefix and query params
   cy.intercept(
     {
       method: 'POST',


### PR DESCRIPTION
## Summary
- add intercept helper for appointments list API responses
- add intercept helper for reviews list and review creation APIs

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ae337b2ad48329b70d846789ce8152