### PR TITLE
Restrict Cypress intercepts to API routes

### DIFF
--- a/frontend/cypress/support/api.ts
+++ b/frontend/cypress/support/api.ts
@@ -1,6 +1,9 @@
 export function interceptAppointmentsList() {
   cy.intercept(
-    { method: 'GET', url: /\/(api\/)?appointments(?:\/)?(?:\?.*)?$/ },
+    {
+      method: 'GET',
+      url: /\/api\/appointments(?:\/)?(?:\?.*)?$/,
+    },
     {
       statusCode: 200,
       body: [
@@ -19,7 +22,10 @@ export function interceptAppointmentsList() {
 
 export function interceptReviewsList() {
   cy.intercept(
-    { method: 'GET', url: /\/(api\/)?reviews(?:\/)?(?:\?.*)?$/ },
+    {
+      method: 'GET',
+      url: /\/api\/reviews(?:\/)?(?:\?.*)?$/,
+    },
     {
       statusCode: 200,
       body: [
@@ -40,7 +46,7 @@ export function interceptCreateReview() {
   cy.intercept(
     {
       method: 'POST',
-      url: /\/(api\/)?(appointments\/\d+\/review|reviews)(?:\/)?(?:\?.*)?$/,
+      url: /\/api\/(appointments\/\d+\/review|reviews)(?:\/)?(?:\?.*)?$/,
     },
     {
       statusCode: 201,


### PR DESCRIPTION
## Summary
- Ensure Cypress intercept helpers target only `/api/*` endpoints
- Prevent intercepts from matching non-API routes

## Testing
- `npm run e2e` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e2096408329b7707732e681d10c