### PR TITLE
style: improve StatsWidget formatting

### DIFF
--- a/frontend/src/components/StatsWidget.tsx
+++ b/frontend/src/components/StatsWidget.tsx
@@ -8,11 +8,19 @@ export default function StatsWidget({ title, value, loading }: Props) {
     return (
         <div className="w-full p-4 sm:p-6 bg-white rounded shadow">
             {loading ? (
-                <div role="status" className="h-6 bg-gray-200 animate-pulse rounded" />
+                <div
+                    role="status"
+                    className="h-6 bg-gray-200 animate-pulse rounded"
+                />
             ) : (
                 <>
-                    <div className="text-xs sm:text-sm text-gray-500">{title}</div>
-                    <div data-testid="value" className="text-xl sm:text-2xl font-bold">
+                    <div className="text-xs sm:text-sm text-gray-500">
+                        {title}
+                    </div>
+                    <div
+                        data-testid="value"
+                        className="text-xl sm:text-2xl font-bold"
+                    >
                         {value}
                     </div>
                 </>


### PR DESCRIPTION
## Summary
- reformat StatsWidget attributes and value layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0280115688329828d5aa19aa40e9e