### PR TITLE
fix(landing): correct maps URL + services button inline styles

### DIFF
--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -172,7 +172,7 @@ export default function HomePage({ founder, galleryImages }: HomePageProps) {
                             <div className="relative">
                                 <div className="absolute" style={{ inset: 0, border: '1px solid rgba(197,168,128,0.25)', borderRadius: '3px', transform: 'translate(8px, 8px)', zIndex: 0 }} />
                                 <iframe
-                                    src={`https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2549.${BUSINESS_INFO.coordinates.lat}!2d${BUSINESS_INFO.coordinates.lng}!3d${BUSINESS_INFO.coordinates.lat}!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zNTDCsDIwJzU1LjEiTiAxOMKwNTUnMTcuMSJF!5e0!3m2!1spl!2spl!4v1234567890123!5m2!1spl!2spl`}
+                                    src={`https://maps.google.com/maps?q=${BUSINESS_INFO.coordinates.lat},${BUSINESS_INFO.coordinates.lng}&z=16&output=embed&hl=pl`}
                                     className="relative w-full"
                                     style={{ height: '380px', borderRadius: '3px', filter: 'grayscale(0.3) contrast(1.05)', zIndex: 1, display: 'block' }}
                                     allowFullScreen

--- a/apps/landing/src/pages/services.tsx
+++ b/apps/landing/src/pages/services.tsx
@@ -124,7 +124,8 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                         </p>
                         <a
                             href={getPanelUrl(BUSINESS_INFO.booking.url)}
-                            className="inline-block bg-brand-gold text-brand-black px-8 py-3 rounded-md hover:opacity-90 transition focus:outline-none focus:ring-2 focus:ring-brand-gold"
+                            className="inline-block px-8 py-3 rounded-md hover:opacity-90 transition focus:outline-none focus:ring-2"
+                            style={{ background: 'var(--brand-gold)', color: '#0d0d0d', fontWeight: 600 }}
                         >
                             {BUSINESS_INFO.booking.text}
                         </a>


### PR DESCRIPTION
## Summary

- **Mapa**: URL `pb=` był malformed — latitude wstrzykiwane jako część parametru skali (`!1d2549.50348641`). Zastąpiono prostym `q=lat,lng&output=embed` który niezawodnie pokazuje lokalizację.
- **Przycisk services**: `bg-brand-gold` (custom Tailwind kolor) nie generował CSS na tej stronie. Zamieniono na `style={{ background: 'var(--brand-gold)' }}` zgodnie z resztą komponentów landing page.

## Test plan

- [ ] Strona główna → Kontakt → mapa pokazuje poprawną lokalizację Bytom
- [ ] /services → przycisk "Umów wizytę" ma złote tło i jest widoczny jako przycisk

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_