### PR TITLE
test: wait for service select form

### DIFF
--- a/frontend/cypress/e2e/appointments.cy.ts
+++ b/frontend/cypress/e2e/appointments.cy.ts
@@ -16,8 +16,9 @@ describe('appointments', () => {
         cy.wait('@getAppointments');
 
         cy.get('[data-date]').first().click();
-
-        cy.get('[data-testid="service-select"]').click({ force: true });
+        cy.get('[data-testid="service-select"]', { timeout: 10000 })
+            .should('exist')
+            .click({ force: true });
         cy.get('[data-radix-collection-item]').contains('Color').click();
         cy.get('[data-testid="service-select"]').contains('Color');
     });


### PR DESCRIPTION
## Summary
- wait for service select to render before clicking in appointments e2e test

## Testing
- `npm test` *(fails: Cannot find module '@radix-ui/react-select')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aedf32b43883299fa957da74995282