### PR TITLE
landing: photo-ready structure — dark gallery, cinematic strip, image-ready service card

### DIFF
--- a/apps/landing/src/components/PhotoStrip.tsx
+++ b/apps/landing/src/components/PhotoStrip.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image';
+import { SALON_GALLERY } from '@/config/content';
+
+type StripItem = { id: number; image: string; alt: string; caption: string };
+
+const STRIP_ITEMS = (SALON_GALLERY as unknown as StripItem[]).slice(0, 5);
+
+export default function PhotoStrip() {
+    return (
+        <div className="photo-strip" aria-hidden="true">
+            {STRIP_ITEMS.map((item) => (
+                <div key={item.id} className="photo-strip__item">
+                    <Image
+                        src={item.image}
+                        alt={item.alt}
+                        fill
+                        style={{ objectFit: 'cover', objectPosition: 'center' }}
+                        sizes="(max-width: 768px) 65vw, 20vw"
+                    />
+                    <div className="photo-strip__overlay" />
+                    <span className="photo-strip__index">{String(item.id).padStart(2, '0')}</span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/apps/landing/src/components/SalonGallery.tsx
+++ b/apps/landing/src/components/SalonGallery.tsx
@@ -36,12 +36,13 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
     const goToNext = useCallback(() => setLightboxIndex(p => (p + 1) % data.length), [data.length]);
 
     return (
-        <section className="py-20 md:py-28" style={{ background: '#ffffff' }}>
+        <section className="py-20 md:py-28" style={{ background: '#0d0d0d' }}>
             <div className="container mx-auto px-4 md:px-8">
                 <SectionHeader
                     eyebrow="Zajrzyj do nas"
                     title="Nasz salon"
                     subtitle="Nowoczesna przestrzeń stworzona z myślą o Twoim komforcie i relaksie."
+                    dark
                 />
 
                 {/* Masonry-style CSS grid */}
@@ -49,8 +50,8 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                     className="hidden md:grid"
                     style={{
                         gridTemplateColumns: 'repeat(4, 1fr)',
-                        gridAutoRows: '200px',
-                        gap: '10px',
+                        gridAutoRows: '220px',
+                        gap: '6px',
                     }}
                 >
                     {data.map((image, index) => {
@@ -62,7 +63,7 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                                 style={{
                                     gridColumn: `span ${span.col}`,
                                     gridRow: `span ${span.row}`,
-                                    borderRadius: '3px',
+                                    borderRadius: '2px',
                                 }}
                                 onClick={() => openLightbox(index)}
                                 onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openLightbox(index); } }}
@@ -74,15 +75,13 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                                     src={image.image}
                                     alt={image.alt}
                                     fill
-                                    style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+                                    style={{ objectFit: 'cover' }}
                                     sizes="(max-width: 768px) 50vw, 25vw"
-                                    className="group-hover:scale-105"
+                                    className="gallery-img"
                                 />
-                                <div
-                                    className="absolute inset-0 flex items-end p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                                    style={{ background: 'linear-gradient(to top, rgba(13,13,13,0.7) 0%, transparent 60%)' }}
-                                >
-                                    <span className="text-white text-sm font-medium tracking-wide">{image.caption}</span>
+                                <div className="gallery-caption">
+                                    <span className="gallery-caption__accent" />
+                                    <span className="gallery-caption__text">{image.caption}</span>
                                 </div>
                             </div>
                         );
@@ -90,12 +89,12 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                 </div>
 
                 {/* Mobile: simple 2-col grid */}
-                <div className="md:hidden grid grid-cols-2 gap-2">
+                <div className="md:hidden grid grid-cols-2 gap-0.5">
                     {data.map((image, index) => (
                         <div
                             key={image.id}
                             className="group relative aspect-square overflow-hidden cursor-pointer"
-                            style={{ borderRadius: '3px' }}
+                            style={{ borderRadius: '2px' }}
                             onClick={() => openLightbox(index)}
                             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openLightbox(index); } }}
                             role="button"
@@ -108,7 +107,7 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                                 fill
                                 style={{ objectFit: 'cover' }}
                                 sizes="50vw"
-                                className="group-hover:scale-105 transition-transform duration-300"
+                                className="gallery-img"
                             />
                         </div>
                     ))}
@@ -117,7 +116,7 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                 <div className="text-center mt-10">
                     <Link
                         href="/gallery"
-                        className="btn-outline-dark inline-block px-8 py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2"
+                        className="btn-outline-white inline-block px-8 py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                         style={{ borderRadius: '2px', letterSpacing: '0.16em' }}
                     >
                         Zobacz pełną galerię

--- a/apps/landing/src/components/ServicesTeaser.tsx
+++ b/apps/landing/src/components/ServicesTeaser.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { Scissors, Sparkles, Wand2, type LucideIcon } from 'lucide-react';
 import SectionHeader from './SectionHeader';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -7,6 +8,8 @@ const SERVICE_ICONS: LucideIcon[] = [Scissors, Sparkles, Wand2];
 const SERVICE_HREFS = ['/services', '/services', '/services'];
 const SERVICE_NUMERALS = ['01', '02', '03'];
 const FEATURED_INDEX = 0;
+// Assign a path like '/images/services/featured.jpg' to activate the photo background
+const FEATURED_BG_IMAGE = '';
 
 export default function ServicesTeaser() {
     const { T } = useLanguage();
@@ -39,6 +42,22 @@ export default function ServicesTeaser() {
                                     transition: 'transform 0.35s cubic-bezier(0.34,1.56,0.64,1), box-shadow 0.35s ease',
                                 }}
                             >
+                                {featured && FEATURED_BG_IMAGE && (
+                                    <Image
+                                        src={FEATURED_BG_IMAGE}
+                                        alt=""
+                                        aria-hidden
+                                        fill
+                                        style={{ objectFit: 'cover', objectPosition: 'center 30%', opacity: 0.35 }}
+                                        sizes="50vw"
+                                    />
+                                )}
+                                {featured && FEATURED_BG_IMAGE && (
+                                    <div
+                                        className="absolute inset-0"
+                                        style={{ background: 'linear-gradient(to right, rgba(13,13,13,0.92) 0%, rgba(13,13,13,0.65) 100%)', zIndex: 0 }}
+                                    />
+                                )}
                                 {/* Numeral watermark */}
                                 <span className="service-numeral" aria-hidden="true">{numeral}</span>
 

--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -19,6 +19,7 @@ import BookingModal from '@/components/BookingModal';
 import StatsBar from '@/components/StatsBar';
 import BookingCta from '@/components/BookingCta';
 import GoldTickerStrip from '@/components/GoldTickerStrip';
+import PhotoStrip from '@/components/PhotoStrip';
 import {
     getFounderMessage,
     getSalonGallery,
@@ -113,16 +114,19 @@ export default function HomePage({ founder, galleryImages }: HomePageProps) {
                     <AboutSpread founder={founder} />
                 </ScrollReveal>
 
-                {/* 7. Gallery */}
+                {/* 7. Cinematic photo strip */}
+                <PhotoStrip />
+
+                {/* 8. Gallery */}
                 <SalonGallery images={galleryImages} />
 
-                {/* 8. Testimonials */}
+                {/* 9. Testimonials */}
                 <Testimonials />
 
-                {/* 9. Booking CTA */}
+                {/* 10. Booking CTA */}
                 <BookingCta />
 
-                {/* 10. Contact */}
+                {/* 11. Contact */}
                 <section className="contact-section" style={{ background: 'var(--brand-black)' }}>
                     <div className="container mx-auto px-4 md:px-8" style={{ paddingTop: '5rem', paddingBottom: '5rem' }}>
                         <SectionHeader eyebrow="Znajdź nas" title="Kontakt" dark />

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -907,10 +907,113 @@ html {
     opacity: 0.82;
 }
 
+/* ── Gallery dark section ─────────────────────────────── */
+.gallery-img {
+    object-fit: cover;
+    transition: transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+.group:hover .gallery-img,
+.group:focus-visible .gallery-img {
+    transform: scale(1.06);
+}
+
+.gallery-caption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 2.5rem 1.1rem 1rem;
+    transform: translateY(8px);
+    opacity: 0;
+    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s ease;
+    background: linear-gradient(to top, rgba(13,13,13,0.93) 0%, rgba(13,13,13,0.4) 65%, transparent 100%);
+    z-index: 2;
+}
+.group:hover .gallery-caption,
+.group:focus-visible .gallery-caption {
+    transform: translateY(0);
+    opacity: 1;
+}
+.gallery-caption__text {
+    font-family: var(--font-playfair), serif;
+    font-size: 0.9rem;
+    font-style: italic;
+    color: rgba(255,255,255,0.88);
+    display: block;
+    line-height: 1.4;
+}
+.gallery-caption__accent {
+    display: block;
+    width: 20px;
+    height: 1px;
+    background: var(--brand-gold);
+    margin-bottom: 0.5rem;
+}
+
+/* ── Cinematic photo strip ────────────────────────────── */
+.photo-strip {
+    display: flex;
+    height: 380px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    gap: 3px;
+    background: #0d0d0d;
+}
+.photo-strip::-webkit-scrollbar { display: none; }
+
+.photo-strip__item {
+    position: relative;
+    flex: 0 0 20%;
+    min-width: 180px;
+    overflow: hidden;
+    transition: flex 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+    cursor: default;
+}
+.photo-strip__item:hover { flex: 0 0 30%; }
+
+.photo-strip__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, transparent 55%);
+    transition: background 0.35s;
+    z-index: 1;
+    pointer-events: none;
+}
+.photo-strip__item:hover .photo-strip__overlay {
+    background: linear-gradient(to top, rgba(0,0,0,0.3) 0%, transparent 60%);
+}
+
+.photo-strip__item img {
+    transition: transform 0.7s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+.photo-strip__item:hover img { transform: scale(1.06); }
+
+.photo-strip__index {
+    position: absolute;
+    bottom: 0.8rem;
+    left: 0.9rem;
+    z-index: 2;
+    font-family: var(--font-playfair), serif;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: rgba(255,255,255,0.28);
+    letter-spacing: 0.12em;
+}
+
+@media (max-width: 768px) {
+    .photo-strip { height: 240px; scroll-snap-type: x mandatory; }
+    .photo-strip__item { flex: 0 0 65%; scroll-snap-align: start; }
+    .photo-strip__item:hover { flex: 0 0 65%; }
+}
+
 /* ── Reduced motion support ───────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
     .hero-img-zoom { animation: none; }
     .gold-ticker-strip__track { animation-duration: 80s; }
     .sr-init, .sr-init * { transition: none !important; animation: none !important; }
     .stats-bar__number, .stats-bar__label { transition: none !important; }
+    .gallery-img { transition: none; }
+    .gallery-caption { transition: none; }
+    .photo-strip__item { transition: none; }
+    .photo-strip__item img { transition: none; }
 }


### PR DESCRIPTION
## Summary

- **SalonGallery** — switched to dark `#0d0d0d` background, tightened grid gap to `6px`, rows to `220px`. Captions now slide up on hover using Playfair italic + gold accent bar. CTA switches to `btn-outline-white` for dark contrast.
- **PhotoStrip** — new full-bleed cinematic component (5 image slots from `SALON_GALLERY`). Desktop: hover expands slot from 20% → 30% of width with subtle zoom. Mobile: horizontal snap-scroll. Placed between `AboutSpread` and `SalonGallery`.
- **ServicesTeaser** — added `FEATURED_BG_IMAGE = ''` constant. Assign any image path to instantly activate a full-bleed photo background with gradient overlay on the featured tall card — zero further code changes needed.
- **globals.css** — `.gallery-img` zoom, `.gallery-caption` slide-up, `.photo-strip` expand-on-hover; all transitions gated behind `prefers-reduced-motion`.

## Test plan

- [ ] Tests: still 6 failures / 26 passing (pre-existing baseline unchanged)
- [ ] Build: clean, no TypeScript errors
- [ ] Gallery section renders dark with captions on hover
- [ ] PhotoStrip renders between About and Gallery sections
- [ ] Setting `FEATURED_BG_IMAGE` to any image path shows it as featured card background

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_