### PR TITLE
fix(api): replace localhost:3000 fallback with production API URL

### DIFF
--- a/apps/landing/.env.local.example
+++ b/apps/landing/.env.local.example
@@ -1,4 +1,7 @@
-NEXT_PUBLIC_API_URL=http://localhost:3000
+# Local API server (apps/api running on port 3001):
+NEXT_PUBLIC_API_URL=http://localhost:3001
+# If you don't run the API locally, point to staging instead:
+# NEXT_PUBLIC_API_URL=https://api.salon-bw.pl
 NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
 NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -110,7 +110,7 @@ export class ApiClient {
         const rawBase =
             options.baseUrl ??
             process.env.NEXT_PUBLIC_API_URL ??
-            "http://localhost:3000";
+            "https://api.salon-bw.pl";
         if (this.debugEnabled()) {
             // Only emit construction telemetry when debug is enabled; this
             // used to be an unconditional `console.log` that leaked the
@@ -127,13 +127,13 @@ export class ApiClient {
             this.baseUrl =
                 u.protocol === "http:" || u.protocol === "https:"
                     ? rawBase
-                    : "http://localhost:3000";
+                    : "https://api.salon-bw.pl";
         } catch {
             // Allow relative paths for proxy usage
             if (rawBase.startsWith("/")) {
                 this.baseUrl = rawBase;
             } else {
-                this.baseUrl = "http://localhost:3000";
+                this.baseUrl = "https://api.salon-bw.pl";
             }
         }
         this.defaultHeaders = {


### PR DESCRIPTION
## Summary

- `ApiClient` in `packages/api/src/api.ts` had `http://localhost:3000` as fallback when `NEXT_PUBLIC_API_URL` is not set
- Port 3000 is the **Next.js landing dev server** port — so login always failed locally without `.env.local` with `ERR_CONNECTION_REFUSED`
- Changed all three fallback occurrences to `https://api.salon-bw.pl`

## Effect

- Local dev without `.env.local`: login now correctly hits `https://api.salon-bw.pl`
- Local dev with `.env.local` set: unchanged (env var takes precedence)
- Production build: unchanged (CI always passes `NEXT_PUBLIC_API_URL` at build time)

## Test plan

- [ ] Start landing dev server locally without `.env.local`, open BookingModal, attempt login — should reach `api.salon-bw.pl` (not localhost)

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_