### PR TITLE
Add admin dashboard shortcuts

### DIFF
--- a/frontend/src/components/ShortcutCard.tsx
+++ b/frontend/src/components/ShortcutCard.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface Props {
+    href: string;
+    icon: ReactNode;
+    label: string;
+}
+
+export default function ShortcutCard({ href, icon, label }: Props) {
+    return (
+        <Link
+            href={href}
+            className="flex flex-col items-center justify-center p-4 bg-white rounded shadow hover:bg-gray-50"
+        >
+            <div className="text-3xl">{icon}</div>
+            <div className="mt-2 text-sm font-medium text-center">{label}</div>
+        </Link>
+    );
+}

--- a/frontend/src/pages/dashboard/admin/index.tsx
+++ b/frontend/src/pages/dashboard/admin/index.tsx
@@ -3,6 +3,7 @@ import DashboardLayout from '@/components/DashboardLayout';
 import StatsWidget from '@/components/StatsWidget';
 import { useDashboard } from '@/hooks/useDashboard';
 import AppointmentListItem from '@/components/AppointmentListItem';
+import ShortcutCard from '@/components/ShortcutCard';
 
 export default function AdminDashboard() {
     const { data, loading, upcoming } = useDashboard();
@@ -25,6 +26,21 @@ export default function AdminDashboard() {
                         value={data?.todayCount ?? null}
                         loading={loading}
                     />
+                </div>
+                <div className="mt-4 grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-5">
+                    <ShortcutCard
+                        href="/employees"
+                        icon="👥"
+                        label="Employees"
+                    />
+                    <ShortcutCard href="/services" icon="✂️" label="Services" />
+                    <ShortcutCard
+                        href="/appointments"
+                        icon="📅"
+                        label="Appointments"
+                    />
+                    <ShortcutCard href="/clients" icon="🧑" label="Clients" />
+                    <ShortcutCard href="/products" icon="🛍️" label="Products" />
                 </div>
                 <ul className="mt-4 space-y-2">
                     {upcoming.slice(0, 5).map((a) => (


### PR DESCRIPTION
## Summary
- add reusable ShortcutCard component for dashboard links
- display shortcut grid linking to key admin pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0428942ec8329ae4c072c85d061d7