### PR TITLE
Use data-testid selector for client review nav

### DIFF
--- a/frontend/cypress/e2e/dashboard-client.cy.ts
+++ b/frontend/cypress/e2e/dashboard-client.cy.ts
@@ -49,7 +49,7 @@ describe('client dashboard reviews crud', () => {
         interceptReviewsList();
         interceptCreateReview();
 
-        cy.contains('Reviews', { timeout: 10000 }).click();
+        cy.get('[data-testid="nav-reviews"]', { timeout: 10000 }).click();
         cy.wait('@getReviews', { timeout: 10000 });
 
         cy.contains('Add Review', { timeout: 10000 })


### PR DESCRIPTION
## Summary
- use data-testid to navigate to reviews in dashboard client e2e test

## Testing
- `npm run e2e` *(fails: dashboard-client.cy.ts, reviews.cy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f59387c8329948fc85e4fceeef3