### PR TITLE
refactor: remove console.error from API client

### DIFF
--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -133,14 +133,6 @@ export class ApiClient {
             return res.data;
         } catch (error: unknown) {
             const err = error as AxiosError<unknown>;
-            if (process.env.NODE_ENV !== 'production') {
-                // Avoid leaking details in production console
-                // eslint-disable-next-line no-console
-                console.error(
-                    'API request failed',
-                    err.response?.data || err.message,
-                );
-            }
             throw this.createError(err);
         }
     }


### PR DESCRIPTION
## Summary
- remove console.error from API client to satisfy lint rules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b360480e5883298d2b8f9a7a3eecdd