### PR TITLE
fix(landing): mobile responsiveness — full-width hero & brand FAB

### DIFF
--- a/apps/landing/src/components/BookNowFab.tsx
+++ b/apps/landing/src/components/BookNowFab.tsx
@@ -23,7 +23,8 @@ export default function BookNowFab() {
             <a
                 href={bookingUrl}
                 onClick={() => trackEvent('begin_checkout', { cta: 'fab' })}
-                className="px-4 py-3 rounded-full shadow-lg bg-blue-600 text-white font-semibold"
+                className="btn-gold px-5 py-3.5 text-xs font-semibold uppercase shadow-lg"
+                style={{ color: '#fff', borderRadius: '2px', letterSpacing: '0.14em' }}
                 aria-label="Umów wizytę"
             >
                 Umów wizytę

--- a/apps/landing/src/components/PublicLayout.tsx
+++ b/apps/landing/src/components/PublicLayout.tsx
@@ -11,7 +11,7 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
                 Przejdź do treści głównej
             </a>
             <Navbar />
-            <main id="main-content" className="flex-1 p-4">
+            <main id="main-content" className="flex-1">
                 {children}
             </main>
             <Footer />


### PR DESCRIPTION
## Summary

- **PublicLayout**: removed `p-4` from `<main>` — the 16px wrapper padding was preventing `SplitHero` (and every other full-bleed section) from being edge-to-edge on all screen sizes. Each section already carries its own `container mx-auto px-4` padding, so subpages are unaffected.
- **BookNowFab**: replaced `bg-blue-600` with `btn-gold` CSS class + brand styles so the mobile sticky button matches the gold/black palette instead of being an out-of-place blue.

## Test plan

- [ ] Home page: SplitHero fills full viewport width with no side margins on mobile (360px, 390px, 414px) and desktop
- [ ] Subpages (services, gallery, contact): layout unchanged — they use their own `container` padding
- [ ] Mobile FAB: button is now gold-coloured, visible at bottom-right on screens < 768px
- [ ] 404 page: full-black section still stretches edge-to-edge

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_