### PR TITLE
⚡ Optimize test data seeding for clients

### DIFF
--- a/backend/salonbw-backend/scripts/seed-test-data.ts
+++ b/backend/salonbw-backend/scripts/seed-test-data.ts
@@ -86,7 +86,7 @@ async function seed() {
                 password: passwordHash,
                 gender: Math.random() > 0.5 ? Gender.Female : Gender.Male,
                 createdAt: subDays(new Date(), Math.floor(Math.random() * 180)),
-            } as any) as User;
+            } as any) as unknown as User;
             newClientsToCreate.push(newClient);
         }
     }
@@ -153,7 +153,7 @@ async function seed() {
             paymentMethod,
             finalizedAt,
             notes: Math.random() > 0.8 ? 'Notatka do wizyty testowej' : null,
-        } as any);
+        } as any) as unknown as Appointment;
 
         await appointmentRepo.save(appointment);
         appointments.push(appointment);
@@ -169,7 +169,7 @@ async function seed() {
                 amount: commissionAmount,
                 percent: commissionPercent,
                 createdAt: finalizedAt || startTime,
-            } as any);
+            } as any) as unknown as Commission;
             await commissionRepo.save(commission);
         }
 
@@ -190,7 +190,7 @@ async function seed() {
                     'Na pewno wrócę',
                     'Polecam każdemu'
                 ][Math.floor(Math.random() * 8)],
-            } as any);
+            } as any) as unknown as Review;
             await reviewRepo.save(review);
         }
     }

--- a/backend/salonbw-backend/scripts/seed-test-data.ts
+++ b/backend/salonbw-backend/scripts/seed-test-data.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { DataSource } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import { config as loadEnv } from 'dotenv';
 import { User, Gender } from '../src/users/user.entity';
 import { Role } from '../src/users/role.enum';
@@ -69,22 +69,39 @@ async function seed() {
         { name: 'Monika Kozłowska', email: 'monika.k@test.pl', phone: '500100114' },
     ];
 
-    const clients: User[] = [];
+    const emails = clientsData.map((c) => c.email);
+    const existingClients = await userRepo.find({
+        where: { email: In(emails) },
+    });
+    const existingClientsMap = new Map(existingClients.map((c) => [c.email, c]));
+
+    const passwordHash = await bcrypt.hash('test123', 10);
+    const newClientsToCreate: User[] = [];
+
     for (const clientData of clientsData) {
-        let client = await userRepo.findOne({ where: { email: clientData.email } });
-        if (!client) {
+        if (!existingClientsMap.has(clientData.email)) {
             const newClient = userRepo.create({
                 ...clientData,
                 role: Role.Client,
-                password: await bcrypt.hash('test123', 10),
+                password: passwordHash,
                 gender: Math.random() > 0.5 ? Gender.Female : Gender.Male,
                 createdAt: subDays(new Date(), Math.floor(Math.random() * 180)),
             } as any);
-            const saved = await userRepo.save(newClient);
-            client = Array.isArray(saved) ? saved[0] : saved;
+            newClientsToCreate.push(newClient);
         }
-        if (client) clients.push(client);
     }
+
+    if (newClientsToCreate.length > 0) {
+        const savedNewClients = await userRepo.save(newClientsToCreate);
+        const savedArray = Array.isArray(savedNewClients)
+            ? savedNewClients
+            : [savedNewClients];
+        savedArray.forEach((c) => existingClientsMap.set(c.email, c));
+    }
+
+    const clients = clientsData
+        .map((c) => existingClientsMap.get(c.email))
+        .filter((c): c is User => !!c);
     console.log(`✅ ${clients.length} clients ready`);
 
     // Create appointments for last 3 months

--- a/backend/salonbw-backend/scripts/seed-test-data.ts
+++ b/backend/salonbw-backend/scripts/seed-test-data.ts
@@ -86,7 +86,7 @@ async function seed() {
                 password: passwordHash,
                 gender: Math.random() > 0.5 ? Gender.Female : Gender.Male,
                 createdAt: subDays(new Date(), Math.floor(Math.random() * 180)),
-            } as any);
+            } as any) as User;
             newClientsToCreate.push(newClient);
         }
     }


### PR DESCRIPTION
💡 **What:** Optimized the client seeding part of `seed-test-data.ts`.
- Replaced individual `findOne` calls with a single bulk query using the `In` operator.
- Replaced individual `save` calls with a single bulk `save`.
- Moved `bcrypt.hash` outside the loop to avoid redundant expensive computations.
- Used a Map for fast lookups by email.

🎯 **Why:** The original code had an N+1 query pattern and performed expensive hashing in each iteration, which would slow down seeding as the number of clients grew.

📊 **Measured Improvement:** While a quantitative baseline was impractical to measure in the current environment due to lack of DB access, the improvement is theoretically significant:
- Database roundtrips for client seeding reduced from O(N) to O(1).
- CPU-intensive bcrypt hashing reduced from O(N) to O(1).
- Client lookups reduced from O(N^2) total (for findOne in loop) to O(N).

---
*PR created automatically by Jules for task [11236865430807246035](https://jules.google.com/task/11236865430807246035) started by @gniewkob*