### PR TITLE
test: wait for appointment modal

### DIFF
--- a/frontend/cypress/e2e/appointments.cy.ts
+++ b/frontend/cypress/e2e/appointments.cy.ts
@@ -15,8 +15,11 @@ describe('appointments', () => {
         cy.wait('@getServices');
         cy.wait('@getAppointments');
 
-        cy.get('[data-date]').first().click();
-        cy.get('[data-testid="service-select"]', { timeout: 10000 }).should('exist').click({ force: true });
+        cy.get('[data-date]').first().click({ force: true });
+        cy.get('[role="dialog"]', { timeout: 10000 }).should('be.visible');
+        cy.get('[role="dialog"] form [data-testid="service-select"]')
+            .should('be.visible')
+            .click({ force: true });
         cy.get('[data-radix-collection-item]').contains('Color').click();
         cy.get('[data-testid="service-select"]').contains('Color');
     });

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -19,7 +19,10 @@ export default function Modal({ open, onClose, children }: Props) {
 
     return (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
-            <div className="bg-white p-4 rounded shadow min-w-[300px]">
+            <div
+                role="dialog"
+                className="bg-white p-4 rounded shadow min-w-[300px]"
+            >
                 {children}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- ensure appointment tests wait for modal by selecting service only after dialog appears
- mark modal container with `role="dialog"`

## Testing
- `npm run e2e` *(fails: Expected to find element `[role="dialog"]` in `appointments.cy.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68aef860d0f083298a4e6dd3e57170a3