### PR TITLE
seo(landing): full audit — h1, OG tags, sitemap priorities, robots.txt fix

### DIFF
--- a/apps/landing/public/robots.txt
+++ b/apps/landing/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://dev.salon-bw.pl/sitemap.xml
+Sitemap: https://salon-bw.pl/sitemap.xml

--- a/apps/landing/src/components/SectionHeader.tsx
+++ b/apps/landing/src/components/SectionHeader.tsx
@@ -4,9 +4,10 @@ interface SectionHeaderProps {
     subtitle?: string;
     dark?: boolean;
     align?: 'center' | 'left';
+    as?: 'h1' | 'h2';
 }
 
-export default function SectionHeader({ eyebrow, title, subtitle, dark = false, align = 'center' }: SectionHeaderProps) {
+export default function SectionHeader({ eyebrow, title, subtitle, dark = false, align = 'center', as: Tag = 'h2' }: SectionHeaderProps) {
     const isLeft = align === 'left';
     return (
         <div className={isLeft ? 'mb-14' : 'text-center mb-14'}>
@@ -16,12 +17,12 @@ export default function SectionHeader({ eyebrow, title, subtitle, dark = false, 
             >
                 {eyebrow}
             </p>
-            <h2
+            <Tag
                 className="text-3xl md:text-4xl font-bold"
                 style={{ fontFamily: "var(--font-playfair), serif", color: dark ? '#ffffff' : '#0d0d0d' }}
             >
                 {title}
-            </h2>
+            </Tag>
             <div className={isLeft ? 'mt-4' : 'mx-auto mt-4'} style={{ width: '40px', height: '2px', background: '#c5a880' }} />
             {subtitle && (
                 <p

--- a/apps/landing/src/pages/contact.tsx
+++ b/apps/landing/src/pages/contact.tsx
@@ -32,6 +32,7 @@ export default function ContactPage() {
                         title={c.title}
                         subtitle={`${BUSINESS_INFO.address.street}, ${BUSINESS_INFO.address.city} · ${BUSINESS_INFO.contact.phone}`}
                         dark
+                        as="h1"
                     />
 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-20 max-w-5xl mx-auto">

--- a/apps/landing/src/pages/gallery.tsx
+++ b/apps/landing/src/pages/gallery.tsx
@@ -162,6 +162,7 @@ export default function GalleryPage({
                         title={g.title}
                         subtitle={g.subtitle}
                         dark
+                        as="h1"
                     />
 
                     {isFallback && (

--- a/apps/landing/src/pages/policy.tsx
+++ b/apps/landing/src/pages/policy.tsx
@@ -7,10 +7,9 @@ export default function PolicyPage() {
         <PublicLayout>
             <Head>
                 <title>Regulamin Świadczenia Usług | Salon Black & White</title>
-                <meta
-                    name="description"
-                    content="Regulamin świadczenia usług drogą elektroniczną oraz zasady korzystania z usług Salonu Fryzjerskiego Black & White."
-                />
+                <meta name="description" content="Regulamin świadczenia usług drogą elektroniczną oraz zasady korzystania z usług Salonu Fryzjerskiego Black & White." />
+                <link rel="canonical" href="https://salon-bw.pl/policy" />
+                <meta name="robots" content="index, follow" />
             </Head>
             <div className="legal-page">
                 <article className="legal-article">

--- a/apps/landing/src/pages/privacy.tsx
+++ b/apps/landing/src/pages/privacy.tsx
@@ -6,10 +6,9 @@ export default function PrivacyPage() {
         <PublicLayout>
             <Head>
                 <title>Polityka Prywatności | Salon Black & White</title>
-                <meta
-                    name="description"
-                    content="Polityka prywatności Salonu Fryzjerskiego Black & White. Informacje o przetwarzaniu danych osobowych (RODO)."
-                />
+                <meta name="description" content="Polityka prywatności Salonu Fryzjerskiego Black & White. Informacje o przetwarzaniu danych osobowych (RODO)." />
+                <link rel="canonical" href="https://salon-bw.pl/privacy" />
+                <meta name="robots" content="index, follow" />
             </Head>
             <div className="legal-page">
                 <article className="legal-article">

--- a/apps/landing/src/pages/services/balayage.tsx
+++ b/apps/landing/src/pages/services/balayage.tsx
@@ -38,11 +38,14 @@ export default function BalayagePage() {
         <PublicLayout>
             <Head>
                 <title>Balayage Bytom — Salon Black &amp; White</title>
-                <meta
-                    name="description"
-                    content="Balayage w Bytomiu — ręczna technika rozjaśniania włosów dająca naturalny, słoneczny efekt bez widocznych odrostów. Salon Black & White, ul. Webera 1a/13."
-                />
+                <meta name="description" content="Balayage w Bytomiu — ręczna technika rozjaśniania włosów dająca naturalny, słoneczny efekt bez widocznych odrostów. Salon Black & White, ul. Webera 1a/13." />
+                <meta name="keywords" content="balayage bytom, rozjaśnianie włosów bytom, naturalne pasemka bytom, ombre bytom, salon fryzjerski bytom" />
+                <meta property="og:title" content="Balayage — Salon Black & White Bytom" />
+                <meta property="og:description" content="Balayage w Bytomiu — ręczna technika rozjaśniania włosów. Naturalny słoneczny efekt bez widocznych odrostów." />
+                <meta property="og:image" content={absUrl('/images/hero/slider1.jpg')} />
+                <meta property="og:type" content="website" />
                 <link rel="canonical" href={absUrl('/services/balayage')} />
+                <meta name="robots" content="index, follow" />
             </Head>
 
             <Script

--- a/apps/landing/src/pages/services/coloring.tsx
+++ b/apps/landing/src/pages/services/coloring.tsx
@@ -38,11 +38,14 @@ export default function ColoringPage() {
         <PublicLayout>
             <Head>
                 <title>Koloryzacja Bytom — Salon Black &amp; White</title>
-                <meta
-                    name="description"
-                    content="Profesjonalna koloryzacja włosów w Bytomiu — farby Wella i Kerastase, color correction, toning. Salon Black & White, ul. Webera 1a/13."
-                />
+                <meta name="description" content="Profesjonalna koloryzacja włosów w Bytomiu — farby Wella i Kerastase, color correction, toning. Salon Black & White, ul. Webera 1a/13." />
+                <meta name="keywords" content="koloryzacja włosów bytom, color correction bytom, farbowanie włosów bytom, toning włosów, salon fryzjerski bytom" />
+                <meta property="og:title" content="Koloryzacja włosów — Salon Black & White Bytom" />
+                <meta property="og:description" content="Profesjonalna koloryzacja włosów w Bytomiu. Farby Wella i Kerastase, color correction, toning, farbowanie odrostów." />
+                <meta property="og:image" content={absUrl('/images/hero/slider1.jpg')} />
+                <meta property="og:type" content="website" />
                 <link rel="canonical" href={absUrl('/services/coloring')} />
+                <meta name="robots" content="index, follow" />
             </Head>
 
             <Script

--- a/apps/landing/src/pages/services/highlights.tsx
+++ b/apps/landing/src/pages/services/highlights.tsx
@@ -38,11 +38,14 @@ export default function HighlightsPage() {
         <PublicLayout>
             <Head>
                 <title>Pasemka Bytom — Salon Black &amp; White</title>
-                <meta
-                    name="description"
-                    content="Pasemka i rozjaśnienia w Bytomiu — klasyczne i dynamiczne efekty głębi i blasku. Salon Black & White, ul. Webera 1a/13."
-                />
+                <meta name="description" content="Pasemka i rozjaśnienia w Bytomiu — klasyczne i dynamiczne efekty głębi i blasku. Salon Black & White, ul. Webera 1a/13." />
+                <meta name="keywords" content="pasemka bytom, rozjaśnienia włosów bytom, highlights bytom, klasyczne pasemka bytom, salon fryzjerski bytom" />
+                <meta property="og:title" content="Pasemka — Salon Black & White Bytom" />
+                <meta property="og:description" content="Pasemka i rozjaśnienia w Bytomiu — klasyczne i dynamiczne efekty głębi i blasku dla Twoich włosów." />
+                <meta property="og:image" content={absUrl('/images/hero/slider1.jpg')} />
+                <meta property="og:type" content="website" />
                 <link rel="canonical" href={absUrl('/services/highlights')} />
+                <meta name="robots" content="index, follow" />
             </Head>
 
             <Script

--- a/apps/landing/src/pages/sitemap.xml.ts
+++ b/apps/landing/src/pages/sitemap.xml.ts
@@ -1,21 +1,30 @@
 import type { GetServerSideProps } from 'next';
 
-const staticPaths = [
-    '/',
-    '/services',
-    '/services/coloring',
-    '/services/highlights',
-    '/services/balayage',
-    '/gallery',
-    '/contact',
-    '/policy',
-    '/privacy',
+const staticPaths: Array<{ path: string; priority: string; changefreq: string }> = [
+    { path: '/',                      priority: '1.0', changefreq: 'weekly'  },
+    { path: '/services',              priority: '0.9', changefreq: 'weekly'  },
+    { path: '/services/coloring',     priority: '0.8', changefreq: 'monthly' },
+    { path: '/services/balayage',     priority: '0.8', changefreq: 'monthly' },
+    { path: '/services/highlights',   priority: '0.8', changefreq: 'monthly' },
+    { path: '/gallery',               priority: '0.7', changefreq: 'weekly'  },
+    { path: '/contact',               priority: '0.8', changefreq: 'monthly' },
+    { path: '/policy',                priority: '0.3', changefreq: 'yearly'  },
+    { path: '/privacy',               priority: '0.3', changefreq: 'yearly'  },
 ];
+
+const today = new Date().toISOString().split('T')[0];
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     const base = process.env.NEXT_PUBLIC_SITE_URL || 'https://salon-bw.pl';
     const urls = staticPaths
-        .map((p) => `<url><loc>${new URL(p, base).toString()}</loc></url>`)
+        .map(({ path, priority, changefreq }) =>
+            `<url>` +
+            `<loc>${new URL(path, base).toString()}</loc>` +
+            `<lastmod>${today}</lastmod>` +
+            `<changefreq>${changefreq}</changefreq>` +
+            `<priority>${priority}</priority>` +
+            `</url>`,
+        )
         .join('');
     const xml =
         `<?xml version="1.0" encoding="UTF-8"?>` +


### PR DESCRIPTION
## Zmiany

### KRYTYCZNE
- **robots.txt** — poprawiono URL sitemapa z `dev.salon-bw.pl` na `salon-bw.pl` (Googlebot wskazywał na subdomenę deweloperską)

### Ważne
- **SectionHeader** — dodano prop `as?: 'h1' | 'h2'` (domyślnie `h2`, backward-compatible); wszystkie istniejące użycia niezmienione
- **gallery.tsx, contact.tsx** — `SectionHeader as="h1"` — strony mają teraz poprawny `<h1>` (wcześniej brak h1 = brak głównego nagłówka dla Google)
- **coloring, balayage, highlights** — dodano `og:title`, `og:description`, `og:image`, `og:type`, `keywords`, `robots` — podstrony usług są teraz w pełni shareable i indeksowalne

### Mniejsze
- **privacy.tsx, policy.tsx** — dodano `canonical` + `robots meta`
- **sitemap.xml.ts** — dodano `<priority>`, `<changefreq>`, `<lastmod>` do każdego URL (homepage: 1.0, usługi: 0.9/0.8, galeria/kontakt: 0.7-0.8, legal: 0.3)

## Test plan
- [ ] `robots.txt` na produkcji wskazuje na `https://salon-bw.pl/sitemap.xml`
- [ ] `/gallery` i `/contact` mają `<h1>` (narzędzia: Screaming Frog lub DevTools)
- [ ] `/services/coloring` share na Facebooku/Twitterze pokazuje poprawne OG preview
- [ ] `/sitemap.xml` zwraca `<priority>`, `<changefreq>`, `<lastmod>` dla każdego URL
- [ ] CI lint/typecheck zielone

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_