### PR TITLE
fix(landing): map border overflow + services button contrast

### DIFF
--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -170,7 +170,7 @@ export default function HomePage({ founder, galleryImages }: HomePageProps) {
                             </div>
 
                             <div className="relative">
-                                <div className="absolute" style={{ inset: 0, margin: '-8px', border: '1px solid rgba(197,168,128,0.25)', borderRadius: '3px', transform: 'translate(8px, 8px)', zIndex: 0 }} />
+                                <div className="absolute" style={{ inset: 0, border: '1px solid rgba(197,168,128,0.25)', borderRadius: '3px', transform: 'translate(8px, 8px)', zIndex: 0 }} />
                                 <iframe
                                     src={`https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2549.${BUSINESS_INFO.coordinates.lat}!2d${BUSINESS_INFO.coordinates.lng}!3d${BUSINESS_INFO.coordinates.lat}!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zNTDCsDIwJzU1LjEiTiAxOMKwNTUnMTcuMSJF!5e0!3m2!1spl!2spl!4v1234567890123!5m2!1spl!2spl`}
                                     className="relative w-full"

--- a/apps/landing/src/pages/services.tsx
+++ b/apps/landing/src/pages/services.tsx
@@ -124,7 +124,7 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                         </p>
                         <a
                             href={getPanelUrl(BUSINESS_INFO.booking.url)}
-                            className="inline-block bg-brand-gold text-white px-8 py-3 rounded-md hover:bg-yellow-700 transition focus:outline-none focus:ring-2 focus:ring-brand-gold"
+                            className="inline-block bg-brand-gold text-brand-black px-8 py-3 rounded-md hover:opacity-90 transition focus:outline-none focus:ring-2 focus:ring-brand-gold"
                         >
                             {BUSINESS_INFO.booking.text}
                         </a>


### PR DESCRIPTION
## Summary

- **Map border**: `margin: -8px` + `translate(8px, 8px)` sumowały się przy prawej/dolnej krawędzi, powodując że border wystawał 16px poza iframe zamiast 8px. Usunięto `margin: -8px`.
- **Services CTA button**: `bg-brand-gold` (#c5a880) + `text-white` = kontrast ~2.2:1 na jasnym tle — przycisk praktycznie niewidoczny bez hover. Zmieniono na `text-brand-black` (ciemny tekst na złotym tle).

## Test plan

- [ ] Strona główna → sekcja Kontakt → border mapy wyrównany z iframe, offset 8px do prawego-dolnego rogu
- [ ] /services → przycisk "Umów wizytę" widoczny bez najechania myszką

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_