### PR TITLE
⚡ optimize test data seeding queries

### DIFF
--- a/backend/salonbw-backend/scripts/seed-test-data.ts
+++ b/backend/salonbw-backend/scripts/seed-test-data.ts
@@ -157,46 +157,60 @@ async function seed() {
             notes: Math.random() > 0.8 ? 'Notatka do wizyty testowej' : null,
         } as any);
 
-        await appointmentRepo.save(appointment);
         appointments.push(appointment);
+    }
 
-        // Create commission for completed appointments
-        if (status === AppointmentStatus.Completed) {
-            const commissionPercent = employee.commissionBase || 30;
-            const commissionAmount = ((paidAmount || 0) * commissionPercent) / 100;
+    // Bulk save appointments
+    const savedAppointments = await appointmentRepo.save(appointments);
+
+    const commissions: any[] = [];
+    const reviews: any[] = [];
+
+    for (const appointment of savedAppointments) {
+        if (appointment.status === AppointmentStatus.Completed) {
+            const commissionPercent = appointment.employee.commissionBase || 30;
+            const commissionAmount = ((appointment.paidAmount || 0) * commissionPercent) / 100;
             
             const commission = commissionRepo.create({
-                employee,
+                employee: appointment.employee,
                 appointment,
                 amount: commissionAmount,
                 percent: commissionPercent,
-                createdAt: finalizedAt || startTime,
+                createdAt: appointment.finalizedAt || appointment.startTime,
             } as any);
-            await commissionRepo.save(commission);
-        }
+            commissions.push(commission);
 
-        // Create review for some completed appointments (35%)
-        if (status === AppointmentStatus.Completed && Math.random() < 0.35) {
-            const review = reviewRepo.create({
-                appointment,
-                client,
-                employee,
-                rating: 3 + Math.floor(Math.random() * 3), // 3-5 stars
-                comment: [
-                    'Świetna obsługa!',
-                    'Bardzo polecam',
-                    'Profesjonalnie wykonana usługa',
-                    'Miła atmosfera',
-                    'Jestem zadowolona',
-                    'Super fryzura!',
-                    'Na pewno wrócę',
-                    'Polecam każdemu'
-                ][Math.floor(Math.random() * 8)],
-            } as any);
-            await reviewRepo.save(review);
+            if (Math.random() < 0.35) {
+                const review = reviewRepo.create({
+                    appointment,
+                    client: appointment.client,
+                    employee: appointment.employee,
+                    rating: 3 + Math.floor(Math.random() * 3), // 3-5 stars
+                    comment: [
+                        'Świetna obsługa!',
+                        'Bardzo polecam',
+                        'Profesjonalnie wykonana usługa',
+                        'Miła atmosfera',
+                        'Jestem zadowolona',
+                        'Super fryzura!',
+                        'Na pewno wrócę',
+                        'Polecam każdemu'
+                    ][Math.floor(Math.random() * 8)],
+                } as any);
+                reviews.push(review);
+            }
         }
     }
-    console.log(`✅ Created ${appointments.length} appointments with commissions and reviews`);
+
+    // Bulk save commissions and reviews
+    if (commissions.length > 0) {
+        await commissionRepo.save(commissions);
+    }
+    if (reviews.length > 0) {
+        await reviewRepo.save(reviews);
+    }
+
+    console.log(`✅ Created ${savedAppointments.length} appointments with ${commissions.length} commissions and ${reviews.length} reviews`);
 
     // Summary stats
     const completedAppointments = appointments.filter((a: any) => a.status === AppointmentStatus.Completed).length;


### PR DESCRIPTION
💡 **What:** 
The optimization implemented involves moving TypeORM repository `save()` operations outside of the generation loop. Appointments, Commissions, and Reviews are now collected into arrays and bulk-inserted once, reducing total queries generated for 200 appointments from over ~600 single insertions down to 3 bulk inserts.

🎯 **Why:** 
The performance problem it solves is an O(N) database insertion bottleneck (often called the N+1 problem on the write side), which significantly slows down execution times since it required round trips to the database for every single test appointment and its associated records generated.

📊 **Measured Improvement:** 
I was unable to show a direct performance execution improvement due to external Docker Hub unauthenticated rate limits on the postgres:15 image preventing me from bringing up a local database to establish a benchmark. However, theoretically speaking, shifting 600 single database queries over the network to 3 bulk query inserts resolves standard relational network IO bottlenecks and substantially improves execution times of the script.

---
*PR created automatically by Jules for task [13134728102128611544](https://jules.google.com/task/13134728102128611544) started by @gniewkob*