### PR TITLE
feat: add cors origin fallback

### DIFF
--- a/backend/salonbw-backend/src/main.ts
+++ b/backend/salonbw-backend/src/main.ts
@@ -27,7 +27,7 @@ async function bootstrap() {
         SwaggerModule.setup('api/docs', app, document);
     }
     app.enableCors({
-        origin: config.get<string>('FRONTEND_URL'),
+        origin: config.get<string>('FRONTEND_URL') ?? true,
         credentials: true,
     });
     await app.listen(config.get<number>('PORT') ?? 3000);


### PR DESCRIPTION
## Summary
- use environment variable FRONTEND_URL with a default true fallback for CORS

## Testing
- `npm test`
- `npm run build` *(fails: Module '@nestjs/websockets' has no exported member 'WebSocketModule')*


------
https://chatgpt.com/codex/tasks/task_e_68b2e19e3e348329b9a75e59dd393f1b