### PR TITLE
style(panel): Phase 2 — button radius + gold active indicator

### DIFF
--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -91,8 +91,8 @@ body {
 }
 
 .salonbw-step.active .salonbw-step__number {
-    background: #25B4C1;
-    color: #fff;
+    background: #c5a880;
+    color: #0d0d0d;
 }
 
 .salonbw-step__label {
@@ -129,7 +129,7 @@ body {
 }
 
 .salonbw-channel:hover {
-    border-color: #25B4C1;
+    border-color: #c5a880;
 }
 
 .salonbw-channel input {
@@ -137,8 +137,8 @@ body {
 }
 
 .salonbw-channel.active {
-    border-color: #25B4C1;
-    background: rgba(37, 180, 193, 0.05);
+    border-color: #c5a880;
+    background: rgba(197, 168, 128, 0.07);
 }
 
 .salonbw-channel__icon {
@@ -185,13 +185,13 @@ body {
 }
 
 .salonbw-template-item:hover {
-    border-color: #25B4C1;
+    border-color: #c5a880;
     background: #f9fafb;
 }
 
 .salonbw-template-item.active {
-    border-color: #25B4C1;
-    background: rgba(37,180,193,0.05);
+    border-color: #c5a880;
+    background: rgba(197, 168, 128, 0.07);
 }
 
 .salonbw-template-item__name {
@@ -229,8 +229,8 @@ body {
 
 .salonbw-input:focus {
     outline: none;
-    border-color: #25B4C1;
-    box-shadow: 0 0 0 2px rgba(37,180,193,0.2);
+    border-color: #c5a880;
+    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
 }
 
 .salonbw-input--sm {
@@ -253,8 +253,8 @@ body {
 
 .salonbw-textarea:focus {
     outline: none;
-    border-color: #25B4C1;
-    box-shadow: 0 0 0 2px rgba(37,180,193,0.2);
+    border-color: #c5a880;
+    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
 }
 
 .salonbw-char-count {
@@ -512,8 +512,8 @@ body {
 
 .salonbw-select:focus {
     outline: none;
-    border-color: #25B4C1;
-    box-shadow: 0 0 0 2px rgba(37,180,193,0.2);
+    border-color: #c5a880;
+    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
 }
 
 .salonbw-select--inline {

--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -362,7 +362,7 @@ body {
 /* Button styles */
 .salonbw-btn {
     padding: 8px 16px;
-    border-radius: 6px;
+    border-radius: 2px;
     font-weight: 500;
     font-size: 0.875rem;
     cursor: pointer;
@@ -371,12 +371,12 @@ body {
 }
 
 .salonbw-btn--primary {
-    background: var(--salon-accent);
-    color: #fff;
+    background: var(--salon-brand);
+    color: #0d0d0d;
 }
 
 .salonbw-btn--primary:hover {
-    filter: brightness(0.95);
+    background: var(--salon-brand-hover);
 }
 
 .salonbw-btn--primary:disabled {
@@ -436,14 +436,14 @@ body {
 }
 
 .salonbw-btn--add {
-    background: var(--salon-accent, #25b4c1);
-    color: #fff;
+    background: var(--salon-brand);
+    color: #0d0d0d;
 }
 
 .salonbw-btn--link {
     background: transparent;
     border: 0;
-    color: var(--salon-accent, #25b4c1);
+    color: var(--salon-accent);
     padding: 0;
     text-decoration: underline;
     cursor: pointer;
@@ -456,7 +456,7 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 4px;
+    border-radius: 2px;
 }
 
 /* Toolbar */

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -2537,7 +2537,7 @@ tr.customer-row:hover .customers-drag-handle {
     margin-top: auto;
 }
 
-/* Active state - green left border */
+/* Active state - gold left border */
 .mainnav .nav li.active::before {
     content: '';
     position: absolute;
@@ -2545,7 +2545,7 @@ tr.customer-row:hover .customers-drag-handle {
     top: 0;
     bottom: 0;
     width: 3px;
-    background: var(--salon-green);
+    background: var(--salon-brand);
 }
 
 .mainnav .nav li a {

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -10,8 +10,8 @@
     --salon-panel-bg: #f5f7f9;
     --salon-text: #505960;
     --salon-muted: #828a92;
-    /* brand active/link blue */
-    --salon-accent: #008bb4;
+    /* brand active/link gold */
+    --salon-accent: #a8895f;
     --salon-mainnav-bg: #24272b;
     --salon-mainnav-active: #181a1e;
     --salon-green: #2ecc71;

--- a/apps/panel/src/styles/salon-theme.css
+++ b/apps/panel/src/styles/salon-theme.css
@@ -5,9 +5,9 @@
 
 /* --- CSS Variables --- */
 :root {
-  --salon-accent: #008bb4;
-  --salon-brand: #25B4C1;
-  --salon-brand-hover: #1f9ba8;
+  --salon-accent: #a8895f;
+  --salon-brand: #c5a880;
+  --salon-brand-hover: #b0896b;
   --salon-bg: #f5f5f5;
   --salon-fg: #333333;
 }
@@ -22,14 +22,14 @@ body {
 /* --- Buttons --- */
 .btn-salon {
   background: var(--salon-brand);
-  color: #fff;
+  color: #0d0d0d;
   border-color: var(--salon-brand);
 }
 .btn-salon:hover,
 .btn-salon:focus {
   background: var(--salon-brand-hover);
   border-color: var(--salon-brand-hover);
-  color: #fff;
+  color: #0d0d0d;
 }
 .btn-salon:disabled {
   opacity: 0.5;
@@ -68,6 +68,7 @@ body {
   font-size: 22px;
   font-weight: 400;
   margin: 20px 0 10px;
+  font-family: 'Playfair Display', Georgia, serif;
 }
 
 /* --- Column row --- */
@@ -79,6 +80,7 @@ body {
   font-size: 22px;
   font-weight: 400;
   margin: 20px 0 30px;
+  font-family: 'Playfair Display', Georgia, serif;
 }
 
 /* --- Boxes --- */
@@ -205,7 +207,7 @@ tr.even td { background: #f4fbff; }
 /* --- Form accent (focus ring) --- */
 .form-control:focus {
   border-color: var(--salon-brand);
-  box-shadow: 0 0 0 0.2rem rgba(37, 180, 193, 0.25);
+  box-shadow: 0 0 0 0.2rem rgba(197, 168, 128, 0.25);
 }
 
 /* --- Pjax link styling --- */


### PR DESCRIPTION
## Summary

Phase 2 of landing ↔ panel design unification — buttons and navigation active states.

### Changes

**`globals.css`**
- `.salonbw-btn` base: `border-radius: 6px` → `2px` (sharp corners matching landing style)
- `.salonbw-btn--primary`: `var(--salon-accent)` → `var(--salon-brand)` (`#c5a880`), text `#fff` → `#0d0d0d`, hover uses `--salon-brand-hover`
- `.salonbw-btn--add`: gold background with dark text (consistent with primary)
- `.salonbw-btn--icon`: `border-radius: 4px` → `2px`
- `.salonbw-btn--link`: removed hardcoded `#25b4c1` teal fallback

**`salon-shell.css`**
- Mainnav active left indicator: `var(--salon-green)` → `var(--salon-brand)` (gold)

## Test plan
- [ ] Any primary action button — should be gold (`#c5a880`) with dark text, sharp 2px corners
- [ ] Click a nav icon in left sidebar — active item should have gold left border instead of green
- [ ] Settings page "Add" buttons — gold background, dark text

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_