### PR TITLE
feat: add dashboard summary endpoint

### DIFF
--- a/backend/salonbw-backend/openapi.json
+++ b/backend/salonbw-backend/openapi.json
@@ -942,6 +942,33 @@
           "commissions"
         ]
       }
+    },
+    "/dashboard": {
+      "get": {
+        "operationId": "DashboardController_getSummary",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSummaryDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get dashboard summary",
+        "tags": [
+          "dashboard"
+        ]
+      }
     }
   },
   "info": {
@@ -1155,6 +1182,38 @@
       "Commission": {
         "type": "object",
         "properties": {}
+      },
+      "DashboardSummaryDto": {
+        "type": "object",
+        "properties": {
+          "clientCount": {
+            "type": "number",
+            "description": "Total number of clients",
+            "example": 42
+          },
+          "employeeCount": {
+            "type": "number",
+            "description": "Total number of employees",
+            "example": 7
+          },
+          "todayAppointments": {
+            "type": "number",
+            "description": "Number of appointments scheduled for today",
+            "example": 5
+          },
+          "upcomingAppointments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Appointment"
+            }
+          }
+        },
+        "required": [
+          "clientCount",
+          "employeeCount",
+          "todayAppointments",
+          "upcomingAppointments"
+        ]
       }
     }
   }

--- a/backend/salonbw-backend/src/app.module.ts
+++ b/backend/salonbw-backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { CommissionsModule } from './commissions/commissions.module';
 import { LogsModule } from './logs/logs.module';
 import { ChatModule } from './chat/chat.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
     imports: [
@@ -42,6 +43,7 @@ import { NotificationsModule } from './notifications/notifications.module';
         LogsModule,
         ChatModule,
         NotificationsModule,
+        DashboardModule,
     ],
     controllers: [AppController, HealthController],
     providers: [AppService],

--- a/backend/salonbw-backend/src/dashboard/dashboard.controller.ts
+++ b/backend/salonbw-backend/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+    ApiBearerAuth,
+    ApiOperation,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '../users/role.enum';
+import { DashboardService } from './dashboard.service';
+import { DashboardSummaryDto } from './dto/dashboard-summary.dto';
+
+@ApiTags('dashboard')
+@Controller('dashboard')
+export class DashboardController {
+    constructor(private readonly dashboardService: DashboardService) {}
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Employee, Role.Admin)
+    @Get()
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get dashboard summary' })
+    @ApiResponse({ status: 200, type: DashboardSummaryDto })
+    getSummary(): Promise<DashboardSummaryDto> {
+        return this.dashboardService.getSummary();
+    }
+}

--- a/backend/salonbw-backend/src/dashboard/dashboard.module.ts
+++ b/backend/salonbw-backend/src/dashboard/dashboard.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/user.entity';
+import { Appointment } from '../appointments/appointment.entity';
+import { DashboardService } from './dashboard.service';
+import { DashboardController } from './dashboard.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([User, Appointment])],
+    providers: [DashboardService],
+    controllers: [DashboardController],
+})
+export class DashboardModule {}

--- a/backend/salonbw-backend/src/dashboard/dashboard.service.ts
+++ b/backend/salonbw-backend/src/dashboard/dashboard.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, MoreThan } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Role } from '../users/role.enum';
+import {
+    Appointment,
+    AppointmentStatus,
+} from '../appointments/appointment.entity';
+import { DashboardSummaryDto } from './dto/dashboard-summary.dto';
+
+@Injectable()
+export class DashboardService {
+    constructor(
+        @InjectRepository(User)
+        private readonly usersRepository: Repository<User>,
+        @InjectRepository(Appointment)
+        private readonly appointmentsRepository: Repository<Appointment>,
+    ) {}
+
+    async getSummary(): Promise<DashboardSummaryDto> {
+        const clientCount = await this.usersRepository.count({
+            where: { role: Role.Client },
+        });
+        const employeeCount = await this.usersRepository.count({
+            where: { role: Role.Employee },
+        });
+
+        const now = new Date();
+        const startOfDay = new Date(now);
+        startOfDay.setHours(0, 0, 0, 0);
+        const endOfDay = new Date(now);
+        endOfDay.setHours(23, 59, 59, 999);
+
+        const todayAppointments = await this.appointmentsRepository.count({
+            where: {
+                startTime: Between(startOfDay, endOfDay),
+                status: AppointmentStatus.Scheduled,
+            },
+        });
+
+        const upcomingAppointments = await this.appointmentsRepository.find({
+            where: {
+                startTime: MoreThan(now),
+                status: AppointmentStatus.Scheduled,
+            },
+            order: { startTime: 'ASC' },
+            take: 5,
+        });
+
+        return {
+            clientCount,
+            employeeCount,
+            todayAppointments,
+            upcomingAppointments,
+        };
+    }
+}

--- a/backend/salonbw-backend/src/dashboard/dto/dashboard-summary.dto.ts
+++ b/backend/salonbw-backend/src/dashboard/dto/dashboard-summary.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Appointment } from '../../appointments/appointment.entity';
+
+export class DashboardSummaryDto {
+    @ApiProperty({ description: 'Total number of clients', example: 42 })
+    clientCount: number;
+
+    @ApiProperty({ description: 'Total number of employees', example: 7 })
+    employeeCount: number;
+
+    @ApiProperty({
+        description: 'Number of appointments scheduled for today',
+        example: 5,
+    })
+    todayAppointments: number;
+
+    @ApiProperty({ type: Appointment, isArray: true })
+    upcomingAppointments: Appointment[];
+}

--- a/backend/salonbw-backend/swagger.ts
+++ b/backend/salonbw-backend/swagger.ts
@@ -21,103 +21,117 @@ import { FormulasService } from './src/formulas/formulas.service';
 import { CommissionsController } from './src/commissions/commissions.controller';
 import { CommissionsService } from './src/commissions/commissions.service';
 import { LogService } from './src/logs/log.service';
+import { DashboardController } from './src/dashboard/dashboard.controller';
+import { DashboardService } from './src/dashboard/dashboard.service';
 
 @Module({
-  controllers: [
-    AppController,
-    HealthController,
-    UsersController,
-    AuthController,
-    AppointmentsController,
-    ServicesController,
-    ProductsController,
-    AppointmentFormulasController,
-    ClientFormulasController,
-    CommissionsController,
-  ],
-  providers: [
-    AppService,
-    {
-      provide: UsersService,
-      useValue: {
-        findByEmail: async () => null,
-        findById: async () => ({ id: 0, role: 'Client' }),
-        createUser: async () => ({ id: 0, role: 'Client' }),
-      },
-    },
-    {
-      provide: AuthService,
-      useValue: {
-        login: () => ({}),
-        refresh: () => ({}),
-      },
-    },
-    {
-      provide: AppointmentsService,
-      useValue: {
-        create: () => ({}),
-        findForUser: () => [],
-        findOne: () => ({}),
-        cancel: () => ({}),
-        completeAppointment: () => ({}),
-      },
-    },
-    {
-      provide: ServicesService,
-      useValue: {
-        create: () => ({}),
-        findAll: () => [],
-        findOne: () => ({}),
-        update: () => ({}),
-        remove: () => undefined,
-      },
-    },
-    {
-      provide: ProductsService,
-      useValue: {
-        create: () => ({}),
-        findAll: () => [],
-        findOne: () => ({}),
-        update: () => ({}),
-        remove: () => undefined,
-      },
-    },
-    {
-      provide: FormulasService,
-      useValue: {
-        addToAppointment: () => ({}),
-        findForClient: () => [],
-      },
-    },
-    {
-      provide: CommissionsService,
-      useValue: {
-        findForUser: () => [],
-        findAll: () => [],
-      },
-    },
-    {
-      provide: LogService,
-      useValue: {
-        logAction: () => undefined,
-        findAll: () => ({ data: [], total: 0, page: 1, limit: 0 }),
-      },
-    },
-  ],
+    controllers: [
+        AppController,
+        HealthController,
+        UsersController,
+        AuthController,
+        AppointmentsController,
+        ServicesController,
+        ProductsController,
+        AppointmentFormulasController,
+        ClientFormulasController,
+        CommissionsController,
+        DashboardController,
+    ],
+    providers: [
+        AppService,
+        {
+            provide: UsersService,
+            useValue: {
+                findByEmail: async () => null,
+                findById: async () => ({ id: 0, role: 'Client' }),
+                createUser: async () => ({ id: 0, role: 'Client' }),
+            },
+        },
+        {
+            provide: AuthService,
+            useValue: {
+                login: () => ({}),
+                refresh: () => ({}),
+            },
+        },
+        {
+            provide: AppointmentsService,
+            useValue: {
+                create: () => ({}),
+                findForUser: () => [],
+                findOne: () => ({}),
+                cancel: () => ({}),
+                completeAppointment: () => ({}),
+            },
+        },
+        {
+            provide: ServicesService,
+            useValue: {
+                create: () => ({}),
+                findAll: () => [],
+                findOne: () => ({}),
+                update: () => ({}),
+                remove: () => undefined,
+            },
+        },
+        {
+            provide: ProductsService,
+            useValue: {
+                create: () => ({}),
+                findAll: () => [],
+                findOne: () => ({}),
+                update: () => ({}),
+                remove: () => undefined,
+            },
+        },
+        {
+            provide: FormulasService,
+            useValue: {
+                addToAppointment: () => ({}),
+                findForClient: () => [],
+            },
+        },
+        {
+            provide: CommissionsService,
+            useValue: {
+                findForUser: () => [],
+                findAll: () => [],
+            },
+        },
+        {
+            provide: LogService,
+            useValue: {
+                logAction: () => undefined,
+                findAll: () => ({ data: [], total: 0, page: 1, limit: 0 }),
+            },
+        },
+        {
+            provide: DashboardService,
+            useValue: {
+                getSummary: () => ({
+                    clientCount: 0,
+                    employeeCount: 0,
+                    todayAppointments: 0,
+                    upcomingAppointments: [],
+                }),
+            },
+        },
+    ],
 })
 class SwaggerAppModule {}
 
 async function generate() {
-  const app = await NestFactory.create(SwaggerAppModule, { logger: false });
-  const config = new DocumentBuilder()
-    .setTitle('SalonBW API')
-    .setDescription('The SalonBW API description')
-    .setVersion('1.0')
-    .addBearerAuth()
-    .build();
-  const document = SwaggerModule.createDocument(app, config);
-  writeFileSync('openapi.json', JSON.stringify(document, null, 2) + '\n');
-  await app.close();
+    const app = await NestFactory.create(SwaggerAppModule, { logger: false });
+    const config = new DocumentBuilder()
+        .setTitle('SalonBW API')
+        .setDescription('The SalonBW API description')
+        .setVersion('1.0')
+        .addBearerAuth()
+        .build();
+    const document = SwaggerModule.createDocument(app, config);
+    writeFileSync('openapi.json', JSON.stringify(document, null, 2) + '\n');
+    await app.close();
 }
 
 void generate();


### PR DESCRIPTION
## Summary
- add dashboard module with service, controller, and DTO exposing counts and upcoming appointments
- register `/dashboard` route and openapi docs
- include stub in swagger generator and module wiring

## Testing
- `npm test`
- `npx eslint "src/dashboard/**/*.ts" "src/app.module.ts" --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b051fbd0788329b222f03a2f430618