### PR TITLE
fix(landing): navbar solid on subpages, global custom cursor

### DIFF
--- a/apps/landing/src/components/Navbar.tsx
+++ b/apps/landing/src/components/Navbar.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { trackEvent } from '@/utils/analytics';
 import type { Route } from 'next';
 import { useAuth } from '@/contexts/AuthContext';
@@ -10,6 +11,8 @@ import { BUSINESS_INFO } from '@/config/content';
 
 export default function Navbar() {
     const { role, initialized, logout } = useAuth();
+    const router = useRouter();
+    const isHomePage = router.pathname === '/';
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
     const [scrolled, setScrolled] = useState(false);
 
@@ -18,6 +21,8 @@ export default function Navbar() {
     const bookingUrl = getPanelUrl(`/auth/login?redirect=${encodeURIComponent('/appointments')}`);
     const effectiveRole = initialized ? role : null;
     const dashboardRoute = effectiveRole ? panelDashboard : undefined;
+
+    const transparent = isHomePage && !scrolled;
 
     useEffect(() => {
         const onScroll = () => setScrolled(window.scrollY > 60);
@@ -47,7 +52,7 @@ export default function Navbar() {
     }, [mobileMenuOpen]);
 
     const navLinkClass = `transition duration-200 text-sm tracking-wide font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 ${
-        scrolled ? 'text-gray-800 hover:text-[#c5a880]' : 'text-white/90 hover:text-[#c5a880]'
+        transparent ? 'text-white/90 hover:text-[#c5a880]' : 'text-gray-800 hover:text-[#c5a880]'
     }`;
 
     return (
@@ -55,10 +60,10 @@ export default function Navbar() {
             aria-label="Nawigacja główna"
             className="sticky top-0 z-50 transition-all duration-400"
             style={{
-                background: scrolled ? 'rgba(255,255,255,0.97)' : 'transparent',
-                backdropFilter: scrolled ? 'blur(12px)' : 'none',
-                boxShadow: scrolled ? '0 1px 24px rgba(0,0,0,0.10)' : 'none',
-                borderBottom: scrolled ? '1px solid rgba(0,0,0,0.06)' : '1px solid transparent',
+                background: transparent ? 'transparent' : 'rgba(255,255,255,0.97)',
+                backdropFilter: transparent ? 'none' : 'blur(12px)',
+                boxShadow: transparent ? 'none' : '0 1px 24px rgba(0,0,0,0.10)',
+                borderBottom: transparent ? '1px solid transparent' : '1px solid rgba(0,0,0,0.06)',
             }}
         >
             <div className="container mx-auto px-4 md:px-8">
@@ -79,7 +84,7 @@ export default function Navbar() {
                             style={{
                                 height: '48px',
                                 width: 'auto',
-                                filter: scrolled ? 'none' : 'brightness(0) invert(1)',
+                                filter: transparent ? 'brightness(0) invert(1)' : 'none',
                                 transition: 'filter 0.3s',
                             }}
                         />
@@ -134,7 +139,7 @@ export default function Navbar() {
                         aria-expanded={mobileMenuOpen}
                         aria-controls="mobile-menu"
                     >
-                        <svg className="w-6 h-6" style={{ color: scrolled ? '#0d0d0d' : '#ffffff' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg className="w-6 h-6" style={{ color: transparent ? '#ffffff' : '#0d0d0d' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             {mobileMenuOpen ? (
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                             ) : (

--- a/apps/landing/src/components/Navbar.tsx
+++ b/apps/landing/src/components/Navbar.tsx
@@ -60,7 +60,7 @@ export default function Navbar() {
             aria-label="Nawigacja główna"
             className="sticky top-0 z-50 transition-all duration-400"
             style={{
-                background: transparent ? 'transparent' : 'rgba(255,255,255,0.97)',
+                background: transparent ? 'linear-gradient(to bottom, rgba(0,0,0,0.45) 0%, transparent 100%)' : 'rgba(255,255,255,0.97)',
                 backdropFilter: transparent ? 'none' : 'blur(12px)',
                 boxShadow: transparent ? 'none' : '0 1px 24px rgba(0,0,0,0.10)',
                 borderBottom: transparent ? '1px solid transparent' : '1px solid rgba(0,0,0,0.06)',

--- a/apps/landing/src/pages/_app.tsx
+++ b/apps/landing/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import { ToastProvider } from '@/contexts/ToastContext';
 import '@/styles/globals.css';
 import RouteProgress from '@/components/RouteProgress';
+import CustomCursor from '@/components/CustomCursor';
 import { playfair, openSans, tangerine } from '@/lib/fonts';
 import { initSentry } from '@/sentry.client';
 import {
@@ -116,6 +117,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
                         </>
                     )}
                     <RouteProgress />
+                    <CustomCursor />
                     <BookNowFab />
                     <Component {...pageProps} />
                 </ToastProvider>

--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -11,7 +11,6 @@ import { getPanelUrl } from '@/utils/panelUrl';
 import SplitHero from '@/components/SplitHero';
 import GoldTicker from '@/components/GoldTicker';
 import StatsBar from '@/components/StatsBar';
-import CustomCursor from '@/components/CustomCursor';
 import ScrollReveal from '@/components/ScrollReveal';
 import FounderMessage from '@/components/FounderMessage';
 import HistoryAccordion from '@/components/HistoryAccordion';
@@ -99,8 +98,6 @@ export default function HomePage({ founder, historyItems, coreValues, galleryIma
             </Script>
 
             <div>
-                <CustomCursor />
-
                 {/* 1. Diagonal split hero */}
                 <SplitHero />
 


### PR DESCRIPTION
## Summary

- **Navbar invisible on subpages**: The navbar was always transparent (white logo/text on white page background). Fixed by introducing `transparent = isHomePage && !scrolled` — only the home page gets a see-through navbar at the top; all other pages always render the solid white bar.
- **Custom cursor disappearing on subpages**: `CustomCursor` was only mounted inside `index.tsx`. Moved to `_app.tsx` so it persists across all routes.
- **index.tsx cleanup**: Removed the now-duplicate `CustomCursor` import and JSX.

## Test plan

- [ ] Home page at scroll 0: transparent navbar, white logo/links visible over dark hero
- [ ] Home page scrolled >60px: solid white navbar appears
- [ ] Any subpage (/services, /gallery, /contact): solid white navbar with dark logo/links on load and on scroll
- [ ] Custom cursor (gold dot + lagging ring) visible on all pages, not just home

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_