### PR TITLE
style(panel): Phase 1 — unify brand tokens with landing (teal → gold)

### DIFF
--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -91,8 +91,8 @@ body {
 }
 
 .salonbw-step.active .salonbw-step__number {
-    background: #25B4C1;
-    color: #fff;
+    background: #c5a880;
+    color: #0d0d0d;
 }
 
 .salonbw-step__label {
@@ -129,7 +129,7 @@ body {
 }
 
 .salonbw-channel:hover {
-    border-color: #25B4C1;
+    border-color: #c5a880;
 }
 
 .salonbw-channel input {
@@ -137,8 +137,8 @@ body {
 }
 
 .salonbw-channel.active {
-    border-color: #25B4C1;
-    background: rgba(37, 180, 193, 0.05);
+    border-color: #c5a880;
+    background: rgba(197, 168, 128, 0.07);
 }
 
 .salonbw-channel__icon {
@@ -185,13 +185,13 @@ body {
 }
 
 .salonbw-template-item:hover {
-    border-color: #25B4C1;
+    border-color: #c5a880;
     background: #f9fafb;
 }
 
 .salonbw-template-item.active {
-    border-color: #25B4C1;
-    background: rgba(37,180,193,0.05);
+    border-color: #c5a880;
+    background: rgba(197, 168, 128, 0.07);
 }
 
 .salonbw-template-item__name {
@@ -229,8 +229,8 @@ body {
 
 .salonbw-input:focus {
     outline: none;
-    border-color: #25B4C1;
-    box-shadow: 0 0 0 2px rgba(37,180,193,0.2);
+    border-color: #c5a880;
+    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
 }
 
 .salonbw-input--sm {
@@ -253,8 +253,8 @@ body {
 
 .salonbw-textarea:focus {
     outline: none;
-    border-color: #25B4C1;
-    box-shadow: 0 0 0 2px rgba(37,180,193,0.2);
+    border-color: #c5a880;
+    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
 }
 
 .salonbw-char-count {
@@ -512,8 +512,8 @@ body {
 
 .salonbw-select:focus {
     outline: none;
-    border-color: #25B4C1;
-    box-shadow: 0 0 0 2px rgba(37,180,193,0.2);
+    border-color: #c5a880;
+    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
 }
 
 .salonbw-select--inline {

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -10,8 +10,8 @@
     --salon-panel-bg: #f5f7f9;
     --salon-text: #505960;
     --salon-muted: #828a92;
-    /* brand active/link blue */
-    --salon-accent: #008bb4;
+    /* brand active/link gold */
+    --salon-accent: #a8895f;
     --salon-mainnav-bg: #24272b;
     --salon-mainnav-active: #181a1e;
     --salon-green: #2ecc71;

--- a/apps/panel/src/styles/salon-theme.css
+++ b/apps/panel/src/styles/salon-theme.css
@@ -5,9 +5,9 @@
 
 /* --- CSS Variables --- */
 :root {
-  --salon-accent: #008bb4;
-  --salon-brand: #25B4C1;
-  --salon-brand-hover: #1f9ba8;
+  --salon-accent: #a8895f;
+  --salon-brand: #c5a880;
+  --salon-brand-hover: #b0896b;
   --salon-bg: #f5f5f5;
   --salon-fg: #333333;
 }
@@ -22,14 +22,14 @@ body {
 /* --- Buttons --- */
 .btn-salon {
   background: var(--salon-brand);
-  color: #fff;
+  color: #0d0d0d;
   border-color: var(--salon-brand);
 }
 .btn-salon:hover,
 .btn-salon:focus {
   background: var(--salon-brand-hover);
   border-color: var(--salon-brand-hover);
-  color: #fff;
+  color: #0d0d0d;
 }
 .btn-salon:disabled {
   opacity: 0.5;
@@ -68,6 +68,7 @@ body {
   font-size: 22px;
   font-weight: 400;
   margin: 20px 0 10px;
+  font-family: 'Playfair Display', Georgia, serif;
 }
 
 /* --- Column row --- */
@@ -79,6 +80,7 @@ body {
   font-size: 22px;
   font-weight: 400;
   margin: 20px 0 30px;
+  font-family: 'Playfair Display', Georgia, serif;
 }
 
 /* --- Boxes --- */
@@ -205,7 +207,7 @@ tr.even td { background: #f4fbff; }
 /* --- Form accent (focus ring) --- */
 .form-control:focus {
   border-color: var(--salon-brand);
-  box-shadow: 0 0 0 0.2rem rgba(37, 180, 193, 0.25);
+  box-shadow: 0 0 0 0.2rem rgba(197, 168, 128, 0.25);
 }
 
 /* --- Pjax link styling --- */


### PR DESCRIPTION
## Summary

Phase 1 of landing ↔ panel design unification — replace teal brand palette with landing's gold palette.

### Changes

**`salon-theme.css`**
- `--salon-accent`: `#008bb4` → `#a8895f` (dark gold, for links/interactive)
- `--salon-brand`: `#25B4C1` → `#c5a880` (brand gold)
- `--salon-brand-hover`: `#1f9ba8` → `#b0896b` (hover gold)
- `.btn-salon` text: `#fff` → `#0d0d0d` (dark text on gold background for contrast)
- `.form-control:focus` box-shadow: teal rgba → gold rgba
- `.salon-section h2`, `.salon-column-row h2`: added `font-family: 'Playfair Display'`

**`salon-shell.css`**
- `--salon-accent`: `#008bb4` → `#a8895f`

**`globals.css`**
- `salonbw-step.active`: teal background → gold background, white text → dark text
- `salonbw-channel`, `salonbw-template-item` hover/active borders: teal → gold
- `salonbw-input`, `salonbw-textarea`, `salonbw-select` focus: teal → gold

### Not changed
- Versum-native color `#56aef0` (button-blue, v2-label-info) — Versum visual parity requirement
- Status colors (green/red/yellow) — semantic, not brand
- Navigation dark background (`#24272b`) — already matches landing's dark aesthetic
- Auth pages — already used gold/black design

## Test plan
- [ ] Open panel settings pages — section headings should use Playfair Display
- [ ] Click any `.btn-salon` button — should be gold with dark text
- [ ] Focus any form input — border and ring should be gold
- [ ] Mass communication flow — channel/template selector should highlight in gold

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_