### PR TITLE
i18n(landing): translate booking buttons in services, HeroSlider, 404

### DIFF
--- a/apps/landing/src/components/HeroSlider.tsx
+++ b/apps/landing/src/components/HeroSlider.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { HERO_SLIDES, BUSINESS_INFO } from '@/config/content';
 import { getPanelUrl } from '@/utils/panelUrl';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 type HeroSlide = { id: number; title: string; description: string; image: string; alt: string };
 
@@ -12,6 +13,7 @@ interface HeroSliderProps {
 }
 
 export default function HeroSlider({ slides }: HeroSliderProps) {
+    const { T } = useLanguage();
     const data = slides ?? (HERO_SLIDES as unknown as HeroSlide[]);
     const [currentSlide, setCurrentSlide] = useState(0);
     const [isAutoPlaying, setIsAutoPlaying] = useState(true);
@@ -116,7 +118,7 @@ export default function HeroSlider({ slides }: HeroSliderProps) {
                             className="btn-gold inline-block px-10 py-4 text-sm font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-offset-2"
                             style={{ letterSpacing: '0.12em', borderRadius: '2px', boxShadow: '0 4px 24px rgba(197,168,128,0.4)' }}
                         >
-                            {BUSINESS_INFO.booking.text}
+                            {T.nav.booking}
                         </a>
                         <Link
                             href="/services"

--- a/apps/landing/src/pages/404.tsx
+++ b/apps/landing/src/pages/404.tsx
@@ -2,9 +2,10 @@ import Head from 'next/head';
 import Link from 'next/link';
 import PublicLayout from '@/components/PublicLayout';
 import { getPanelUrl } from '@/utils/panelUrl';
-import { BUSINESS_INFO } from '@/config/content';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function NotFound() {
+    const { T } = useLanguage();
     const bookingUrl = getPanelUrl(`/auth/login?redirect=${encodeURIComponent('/appointments')}`);
     return (
         <PublicLayout>
@@ -34,7 +35,7 @@ export default function NotFound() {
                             Wróć na stronę główną
                         </Link>
                         <a href={bookingUrl} className="split-hero__cta-secondary" style={{ display: 'inline-block', padding: '0.85rem 2rem', fontSize: '0.75rem', letterSpacing: '0.14em', fontWeight: 600, textTransform: 'uppercase' }}>
-                            {BUSINESS_INFO.booking.text}
+                            {T.nav.booking}
                         </a>
                     </div>
                 </div>

--- a/apps/landing/src/pages/services.tsx
+++ b/apps/landing/src/pages/services.tsx
@@ -121,7 +121,7 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                         className="btn-gold text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                         style={{ color: '#fff', padding: '0.85rem 2.5rem', borderRadius: '2px', letterSpacing: '0.16em' }}
                     >
-                        {BUSINESS_INFO.booking.text}
+                        {T.nav.booking}
                     </button>
                 </div>
 
@@ -204,7 +204,7 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                             className="btn-gold text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                             style={{ color: '#fff', padding: '0.85rem 2.5rem', borderRadius: '2px', letterSpacing: '0.16em' }}
                         >
-                            {BUSINESS_INFO.booking.text}
+                            {T.nav.booking}
                         </button>
                         <p style={{ marginTop: '1.5rem', fontSize: '0.8rem', color: 'rgba(255,255,255,0.3)' }}>
                             <a


### PR DESCRIPTION
## Problem

Pozostałe hardcoded `BUSINESS_INFO.booking.text` ("Umów wizytę") w 4 miejscach:
- `services.tsx` — przycisk w hero (góra strony) + przycisk w sekcji CTA pod listą usług
- `HeroSlider.tsx` — przycisk booking
- `404.tsx` — link booking

## Zmiana

Wszystkie 4 zamieniono na `T.nav.booking` (PL: Umów wizytę / EN: Book now / DE: Termin buchen). Usunięto zbędny import `BUSINESS_INFO` z `404.tsx`.

## Weryfikacja

- [ ] `/services` EN: oba przyciski → „Book now"
- [ ] HeroSlider EN: „Book now"
- [ ] 404 EN: „Book now"

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_