### PR TITLE
Ensure service modal visible for appointment selection

### DIFF
--- a/frontend/cypress/e2e/appointments.cy.ts
+++ b/frontend/cypress/e2e/appointments.cy.ts
@@ -14,9 +14,10 @@ describe('appointments', () => {
         cy.wait('@profile');
         cy.wait('@getServices');
         cy.wait('@getAppointments');
-
-        cy.get('[data-date]').first().click();
-        cy.get('[data-testid="service-select"]', { timeout: 10000 }).should('exist').click({ force: true });
+        cy.get('[data-date]').first().click({ force: true });
+        cy.get('form [data-testid="service-select"]', { timeout: 10000 })
+            .should('be.visible')
+            .click({ force: true });
         cy.get('[data-radix-collection-item]').contains('Color').click();
         cy.get('[data-testid="service-select"]').contains('Color');
     });


### PR DESCRIPTION
## Summary
- force calendar day click in appointments Cypress test
- wait for service selection modal to be visible before interacting

## Testing
- `npm run e2e` *(fails: Timed out retrying after 10000ms: Expected to find element: `form [data-testid="service-select"]`, but never found it.)*

------
https://chatgpt.com/codex/tasks/task_e_68aef4d58fa483298ada4a632f2d4029