### PR TITLE
i18n(landing): translate BookingCta button, modal label and close button

### DIFF
--- a/apps/landing/src/components/BookingCta.tsx
+++ b/apps/landing/src/components/BookingCta.tsx
@@ -11,7 +11,7 @@ export default function BookingCta() {
     const b = T.bookingCta;
 
     return (
-        <section className="booking-cta-section" aria-label={BUSINESS_INFO.booking.text}>
+        <section className="booking-cta-section" aria-label={T.nav.booking}>
             <Image
                 src="/images/hero/DSC_9583.jpg"
                 alt=""
@@ -37,9 +37,9 @@ export default function BookingCta() {
                 <button
                     onClick={() => setOpen(true)}
                     className="split-hero__cta-primary"
-                    aria-label={BUSINESS_INFO.booking.text}
+                    aria-label={T.nav.booking}
                 >
-                    {BUSINESS_INFO.booking.text}
+                    {T.nav.booking}
                 </button>
             </div>
 

--- a/apps/landing/src/components/BookingModal.tsx
+++ b/apps/landing/src/components/BookingModal.tsx
@@ -159,7 +159,7 @@ export default function BookingModal({
                         >
                             {service
                                 ? m.bookingServiceLabel
-                                : BUSINESS_INFO.booking.text}
+                                : T.nav.booking}
                         </p>
                         <h2
                             style={{
@@ -461,7 +461,7 @@ export default function BookingModal({
                             cursor: 'pointer',
                         }}
                     >
-                        Zamknij
+                        {m.close}
                     </button>
                 </div>
             </div>

--- a/apps/landing/src/i18n/translations.ts
+++ b/apps/landing/src/i18n/translations.ts
@@ -173,6 +173,7 @@ const t = {
             submitting: 'Logowanie…',
             noAccount: 'Nie masz konta?',
             register: 'Zarejestruj się',
+            close: 'Zamknij',
         },
         salonGallery: {
             eyebrow: 'Zajrzyj do nas',
@@ -398,6 +399,7 @@ const t = {
             submitting: 'Logging in…',
             noAccount: 'No account?',
             register: 'Register',
+            close: 'Close',
         },
         salonGallery: {
             eyebrow: 'Take a look inside',
@@ -623,6 +625,7 @@ const t = {
             submitting: 'Wird angemeldet…',
             noAccount: 'Kein Konto?',
             register: 'Registrieren',
+            close: 'Schließen',
         },
         salonGallery: {
             eyebrow: 'Schauen Sie rein',

--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -173,7 +173,7 @@ export default function HomePage({ founder, galleryImages }: HomePageProps) {
                                         className="split-hero__cta-primary text-xs font-semibold uppercase text-center px-8 py-3.5"
                                         style={{ letterSpacing: '0.14em' }}
                                     >
-                                        {BUSINESS_INFO.booking.text}
+                                        {T.nav.booking}
                                     </button>
                                     <Link
                                         href="/contact"


### PR DESCRIPTION
## Problem

Pozostałe hardcoded polskie stringi widoczne przy języku EN/DE:
- `BookingCta` — przycisk + `aria-label` sekcji używały `BUSINESS_INFO.booking.text` (zawsze PL)
- Sekcja kontakt na homepage (`index.tsx`) — j.w.
- `BookingModal` — górny label `UMÓW WIZYTĘ` gdy brak wybranej usługi
- `BookingModal` — przycisk `Zamknij` na dole modalu

## Zmiana

- `BookingCta` + `index.tsx`: `BUSINESS_INFO.booking.text` → `T.nav.booking`
- `BookingModal` label: `BUSINESS_INFO.booking.text` → `T.nav.booking`
- `BookingModal` close: `'Zamknij'` → `m.close`
- `translations.ts`: dodano `modal.close` (PL: Zamknij / EN: Close / DE: Schließen)

## Weryfikacja

- [ ] EN: BookingCta przycisk → „Book now", modal label → „Book now", przycisk zamknięcia → „Close"
- [ ] DE: „Termin buchen" / „Schließen"

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_