### PR TITLE
feat: display upcoming appointments on admin dashboard

### DIFF
--- a/frontend/src/components/AppointmentListItem.tsx
+++ b/frontend/src/components/AppointmentListItem.tsx
@@ -1,0 +1,22 @@
+import { Appointment } from '@/types';
+
+interface Props {
+    appointment: Appointment;
+}
+
+export default function AppointmentListItem({ appointment }: Props) {
+    return (
+        <li className="border p-2">
+            <div>{new Date(appointment.startTime).toLocaleString()}</div>
+            <div className="text-sm text-gray-500">
+                {appointment.client?.name}
+            </div>
+            <div className="text-sm text-gray-500">
+                {appointment.service?.name}
+            </div>
+            <div className="text-sm text-gray-500">
+                {appointment.employee?.fullName}
+            </div>
+        </li>
+    );
+}

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -25,5 +25,5 @@ export function useDashboard() {
         };
     }, [apiFetch]);
 
-    return { data, loading };
+    return { data, upcoming: data?.upcoming ?? [], loading };
 }

--- a/frontend/src/pages/dashboard/admin/index.tsx
+++ b/frontend/src/pages/dashboard/admin/index.tsx
@@ -2,9 +2,10 @@ import RouteGuard from '@/components/RouteGuard';
 import DashboardLayout from '@/components/DashboardLayout';
 import StatsWidget from '@/components/StatsWidget';
 import { useDashboard } from '@/hooks/useDashboard';
+import AppointmentListItem from '@/components/AppointmentListItem';
 
 export default function AdminDashboard() {
-    const { data, loading } = useDashboard();
+    const { data, loading, upcoming } = useDashboard();
     return (
         <RouteGuard roles={['admin']}>
             <DashboardLayout>
@@ -25,6 +26,11 @@ export default function AdminDashboard() {
                         loading={loading}
                     />
                 </div>
+                <ul className="mt-4 space-y-2">
+                    {upcoming.slice(0, 5).map((a) => (
+                        <AppointmentListItem key={a.id} appointment={a} />
+                    ))}
+                </ul>
             </DashboardLayout>
         </RouteGuard>
     );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,6 +16,8 @@ export interface Appointment {
     id: number;
     startTime: string;
     client?: Client;
+    service?: Service;
+    employee?: Employee;
     paymentStatus?: string;
 }
 


### PR DESCRIPTION
## Summary
- add `AppointmentListItem` to show appointment date, client, service, and employee
- surface `upcoming` appointments from `useDashboard` and render the first five on the admin dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03dce20a0832981c09686fa17036a