### PR TITLE
fix(landing): correct .env.local.example API URL for local dev

### DIFF
--- a/apps/landing/.env.local.example
+++ b/apps/landing/.env.local.example
@@ -1,4 +1,7 @@
-NEXT_PUBLIC_API_URL=http://localhost:3000
+# Local API server (apps/api running on port 3001):
+NEXT_PUBLIC_API_URL=http://localhost:3001
+# If you don't run the API locally, point to staging instead:
+# NEXT_PUBLIC_API_URL=https://api.salon-bw.pl
 NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
 NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0


### PR DESCRIPTION
## Summary

- `.env.local.example` pointed `NEXT_PUBLIC_API_URL` to `localhost:3000` — the same port as the Next.js landing dev server, so login always failed locally with `ERR_CONNECTION_REFUSED`
- Corrected to `localhost:3001` (the API server port) with a commented alternative for developers who don't run the API locally (`https://api.salon-bw.pl`)

## Root cause analysis

Login failure (`localhost:3000/auth/login ERR_CONNECTION_REFUSED`) was a **local dev issue only**. `NEXT_PUBLIC_*` vars are baked into the bundle at build time — the production CI build correctly passes `NEXT_PUBLIC_API_URL=https://api.salon-bw.pl`, so production was never affected.

## Test plan

- [ ] Copy `.env.local.example` → `.env.local`, uncomment staging URL, start landing dev server, verify BookingModal login reaches `api.salon-bw.pl`

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_