### PR TITLE
i18n(landing): translate all booking CTA buttons

### DIFF
--- a/apps/landing/src/components/BookNowFab.tsx
+++ b/apps/landing/src/components/BookNowFab.tsx
@@ -3,9 +3,11 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { trackEvent } from '@/utils/analytics';
 import BookingModal from '@/components/BookingModal';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function BookNowFab() {
     const router = useRouter();
+    const { T } = useLanguage();
     const path = router.pathname || '/';
     const hidden =
         path.startsWith('/dashboard') ||
@@ -23,9 +25,9 @@ export default function BookNowFab() {
                     onClick={() => { trackEvent('begin_checkout', { cta: 'fab' }); setModalOpen(true); }}
                     className="btn-gold px-5 py-3.5 text-xs font-semibold uppercase shadow-lg"
                     style={{ color: '#fff', borderRadius: '2px', letterSpacing: '0.14em' }}
-                    aria-label="Umów wizytę"
+                    aria-label={T.nav.booking}
                 >
-                    Umów wizytę
+                    {T.nav.booking}
                 </button>
             </div>
             <BookingModal open={modalOpen} onClose={() => setModalOpen(false)} />

--- a/apps/landing/src/components/BookingModal.tsx
+++ b/apps/landing/src/components/BookingModal.tsx
@@ -123,7 +123,7 @@ export default function BookingModal({
             <div
                 role="dialog"
                 aria-modal="true"
-                aria-label="Umów wizytę"
+                aria-label={m.bookingTitle}
                 className="w-full max-w-sm"
                 style={{
                     background: '#0d0d0d',

--- a/apps/landing/src/pages/services/balayage.tsx
+++ b/apps/landing/src/pages/services/balayage.tsx
@@ -7,6 +7,7 @@ import BookingModal from '@/components/BookingModal';
 import { BUSINESS_INFO } from '@/config/content';
 import { jsonLd, absUrl } from '@/utils/seo';
 import { trackEvent } from '@/utils/analytics';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const ITEMS = [
     'Naturalny efekt bez widocznych odrostów',
@@ -18,6 +19,7 @@ const ITEMS = [
 
 export default function BalayagePage() {
     const [open, setOpen] = useState(false);
+    const { T } = useLanguage();
     const name = BUSINESS_INFO.name;
 
     useEffect(() => {
@@ -151,7 +153,7 @@ export default function BalayagePage() {
                         }}
                         className="split-hero__cta-primary"
                     >
-                        Umów wizytę
+                        {T.nav.booking}
                     </button>
                 </div>
             </section>

--- a/apps/landing/src/pages/services/coloring.tsx
+++ b/apps/landing/src/pages/services/coloring.tsx
@@ -7,6 +7,7 @@ import BookingModal from '@/components/BookingModal';
 import { BUSINESS_INFO } from '@/config/content';
 import { jsonLd, absUrl } from '@/utils/seo';
 import { trackEvent } from '@/utils/analytics';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const ITEMS = [
     'Koloryzacja jednolita i wielotonowa',
@@ -18,6 +19,7 @@ const ITEMS = [
 
 export default function ColoringPage() {
     const [open, setOpen] = useState(false);
+    const { T } = useLanguage();
     const name = BUSINESS_INFO.name;
 
     useEffect(() => {
@@ -149,7 +151,7 @@ export default function ColoringPage() {
                         className="split-hero__cta-primary"
                         data-testid="coloring-cta"
                     >
-                        Umów wizytę
+                        {T.nav.booking}
                     </button>
                 </div>
             </section>

--- a/apps/landing/src/pages/services/highlights.tsx
+++ b/apps/landing/src/pages/services/highlights.tsx
@@ -7,6 +7,7 @@ import BookingModal from '@/components/BookingModal';
 import { BUSINESS_INFO } from '@/config/content';
 import { jsonLd, absUrl } from '@/utils/seo';
 import { trackEvent } from '@/utils/analytics';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const ITEMS = [
     'Pasemka klasyczne i dynamiczne',
@@ -18,6 +19,7 @@ const ITEMS = [
 
 export default function HighlightsPage() {
     const [open, setOpen] = useState(false);
+    const { T } = useLanguage();
     const name = BUSINESS_INFO.name;
 
     useEffect(() => {
@@ -150,7 +152,7 @@ export default function HighlightsPage() {
                         }}
                         className="split-hero__cta-primary"
                     >
-                        Umów wizytę
+                        {T.nav.booking}
                     </button>
                 </div>
             </section>


### PR DESCRIPTION
## Problem

Przyciski „Umów wizytę" były hardcodowane po polsku w 5 miejscach:
- `BookNowFab` (pływający przycisk na mobile) — brak `useLanguage`
- `BookingModal` — `aria-label="Umów wizytę"` hardcoded
- `/services/coloring` — brak `useLanguage`, hardcoded tekst przycisku
- `/services/balayage` — j.w.
- `/services/highlights` — j.w.

## Zmiana

Wszystkie używają teraz `T.nav.booking` (PL: „Umów wizytę" / EN: „Book now" / DE: „Termin buchen") lub `T.modal.bookingTitle` dla aria-label.

## Weryfikacja

- [ ] Zmień język na EN → przycisk „Book now" na podstronach usług i FAB
- [ ] DE → „Termin buchen"
- [ ] PL bez zmian

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_