### PR TITLE
feat: online_pending & rescheduled_pending statuses (Phase 2)

### DIFF
--- a/apps/panel/jest.config.js
+++ b/apps/panel/jest.config.js
@@ -17,9 +17,9 @@ module.exports = {
         '<rootDir>/.next/',
         // Prevent jest-haste-map "duplicate manual mock" collisions with sibling
         // apps that vendor the same packages (e.g. apps/landing/vendor/picocolors
-        // vs apps/panel/vendor/picocolors). Without this, running any panel test
-        // whose filename also exists in landing's __tests__ would fail at
-        // module-map build time.
+        // vs apps/panel/vendor/picocolors). Exclude both vendor dirs so haste
+        // never sees duplicate package names.
+        '<rootDir>/vendor/',
         '<rootDir>/../landing/',
     ],
     coverageThreshold: {

--- a/apps/panel/src/__tests__/appointmentDrawer.test.tsx
+++ b/apps/panel/src/__tests__/appointmentDrawer.test.tsx
@@ -108,6 +108,9 @@ describe('AppointmentDrawer', () => {
         useWarehouseSalesMock.mockReset();
         useCustomerAlertsMock.mockReset();
         trackEventMock.mockReset();
+        // Default: resolve with empty array so formula/notes fetch in useEffect
+        // doesn't throw TypeError when apiFetch returns undefined after reset.
+        apiFetchMock.mockResolvedValue([]);
         useWarehouseSalesMock.mockReturnValue({ data: { items: [] } });
         useCustomerAlertsMock.mockReturnValue({
             alerts: [],
@@ -561,6 +564,7 @@ describe('AppointmentDrawer', () => {
         expect(sectionHeadings).toEqual([
             'Wizyta',
             'Klient',
+            'Formularz zabiegu',
             'Sprzedaż',
             'Akcje',
         ]);

--- a/apps/panel/src/__tests__/calendarPage.test.tsx
+++ b/apps/panel/src/__tests__/calendarPage.test.tsx
@@ -911,23 +911,23 @@ describe('CalendarPage', () => {
 
         render(<CalendarPage />);
 
-        expect(screen.getByText('Nadchodzace wizyty')).toBeInTheDocument();
+        expect(screen.getByText('Nadchodzące wizyty')).toBeInTheDocument();
         expect(screen.getByText('Historia wizyt')).toBeInTheDocument();
         expect(screen.queryByText('Nowa wizyta')).not.toBeInTheDocument();
         expect(screen.getByText(/Strzyzenie/i)).toBeInTheDocument();
         expect(screen.getByText(/Koloryzacja/i)).toBeInTheDocument();
         expect(screen.queryByText(/Makijaz/i)).not.toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getByRole('button', { name: 'Poproś o anulowanie' }),
         ).toBeInTheDocument();
         expect(
-            screen.getAllByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getAllByRole('button', { name: 'Poproś o anulowanie' }),
         ).toHaveLength(1);
 
         fireEvent.click(screen.getByRole('button', { name: /Koloryzacja/i }));
         expect(
             screen.getByTestId('client-appointment-details'),
-        ).toHaveTextContent('Szczegoly wizyty (tylko odczyt)');
+        ).toHaveTextContent('Szczegóły wizyty (tylko odczyt)');
         expect(
             screen.getByTestId('client-appointment-details'),
         ).toHaveTextContent('Koloryzacja');
@@ -939,7 +939,7 @@ describe('CalendarPage', () => {
         );
 
         fireEvent.click(
-            screen.getByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getByRole('button', { name: 'Poproś o anulowanie' }),
         );
         await waitFor(() =>
             expect(apiFetchMock).toHaveBeenCalledWith(
@@ -953,7 +953,7 @@ describe('CalendarPage', () => {
         await waitFor(() =>
             expect(
                 screen.getByText(
-                    'Prosba o anulowanie zostala zapisana. Recepcja skontaktuje sie z Toba.',
+                    'Prośba o anulowanie została zapisana. Recepcja skontaktuje się z Tobą.',
                 ),
             ).toBeInTheDocument(),
         );
@@ -1006,7 +1006,7 @@ describe('CalendarPage', () => {
         render(<CalendarPage />);
 
         const buttons = screen.getAllByRole('button', {
-            name: 'Popros o anulowanie',
+            name: 'Poproś o anulowanie',
         });
         expect(buttons).toHaveLength(1);
 
@@ -1025,7 +1025,7 @@ describe('CalendarPage', () => {
         await waitFor(() =>
             expect(
                 screen.getByText(
-                    'Prosba o anulowanie zostala zapisana. Recepcja skontaktuje sie z Toba.',
+                    'Prośba o anulowanie została zapisana. Recepcja skontaktuje się z Tobą.',
                 ),
             ).toBeInTheDocument(),
         );

--- a/apps/panel/src/__tests__/clientAppointmentHistoryView.test.tsx
+++ b/apps/panel/src/__tests__/clientAppointmentHistoryView.test.tsx
@@ -115,7 +115,7 @@ describe('ClientAppointmentHistoryView', () => {
         const details = screen.getByTestId('client-appointment-details');
         expect(details).toHaveTextContent('Szczegoly wizyty (tylko odczyt)');
         expect(details).toHaveTextContent('Masaż');
-        expect(details).toHaveTextContent('confirmed');
+        expect(details).toHaveTextContent('Potwierdzona');
         expect(details).toHaveTextContent('Monika Zielinska');
         expect(details).toHaveTextContent('11 cze 2026');
     });

--- a/apps/panel/src/__tests__/clientAppointmentHistoryView.test.tsx
+++ b/apps/panel/src/__tests__/clientAppointmentHistoryView.test.tsx
@@ -56,7 +56,7 @@ describe('ClientAppointmentHistoryView', () => {
             />,
         );
 
-        expect(screen.getByText('Nadchodzace wizyty')).toBeInTheDocument();
+        expect(screen.getByText('Nadchodzące wizyty')).toBeInTheDocument();
         expect(
             screen.getByRole('button', { name: /Koloryzacja/i }),
         ).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('ClientAppointmentHistoryView', () => {
         );
 
         expect(
-            screen.getByText('Brak nadchodzacych wizyt.'),
+            screen.getByText('Brak nadchodzących wizyt.'),
         ).toBeInTheDocument();
         expect(
             screen.getByText('Brak wizyt archiwalnych.'),
@@ -113,7 +113,7 @@ describe('ClientAppointmentHistoryView', () => {
         );
 
         const details = screen.getByTestId('client-appointment-details');
-        expect(details).toHaveTextContent('Szczegoly wizyty (tylko odczyt)');
+        expect(details).toHaveTextContent('Szczegóły wizyty (tylko odczyt)');
         expect(details).toHaveTextContent('Masaż');
         expect(details).toHaveTextContent('Potwierdzona');
         expect(details).toHaveTextContent('Monika Zielinska');
@@ -176,7 +176,7 @@ describe('ClientAppointmentHistoryView', () => {
 
         expect(
             screen.getByTestId('client-appointment-details'),
-        ).toHaveTextContent('Wybierz wizyte z listy, aby zobaczyc szczegoly.');
+        ).toHaveTextContent('Wybierz wizytę z listy, aby zobaczyć szczegóły.');
     });
 
     it('does not render mutating action buttons in client read-only view', () => {
@@ -218,10 +218,10 @@ describe('ClientAppointmentHistoryView', () => {
         );
 
         expect(
-            screen.getByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getByRole('button', { name: 'Poproś o anulowanie' }),
         ).toBeInTheDocument();
         expect(
-            screen.getAllByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getAllByRole('button', { name: 'Poproś o anulowanie' }),
         ).toHaveLength(1);
     });
 
@@ -238,7 +238,7 @@ describe('ClientAppointmentHistoryView', () => {
         );
 
         fireEvent.click(
-            screen.getByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getByRole('button', { name: 'Poproś o anulowanie' }),
         );
 
         await waitFor(() =>
@@ -246,7 +246,7 @@ describe('ClientAppointmentHistoryView', () => {
         );
         expect(
             screen.getByText(
-                'Prosba o anulowanie zostala zapisana. Recepcja skontaktuje sie z Toba.',
+                'Prośba o anulowanie została zapisana. Recepcja skontaktuje się z Tobą.',
             ),
         ).toBeInTheDocument();
     });
@@ -266,7 +266,7 @@ describe('ClientAppointmentHistoryView', () => {
         );
 
         fireEvent.click(
-            screen.getByRole('button', { name: 'Popros o anulowanie' }),
+            screen.getByRole('button', { name: 'Poproś o anulowanie' }),
         );
 
         await waitFor(() =>
@@ -274,7 +274,7 @@ describe('ClientAppointmentHistoryView', () => {
         );
         expect(
             screen.getByText(
-                'Nie udalo sie wyslac prosby o anulowanie. Sprobuj ponownie.',
+                'Nie udało się wysłać prośby o anulowanie. Spróbuj ponownie.',
             ),
         ).toBeInTheDocument();
     });

--- a/apps/panel/src/__tests__/finalizationModal.test.tsx
+++ b/apps/panel/src/__tests__/finalizationModal.test.tsx
@@ -36,6 +36,7 @@ jest.mock('@tanstack/react-query', () => ({
 describe('FinalizationModal', () => {
     beforeEach(() => {
         apiFetchMock.mockReset();
+        apiFetchMock.mockResolvedValue([]);
         mutateMock.mockReset();
         invalidateMock.mockReset();
         useQueryMock.mockReset();

--- a/apps/panel/src/__tests__/staffAppointmentCalendarView.test.tsx
+++ b/apps/panel/src/__tests__/staffAppointmentCalendarView.test.tsx
@@ -10,6 +10,7 @@ import StaffAppointmentCalendarView from '@/components/calendar/StaffAppointment
 const cancelMock = jest.fn();
 const completeMock = jest.fn();
 const updateStatusMock = jest.fn();
+const apiFetchMock = jest.fn();
 
 jest.mock('@/hooks/useAppointments', () => ({
     useAppointmentMutations: () => ({
@@ -17,6 +18,20 @@ jest.mock('@/hooks/useAppointments', () => ({
         completeAppointment: { mutateAsync: completeMock },
         updateAppointmentStatus: { mutateAsync: updateStatusMock },
     }),
+}));
+
+jest.mock('@/contexts/AuthContext', () => ({
+    useAuth: () => ({ apiFetch: apiFetchMock }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: jest.fn(() => ({ data: [] })),
+    useMutation: jest.fn(() => ({
+        mutate: jest.fn(),
+        isPending: false,
+        isError: false,
+    })),
+    useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() })),
 }));
 
 const baseAppointment = {
@@ -43,6 +58,8 @@ describe('StaffAppointmentCalendarView', () => {
         cancelMock.mockReset();
         completeMock.mockReset();
         updateStatusMock.mockReset();
+        apiFetchMock.mockReset();
+        apiFetchMock.mockResolvedValue([]);
     });
 
     it('renders active appointment row and action buttons', () => {
@@ -82,17 +99,17 @@ describe('StaffAppointmentCalendarView', () => {
         );
     });
 
-    it('calls completeAppointment on Zakoncz', async () => {
-        completeMock.mockResolvedValueOnce(undefined);
-
+    it('opens FinalizationModal on Finalizuj for in_progress appointment', () => {
         render(
             <StaffAppointmentCalendarView
                 appointments={[{ ...baseAppointment, status: 'in_progress' }]}
             />,
         );
-        fireEvent.click(screen.getByRole('button', { name: 'Zakończ' }));
-
-        await waitFor(() => expect(completeMock).toHaveBeenCalledWith(101));
+        expect(
+            screen.getByRole('button', { name: 'Finalizuj' }),
+        ).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Finalizuj' }));
+        expect(completeMock).not.toHaveBeenCalled();
     });
 
     it('calls updateAppointmentStatus(... no_show) on No-show', async () => {

--- a/apps/panel/src/components/calendar/AppointmentDrawer.tsx
+++ b/apps/panel/src/components/calendar/AppointmentDrawer.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import type { Appointment, Customer, Employee, Service } from '@/types';
+import type {
+    Appointment,
+    Customer,
+    Employee,
+    Formula,
+    Service,
+} from '@/types';
 import { useServices } from '@/hooks/useServices';
 import { useEmployees } from '@/hooks/useEmployees';
 import {
@@ -115,6 +121,17 @@ export default function AppointmentDrawer({
     const [error, setError] = useState<string | null>(null);
     const [finalizationOpen, setFinalizationOpen] = useState(false);
 
+    const [internalNote, setInternalNote] = useState('');
+    const [noteSaving, setNoteSaving] = useState(false);
+    const [noteSaved, setNoteSaved] = useState(false);
+    const noteSavedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const [formulaText, setFormulaText] = useState('');
+    const [formulaSaving, setFormulaSaving] = useState(false);
+    const [formulaError, setFormulaError] = useState<string | null>(null);
+    const [formulas, setFormulas] = useState<Formula[]>([]);
+    const [formulasLoaded, setFormulasLoaded] = useState(false);
+
     const title =
         mode === 'create' ? 'Nowa wizyta' : `Wizyta #${appointment?.id ?? ''}`;
 
@@ -160,12 +177,33 @@ export default function AppointmentDrawer({
     useEffect(() => {
         if (!open) return;
 
+        setInternalNote('');
+        setNoteSaved(false);
+        setFormulaText('');
+        setFormulaError(null);
+        setFormulas([]);
+        setFormulasLoaded(false);
+
         if (mode === 'edit' && appointment) {
             setStartTime(toLocalDateTimeInput(new Date(appointment.startTime)));
             setEmployeeId(appointment.employee?.id ?? '');
             setServiceId(appointment.service?.id ?? '');
             setClientId(appointment.client?.id ?? '');
+            setInternalNote(appointment.internalNote ?? '');
             setError(null);
+
+            const clientId = appointment.client?.id;
+            const canShowFormulas =
+                appointment.status === 'in_progress' ||
+                appointment.status === 'completed';
+            if (clientId && canShowFormulas) {
+                apiFetch<Formula[]>(`/customers/${clientId}/formulas`)
+                    .then((data) => {
+                        setFormulas(data.slice(0, 3));
+                        setFormulasLoaded(true);
+                    })
+                    .catch(() => setFormulasLoaded(true));
+            }
             return;
         }
 
@@ -190,6 +228,7 @@ export default function AppointmentDrawer({
         initialEndTime,
         initialEmployeeId,
         initialServiceId,
+        apiFetch,
     ]);
 
     if (!open) return null;
@@ -365,6 +404,57 @@ export default function AppointmentDrawer({
         }
     };
 
+    const handleSaveNote = async () => {
+        if (!appointment?.id) return;
+        setNoteSaving(true);
+        try {
+            await apiFetch(`/appointments/${appointment.id}/notes`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ internalNote: internalNote || null }),
+            });
+            if (noteSavedTimer.current) clearTimeout(noteSavedTimer.current);
+            setNoteSaved(true);
+            noteSavedTimer.current = setTimeout(
+                () => setNoteSaved(false),
+                2000,
+            );
+        } finally {
+            setNoteSaving(false);
+        }
+    };
+
+    const handleSaveFormula = async () => {
+        if (!appointment?.id || !formulaText.trim()) return;
+        setFormulaSaving(true);
+        setFormulaError(null);
+        try {
+            await apiFetch(`/appointments/${appointment.id}/formulas`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    description: formulaText.trim(),
+                    date: new Date().toISOString(),
+                }),
+            });
+            setFormulaText('');
+            if (appointment.client?.id) {
+                const data = await apiFetch<Formula[]>(
+                    `/customers/${appointment.client.id}/formulas`,
+                );
+                setFormulas(data.slice(0, 3));
+            }
+        } catch {
+            setFormulaError('Nie udało się zapisać formularza.');
+        } finally {
+            setFormulaSaving(false);
+        }
+    };
+
+    const canShowFormulaSection =
+        isEditMode &&
+        (currentStatus === 'in_progress' || currentStatus === 'completed');
+
     return (
         <>
             <div
@@ -384,7 +474,10 @@ export default function AppointmentDrawer({
                     </button>
                 </div>
 
-                <div className="p-3 d-flex flex-column gap-3">
+                <div
+                    className="p-3 d-flex flex-column gap-3 overflow-y-auto"
+                    style={{ flex: 1 }}
+                >
                     <div className="rounded border p-2">
                         <strong className="d-block mb-2">Wizyta</strong>
                         <div>
@@ -739,6 +832,116 @@ export default function AppointmentDrawer({
                                     </div>
                                 ))}
                             </div>
+                        </div>
+                    ) : null}
+
+                    {canShowFormulaSection ? (
+                        <div className="rounded border p-2">
+                            <strong className="d-block mb-2">
+                                Formularz zabiegu
+                            </strong>
+
+                            <div className="mb-2">
+                                <label
+                                    className="form-label form-label-sm mb-1"
+                                    htmlFor="appointment-internal-note"
+                                >
+                                    Notatka wewnętrzna
+                                </label>
+                                <textarea
+                                    id="appointment-internal-note"
+                                    className="form-control form-control-sm"
+                                    rows={2}
+                                    value={internalNote}
+                                    onChange={(e) =>
+                                        setInternalNote(e.target.value)
+                                    }
+                                    placeholder="Uwagi widoczne tylko dla personelu..."
+                                />
+                                <div className="d-flex align-items-center gap-2 mt-1">
+                                    <button
+                                        type="button"
+                                        className="btn btn-outline-secondary btn-sm"
+                                        onClick={() => void handleSaveNote()}
+                                        disabled={noteSaving}
+                                    >
+                                        {noteSaving
+                                            ? 'Zapisywanie…'
+                                            : 'Zapisz notatkę'}
+                                    </button>
+                                    {noteSaved && (
+                                        <span className="small text-success">
+                                            Zapisano
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+
+                            <div className="mb-2">
+                                <label
+                                    className="form-label form-label-sm mb-1"
+                                    htmlFor="appointment-formula"
+                                >
+                                    Receptura / formularz zabiegu
+                                </label>
+                                <textarea
+                                    id="appointment-formula"
+                                    className="form-control form-control-sm"
+                                    rows={3}
+                                    value={formulaText}
+                                    onChange={(e) =>
+                                        setFormulaText(e.target.value)
+                                    }
+                                    placeholder="Np. kolor: 7.1 + 8 vol, 40 min..."
+                                />
+                                {formulaError && (
+                                    <div className="small text-danger mt-1">
+                                        {formulaError}
+                                    </div>
+                                )}
+                                <button
+                                    type="button"
+                                    className="btn btn-outline-primary btn-sm mt-1"
+                                    onClick={() => void handleSaveFormula()}
+                                    disabled={
+                                        formulaSaving || !formulaText.trim()
+                                    }
+                                >
+                                    {formulaSaving
+                                        ? 'Zapisywanie…'
+                                        : 'Zapisz formularz'}
+                                </button>
+                            </div>
+
+                            {formulasLoaded && formulas.length > 0 && (
+                                <div>
+                                    <div className="small fw-medium text-muted mb-1">
+                                        Poprzednie formularze klienta
+                                    </div>
+                                    <div className="d-flex flex-column gap-1">
+                                        {formulas.map((f) => (
+                                            <div
+                                                key={f.id}
+                                                className="small bg-light rounded px-2 py-1"
+                                            >
+                                                <div
+                                                    className="text-muted mb-0"
+                                                    style={{
+                                                        fontSize: '0.75rem',
+                                                    }}
+                                                >
+                                                    {new Date(
+                                                        f.date,
+                                                    ).toLocaleDateString(
+                                                        'pl-PL',
+                                                    )}
+                                                </div>
+                                                <div>{f.description}</div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     ) : null}
 

--- a/apps/panel/src/components/calendar/AppointmentDrawer.tsx
+++ b/apps/panel/src/components/calendar/AppointmentDrawer.tsx
@@ -202,13 +202,21 @@ export default function AppointmentDrawer({
         Number(clientId) > 0;
     const isEditMode = mode === 'edit';
     const currentStatus = appointment?.status ?? 'scheduled';
-    const canConfirm = currentStatus === 'scheduled';
+    const isOnlinePending = currentStatus === 'online_pending';
+    const isRescheduledPending = currentStatus === 'rescheduled_pending';
+    const canConfirm =
+        currentStatus === 'scheduled' ||
+        isOnlinePending ||
+        isRescheduledPending;
     const canStart =
         currentStatus === 'scheduled' || currentStatus === 'confirmed';
     const canNoShow =
         currentStatus === 'scheduled' || currentStatus === 'confirmed';
     const canCancel =
-        currentStatus === 'scheduled' || currentStatus === 'confirmed';
+        currentStatus === 'scheduled' ||
+        currentStatus === 'confirmed' ||
+        isOnlinePending ||
+        isRescheduledPending;
     const canComplete = currentStatus === 'in_progress';
 
     const handleCreate = async () => {
@@ -455,7 +463,61 @@ export default function AppointmentDrawer({
                         </div>
                         {appointment ? (
                             <div className="mt-2 pt-2 border-top small">
-                                <div>Status: {appointment.status ?? '-'}</div>
+                                <div className="d-flex align-items-center gap-2 mb-1">
+                                    <span>Status:</span>
+                                    <span
+                                        className={`badge ${
+                                            currentStatus === 'online_pending'
+                                                ? 'text-bg-warning'
+                                                : currentStatus ===
+                                                    'rescheduled_pending'
+                                                  ? 'text-bg-warning'
+                                                  : currentStatus ===
+                                                      'confirmed'
+                                                    ? 'text-bg-success'
+                                                    : currentStatus ===
+                                                        'in_progress'
+                                                      ? 'text-bg-primary'
+                                                      : currentStatus ===
+                                                          'cancelled'
+                                                        ? 'text-bg-danger'
+                                                        : 'text-bg-secondary'
+                                        }`}
+                                    >
+                                        {currentStatus === 'online_pending'
+                                            ? 'Oczekuje na potwierdzenie'
+                                            : currentStatus ===
+                                                'rescheduled_pending'
+                                              ? 'Przeniesiona — wymaga akceptacji'
+                                              : currentStatus === 'confirmed'
+                                                ? 'Potwierdzona'
+                                                : currentStatus ===
+                                                    'in_progress'
+                                                  ? 'W trakcie'
+                                                  : currentStatus ===
+                                                      'completed'
+                                                    ? 'Zakończona'
+                                                    : currentStatus ===
+                                                        'cancelled'
+                                                      ? 'Anulowana'
+                                                      : currentStatus ===
+                                                          'no_show'
+                                                        ? 'No-show'
+                                                        : 'Zaplanowana'}
+                                    </span>
+                                </div>
+                                {isOnlinePending && (
+                                    <p className="text-warning-emphasis small mb-1">
+                                        Klient zarezerwował online — potwierdź
+                                        lub odrzuć rezerwację.
+                                    </p>
+                                )}
+                                {isRescheduledPending && (
+                                    <p className="text-warning-emphasis small mb-1">
+                                        Wizyta przeniesiona — oczekuje na
+                                        akceptację klienta.
+                                    </p>
+                                )}
                                 <div>
                                     Płatność:{' '}
                                     {appointment.paymentStatus ?? 'nieopłacona'}
@@ -779,7 +841,7 @@ export default function AppointmentDrawer({
                                     {canConfirm ? (
                                         <button
                                             type="button"
-                                            className="btn btn-outline-primary"
+                                            className={`btn ${isOnlinePending ? 'btn-success' : 'btn-outline-primary'}`}
                                             onClick={() =>
                                                 void handleStatusChange(
                                                     'confirmed',
@@ -787,7 +849,11 @@ export default function AppointmentDrawer({
                                             }
                                             disabled={saving}
                                         >
-                                            Potwierdź
+                                            {isOnlinePending
+                                                ? 'Potwierdź rezerwację'
+                                                : isRescheduledPending
+                                                  ? 'Zaakceptuj nowy termin'
+                                                  : 'Potwierdź'}
                                         </button>
                                     ) : null}
                                     {canStart ? (

--- a/apps/panel/src/components/calendar/AppointmentDrawer.tsx
+++ b/apps/panel/src/components/calendar/AppointmentDrawer.tsx
@@ -746,12 +746,15 @@ export default function AppointmentDrawer({
                                 </div>
                             </div>
                         )}
-                        {appointment?.client?.phone || appointment?.client?.email ? (
+                        {appointment?.client?.phone ||
+                        appointment?.client?.email ? (
                             <div className="mt-2 pt-2 border-top small">
                                 {appointment.client.phone && (
                                     <div>
                                         Tel:{' '}
-                                        <a href={`tel:${appointment.client.phone}`}>
+                                        <a
+                                            href={`tel:${appointment.client.phone}`}
+                                        >
                                             {appointment.client.phone}
                                         </a>
                                     </div>
@@ -759,7 +762,9 @@ export default function AppointmentDrawer({
                                 {appointment.client.email && (
                                     <div>
                                         E-mail:{' '}
-                                        <a href={`mailto:${appointment.client.email}`}>
+                                        <a
+                                            href={`mailto:${appointment.client.email}`}
+                                        >
                                             {appointment.client.email}
                                         </a>
                                     </div>

--- a/apps/panel/src/components/calendar/AppointmentDrawer.tsx
+++ b/apps/panel/src/components/calendar/AppointmentDrawer.tsx
@@ -746,6 +746,26 @@ export default function AppointmentDrawer({
                                 </div>
                             </div>
                         )}
+                        {appointment?.client?.phone || appointment?.client?.email ? (
+                            <div className="mt-2 pt-2 border-top small">
+                                {appointment.client.phone && (
+                                    <div>
+                                        Tel:{' '}
+                                        <a href={`tel:${appointment.client.phone}`}>
+                                            {appointment.client.phone}
+                                        </a>
+                                    </div>
+                                )}
+                                {appointment.client.email && (
+                                    <div>
+                                        E-mail:{' '}
+                                        <a href={`mailto:${appointment.client.email}`}>
+                                            {appointment.client.email}
+                                        </a>
+                                    </div>
+                                )}
+                            </div>
+                        ) : null}
                         {appointment ? (
                             <div className="mt-2 pt-2 border-top small">
                                 <div className="d-flex align-items-center justify-content-between">

--- a/apps/panel/src/components/calendar/ClientAppointmentHistoryView.tsx
+++ b/apps/panel/src/components/calendar/ClientAppointmentHistoryView.tsx
@@ -93,14 +93,14 @@ export default function ClientAppointmentHistoryView({
                 kind: 'success',
                 appointmentId,
                 message:
-                    'Prosba o anulowanie zostala zapisana. Recepcja skontaktuje sie z Toba.',
+                    'Prośba o anulowanie została zapisana. Recepcja skontaktuje się z Tobą.',
             });
         } catch {
             setRequestState({
                 kind: 'error',
                 appointmentId,
                 message:
-                    'Nie udalo sie wyslac prosby o anulowanie. Sprobuj ponownie.',
+                    'Nie udało się wysłać prośby o anulowanie. Spróbuj ponownie.',
             });
         } finally {
             setPendingRequestId(null);
@@ -119,7 +119,7 @@ export default function ClientAppointmentHistoryView({
                     + Zarezerwuj wizytę
                 </button>
             </div>
-            <div className="d-flex flex-wrap align-items-end gap-3 rounded border bg-white p-2">
+            <div className="d-flex flex-wrap align-items-end gap-3 rounded border p-2">
                 <div>
                     <label
                         className="form-label form-label-sm mb-1"
@@ -144,11 +144,11 @@ export default function ClientAppointmentHistoryView({
             </div>
             <div className="row g-3">
                 <section className="col-12 col-lg-6">
-                    <div className="border rounded bg-white p-3 h-100">
-                        <h3 className="h6 mb-2">Nadchodzace wizyty</h3>
+                    <div className="border rounded p-3 h-100">
+                        <h3 className="h6 mb-2">Nadchodzące wizyty</h3>
                         {futureAppointments.length === 0 ? (
                             <p className="text-muted small mb-0">
-                                Brak nadchodzacych wizyt.
+                                Brak nadchodzących wizyt.
                             </p>
                         ) : (
                             <div className="d-flex flex-column gap-2">
@@ -237,8 +237,8 @@ export default function ClientAppointmentHistoryView({
                                             >
                                                 {pendingRequestId ===
                                                 appointment.id
-                                                    ? 'Wysylanie...'
-                                                    : 'Popros o anulowanie'}
+                                                    ? 'Wysyłanie...'
+                                                    : 'Poproś o anulowanie'}
                                             </button>
                                         ) : null}
                                         {requestState?.appointmentId ===
@@ -261,7 +261,7 @@ export default function ClientAppointmentHistoryView({
                     </div>
                 </section>
                 <section className="col-12 col-lg-6">
-                    <div className="border rounded bg-white p-3 h-100">
+                    <div className="border rounded p-3 h-100">
                         <h3 className="h6 mb-2">Historia wizyt</h3>
                         {archivedAppointments.length === 0 ? (
                             <p className="text-muted small mb-0">
@@ -293,13 +293,13 @@ export default function ClientAppointmentHistoryView({
                 </section>
             </div>
             <section
-                className="border rounded bg-white p-3"
+                className="border rounded p-3"
                 data-testid="client-appointment-details"
             >
-                <h3 className="h6 mb-2">Szczegoly wizyty (tylko odczyt)</h3>
+                <h3 className="h6 mb-2">Szczegóły wizyty (tylko odczyt)</h3>
                 {selectedAppointment ? (
                     <dl className="row mb-0">
-                        <dt className="col-sm-3">Usluga</dt>
+                        <dt className="col-sm-3">Usługa</dt>
                         <dd className="col-sm-9">
                             {selectedAppointment.service?.name ?? '-'}
                         </dd>
@@ -324,7 +324,7 @@ export default function ClientAppointmentHistoryView({
                     </dl>
                 ) : (
                     <p className="text-muted small mb-0">
-                        Wybierz wizyte z listy, aby zobaczyc szczegoly.
+                        Wybierz wizytę z listy, aby zobaczyć szczegóły.
                     </p>
                 )}
             </section>

--- a/apps/panel/src/components/calendar/ClientAppointmentHistoryView.tsx
+++ b/apps/panel/src/components/calendar/ClientAppointmentHistoryView.tsx
@@ -2,12 +2,24 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import type { Appointment } from '@/types';
 
+const STATUS_LABELS: Record<string, string> = {
+    scheduled: 'Zaplanowana',
+    confirmed: 'Potwierdzona',
+    in_progress: 'W trakcie',
+    completed: 'Zakończona',
+    cancelled: 'Anulowana',
+    no_show: 'No-show',
+    online_pending: 'Oczekuje na potwierdzenie',
+    rescheduled_pending: 'Przeniesiona — wymaga akceptacji',
+};
+
 interface ClientAppointmentHistoryViewProps {
     currentDateParam: string;
     futureAppointments: Appointment[];
     archivedAppointments: Appointment[];
     onDateChange: (nextDate: Date) => void;
     onRequestCancellation?: (appointmentId: number) => Promise<void>;
+    onAcceptReschedule?: (appointmentId: number) => Promise<void>;
 }
 
 function formatAppointmentDate(date: string): string {
@@ -23,8 +35,10 @@ export default function ClientAppointmentHistoryView({
     archivedAppointments,
     onDateChange,
     onRequestCancellation,
+    onAcceptReschedule,
 }: ClientAppointmentHistoryViewProps) {
     const router = useRouter();
+    const [pendingAcceptId, setPendingAcceptId] = useState<number | null>(null);
     const [selectedAppointmentId, setSelectedAppointmentId] = useState<
         number | null
     >(null);
@@ -58,6 +72,16 @@ export default function ClientAppointmentHistoryView({
         if (appointmentsById.has(selectedAppointmentId)) return;
         setSelectedAppointmentId(null);
     }, [appointmentsById, selectedAppointmentId]);
+
+    const handleAcceptReschedule = async (appointmentId: number) => {
+        if (!onAcceptReschedule) return;
+        setPendingAcceptId(appointmentId);
+        try {
+            await onAcceptReschedule(appointmentId);
+        } finally {
+            setPendingAcceptId(null);
+        }
+    };
 
     const handleRequestCancellation = async (appointmentId: number) => {
         if (!onRequestCancellation) return;
@@ -131,7 +155,14 @@ export default function ClientAppointmentHistoryView({
                                 {futureAppointments.map((appointment) => (
                                     <div
                                         key={appointment.id}
-                                        className="d-flex flex-column gap-2 border rounded p-2"
+                                        className={`d-flex flex-column gap-2 border rounded p-2 ${
+                                            appointment.status ===
+                                                'online_pending' ||
+                                            appointment.status ===
+                                                'rescheduled_pending'
+                                                ? 'border-warning'
+                                                : ''
+                                        }`}
                                     >
                                         <button
                                             type="button"
@@ -149,6 +180,47 @@ export default function ClientAppointmentHistoryView({
                                                 appointment.startTime,
                                             )}
                                         </button>
+                                        {appointment.status && (
+                                            <span
+                                                className={`badge align-self-start ${
+                                                    appointment.status ===
+                                                        'online_pending' ||
+                                                    appointment.status ===
+                                                        'rescheduled_pending'
+                                                        ? 'text-bg-warning'
+                                                        : appointment.status ===
+                                                            'confirmed'
+                                                          ? 'text-bg-success'
+                                                          : 'text-bg-secondary'
+                                                }`}
+                                            >
+                                                {STATUS_LABELS[
+                                                    appointment.status
+                                                ] ?? appointment.status}
+                                            </span>
+                                        )}
+                                        {appointment.status ===
+                                            'rescheduled_pending' &&
+                                        onAcceptReschedule ? (
+                                            <button
+                                                type="button"
+                                                className="btn btn-success btn-sm align-self-start"
+                                                onClick={() =>
+                                                    void handleAcceptReschedule(
+                                                        appointment.id,
+                                                    )
+                                                }
+                                                disabled={
+                                                    pendingAcceptId ===
+                                                    appointment.id
+                                                }
+                                            >
+                                                {pendingAcceptId ===
+                                                appointment.id
+                                                    ? 'Akceptowanie...'
+                                                    : 'Zaakceptuj nowy termin'}
+                                            </button>
+                                        ) : null}
                                         {onRequestCancellation ? (
                                             <button
                                                 type="button"
@@ -233,7 +305,11 @@ export default function ClientAppointmentHistoryView({
                         </dd>
                         <dt className="col-sm-3">Status</dt>
                         <dd className="col-sm-9">
-                            {selectedAppointment.status ?? 'scheduled'}
+                            {STATUS_LABELS[
+                                selectedAppointment.status ?? 'scheduled'
+                            ] ??
+                                selectedAppointment.status ??
+                                'Zaplanowana'}
                         </dd>
                         <dt className="col-sm-3">Termin</dt>
                         <dd className="col-sm-9">

--- a/apps/panel/src/components/calendar/EventCard.tsx
+++ b/apps/panel/src/components/calendar/EventCard.tsx
@@ -46,6 +46,8 @@ const STATUS_STYLES: Record<string, string> = {
     completed: 'opacity-60',
     cancelled: 'opacity-40 line-through',
     no_show: 'opacity-40 bg-red-100',
+    online_pending: 'opacity-100 ring-2 ring-orange-400',
+    rescheduled_pending: 'opacity-100 ring-2 ring-yellow-500',
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -55,6 +57,8 @@ const STATUS_LABELS: Record<string, string> = {
     completed: 'Zakończona',
     cancelled: 'Anulowana',
     no_show: 'No-show',
+    online_pending: 'Oczekuje na potwierdzenie',
+    rescheduled_pending: 'Przeniesiona — wymaga akceptacji',
 };
 
 const ALERT_BADGE_STYLES: Record<ReceptionAlertSeverity, string> = {

--- a/apps/panel/src/components/calendar/FinalizationModal.tsx
+++ b/apps/panel/src/components/calendar/FinalizationModal.tsx
@@ -12,6 +12,7 @@ import type {
     FinalizeAppointmentRequest,
     ProductSaleItem,
     Product,
+    UsageItem,
 } from '@/types';
 
 interface Props {
@@ -46,6 +47,7 @@ export default function FinalizationModal({
     const [note, setNote] = useState<string>('');
     const [productSales, setProductSales] = useState<ProductSaleItem[]>([]);
     const [showProductPicker, setShowProductPicker] = useState(false);
+    const [usageItems, setUsageItems] = useState<UsageItem[]>([]);
     const [uiError, setUiError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
     const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -141,6 +143,7 @@ export default function FinalizationModal({
         setTipPln('');
         setNote('');
         setProductSales([]);
+        setUsageItems([]);
         setShowProductPicker(false);
         setUiError(null);
         setSuccessMessage(null);
@@ -156,6 +159,17 @@ export default function FinalizationModal({
         },
         [],
     );
+
+    useEffect(() => {
+        if (!open || !appointment?.id) return;
+        apiFetch<UsageItem[]>(`/appointments/${appointment.id}/usage`)
+            .then((data) => {
+                if (Array.isArray(data) && data.length > 0) {
+                    setUsageItems(data);
+                }
+            })
+            .catch(() => {});
+    }, [open, appointment?.id, apiFetch]);
 
     const handleSubmit = () => {
         if (!appointment) return;
@@ -174,6 +188,14 @@ export default function FinalizationModal({
             discountCents: Math.round(summary.discount * 100),
             products: productSales.length > 0 ? productSales : undefined,
             note: note || undefined,
+            usageItems:
+                usageItems.length > 0
+                    ? usageItems.map((item) => ({
+                          productId: item.productId,
+                          quantity: item.quantity,
+                          unit: item.unit,
+                      }))
+                    : undefined,
         };
 
         finalizeMutation.mutate(data);
@@ -471,6 +493,69 @@ export default function FinalizationModal({
                         </div>
                     )}
                 </div>
+
+                {/* Materials used */}
+                {usageItems.length > 0 && (
+                    <div className="mb-3">
+                        <label className="d-block small fw-medium text-body mb-2">
+                            Użyte materiały
+                        </label>
+                        <div className="d-flex flex-column gap-2">
+                            {usageItems.map((item, idx) => (
+                                <div
+                                    key={item.productId}
+                                    className="d-flex align-items-center gap-2 bg-light rounded px-2 py-1"
+                                >
+                                    <span className="flex-fill small">
+                                        {item.productName}
+                                    </span>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        step="1"
+                                        value={item.quantity}
+                                        onChange={(e) => {
+                                            const qty =
+                                                parseInt(e.target.value) || 1;
+                                            setUsageItems((prev) =>
+                                                prev.map((it, i) =>
+                                                    i === idx
+                                                        ? {
+                                                              ...it,
+                                                              quantity:
+                                                                  Math.max(
+                                                                      1,
+                                                                      qty,
+                                                                  ),
+                                                          }
+                                                        : it,
+                                                ),
+                                            );
+                                        }}
+                                        className="form-control form-control-sm"
+                                        style={{ width: '70px' }}
+                                    />
+                                    <span className="small text-muted">
+                                        {item.unit}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        className="text-danger small"
+                                        onClick={() =>
+                                            setUsageItems((prev) =>
+                                                prev.filter(
+                                                    (_, i) => i !== idx,
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        ×
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
 
                 {/* Note */}
                 <div className="mb-3">

--- a/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
+++ b/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
@@ -171,104 +171,105 @@ export default function StaffAppointmentCalendarView({
 
     return (
         <>
-        <FinalizationModal
-            open={finalizingAppointment !== null}
-            appointment={finalizingAppointment}
-            onClose={() => setFinalizingAppointment(null)}
-            onSuccess={() => {
-                setFinalizingAppointment(null);
-                onChanged?.();
-            }}
-        />
-        <div className="salonbw-reception-list">
-            {sortedAppointments.map((appointment) => {
-                const status = appointment.status || 'scheduled';
-                const statusConfig =
-                    STATUS_CONFIG[status] || STATUS_CONFIG.scheduled;
-                const actions = readOnly ? [] : statusConfig.actions;
-                return (
-                    <article
-                        key={appointment.id}
-                        className="salonbw-reception-item"
-                    >
-                        <div className="salonbw-reception-item__header">
-                            <div>
-                                <h4 className="salonbw-reception-item__title">
-                                    {appointment.service?.name || 'Wizyta'}
-                                </h4>
-                                <div className="salonbw-reception-item__meta">
-                                    <span>
-                                        {formatTime(appointment.startTime)} -{' '}
-                                        {formatTime(
-                                            appointment.endTime ??
+            <FinalizationModal
+                open={finalizingAppointment !== null}
+                appointment={finalizingAppointment}
+                onClose={() => setFinalizingAppointment(null)}
+                onSuccess={() => {
+                    setFinalizingAppointment(null);
+                    onChanged?.();
+                }}
+            />
+            <div className="salonbw-reception-list">
+                {sortedAppointments.map((appointment) => {
+                    const status = appointment.status || 'scheduled';
+                    const statusConfig =
+                        STATUS_CONFIG[status] || STATUS_CONFIG.scheduled;
+                    const actions = readOnly ? [] : statusConfig.actions;
+                    return (
+                        <article
+                            key={appointment.id}
+                            className="salonbw-reception-item"
+                        >
+                            <div className="salonbw-reception-item__header">
+                                <div>
+                                    <h4 className="salonbw-reception-item__title">
+                                        {appointment.service?.name || 'Wizyta'}
+                                    </h4>
+                                    <div className="salonbw-reception-item__meta">
+                                        <span>
+                                            {formatTime(appointment.startTime)}{' '}
+                                            -{' '}
+                                            {formatTime(
+                                                appointment.endTime ??
+                                                    appointment.startTime,
+                                            )}
+                                        </span>
+                                        <span>·</span>
+                                        <span>
+                                            {formatDuration(
                                                 appointment.startTime,
-                                        )}
-                                    </span>
-                                    <span>·</span>
-                                    <span>
-                                        {formatDuration(
-                                            appointment.startTime,
-                                            appointment.endTime,
-                                        )}
-                                    </span>
+                                                appointment.endTime,
+                                            )}
+                                        </span>
+                                    </div>
                                 </div>
+                                <span
+                                    className={`salonbw-status-badge ${statusConfig.className}`}
+                                >
+                                    {statusConfig.label}
+                                </span>
                             </div>
-                            <span
-                                className={`salonbw-status-badge ${statusConfig.className}`}
-                            >
-                                {statusConfig.label}
-                            </span>
-                        </div>
-                        <div className="salonbw-reception-item__details">
-                            <span>
-                                {appointment.client?.name || 'Brak klienta'}
-                            </span>
-                        </div>
-                        <div className="salonbw-reception-item__actions">
-                            {actions.map((action) => {
-                                const config = ACTION_CONFIG[action];
-                                const isPending =
-                                    pendingAction?.appointmentId ===
-                                        appointment.id &&
-                                    pendingAction.action === action;
-                                return (
-                                    <button
-                                        key={action}
-                                        type="button"
-                                        className={`salonbw-btn salonbw-btn--sm ${config.className}`}
-                                        onClick={() =>
-                                            void handleAction(
-                                                appointment,
-                                                action,
-                                            )
-                                        }
-                                        disabled={Boolean(pendingAction)}
-                                    >
-                                        {isPending
-                                            ? 'Zapisywanie...'
-                                            : config.label}
-                                    </button>
-                                );
-                            })}
-                            <button
-                                type="button"
-                                className="salonbw-btn salonbw-btn--sm salonbw-btn--secondary"
-                                onClick={() =>
-                                    onOpenAppointment?.(appointment.id)
-                                }
-                            >
-                                Otwórz
-                            </button>
-                        </div>
-                        {actionErrorByAppointmentId[appointment.id] ? (
-                            <p className="text-danger small mb-0 mt-2">
-                                {actionErrorByAppointmentId[appointment.id]}
-                            </p>
-                        ) : null}
-                    </article>
-                );
-            })}
-        </div>
+                            <div className="salonbw-reception-item__details">
+                                <span>
+                                    {appointment.client?.name || 'Brak klienta'}
+                                </span>
+                            </div>
+                            <div className="salonbw-reception-item__actions">
+                                {actions.map((action) => {
+                                    const config = ACTION_CONFIG[action];
+                                    const isPending =
+                                        pendingAction?.appointmentId ===
+                                            appointment.id &&
+                                        pendingAction.action === action;
+                                    return (
+                                        <button
+                                            key={action}
+                                            type="button"
+                                            className={`salonbw-btn salonbw-btn--sm ${config.className}`}
+                                            onClick={() =>
+                                                void handleAction(
+                                                    appointment,
+                                                    action,
+                                                )
+                                            }
+                                            disabled={Boolean(pendingAction)}
+                                        >
+                                            {isPending
+                                                ? 'Zapisywanie...'
+                                                : config.label}
+                                        </button>
+                                    );
+                                })}
+                                <button
+                                    type="button"
+                                    className="salonbw-btn salonbw-btn--sm salonbw-btn--secondary"
+                                    onClick={() =>
+                                        onOpenAppointment?.(appointment.id)
+                                    }
+                                >
+                                    Otwórz
+                                </button>
+                            </div>
+                            {actionErrorByAppointmentId[appointment.id] ? (
+                                <p className="text-danger small mb-0 mt-2">
+                                    {actionErrorByAppointmentId[appointment.id]}
+                                </p>
+                            ) : null}
+                        </article>
+                    );
+                })}
+            </div>
         </>
     );
 }

--- a/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
+++ b/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
@@ -54,6 +54,16 @@ const STATUS_CONFIG: Record<AppointmentStatus | string, StatusConfig> = {
         className: 'salonbw-status--no-show',
         actions: [],
     },
+    online_pending: {
+        label: 'Oczekuje online',
+        className: 'salonbw-status--online_pending',
+        actions: ['cancel'],
+    },
+    rescheduled_pending: {
+        label: 'Przeniesiona',
+        className: 'salonbw-status--rescheduled_pending',
+        actions: ['cancel'],
+    },
 };
 
 const ACTION_CONFIG: Record<

--- a/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
+++ b/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
@@ -3,6 +3,7 @@ import { format, parseISO } from 'date-fns';
 import { pl } from 'date-fns/locale';
 import type { Appointment, AppointmentStatus } from '@/types';
 import { useAppointmentMutations } from '@/hooks/useAppointments';
+import FinalizationModal from './FinalizationModal';
 
 interface StaffAppointmentCalendarViewProps {
     appointments: Appointment[];
@@ -14,7 +15,7 @@ interface StaffAppointmentCalendarViewProps {
     onOpenAppointment?: (appointmentId: number) => void;
 }
 
-type ActionKey = 'start' | 'complete' | 'no_show' | 'cancel';
+type ActionKey = 'start' | 'finalize' | 'no_show' | 'cancel';
 
 type StatusConfig = {
     label: string;
@@ -36,7 +37,7 @@ const STATUS_CONFIG: Record<AppointmentStatus | string, StatusConfig> = {
     in_progress: {
         label: 'W trakcie',
         className: 'salonbw-status--in-progress',
-        actions: ['complete', 'cancel'],
+        actions: ['finalize', 'cancel'],
     },
     completed: {
         label: 'Zakończona',
@@ -64,10 +65,9 @@ const ACTION_CONFIG: Record<
         className: 'salonbw-btn--primary',
         nextStatus: 'in_progress',
     },
-    complete: {
-        label: 'Zakończ',
+    finalize: {
+        label: 'Finalizuj',
         className: 'salonbw-btn--success',
-        nextStatus: 'completed',
     },
     no_show: {
         label: 'No-show',
@@ -89,7 +89,7 @@ export default function StaffAppointmentCalendarView({
     onChanged,
     onOpenAppointment,
 }: StaffAppointmentCalendarViewProps) {
-    const { cancelAppointment, completeAppointment, updateAppointmentStatus } =
+    const { cancelAppointment, updateAppointmentStatus } =
         useAppointmentMutations();
     const [pendingAction, setPendingAction] = useState<{
         appointmentId: number;
@@ -97,6 +97,8 @@ export default function StaffAppointmentCalendarView({
     } | null>(null);
     const [actionErrorByAppointmentId, setActionErrorByAppointmentId] =
         useState<Record<number, string>>({});
+    const [finalizingAppointment, setFinalizingAppointment] =
+        useState<Appointment | null>(null);
 
     const sortedAppointments = [...appointments].sort(
         (a, b) =>
@@ -120,6 +122,11 @@ export default function StaffAppointmentCalendarView({
         appointment: Appointment,
         action: ActionKey,
     ) => {
+        if (action === 'finalize') {
+            setFinalizingAppointment(appointment);
+            return;
+        }
+
         setPendingAction({ appointmentId: appointment.id, action });
         setActionErrorByAppointmentId((current) => {
             const next = { ...current };
@@ -130,8 +137,6 @@ export default function StaffAppointmentCalendarView({
         try {
             if (action === 'cancel') {
                 await cancelAppointment.mutateAsync(appointment.id);
-            } else if (action === 'complete') {
-                await completeAppointment.mutateAsync(appointment.id);
             } else {
                 await updateAppointmentStatus.mutateAsync({
                     id: appointment.id,
@@ -165,6 +170,16 @@ export default function StaffAppointmentCalendarView({
     }
 
     return (
+        <>
+        <FinalizationModal
+            open={finalizingAppointment !== null}
+            appointment={finalizingAppointment}
+            onClose={() => setFinalizingAppointment(null)}
+            onSuccess={() => {
+                setFinalizingAppointment(null);
+                onChanged?.();
+            }}
+        />
         <div className="salonbw-reception-list">
             {sortedAppointments.map((appointment) => {
                 const status = appointment.status || 'scheduled';
@@ -254,5 +269,6 @@ export default function StaffAppointmentCalendarView({
                 );
             })}
         </div>
+        </>
     );
 }

--- a/apps/panel/src/components/salon/SalonTopbar.tsx
+++ b/apps/panel/src/components/salon/SalonTopbar.tsx
@@ -6,13 +6,26 @@ import SalonIcon from './SalonIcon';
 import { buildTopbarViewModel } from '@/lib/topbar/topbarModel';
 
 export default function SalonTopbar() {
-    const { user, logout } = useAuth();
+    const { user, logout, apiFetch } = useAuth();
     const router = useRouter();
     const [userMenuOpen, setUserMenuOpen] = useState(false);
     const [helpMenuOpen, setHelpMenuOpen] = useState(false);
     const userMenuRef = useRef<HTMLLIElement>(null);
     const helpMenuRef = useRef<HTMLLIElement>(null);
+    const [onlinePendingCount, setOnlinePendingCount] = useState(0);
     const topbar = buildTopbarViewModel(user);
+
+    useEffect(() => {
+        if (!user || user.role === 'client') return;
+        const fetchCount = () => {
+            apiFetch<{ count: number }>('/appointments/online-pending-count')
+                .then((data) => setOnlinePendingCount(data.count))
+                .catch(() => undefined);
+        };
+        fetchCount();
+        const interval = setInterval(fetchCount, 60_000);
+        return () => clearInterval(interval);
+    }, [user, apiFetch]);
 
     useEffect(() => {
         const handleClickOutside = (
@@ -99,6 +112,22 @@ export default function SalonTopbar() {
                             ></div>
                         </div>
                     </li>
+                    {onlinePendingCount > 0 ? (
+                        <li className="d-flex align-items-center">
+                            <Link
+                                href="/calendar"
+                                className="link d-flex align-items-center gap-1 px-2"
+                                title="Wizyty oczekujące na potwierdzenie"
+                            >
+                                <span className="badge bg-warning text-dark">
+                                    {onlinePendingCount}
+                                </span>
+                                <span className="d-none d-md-inline small">
+                                    oczekujące
+                                </span>
+                            </Link>
+                        </li>
+                    ) : null}
                     {topbar.notifications.enabled ? (
                         <li
                             className="notification_center"

--- a/apps/panel/src/pages/_document.tsx
+++ b/apps/panel/src/pages/_document.tsx
@@ -9,7 +9,7 @@ interface CustomDocumentProps extends DocumentProps {
 export default function Document(props: CustomDocumentProps) {
     // Next.js automatically passes nonce to Script components when CSP is set via middleware
     return (
-        <Html lang="en">
+        <Html lang="pl" data-bs-theme="dark">
             <Head nonce={props.nonce}>
                 <link rel="preconnect" href="https://fonts.googleapis.com" />
                 <link

--- a/apps/panel/src/pages/booking.tsx
+++ b/apps/panel/src/pages/booking.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/router';
 import RouteGuard from '@/components/RouteGuard';
 import SalonShell from '@/components/salon/SalonShell';
@@ -66,6 +66,8 @@ export default function BookingPage() {
         null,
     );
 
+    const slotsAbortRef = useRef<AbortController | null>(null);
+
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState('');
     const [submitted, setSubmitted] = useState(false);
@@ -103,19 +105,30 @@ export default function BookingPage() {
 
     const loadSlots = useCallback(
         (date: string, svcId: number) => {
+            slotsAbortRef.current?.abort();
+            const controller = new AbortController();
+            slotsAbortRef.current = controller;
+
             setSlotsLoading(true);
             setSlotsError('');
             setSelectedSlot(null);
             apiFetch<AvailableSlot[]>(
                 `/calendar/available-slots?serviceId=${svcId}&date=${date}`,
+                { signal: controller.signal },
             )
-                .then(setSlots)
-                .catch(() => {
+                .then((data) => {
+                    if (!controller.signal.aborted) setSlots(data);
+                })
+                .catch((err: unknown) => {
+                    if (err instanceof Error && err.name === 'AbortError')
+                        return;
                     setSlotsError(
                         'Nie udało się załadować dostępnych terminów.',
                     );
                 })
-                .finally(() => setSlotsLoading(false));
+                .finally(() => {
+                    if (!controller.signal.aborted) setSlotsLoading(false);
+                });
         },
         [apiFetch],
     );
@@ -345,7 +358,7 @@ function ServiceStep({
                             <button
                                 key={svc.id}
                                 type="button"
-                                className="d-flex justify-content-between align-items-center border rounded p-3 bg-white text-start w-100"
+                                className="d-flex justify-content-between align-items-center border rounded p-3 text-start w-100"
                                 style={{
                                     cursor: 'pointer',
                                     transition: 'border-color 0.15s',
@@ -422,7 +435,7 @@ function SlotStep({
 
     return (
         <div>
-            <div className="border rounded bg-white p-3 mb-3">
+            <div className="border rounded p-3 mb-3">
                 <strong>{service.name}</strong>
                 <span className="text-muted ms-2">
                     {service.duration} min ·{' '}
@@ -522,7 +535,7 @@ function ConfirmStep({
 
     return (
         <div>
-            <div className="border rounded bg-white p-3 mb-4">
+            <div className="border rounded p-3 mb-4">
                 <dl className="row mb-0">
                     <dt className="col-5 text-muted small fw-normal">Usługa</dt>
                     <dd className="col-7 mb-2">

--- a/apps/panel/src/pages/calendar.tsx
+++ b/apps/panel/src/pages/calendar.tsx
@@ -2192,6 +2192,22 @@ export default function CalendarPage() {
                                         },
                                     );
                                 }}
+                                onAcceptReschedule={async (appointmentId) => {
+                                    await apiFetch(
+                                        `/appointments/${appointmentId}/status`,
+                                        {
+                                            method: 'PATCH',
+                                            headers: {
+                                                'Content-Type':
+                                                    'application/json',
+                                            },
+                                            body: JSON.stringify({
+                                                status: 'confirmed',
+                                            }),
+                                        },
+                                    );
+                                    void refetch();
+                                }}
                             />
                         ) : (
                             <CalendarView

--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -1,14 +1,6 @@
 :root {
-    --background: #f5f5f5;
-    --foreground: #333333;
-}
-
-/* Dark mode overrides (optional, keeping for compatibility but default is light) */
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #f5f5f5; /* Force light mode base for consistency with the source design for now */
-        --foreground: #333333;
-    }
+    --background: #0d0d0d;
+    --foreground: #e8e0d5;
 }
 
 body {
@@ -25,10 +17,10 @@ body {
 }
 
 .salonbw-mass-communication__section {
-    background: #fff;
+    background: #161616;
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-    border: 1px solid #e5e7eb;
+    box-shadow: none;
+    border: 1px solid #252525;
     padding: 24px;
     margin-bottom: 16px;
 }
@@ -36,20 +28,21 @@ body {
 .salonbw-mass-communication__section h3 {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #e8e0d5;
     margin-bottom: 16px;
+    font-family: 'Playfair Display', Georgia, serif;
 }
 
 .salonbw-mass-communication__subsection {
     margin-top: 16px;
     padding-left: 16px;
-    border-left: 2px solid #e5e7eb;
+    border-left: 2px solid #252525;
 }
 
 .salonbw-mass-communication__subsection h4 {
     font-size: 0.875rem;
     font-weight: 500;
-    color: #4b5563;
+    color: #7a7068;
     margin-bottom: 12px;
 }
 
@@ -59,7 +52,7 @@ body {
     align-items: center;
     margin-top: 24px;
     padding-top: 16px;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid #252525;
 }
 
 /* Step indicator */
@@ -81,8 +74,8 @@ body {
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: #e5e7eb;
-    color: #4b5563;
+    background: #2a2520;
+    color: #7a7068;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -97,18 +90,18 @@ body {
 
 .salonbw-step__label {
     font-size: 0.875rem;
-    color: #4b5563;
+    color: #7a7068;
     font-weight: 500;
 }
 
 .salonbw-step.active .salonbw-step__label {
-    color: #111827;
+    color: #e8e0d5;
 }
 
 .salonbw-step__divider {
     width: 48px;
     height: 1px;
-    background: #d1d5db;
+    background: #252525;
     margin: 0 16px;
 }
 
@@ -123,9 +116,10 @@ body {
     align-items: center;
     gap: 8px;
     padding: 16px;
-    border: 2px solid #e5e7eb;
+    border: 2px solid #252525;
     border-radius: 8px;
     cursor: pointer;
+    background: transparent;
 }
 
 .salonbw-channel:hover {
@@ -158,7 +152,7 @@ body {
     width: 16px;
     height: 16px;
     border-radius: 3px;
-    border-color: #d1d5db;
+    border-color: #2a2a2a;
 }
 
 .salonbw-group-dot {
@@ -179,32 +173,33 @@ body {
 
 .salonbw-template-item {
     padding: 16px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid #252525;
     border-radius: 8px;
     cursor: pointer;
+    background: transparent;
 }
 
 .salonbw-template-item:hover {
     border-color: #c5a880;
-    background: #f9fafb;
+    background: rgba(197, 168, 128, 0.05);
 }
 
 .salonbw-template-item.active {
     border-color: #c5a880;
-    background: rgba(197, 168, 128, 0.07);
+    background: rgba(197, 168, 128, 0.08);
 }
 
 .salonbw-template-item__name {
     display: block;
     font-weight: 500;
-    color: #1f2937;
+    color: #e8e0d5;
     margin-bottom: 4px;
 }
 
 .salonbw-template-item__preview {
     display: block;
     font-size: 0.875rem;
-    color: #6b7280;
+    color: #7a7068;
 }
 
 /* Form styles */
@@ -216,15 +211,18 @@ body {
     display: block;
     font-size: 0.875rem;
     font-weight: 500;
-    color: #374151;
+    color: #7a7068;
     margin-bottom: 4px;
+    letter-spacing: 0.02em;
 }
 
 .salonbw-input {
     width: 100%;
     padding: 8px 12px;
-    border: 1px solid #d1d5db;
+    background: #141414;
+    border: 1px solid #2a2a2a;
     border-radius: 6px;
+    color: #e8e0d5;
 }
 
 .salonbw-input:focus {
@@ -246,9 +244,11 @@ body {
 .salonbw-textarea {
     width: 100%;
     padding: 8px 12px;
-    border: 1px solid #d1d5db;
+    background: #141414;
+    border: 1px solid #2a2a2a;
     border-radius: 6px;
     resize: none;
+    color: #e8e0d5;
 }
 
 .salonbw-textarea:focus {
@@ -261,13 +261,14 @@ body {
     display: block;
     text-align: right;
     font-size: 0.75rem;
-    color: #6b7280;
+    color: #5a5450;
     margin-top: 4px;
 }
 
 /* Variables help */
 .salonbw-variables-help {
-    background: #f9fafb;
+    background: #141414;
+    border: 1px solid #252525;
     padding: 16px;
     border-radius: 8px;
     margin-top: 16px;
@@ -276,17 +277,17 @@ body {
 .salonbw-variables-help h4 {
     font-size: 0.875rem;
     font-weight: 500;
-    color: #374151;
+    color: #7a7068;
     margin-bottom: 8px;
 }
 
 .salonbw-variables-help code {
     display: inline-block;
     padding: 2px 8px;
-    background: #e5e7eb;
+    background: #252525;
     border-radius: 4px;
     font-size: 0.75rem;
-    color: #374151;
+    color: #c5a880;
     margin-right: 8px;
     font-family: monospace;
 }
@@ -307,8 +308,8 @@ body {
     width: 64px;
     height: 64px;
     border-radius: 50%;
-    background: #dcfce7;
-    color: #16a34a;
+    background: rgba(34, 197, 94, 0.12);
+    color: #4ade80;
     font-size: 1.875rem;
     display: flex;
     align-items: center;
@@ -319,7 +320,8 @@ body {
 .salonbw-send-result h3 {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #e8e0d5;
+    font-family: 'Playfair Display', Georgia, serif;
     margin-bottom: 24px;
 }
 
@@ -351,12 +353,12 @@ body {
 
 .salonbw-stat__label {
     font-size: 0.875rem;
-    color: #4b5563;
+    color: #7a7068;
 }
 
 .salonbw-recipient-count {
     font-size: 0.875rem;
-    color: #4b5563;
+    color: #7a7068;
 }
 
 /* Button styles */
@@ -385,21 +387,22 @@ body {
 }
 
 .salonbw-btn--light {
-    background: #f3f4f6;
-    color: #374151;
+    background: #1e1e1e;
+    color: #c0b8af;
 }
 
 .salonbw-btn--light:hover {
-    background: #e5e7eb;
+    background: #2a2a2a;
 }
 
 .salonbw-btn--danger {
-    background: #fee2e2;
-    color: #b91c1c;
+    background: rgba(185, 28, 28, 0.15);
+    color: #f87171;
+    border: 1px solid rgba(185, 28, 28, 0.3);
 }
 
 .salonbw-btn--danger:hover {
-    background: #fecaca;
+    background: rgba(185, 28, 28, 0.25);
 }
 
 .salonbw-btn--sm {
@@ -408,13 +411,14 @@ body {
 }
 
 .salonbw-btn--default {
-    background: #fff;
-    border: 1px solid #d1d5db;
-    color: #374151;
+    background: #1a1a1a;
+    border: 1px solid #2a2a2a;
+    color: #c0b8af;
 }
 
 .salonbw-btn--default:hover {
-    background: #f9fafb;
+    background: #242420;
+    color: #e8e0d5;
 }
 
 .salonbw-btn--success {
@@ -468,30 +472,33 @@ body {
 
 .salonbw-toolbar-btn {
     padding: 6px 12px;
-    background: #fff;
-    border: 1px solid #d1d5db;
+    background: #1a1a1a;
+    border: 1px solid #2a2a2a;
     border-radius: 4px;
     font-size: 0.875rem;
     cursor: pointer;
-    color: #374151;
+    color: #c0b8af;
 }
 
 .salonbw-toolbar-btn:hover {
-    background: #f9fafb;
+    background: #242420;
+    color: #e8e0d5;
 }
 
 .salonbw-toolbar-search {
     padding: 6px 12px;
-    border: 1px solid #d1d5db;
+    background: #141414;
+    border: 1px solid #2a2a2a;
     border-radius: 4px;
     font-size: 0.875rem;
     width: 200px;
+    color: #e8e0d5;
 }
 
 /* Labels */
 .salonbw-label {
     font-size: 0.875rem;
-    color: #374151;
+    color: #c0b8af;
 }
 
 .salonbw-label-xs {
@@ -499,15 +506,17 @@ body {
     padding: 2px 6px;
     font-size: 0.75rem;
     border-radius: 4px;
-    background: #e5e7eb;
-    color: #374151;
+    background: #252525;
+    color: #9a9088;
 }
 
 /* Select */
 .salonbw-select {
     padding: 8px 12px;
-    border: 1px solid #d1d5db;
+    background: #141414;
+    border: 1px solid #2a2a2a;
     border-radius: 6px;
+    color: #e8e0d5;
 }
 
 .salonbw-select:focus {
@@ -518,9 +527,11 @@ body {
 
 .salonbw-select--inline {
     padding: 4px 8px;
-    border: 1px solid #d1d5db;
+    background: #141414;
+    border: 1px solid #2a2a2a;
     border-radius: 4px;
     font-size: 0.875rem;
+    color: #e8e0d5;
 }
 
 /* Table */
@@ -536,22 +547,23 @@ body {
 .salonbw-table th {
     text-align: left;
     padding: 12px;
-    border-bottom: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-bottom: 1px solid #252525;
+    background: #141414;
     font-weight: 600;
-    color: #374151;
+    color: #c5a880;
     font-size: 0.875rem;
 }
 
 .salonbw-table td {
     text-align: left;
     padding: 12px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #252525;
     font-size: 0.875rem;
+    color: #c0b8af;
 }
 
 .salonbw-table tr:hover {
-    background: #f9fafb;
+    background: #1a1612;
 }
 
 /* Badge */
@@ -563,23 +575,23 @@ body {
     font-size: 0.75rem;
     font-weight: 500;
     border-radius: 9999px;
-    background: #f3f4f6;
-    color: #374151;
+    background: #252525;
+    color: #c0b8af;
 }
 
 .salonbw-badge--success {
-    background: #dcfce7;
-    color: #166534;
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
 }
 
 .salonbw-badge--inactive {
-    background: #e5e7eb;
-    color: #4b5563;
+    background: #252525;
+    color: #5a5450;
 }
 
 .salonbw-badge--error {
-    background: #fee2e2;
-    color: #991b1b;
+    background: rgba(185, 28, 28, 0.15);
+    color: #f87171;
 }
 
 .salonbw-badge--sm {
@@ -595,7 +607,7 @@ body {
 
 /* Text utilities */
 .salonbw-muted {
-    color: #6b7280;
+    color: #7a7068;
 }
 
 .salonbw-link {
@@ -618,7 +630,7 @@ body {
 /* Template preview */
 .salonbw-template-preview {
     max-width: 320px;
-    color: #4b5563;
+    color: #7a7068;
 }
 
 /* Empty / loading states */
@@ -626,23 +638,23 @@ body {
 .salonbw-empty-state {
     text-align: center;
     padding: 48px 0;
-    color: #6b7280;
-    background: #fff;
+    color: #7a7068;
+    background: #161616;
     border-radius: 8px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid #252525;
 }
 
 .salonbw-loading {
     text-align: center;
     padding: 48px 0;
-    color: #6b7280;
+    color: #5a5450;
 }
 
 /* Modal styles */
 .salonbw-modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0,0,0,0.5);
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -651,9 +663,10 @@ body {
 }
 
 .salonbw-modal {
-    background: #fff;
+    background: #1c1c1c;
     border-radius: 8px;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+    border: 1px solid #2a2a2a;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
     max-width: 672px;
     width: 100%;
     max-height: 90vh;
@@ -665,18 +678,19 @@ body {
     justify-content: space-between;
     align-items: center;
     padding: 16px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #252525;
 }
 
 .salonbw-modal__header h3 {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #e8e0d5;
+    font-family: 'Playfair Display', Georgia, serif;
 }
 
 .salonbw-modal__close {
     font-size: 1.5rem;
-    color: #9ca3af;
+    color: #4a4440;
     cursor: pointer;
     width: 32px;
     height: 32px;
@@ -687,8 +701,8 @@ body {
 }
 
 .salonbw-modal__close:hover {
-    color: #4b5563;
-    background: #f3f4f6;
+    color: #c5a880;
+    background: #2a2414;
 }
 
 .salonbw-modal__body {
@@ -704,8 +718,8 @@ body {
     justify-content: flex-end;
     gap: 8px;
     padding: 16px;
-    border-top: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-top: 1px solid #252525;
+    background: #141414;
 }
 
 .salonbw-form-row {
@@ -725,9 +739,9 @@ body {
     gap: 16px;
     margin-bottom: 24px;
     padding: 16px;
-    background: #fff;
+    background: #161616;
     border-radius: 8px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid #252525;
 }
 
 .salonbw-reception-summary__item {
@@ -735,43 +749,43 @@ body {
     text-align: center;
     padding: 12px;
     border-radius: 8px;
-    background: #f9fafb;
+    background: #1c1c1c;
 }
 
 .salonbw-reception-summary__item--scheduled {
-    background: #eff6ff;
+    background: #0d1520;
 }
 
 .salonbw-reception-summary__item--confirmed {
-    background: #faf5ff;
+    background: #12101a;
 }
 
 .salonbw-reception-summary__item--in-progress {
-    background: #fefce8;
+    background: #1a1408;
 }
 
 .salonbw-reception-summary__item--completed {
-    background: #f0fdf4;
+    background: #0d180f;
 }
 
 .salonbw-reception-summary__value {
     display: block;
     font-size: 1.5rem;
     font-weight: 700;
-    color: #1f2937;
+    color: #e8e0d5;
 }
 
 .salonbw-reception-summary__label {
     display: block;
     font-size: 0.875rem;
-    color: #6b7280;
+    color: #7a7068;
     margin-top: 4px;
 }
 
 .salonbw-reception-table-wrap {
-    background: #fff;
+    background: #161616;
     border-radius: 8px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid #252525;
     overflow: hidden;
 }
 
@@ -783,22 +797,23 @@ body {
 .salonbw-reception-table th {
     text-align: left;
     padding: 12px;
-    border-bottom: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-bottom: 1px solid #252525;
+    background: #141414;
     font-weight: 600;
-    color: #374151;
+    color: #c5a880;
     font-size: 0.875rem;
 }
 
 .salonbw-reception-table td {
     text-align: left;
     padding: 12px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #252525;
     font-size: 0.875rem;
+    color: #c0b8af;
 }
 
 .salonbw-reception-table tbody tr:hover {
-    background: #f9fafb;
+    background: #1a1612;
 }
 
 .salonbw-reception-table tbody tr:last-child td {
@@ -806,11 +821,11 @@ body {
 }
 
 .salonbw-reception-row--overdue {
-    background: rgba(254,242,242,0.5);
+    background: rgba(185, 28, 28, 0.08);
 }
 
 .salonbw-reception-row--overdue:hover {
-    background: #fef2f2;
+    background: rgba(185, 28, 28, 0.12);
 }
 
 .salonbw-reception-row--processing {
@@ -836,7 +851,7 @@ body {
 
 .salonbw-reception-phone {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: #5a5450;
     margin-top: 4px;
 }
 
@@ -847,7 +862,7 @@ body {
 }
 
 .salonbw-reception-no-actions {
-    color: #9ca3af;
+    color: #3a3430;
 }
 
 .salonbw-status-badge {
@@ -859,41 +874,53 @@ body {
 }
 
 .salonbw-status--scheduled {
-    background: #dbeafe;
-    color: #1e40af;
+    background: rgba(59, 130, 246, 0.15);
+    color: #7eb5e0;
 }
 
 .salonbw-status--confirmed {
-    background: #ede9fe;
-    color: #5b21b6;
+    background: rgba(139, 92, 246, 0.15);
+    color: #b08fe0;
 }
 
 .salonbw-status--in-progress {
-    background: #fef9c3;
-    color: #854d0e;
+    background: rgba(197, 168, 128, 0.15);
+    color: #c5a880;
 }
 
 .salonbw-status--completed {
-    background: #dcfce7;
-    color: #166534;
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
 }
 
 .salonbw-status--cancelled {
-    background: #e5e7eb;
-    color: #4b5563;
+    background: rgba(107, 114, 128, 0.15);
+    color: #7a7068;
 }
 
 .salonbw-status--no-show {
-    background: #fee2e2;
-    color: #991b1b;
+    background: rgba(185, 28, 28, 0.15);
+    color: #f87171;
+}
+
+.salonbw-status--online-pending,
+.salonbw-status--online_pending {
+    background: rgba(251, 191, 36, 0.15);
+    color: #fbbf24;
+}
+
+.salonbw-status--rescheduled-pending,
+.salonbw-status--rescheduled_pending {
+    background: rgba(249, 115, 22, 0.15);
+    color: #fb923c;
 }
 
 .salonbw-reception-empty {
     text-align: center;
     padding: 64px 0;
-    background: #fff;
+    background: #161616;
     border-radius: 8px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid #252525;
 }
 
 .salonbw-reception-empty__icon {
@@ -904,12 +931,13 @@ body {
 .salonbw-reception-empty h3 {
     font-size: 1.125rem;
     font-weight: 500;
-    color: #1f2937;
+    color: #e8e0d5;
+    font-family: 'Playfair Display', Georgia, serif;
     margin-bottom: 8px;
 }
 
 .salonbw-reception-empty p {
-    color: #6b7280;
+    color: #7a7068;
 }
 
 /* Pagination */
@@ -918,7 +946,7 @@ body {
     align-items: center;
     justify-content: space-between;
     padding: 12px 0;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid #252525;
     margin-top: 16px;
 }
 
@@ -931,12 +959,14 @@ body {
 
 .salonbw-list-item {
     padding: 10px 15px;
-    border: 1px solid #ddd;
+    border: 1px solid #252525;
     border-top: 0;
+    background: #161616;
+    color: #c0b8af;
 }
 
 .salonbw-list-item:first-child {
-    border-top: 1px solid #ddd;
+    border-top: 1px solid #252525;
     border-radius: 4px 4px 0 0;
 }
 
@@ -974,7 +1004,7 @@ body {
     align-items: center;
     justify-content: center;
     border-radius: 4px;
-    color: #6b7280;
+    color: #5a5450;
     cursor: pointer;
     border: 0;
     background: transparent;
@@ -982,21 +1012,24 @@ body {
 }
 
 .salonbw-icon-btn:hover {
-    background: #f3f4f6;
+    background: #1e1a14;
+    color: #c5a880;
 }
 
 /* Alert */
 .salonbw-alert {
     padding: 12px 16px;
     border-radius: 6px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid #252525;
+    background: #141414;
+    color: #c0b8af;
     margin-bottom: 16px;
 }
 
 .salonbw-alert-info {
-    background: #eff6ff;
-    border-color: #bfdbfe;
-    color: #1e40af;
+    background: #0d1520;
+    border-color: #1e3050;
+    color: #7eb5e0;
 }
 
 /* Checkbox large */
@@ -1053,44 +1086,46 @@ body {
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: #6b7280;
+    letter-spacing: 0.08em;
+    color: #5a5450;
     margin-bottom: 12px;
 }
 
 /* Sidebar */
 .salonbw-sidebar {
-    background: #fff;
-    border-right: 1px solid #e5e7eb;
+    background: #0f0f0f;
+    border-right: 1px solid #1e1e1e;
     height: 100%;
     overflow-y: auto;
 }
 
 .salonbw-sidebar-section {
     padding: 16px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #1e1e1e;
 }
 
 .salonbw-sidebar__section {
     padding: 16px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #1e1e1e;
 }
 
 .salonbw-sidebar__header {
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
-    color: #6b7280;
+    color: #4a4440;
     margin-bottom: 8px;
 }
 
 .salonbw-sidebar__search {
     width: 100%;
     padding: 6px 10px;
-    border: 1px solid #d1d5db;
+    background: #141414;
+    border: 1px solid #2a2a2a;
     border-radius: 4px;
     font-size: 0.875rem;
     margin-bottom: 12px;
+    color: #e8e0d5;
 }
 
 .salonbw-sidebar__nav {
@@ -1122,8 +1157,8 @@ body {
 /* Panel sub section */
 .salonbw-panel-sub {
     padding: 16px;
-    background: #fff;
-    border: 1px solid #e5e7eb;
+    background: #161616;
+    border: 1px solid #252525;
     border-radius: 6px;
     margin-bottom: 12px;
 }
@@ -1131,18 +1166,18 @@ body {
 .salonbw-panel-sub__title {
     font-size: 1rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #e8e0d5;
     margin-bottom: 4px;
 }
 
 .salonbw-panel-sub__description {
     font-size: 0.875rem;
-    color: #6b7280;
+    color: #7a7068;
 }
 
 .salonbw-panel-sub__meta {
     font-size: 0.75rem;
-    color: #9ca3af;
+    color: #4a4440;
     margin-top: 4px;
 }
 
@@ -1152,7 +1187,7 @@ body {
     align-items: center;
     gap: 8px;
     font-size: 0.875rem;
-    color: #6b7280;
+    color: #5a5450;
     margin-bottom: 16px;
 }
 
@@ -1175,7 +1210,7 @@ body {
 }
 
 .salonbw-employee-filter__item:hover {
-    background: #f3f4f6;
+    background: #1e1a14;
 }
 
 .salonbw-employee-filter__color {
@@ -1187,13 +1222,13 @@ body {
 
 .salonbw-employee-filter__name {
     font-size: 0.875rem;
-    color: #374151;
+    color: #c0b8af;
 }
 
 /* Widget (stats sub-panel) */
 .salonbw-widget {
-    background: #fff;
-    border: 1px solid #e5e7eb;
+    background: #161616;
+    border: 1px solid #252525;
     border-radius: 8px;
     overflow: hidden;
     margin-bottom: 16px;
@@ -1201,11 +1236,11 @@ body {
 
 .salonbw-widget__header {
     padding: 12px 16px;
-    background: #f9fafb;
-    border-bottom: 1px solid #e5e7eb;
+    background: #141414;
+    border-bottom: 1px solid #252525;
     font-size: 0.875rem;
     font-weight: 600;
-    color: #374151;
+    color: #c5a880;
 }
 
 .salonbw-widget__content {
@@ -1221,7 +1256,7 @@ body {
 .salonbw-dashboard__empty {
     padding: 64px 0;
     text-align: center;
-    color: #6b7280;
+    color: #5a5450;
     font-size: 0.875rem;
 }
 
@@ -1235,7 +1270,8 @@ body {
 .salonbw-dashboard__title {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #e8e0d5;
+    font-family: 'Playfair Display', Georgia, serif;
 }
 
 .salonbw-dashboard__period {
@@ -1244,14 +1280,14 @@ body {
     gap: 16px;
     margin-bottom: 20px;
     padding-bottom: 12px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid #252525;
 }
 
 .salonbw-dashboard__period-btn {
     padding: 4px 12px;
     font-size: 0.875rem;
     border-radius: 4px;
-    color: #4b5563;
+    color: #7a7068;
     background: transparent;
     border: 0;
     cursor: pointer;
@@ -1264,7 +1300,7 @@ body {
 
 .salonbw-dashboard__period-label {
     font-size: 0.875rem;
-    color: #6b7280;
+    color: #5a5450;
     margin-left: auto;
 }
 
@@ -1277,17 +1313,17 @@ body {
 }
 
 .salonbw-stat-card {
-    background: #fff;
-    border: 1px solid #e5e7eb;
+    background: #161616;
+    border: 1px solid #252525;
     border-radius: 8px;
     padding: 16px;
 }
 
 .salonbw-stat-card__title {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: #5a5450;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     margin-bottom: 8px;
 }
 
@@ -1297,14 +1333,14 @@ body {
     gap: 8px;
     font-size: 1.5rem;
     font-weight: 700;
-    color: #1f2937;
+    color: #e8e0d5;
     margin-bottom: 12px;
 }
 
 .salonbw-stat-card__change {
     font-size: 0.75rem;
     font-weight: 400;
-    color: #9ca3af;
+    color: #4a4440;
 }
 
 .salonbw-stat-card__change.positive {
@@ -1346,8 +1382,8 @@ body {
 }
 
 .salonbw-dashboard__section {
-    background: #fff;
-    border: 1px solid #e5e7eb;
+    background: #161616;
+    border: 1px solid #252525;
     border-radius: 8px;
     display: flex;
     flex-direction: column;
@@ -1359,13 +1395,13 @@ body {
     align-items: center;
     justify-content: space-between;
     padding: 12px 16px;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid #1e1e1e;
 }
 
 .salonbw-dashboard__section-header h2 {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #374151;
+    color: #e8e0d5;
 }
 
 .salonbw-dashboard__section-actions {
@@ -1379,7 +1415,7 @@ body {
     font-size: 0.75rem;
     color: var(--salon-accent);
     padding: 8px 0;
-    border-top: 1px solid #f3f4f6;
+    border-top: 1px solid #252525;
     text-decoration: none;
     margin-top: auto;
 }
@@ -1400,7 +1436,7 @@ body {
     align-items: flex-start;
     gap: 12px;
     padding: 12px 16px;
-    border-bottom: 1px solid #f9fafb;
+    border-bottom: 1px solid #1e1e1e;
 }
 
 .salonbw-activity-item--empty,
@@ -1408,7 +1444,7 @@ body {
     padding: 24px 16px;
     text-align: center;
     font-size: 0.875rem;
-    color: #9ca3af;
+    color: #3a3430;
 }
 
 .salonbw-activity-item__avatar {
@@ -1432,7 +1468,7 @@ body {
 
 .salonbw-activity-item__title {
     font-size: 0.875rem;
-    color: #1f2937;
+    color: #e8e0d5;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -1440,7 +1476,7 @@ body {
 
 .salonbw-activity-item__meta {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: #7a7068;
     margin-top: 2px;
 }
 
@@ -1450,13 +1486,13 @@ body {
     align-items: center;
     gap: 12px;
     padding: 12px 16px;
-    border-bottom: 1px solid #f9fafb;
+    border-bottom: 1px solid #1e1e1e;
 }
 
 .salonbw-appointment-item__time {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #c5a880;
     width: 48px;
     flex-shrink: 0;
 }
@@ -1468,7 +1504,7 @@ body {
 
 .salonbw-appointment-item__client {
     font-size: 0.875rem;
-    color: #1f2937;
+    color: #e8e0d5;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -1476,7 +1512,7 @@ body {
 
 .salonbw-appointment-item__service {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: #7a7068;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -1486,52 +1522,52 @@ body {
    VERSUM CALENDAR STYLES - Matching Original
    ============================================ */
 
-/* Calendar background - white like oryginalny shell panelu */
+/* Calendar background - dark luxury */
 .fc {
-    --fc-border-color: #e5e7eb;
-    --fc-page-bg-color: #ffffff;
-    --fc-neutral-bg-color: #ffffff;
+    --fc-border-color: #252525;
+    --fc-page-bg-color: #0d0d0d;
+    --fc-neutral-bg-color: #111111;
 }
 
 .fc-view-harness {
-    background: #ffffff !important;
+    background: #0d0d0d !important;
 }
 
 .fc-timegrid-body {
-    background: #ffffff !important;
+    background: #0d0d0d !important;
 }
 
 .fc-timegrid-slots {
-    background: #ffffff !important;
+    background: #0d0d0d !important;
 }
 
 .fc-timegrid-slot {
-    background: #ffffff !important;
-    border-bottom: 1px solid #f3f4f6 !important;
+    background: #0d0d0d !important;
+    border-bottom: 1px solid #1e1e1e !important;
 }
 
 .fc-timegrid-slot-lane {
-    background: #ffffff !important;
+    background: #0d0d0d !important;
 }
 
 /* Header styling */
 .fc-col-header-cell {
-    background: #f3f4f6 !important;
-    border-bottom: 2px solid #d1d5db !important;
+    background: #141414 !important;
+    border-bottom: 2px solid #252525 !important;
     padding: 8px 4px !important;
 }
 
 .fc-col-header-cell-cushion {
-    color: #374151 !important;
+    color: #c5a880 !important;
     font-weight: 600 !important;
     font-size: 13px !important;
 }
 
-/* Event styling - source-like gray blocks */
+/* Event styling */
 .fc-event {
     border: none !important;
     border-radius: 3px !important;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4) !important;
 }
 
 .fc-event-main {
@@ -1541,13 +1577,13 @@ body {
 .fc-event-title {
     font-weight: 500 !important;
     font-size: 12px !important;
-    color: #1f2937 !important;
+    color: #0d0d0d !important;
 }
 
 /* Time text in events */
 .fc-event-time {
     font-size: 11px !important;
-    color: #6b7280 !important;
+    color: rgba(0, 0, 0, 0.7) !important;
     font-weight: 500 !important;
 }
 
@@ -1563,11 +1599,11 @@ body {
 
 /* Day grid (month view) */
 .fc-daygrid-day {
-    background: #ffffff !important;
+    background: #0d0d0d !important;
 }
 
 .fc-daygrid-day.fc-day-today {
-    background: #fef3c7 !important;
+    background: rgba(197, 168, 128, 0.06) !important;
 }
 
 .fc-daygrid-day-top {
@@ -1576,23 +1612,23 @@ body {
 
 .fc-daygrid-day-number {
     font-size: 13px !important;
-    color: #374151 !important;
+    color: #7a7068 !important;
     font-weight: 500 !important;
 }
 
 /* Week number column */
 .fc-timegrid-axis {
-    background: #f3f4f6 !important;
+    background: #141414 !important;
     font-weight: 600 !important;
-    color: #6b7280 !important;
+    color: #5a5450 !important;
     font-size: 11px !important;
 }
 
 /* Toolbar buttons */
 .fc-button {
-    background: #ffffff !important;
-    border: 1px solid #d1d5db !important;
-    color: #374151 !important;
+    background: #1a1a1a !important;
+    border: 1px solid #2a2a2a !important;
+    color: #c0b8af !important;
     font-weight: 500 !important;
     text-transform: lowercase !important;
     padding: 6px 12px !important;
@@ -1600,14 +1636,15 @@ body {
 }
 
 .fc-button:hover {
-    background: #f3f4f6 !important;
-    border-color: #9ca3af !important;
+    background: #242420 !important;
+    border-color: #3a3a38 !important;
+    color: #e8e0d5 !important;
 }
 
 .fc-button-active {
-    background: #3b82f6 !important;
-    border-color: #3b82f6 !important;
-    color: #ffffff !important;
+    background: #2a2114 !important;
+    border-color: #c5a880 !important;
+    color: #c5a880 !important;
 }
 
 /* ============================================
@@ -1629,8 +1666,8 @@ body {
    ============================================ */
 
 .salonbw-mini-cal {
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
+    background: #111111;
+    border: 1px solid #252525;
     border-radius: 4px;
     padding: 12px;
 }
@@ -1640,12 +1677,12 @@ body {
     justify-content: space-around;
     margin-bottom: 8px;
     padding-bottom: 8px;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid #252525;
 }
 
 .salonbw-mini-cal__weekdays span {
     font-size: 11px;
-    color: #9ca3af;
+    color: #4a4440;
     text-transform: lowercase;
     width: 28px;
     text-align: center;
@@ -1665,7 +1702,7 @@ body {
     align-items: center;
     justify-content: center;
     font-size: 12px;
-    color: #374151;
+    color: #c0b8af;
     background: transparent;
     border: none;
     border-radius: 3px;
@@ -1675,19 +1712,364 @@ body {
 }
 
 .salonbw-mini-cal__day:hover {
-    background: #f3f4f6;
+    background: #1e1a14;
+    color: #c5a880;
 }
 
 .salonbw-mini-cal__day--selected {
-    background: #3b82f6 !important;
-    color: white !important;
+    background: #c5a880 !important;
+    color: #0d0d0d !important;
 }
 
 .salonbw-mini-cal__day--today {
-    border: 1px solid #3b82f6;
+    border: 1px solid #c5a880;
     font-weight: 600;
+    color: #c5a880;
 }
 
 .salonbw-mini-cal__day--other-month {
-    color: #d1d5db;
+    color: #3a3430;
+}
+
+/* ==============================================
+   LUXURY DARK — Structural overrides
+   Covers hardcoded colors in salon-shell.css
+   CSS variables handle the rest.
+   ============================================== */
+
+/* Bootstrap 5.3 dark mode luxury token overrides */
+[data-bs-theme='dark'] {
+    --bs-body-bg: #0d0d0d;
+    --bs-body-color: #e8e0d5;
+    --bs-secondary-bg: #161616;
+    --bs-tertiary-bg: #111111;
+    --bs-border-color: #252525;
+    --bs-border-color-translucent: rgba(255, 255, 255, 0.06);
+    --bs-secondary-color: #7a7068;
+    --bs-tertiary-color: #5a5450;
+    --bs-emphasis-color: #f0e8dc;
+    --bs-link-color: #c5a880;
+    --bs-link-hover-color: #d4b896;
+    --bs-heading-color: #e8e0d5;
+    --bs-card-bg: #161616;
+    --bs-card-border-color: #252525;
+    --bs-input-bg: #141414;
+    --bs-input-border-color: #353535;
+    --bs-input-color: #e8e0d5;
+    --bs-form-select-bg: #141414;
+    --bs-dropdown-bg: #1c1c1c;
+    --bs-dropdown-border-color: #2a2a2a;
+    --bs-dropdown-link-color: #e8e0d5;
+    --bs-dropdown-link-hover-bg: #2a2414;
+    --bs-table-bg: transparent;
+    --bs-table-striped-bg: rgba(197, 168, 128, 0.04);
+    --bs-table-hover-bg: rgba(197, 168, 128, 0.06);
+    --bs-table-border-color: #252525;
+    --bs-modal-bg: #1c1c1c;
+    --bs-modal-header-border-color: #252525;
+    --bs-list-group-bg: #161616;
+    --bs-list-group-border-color: #252525;
+    --bs-list-group-action-hover-bg: #1e1a14;
+    --bs-nav-tabs-border-color: #252525;
+    --bs-nav-tabs-link-active-bg: #161616;
+    --bs-nav-tabs-link-active-border-color: #252525;
+    --bs-nav-pills-link-active-bg: #c5a880;
+    --bs-pagination-bg: #161616;
+    --bs-pagination-border-color: #252525;
+    --bs-pagination-active-bg: #c5a880;
+    --bs-pagination-active-border-color: #c5a880;
+    --bs-progress-bg: #1e1e1e;
+    --bs-code-color: #c5a880;
+}
+
+/* Topbar */
+.navbar.navbar-default {
+    background: #0a0a0a;
+    border-bottom-color: #1c1c1c;
+}
+
+.navbar .brand a {
+    color: #c5a880;
+}
+
+.navbar .brand a:hover {
+    color: #d4b896;
+}
+
+.navbar .navbar-right > li > a:not(.button) {
+    color: #7a7068;
+}
+
+/* Sidenav */
+#sidenav,
+.sidenav {
+    background: #0f0f0f;
+    border-right-color: #1c1c1c;
+}
+
+#sidenav .nav-header,
+.sidenav .nav-header {
+    color: #3a3430;
+}
+
+#sidenav .nav-list li a,
+.sidenav .nav-list li a {
+    color: #7a7068;
+}
+
+#sidenav .nav-list li a:hover,
+#sidenav .nav-list li.active a,
+.sidenav .nav-list li a:hover,
+.sidenav .nav-list li.active a {
+    background: #1e1a14;
+    color: #c5a880;
+}
+
+/* Main content */
+.main-content {
+    background: #0d0d0d;
+}
+
+/* Legacy custom modals (non-Bootstrap bs5) */
+.modal-content {
+    background: #1c1c1c;
+    border-color: #252525;
+}
+
+.modal-header {
+    background: #141414;
+    border-bottom-color: #252525;
+}
+
+.modal-title {
+    color: #e8e0d5;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.modal-footer {
+    background: #141414;
+    border-top-color: #252525;
+}
+
+.close {
+    color: #4a4440;
+}
+
+.close:hover {
+    color: #c5a880;
+}
+
+/* Legacy buttons */
+.btn-default {
+    background: #1a1a1a;
+    border-color: #2a2a2a;
+    color: #c0b8af;
+}
+
+.btn-default:hover {
+    background: #222220;
+    color: #e8e0d5;
+}
+
+/* Legacy label */
+.label-default {
+    background: #1e1e1e;
+    border-color: #2a2a2a;
+    color: #7a7068;
+}
+
+/* Breadcrumb */
+.breadcrumb {
+    color: #4a4440;
+}
+
+.breadcrumb li + li::before {
+    color: #2a2420;
+}
+
+/* Shell table overrides */
+#salonbw-shell-root .salonbw-table th {
+    background: #141414;
+    color: #c5a880;
+    border-color: #252525;
+}
+
+#salonbw-shell-root .salonbw-table td {
+    color: #c0b8af;
+    border-color: #252525;
+}
+
+#salonbw-shell-root .salonbw-table tr:hover {
+    background: #1a1612;
+}
+
+/* Data table row colors */
+.data_table .table-bordered tr.odd td {
+    background: #161616;
+}
+.data_table .table-bordered tr.even td {
+    background: #1a1a1a;
+}
+
+/* Calendar view components */
+.calendar-view-drafts__item {
+    background: #161616;
+    border-color: #252525;
+}
+
+.calendar-view-drafts__title,
+.calendar-view-form-list__heading {
+    color: #e8e0d5;
+}
+
+.calendar-view-drafts__meta {
+    color: #7a7068;
+}
+
+.calendar-view-checkbox {
+    color: #c0b8af;
+}
+
+/* Communication */
+.communication-reminder-card {
+    background: #161616;
+    border-color: #252525;
+    color: #c0b8af;
+}
+
+.sms_thread .message {
+    background: #161616;
+    border-color: #252525;
+}
+
+.sms_thread .message.customer {
+    background: #0f1e1c;
+    border-color: #1a4040;
+}
+
+.communication-preview-sms,
+.communication-preview-email__body {
+    background: #161616;
+    border-color: #252525;
+    color: #c0b8af;
+}
+
+.communication-preview-email__subject {
+    color: #e8e0d5;
+}
+
+/* Reception list card (StaffAppointmentCalendarView) */
+.salonbw-reception-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.salonbw-reception-item {
+    background: #161616;
+    border: 1px solid #252525;
+    border-radius: 6px;
+    padding: 14px 16px;
+}
+
+.salonbw-reception-item__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.salonbw-reception-item__title {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: #e8e0d5;
+    margin: 0;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.salonbw-reception-item__meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: #7a7068;
+    margin-top: 3px;
+}
+
+.salonbw-reception-item__details {
+    font-size: 0.8125rem;
+    color: #9a9088;
+    margin-bottom: 10px;
+}
+
+.salonbw-reception-item__actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+/* Secondary button variant (missing from original) */
+.salonbw-btn--secondary {
+    background: #1e1e1e;
+    color: #c0b8af;
+    border: 1px solid #2a2a2a;
+}
+
+.salonbw-btn--secondary:hover {
+    background: #2a2a2a;
+    color: #e8e0d5;
+}
+
+/* Luxury typography for content headings */
+h1,
+h2,
+h3 {
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.salonbw-section-title,
+.salonbw-sidebar__header,
+.salonbw-widget__header {
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+/* Loading state */
+.salonbw-loading {
+    color: #5a5450;
+}
+
+/* Topbar search input and dropdown */
+.navbar .omnibox {
+    background-color: #1a1a1a;
+    border-color: #2a2a2a;
+    color: #e8e0d5;
+}
+
+.navbar .omnibox:focus {
+    border-color: #c5a880;
+    box-shadow: none;
+}
+
+.navbar .dropdown-toggle {
+    color: #7a7068;
+}
+
+.navbar .dropdown-menu {
+    background: #1c1c1c;
+    border-color: #2a2a2a;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.navbar .dropdown-menu .divider {
+    background: #252525;
+}
+
+.navbar .dropdown-menu .main-menu-li a {
+    color: #c0b8af;
+}
+
+.navbar .dropdown-menu .main-menu-li a:hover {
+    background: #2a2414;
+    color: #c5a880;
 }

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -5,15 +5,15 @@
     --salon-sidenav-w: 214px;
     --salon-content-max: 1010px;
     --salon-content-pad: 20px;
-    --salon-border: #cfd4da;
-    --salon-bg: #eceff2;
-    --salon-panel-bg: #f5f7f9;
-    --salon-text: #505960;
-    --salon-muted: #828a92;
+    --salon-border: #252525;
+    --salon-bg: #0d0d0d;
+    --salon-panel-bg: #111111;
+    --salon-text: #e8e0d5;
+    --salon-muted: #7a7068;
     /* brand active/link gold */
-    --salon-accent: #a8895f;
-    --salon-mainnav-bg: #24272b;
-    --salon-mainnav-active: #181a1e;
+    --salon-accent: #c5a880;
+    --salon-mainnav-bg: #0a0a0a;
+    --salon-mainnav-active: #060606;
     --salon-green: #2ecc71;
 }
 
@@ -3021,8 +3021,8 @@ body.e2e-statistics .main-content .inner {
 }
 
 @media (max-width: 1100px) {
-    .statistics-module [style*="width: 500px"],
-    .statistics-module [style*="width: 550px"] {
+    .statistics-module [style*='width: 500px'],
+    .statistics-module [style*='width: 550px'] {
         width: 100% !important;
     }
 }
@@ -3038,18 +3038,20 @@ body.e2e-statistics .main-content .inner {
 .icon.sprite-exel_blue {
     width: 14px;
     height: 14px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-5-5l-1.5-3 1.5-3H11l-1 2-1-2H7.5l1.5 3-1.5 3H9l1-2 1 2H13z'/%3E%3C/svg%3E") no-repeat center;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-5-5l-1.5-3 1.5-3H11l-1 2-1-2H7.5l1.5 3-1.5 3H9l1-2 1 2H13z'/%3E%3C/svg%3E")
+        no-repeat center;
     background-size: contain;
 }
 .icon.sprite-print_blue {
     width: 14px;
     height: 14px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z'/%3E%3C/svg%3E") no-repeat center;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z'/%3E%3C/svg%3E")
+        no-repeat center;
     background-size: contain;
 }
 /* source settings icons (sprite sheet positions from vendor responsive.css). */
 .icon[class*='sprite-settings_'] {
-    background-image: url("/salonbw-calendar/assets/sprite-0e259010a938c8acddfd8c0e840c1137717ec91fc92bb50531a77cdacf9b4c3d.png");
+    background-image: url('/salonbw-calendar/assets/sprite-0e259010a938c8acddfd8c0e840c1137717ec91fc92bb50531a77cdacf9b4c3d.png');
     background-repeat: no-repeat;
 }
 .icon.sprite-settings_blue {
@@ -3089,7 +3091,7 @@ body.e2e-statistics .main-content .inner {
 }
 .icon.sprite-breadcrumbs_settings,
 .icon.sprite-extension_star_black {
-    background-image: url("/salonbw-calendar/assets/sprite-0e259010a938c8acddfd8c0e840c1137717ec91fc92bb50531a77cdacf9b4c3d.png");
+    background-image: url('/salonbw-calendar/assets/sprite-0e259010a938c8acddfd8c0e840c1137717ec91fc92bb50531a77cdacf9b4c3d.png');
     background-repeat: no-repeat;
 }
 .icon.sprite-breadcrumbs_settings {
@@ -3105,7 +3107,8 @@ body.e2e-statistics .main-content .inner {
 .icon.sprite-active_green {
     width: 14px;
     height: 14px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2317d38f' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20%2C6 9%2C17 4%2C12'/%3E%3C/svg%3E") no-repeat center;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2317d38f' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20%2C6 9%2C17 4%2C12'/%3E%3C/svg%3E")
+        no-repeat center;
     background-size: contain;
 }
 
@@ -3113,7 +3116,10 @@ body.e2e-statistics .main-content .inner {
    Statistics data_table — source `.data_table` + `.table.table-bordered` override
    Source: computed styles from source panel capture /statistics/dashboard
    ============================================= */
-.data_table { display: block; overflow-x: auto; }
+.data_table {
+    display: block;
+    overflow-x: auto;
+}
 .data_table .table-bordered {
     width: 100%;
     border-collapse: collapse;
@@ -3145,13 +3151,19 @@ body.e2e-statistics .main-content .inner {
     text-align: left;
     line-height: 1.43;
 }
-.data_table .table-bordered tr.odd td { background: #fff; }
-.data_table .table-bordered tr.even td { background: #f4fbff; }
+.data_table .table-bordered tr.odd td {
+    background: #fff;
+}
+.data_table .table-bordered tr.even td {
+    background: #f4fbff;
+}
 /* =============================================
    Stats-tabs (jQuery UI-like tab control)
    Source: computed styles from source panel capture /statistics/employees
    ============================================= */
-.stats-tabs { margin-top: 8px; }
+.stats-tabs {
+    margin-top: 8px;
+}
 .stats-tabs > ul {
     list-style: none;
     margin: 0;
@@ -3285,7 +3297,7 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     .sidenav {
         display: none;
     }
-    
+
     .navbar .brand {
         left: 60px;
     }
@@ -3309,10 +3321,19 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     margin: 0 0 30px;
     overflow: hidden;
 }
-.column_row.secondary_menu .pull_left { float: left; }
-.column_row.secondary_menu .pull_right { float: right; }
-.column_row.secondary_menu .simple-list { height: 48px; }
-.column_row.secondary_menu .simple-list li { display: flex; align-items: stretch; }
+.column_row.secondary_menu .pull_left {
+    float: left;
+}
+.column_row.secondary_menu .pull_right {
+    float: right;
+}
+.column_row.secondary_menu .simple-list {
+    height: 48px;
+}
+.column_row.secondary_menu .simple-list li {
+    display: flex;
+    align-items: stretch;
+}
 .column_row.secondary_menu .simple-list li a {
     display: flex;
     align-items: center;
@@ -3325,7 +3346,9 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     white-space: nowrap;
     border-bottom: 3px solid transparent;
 }
-.column_row.secondary_menu .simple-list li a .icon { margin-right: 5px; }
+.column_row.secondary_menu .simple-list li a .icon {
+    margin-right: 5px;
+}
 .column_row.secondary_menu .simple-list li.active a {
     font-size: 11px;
     font-weight: 700;
@@ -3333,10 +3356,14 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     border-bottom: 4px solid #3795de;
     padding-top: 8px;
 }
-.column_row.secondary_menu .simple-list li.active a .icon { color: #3795de; }
+.column_row.secondary_menu .simple-list li.active a .icon {
+    color: #3795de;
+}
 
 /* .icon_link — warehouse action icons (.icon_link.stockroom_sell etc.) */
-.col-actions-45 { width: 45px; }
+.col-actions-45 {
+    width: 45px;
+}
 
 .icon_link {
     display: inline-block;
@@ -3348,24 +3375,38 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     text-align: center;
     vertical-align: middle;
 }
-.icon_link:hover { color: #23527c; text-decoration: none; }
-.icon_link .icon { width: 16px; height: 16px; vertical-align: middle; }
+.icon_link:hover {
+    color: #23527c;
+    text-decoration: none;
+}
+.icon_link .icon {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+}
 
 /* Warehouse action sprite icons */
 .icon.sprite-stock_action_sell {
-    width: 16px; height: 16px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-14.8-14l.7 2h13.1l-1.8 8H6.9L4.4 2H2V0H0v2h2l.2 1zM6.5 14h10l.4-2H6.1l.4 2z'/%3E%3C/svg%3E") no-repeat center;
+    width: 16px;
+    height: 16px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-14.8-14l.7 2h13.1l-1.8 8H6.9L4.4 2H2V0H0v2h2l.2 1zM6.5 14h10l.4-2H6.1l.4 2z'/%3E%3C/svg%3E")
+        no-repeat center;
     background-size: contain;
 }
 .icon.sprite-stock_action_consumption {
-    width: 16px; height: 16px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z'/%3E%3C/svg%3E") no-repeat center;
+    width: 16px;
+    height: 16px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z'/%3E%3C/svg%3E")
+        no-repeat center;
     background-size: contain;
 }
 
 /* Warehouse nav sprite icons */
 .icon.sprite-stock_stocktaking {
-    width: 14px; height: 14px; display: inline-block; vertical-align: middle;
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    vertical-align: middle;
     background: currentColor;
     -webkit-mask-size: contain;
     mask-size: contain;
@@ -3693,22 +3734,55 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     padding-right: 15px;
     box-sizing: border-box;
 }
-.mb-xs { margin-bottom: 4px; }
-.mb-s  { margin-bottom: 8px; }
-.mb-m  { margin-bottom: 12px; }
-.mb-l  { margin-bottom: 16px; }
-.mb-xl { margin-bottom: 30px; }
-.mt-xs { margin-top: 5px; }
-.ml-s { margin-left: 8px; }
-.mr-s { margin-right: 8px; }
-.ml-xs { margin-left: 4px; }
-.ml-s { margin-left: 8px; }
-.pull-left { float: left; }
-.pull_left { float: left; }
-.pull_right { float: right; }
-.c { clear: both; display: block; }
-.jc-end { justify-content: flex-end; }
-.flex-wrap { flex-wrap: wrap; }
+.mb-xs {
+    margin-bottom: 4px;
+}
+.mb-s {
+    margin-bottom: 8px;
+}
+.mb-m {
+    margin-bottom: 12px;
+}
+.mb-l {
+    margin-bottom: 16px;
+}
+.mb-xl {
+    margin-bottom: 30px;
+}
+.mt-xs {
+    margin-top: 5px;
+}
+.ml-s {
+    margin-left: 8px;
+}
+.mr-s {
+    margin-right: 8px;
+}
+.ml-xs {
+    margin-left: 4px;
+}
+.ml-s {
+    margin-left: 8px;
+}
+.pull-left {
+    float: left;
+}
+.pull_left {
+    float: left;
+}
+.pull_right {
+    float: right;
+}
+.c {
+    clear: both;
+    display: block;
+}
+.jc-end {
+    justify-content: flex-end;
+}
+.flex-wrap {
+    flex-wrap: wrap;
+}
 /* Input + select toolbar row (warehouse search bar) */
 .input-with-select-sm {
     display: flex;
@@ -3716,7 +3790,7 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     gap: 5px;
     height: 28px;
 }
-.input-with-select-sm input[type="text"] {
+.input-with-select-sm input[type='text'] {
     width: 180px;
     height: 28px;
     padding: 5px;
@@ -3803,27 +3877,43 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     line-height: 20px;
     border-top: 1px solid #ddd;
 }
-.table-bordered tr.odd td { background: #fff; }
-.table-bordered tr.even td { background: #f4fbff; }
+.table-bordered tr.odd td {
+    background: #fff;
+}
+.table-bordered tr.even td {
+    background: #f4fbff;
+}
 /* Full-block link cell */
-.table-bordered td.link_body { padding: 0; }
+.table-bordered td.link_body {
+    padding: 0;
+}
 .table-bordered td.link_body a {
     display: block;
     padding: 7px 10px 6px;
     color: #337ab7;
     text-decoration: none;
 }
-.table-bordered td.link_body a:hover { text-decoration: underline; }
+.table-bordered td.link_body a:hover {
+    text-decoration: underline;
+}
 /* Center align */
 .table-bordered td.center_text,
-.table-bordered th.center_text { text-align: center; }
+.table-bordered th.center_text {
+    text-align: center;
+}
 /* Price right-align */
-.table-bordered td.text-right { text-align: right; }
+.table-bordered td.text-right {
+    text-align: right;
+}
 /* Text-right padding-right for price cells */
-.pr-m { padding-right: 16px !important; }
+.pr-m {
+    padding-right: 16px !important;
+}
 
 /* --- Pagination size select --- */
-.pagination-size-select { width: 55px; }
+.pagination-size-select {
+    width: 55px;
+}
 
 /* --- Services search input --- */
 .services-search-input {
@@ -3855,13 +3945,26 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     display: inline-block;
     box-sizing: border-box;
 }
-.conjunction { margin: 0 4px; }
-.button_next { margin-left: 8px; }
-.fc-icon-right-single-arrow::before { content: '›'; font-size: 16px; }
-.fc-icon-left-single-arrow::before { content: '‹'; font-size: 16px; }
+.conjunction {
+    margin: 0 4px;
+}
+.button_next {
+    margin-left: 8px;
+}
+.fc-icon-right-single-arrow::before {
+    content: '›';
+    font-size: 16px;
+}
+.fc-icon-left-single-arrow::before {
+    content: '‹';
+    font-size: 16px;
+}
 
 /* --- dl-horizontal (service/product detail metadata) --- */
-.dl-horizontal { margin-bottom: 20px; overflow: hidden; }
+.dl-horizontal {
+    margin-bottom: 20px;
+    overflow: hidden;
+}
 .dl-horizontal dt {
     float: left;
     width: 160px;
@@ -3884,7 +3987,11 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     margin-bottom: 5px;
     line-height: 18.6px;
 }
-.dl-horizontal::after { content: ''; display: table; clear: both; }
+.dl-horizontal::after {
+    content: '';
+    display: table;
+    clear: both;
+}
 
 /* --- list-group (service variants) --- */
 .list-group {
@@ -3904,15 +4011,32 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     cursor: pointer;
     position: relative;
 }
-.list-group-item:first-child { border-radius: 4px 4px 0 0; }
-.list-group-item:last-child { border-radius: 0 0 4px 4px; margin-bottom: 0; }
-.list-group-item:hover { background: #f5f5f5; text-decoration: none; }
-.list-group-item .h4 { font-size: 18px; font-weight: 500; display: inline; }
+.list-group-item:first-child {
+    border-radius: 4px 4px 0 0;
+}
+.list-group-item:last-child {
+    border-radius: 0 0 4px 4px;
+    margin-bottom: 0;
+}
+.list-group-item:hover {
+    background: #f5f5f5;
+    text-decoration: none;
+}
+.list-group-item .h4 {
+    font-size: 18px;
+    font-weight: 500;
+    display: inline;
+}
 .no-radius .list-group-item,
-.no-radius.list-group-item { border-radius: 0; }
+.no-radius.list-group-item {
+    border-radius: 0;
+}
 
 /* --- column_row / buttons-row (detail page toolbar) --- */
-.column_row { display: block; padding: 10px; }
+.column_row {
+    display: block;
+    padding: 10px;
+}
 h2.column_row {
     font-size: 22px;
     font-weight: 400;
@@ -3927,27 +4051,79 @@ h2.column_row small {
     margin-left: 8px;
     font-weight: 400;
 }
-.buttons-row { margin: 0 -15px 30px; display: flex; }
-.right-buttons { padding: 0 15px; text-align: right; flex: 1; }
-.text-right { text-align: right; }
+.buttons-row {
+    margin: 0 -15px 30px;
+    display: flex;
+}
+.right-buttons {
+    padding: 0 15px;
+    text-align: right;
+    flex: 1;
+}
+.text-right {
+    text-align: right;
+}
 
 /* Customer/detail source-native layout classes */
-.row-col_row { overflow: hidden; margin-bottom: 20px; }
-.row-col { display: block; }
-.row-col.single-detail-row { margin: 0 0 10px; }
+.row-col_row {
+    overflow: hidden;
+    margin-bottom: 20px;
+}
+.row-col {
+    display: block;
+}
+.row-col.single-detail-row {
+    margin: 0 0 10px;
+}
 .row-col.single-detail-row .lbl {
     display: inline-block;
     min-width: 88px;
     margin-right: 4px;
 }
-.details-row { margin: 0 0 20px; }
-.icon_box { display: inline-block; color: #636363; margin: 0 1px 0 0; vertical-align: middle; }
-.info-box { padding: 15px; border: 1px solid #c8c8c8; margin: 0 0 20px; background: #fff; }
-.box-title { font-weight: 700; font-size: 13px; margin: 0 0 8px; color: #3f464d; }
-.box-rows { padding: 0; color: #545454; font-size: 12px; }
-.lbl, .light_text { color: #b9b9c8; }
-.caret { display: inline-block; width: 0; height: 0; margin-left: 2px; vertical-align: middle; border-top: 4px dashed; border-right: 4px solid transparent; border-left: 4px solid transparent; }
-.button-small { padding: 2px 8px; font-size: 12px; }
+.details-row {
+    margin: 0 0 20px;
+}
+.icon_box {
+    display: inline-block;
+    color: #636363;
+    margin: 0 1px 0 0;
+    vertical-align: middle;
+}
+.info-box {
+    padding: 15px;
+    border: 1px solid #c8c8c8;
+    margin: 0 0 20px;
+    background: #fff;
+}
+.box-title {
+    font-weight: 700;
+    font-size: 13px;
+    margin: 0 0 8px;
+    color: #3f464d;
+}
+.box-rows {
+    padding: 0;
+    color: #545454;
+    font-size: 12px;
+}
+.lbl,
+.light_text {
+    color: #b9b9c8;
+}
+.caret {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: 2px;
+    vertical-align: middle;
+    border-top: 4px dashed;
+    border-right: 4px solid transparent;
+    border-left: 4px solid transparent;
+}
+.button-small {
+    padding: 2px 8px;
+    font-size: 12px;
+}
 .box-rows .link-more {
     display: block;
     margin-top: 8px;
@@ -4215,7 +4391,10 @@ body.settings-dashboard-landing .main-content > .inner {
     padding: 0;
 }
 
-.settings-detail-layout .simple_form.edit_branch .add_phone_number button:hover {
+.settings-detail-layout
+    .simple_form.edit_branch
+    .add_phone_number
+    button:hover {
     color: #3795de;
 }
 
@@ -4627,20 +4806,26 @@ body.settings-dashboard-landing .main-content > .inner {
     max-width: 520px;
 }
 
-.settings-customer-group-form-page .simple_form.new_physical_customers_group ol {
+.settings-customer-group-form-page
+    .simple_form.new_physical_customers_group
+    ol {
     list-style: decimal;
     margin: 0;
     padding-left: 18px;
 }
 
-.settings-customer-group-form-page .simple_form.new_physical_customers_group li.control-group {
+.settings-customer-group-form-page
+    .simple_form.new_physical_customers_group
+    li.control-group {
     color: #747474;
     display: flex;
     gap: 18px;
     margin-bottom: 14px;
 }
 
-.settings-customer-group-form-page .simple_form.new_physical_customers_group .control-label {
+.settings-customer-group-form-page
+    .simple_form.new_physical_customers_group
+    .control-label {
     color: #686868;
     flex: 0 0 118px;
     font-size: 13px;
@@ -4649,13 +4834,19 @@ body.settings-dashboard-landing .main-content > .inner {
     padding-top: 7px;
 }
 
-.settings-customer-group-form-page .simple_form.new_physical_customers_group .controls {
+.settings-customer-group-form-page
+    .simple_form.new_physical_customers_group
+    .controls {
     display: flex;
     flex: 1 1 auto;
 }
 
-.settings-customer-group-form-page .simple_form.new_physical_customers_group input,
-.settings-customer-group-form-page .simple_form.new_physical_customers_group select {
+.settings-customer-group-form-page
+    .simple_form.new_physical_customers_group
+    input,
+.settings-customer-group-form-page
+    .simple_form.new_physical_customers_group
+    select {
     border: 1px solid #c6ccd2;
     border-radius: 2px;
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -5435,11 +5626,15 @@ body.settings-dashboard-landing .main-content > .inner {
         overflow-x: auto;
     }
 
-    .settings-customer-group-form-page .simple_form.new_physical_customers_group li.control-group {
+    .settings-customer-group-form-page
+        .simple_form.new_physical_customers_group
+        li.control-group {
         display: block;
     }
 
-    .settings-customer-group-form-page .simple_form.new_physical_customers_group .control-label {
+    .settings-customer-group-form-page
+        .simple_form.new_physical_customers_group
+        .control-label {
         display: block;
         margin-bottom: 6px;
         padding-top: 0;

--- a/apps/panel/src/styles/salon-theme.css
+++ b/apps/panel/src/styles/salon-theme.css
@@ -5,214 +5,299 @@
 
 /* --- CSS Variables --- */
 :root {
-  --salon-accent: #a8895f;
-  --salon-brand: #c5a880;
-  --salon-brand-hover: #b0896b;
-  --salon-bg: #f5f5f5;
-  --salon-fg: #333333;
+    --salon-accent: #c5a880;
+    --salon-brand: #c5a880;
+    --salon-brand-hover: #d4b896;
+    --salon-bg: #0d0d0d;
+    --salon-fg: #e8e0d5;
 }
 
 /* --- Body defaults --- */
 body {
-  background: var(--salon-bg);
-  color: var(--salon-fg);
-  font-family: 'Open Sans', sans-serif;
+    background: var(--salon-bg);
+    color: var(--salon-fg);
+    font-family: 'Open Sans', sans-serif;
 }
 
 /* --- Buttons --- */
 .btn-salon {
-  background: var(--salon-brand);
-  color: #0d0d0d;
-  border-color: var(--salon-brand);
+    background: var(--salon-brand);
+    color: #0d0d0d;
+    border-color: var(--salon-brand);
 }
 .btn-salon:hover,
 .btn-salon:focus {
-  background: var(--salon-brand-hover);
-  border-color: var(--salon-brand-hover);
-  color: #0d0d0d;
+    background: var(--salon-brand-hover);
+    border-color: var(--salon-brand-hover);
+    color: #0d0d0d;
 }
 .btn-salon:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .button-blue {
-  background: #56aef0;
-  color: #fff;
-  border: 1px solid #56aef0;
-  display: inline-block;
-  padding: 6px 12px;
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1.42857;
-  text-decoration: none;
+    background: #56aef0;
+    color: #fff;
+    border: 1px solid #56aef0;
+    display: inline-block;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1.42857;
+    text-decoration: none;
 }
-.button-blue:hover { filter: brightness(0.95); color: #fff; text-decoration: none; }
+.button-blue:hover {
+    filter: brightness(0.95);
+    color: #fff;
+    text-decoration: none;
+}
 
-.button { display: inline-block; padding: 6px 12px; cursor: pointer; font-size: 13px; text-decoration: none; }
-.button-link { background: transparent; color: var(--salon-accent); border: none; padding: 6px 12px; cursor: pointer; }
-.button-link:hover { text-decoration: underline; }
+.button {
+    display: inline-block;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 13px;
+    text-decoration: none;
+}
+.button-link {
+    background: transparent;
+    color: var(--salon-accent);
+    border: none;
+    padding: 6px 12px;
+    cursor: pointer;
+}
+.button-link:hover {
+    text-decoration: underline;
+}
 
 /* --- Sections (PanelSection wrapper) --- */
 .salon-section {
-  padding: 15px 20px;
-  background: #fff;
-  margin-bottom: 20px;
+    padding: 15px 20px;
+    background: #161616;
+    margin-bottom: 20px;
 }
 .salon-section > .actions {
-  float: right;
-  text-align: right;
-  line-height: 36px;
+    float: right;
+    text-align: right;
+    line-height: 36px;
 }
 .salon-section > h2 {
-  font-size: 22px;
-  font-weight: 400;
-  margin: 20px 0 10px;
-  font-family: 'Playfair Display', Georgia, serif;
+    font-size: 22px;
+    font-weight: 400;
+    margin: 20px 0 10px;
+    font-family: 'Playfair Display', Georgia, serif;
+    color: #e8e0d5;
+    letter-spacing: 0.01em;
 }
 
 /* --- Column row --- */
 .salon-column-row {
-  padding: 15px 20px;
-  background: #fff;
+    padding: 15px 20px;
+    background: #161616;
 }
 .salon-column-row h2 {
-  font-size: 22px;
-  font-weight: 400;
-  margin: 20px 0 30px;
-  font-family: 'Playfair Display', Georgia, serif;
+    font-size: 22px;
+    font-weight: 400;
+    margin: 20px 0 30px;
+    font-family: 'Playfair Display', Georgia, serif;
+    color: #e8e0d5;
+    letter-spacing: 0.01em;
 }
 
 /* --- Boxes --- */
 .box {
-  background: #fff;
-  border: 1px solid #e5e5e5;
-  border-radius: 2px;
-  margin-bottom: 15px;
-  padding: 15px;
+    background: #161616;
+    border: 1px solid #252525;
+    border-radius: 2px;
+    margin-bottom: 15px;
+    padding: 15px;
 }
 .info-box {
-  background: #fff;
-  border: 1px solid #e5e5e5;
-  border-radius: 2px;
-  padding: 15px;
-  margin-bottom: 15px;
+    background: #161616;
+    border: 1px solid #252525;
+    border-radius: 2px;
+    padding: 15px;
+    margin-bottom: 15px;
 }
 .info-box .box-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: #666;
-  margin-bottom: 10px;
+    font-size: 13px;
+    font-weight: 600;
+    color: #7a7068;
+    margin-bottom: 10px;
 }
 .info-box .bottom-link {
-  margin-top: 10px;
-  text-align: right;
+    margin-top: 10px;
+    text-align: right;
 }
-.info-box .bottom-link a { color: var(--salon-accent); font-size: 12px; }
+.info-box .bottom-link a {
+    color: var(--salon-accent);
+    font-size: 12px;
+}
 
 /* --- Tree nav (sidebar customer groups) --- */
-.tree { padding: 0; }
+.tree {
+    padding: 0;
+}
 .tree a.root {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  color: #333;
-  text-decoration: none;
-  font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    color: #9a9088;
+    text-decoration: none;
+    font-weight: 600;
 }
-.tree ul { list-style: none; padding-left: 15px; margin: 0; }
+.tree ul {
+    list-style: none;
+    padding-left: 15px;
+    margin: 0;
+}
 .tree li a {
-  display: block;
-  padding: 4px 10px;
-  color: #555;
-  text-decoration: none;
-  font-size: 13px;
+    display: block;
+    padding: 4px 10px;
+    color: #7a7068;
+    text-decoration: none;
+    font-size: 13px;
 }
-.tree li a:hover { background: #f5f8fa; }
+.tree li a:hover {
+    background: #1e1a14;
+    color: #c5a880;
+}
 
 /* --- Icon box --- */
 .icon_box {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
 }
 
 /* --- Table enhancements (on top of Bootstrap .table) --- */
 .table-bordered th div {
-  padding: 16px 24px 16px 8px;
+    padding: 16px 24px 16px 8px;
 }
 .table-bordered th {
-  font-size: 11px;
-  font-weight: 600;
-  background: #f5f8fa;
+    font-size: 11px;
+    font-weight: 600;
+    background: #141414;
+    color: #c5a880;
 }
 .table-bordered td {
-  font-size: 13px;
-  padding: 7px 10px 6px;
-  border-top: 1px solid #ddd;
+    font-size: 13px;
+    padding: 7px 10px 6px;
+    border-top: 1px solid #252525;
+    color: #c0b8af;
 }
-tr.odd td { background: #fff; }
-tr.even td { background: #f4fbff; }
+tr.odd td {
+    background: #161616;
+}
+tr.even td {
+    background: #1a1a1a;
+}
 
 /* --- DL horizontal (detail views) --- */
-.dl-horizontal dt { float: left; width: 160px; text-align: right; font-weight: 600; }
-.dl-horizontal dd { margin-left: 170px; }
+.dl-horizontal dt {
+    float: left;
+    width: 160px;
+    text-align: right;
+    font-weight: 600;
+}
+.dl-horizontal dd {
+    margin-left: 170px;
+}
 
 /* --- Actions toolbar --- */
-.actions { text-align: right; line-height: 36px; }
+.actions {
+    text-align: right;
+    line-height: 36px;
+}
 
 /* --- Breadcrumb override --- */
 .breadcrumb li,
 .breadcrumb a {
-  font-size: 20px;
-  font-weight: 300;
-  font-family: 'Lato', sans-serif;
+    font-size: 20px;
+    font-weight: 300;
+    font-family: 'Lato', sans-serif;
 }
 
 /* --- Status colors (SalonBW-specific shades) --- */
-.text-salon-green { color: #5cb85c; }
-.text-salon-blue { color: #56aef0; }
-.text-salon-red { color: #d9534f; }
-.bg-salon-green { background: #5cb85c; color: #fff; }
-.bg-salon-blue { background: #56aef0; color: #fff; }
-.bg-salon-red { background: #d9534f; color: #fff; }
+.text-salon-green {
+    color: #5cb85c;
+}
+.text-salon-blue {
+    color: #56aef0;
+}
+.text-salon-red {
+    color: #d9534f;
+}
+.bg-salon-green {
+    background: #5cb85c;
+    color: #fff;
+}
+.bg-salon-blue {
+    background: #56aef0;
+    color: #fff;
+}
+.bg-salon-red {
+    background: #d9534f;
+    color: #fff;
+}
 
 /* --- Date range input --- */
 .salon-date-range {
-  width: 210px;
-  height: 28px;
-  color: #919191;
-  border: 1px solid #bfbfbf;
-  padding: 4px 8px;
-  font-size: 13px;
+    width: 210px;
+    height: 28px;
+    color: #919191;
+    border: 1px solid #bfbfbf;
+    padding: 4px 8px;
+    font-size: 13px;
 }
 
 /* --- Overflow ellipsis utility --- */
 .overflow_with_ellipsis {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* --- SalonBW badge variants --- */
-.badge-salon { background: var(--salon-brand); color: #0d0d0d; border-radius: 2px; }
-.badge-salon-success { background: #dff0d8; color: #3c763d; }
-.badge-salon-warning { background: #fcf8e3; color: #8a6d3b; }
-.badge-salon-error { background: #f2dede; color: #a94442; }
-.badge-salon-inactive { background: #e5e5e5; color: #666; }
+.badge-salon {
+    background: var(--salon-brand);
+    color: #0d0d0d;
+    border-radius: 2px;
+}
+.badge-salon-success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+}
+.badge-salon-warning {
+    background: rgba(234, 179, 8, 0.15);
+    color: #fbbf24;
+}
+.badge-salon-error {
+    background: rgba(185, 28, 28, 0.15);
+    color: #f87171;
+}
+.badge-salon-inactive {
+    background: #252525;
+    color: #7a7068;
+}
 
 /* --- Form accent (focus ring) --- */
 .form-control:focus {
-  border-color: var(--salon-brand);
-  box-shadow: 0 0 0 0.2rem rgba(197, 168, 128, 0.25);
+    border-color: var(--salon-brand);
+    box-shadow: 0 0 0 0.2rem rgba(197, 168, 128, 0.25);
 }
 
 /* --- Pjax link styling --- */
-a.pjax_link { color: var(--salon-accent); }
-a.pjax_link:hover { text-decoration: underline; }
+a.pjax_link {
+    color: var(--salon-accent);
+}
+a.pjax_link:hover {
+    text-decoration: underline;
+}
 
 /* =============================================
    Sprite icons
@@ -223,409 +308,414 @@ a.pjax_link:hover { text-decoration: underline; }
 
 /* Base sprite rule — sets shared background-image for all .sprite-* icons */
 .icon[class*='sprite-'] {
-  display: inline-block;
-  vertical-align: middle;
-  background-image: url("/salonbw-calendar/assets/sprite-0e259010a938c8acddfd8c0e840c1137717ec91fc92bb50531a77cdacf9b4c3d.png");
-  background-repeat: no-repeat;
-  position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    background-image: url('/salonbw-calendar/assets/sprite-0e259010a938c8acddfd8c0e840c1137717ec91fc92bb50531a77cdacf9b4c3d.png');
+    background-repeat: no-repeat;
+    position: relative;
 }
 
 /* SVG-based sprites (overrides above background-image) */
 .icon.sprite-exel_blue {
-  width: 14px;
-  height: 14px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-5-5l-1.5-3 1.5-3H11l-1 2-1-2H7.5l1.5 3-1.5 3H9l1-2 1 2H13z'/%3E%3C/svg%3E") no-repeat center;
-  background-size: contain;
+    width: 14px;
+    height: 14px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-5-5l-1.5-3 1.5-3H11l-1 2-1-2H7.5l1.5 3-1.5 3H9l1-2 1 2H13z'/%3E%3C/svg%3E")
+        no-repeat center;
+    background-size: contain;
 }
 .icon.sprite-print_blue {
-  width: 14px;
-  height: 14px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z'/%3E%3C/svg%3E") no-repeat center;
-  background-size: contain;
+    width: 14px;
+    height: 14px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2356aef0'%3E%3Cpath d='M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z'/%3E%3C/svg%3E")
+        no-repeat center;
+    background-size: contain;
 }
 .icon.sprite-active_green {
-  width: 14px;
-  height: 14px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2317d38f' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20%2C6 9%2C17 4%2C12'/%3E%3C/svg%3E") no-repeat center;
-  background-size: contain;
+    width: 14px;
+    height: 14px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2317d38f' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20%2C6 9%2C17 4%2C12'/%3E%3C/svg%3E")
+        no-repeat center;
+    background-size: contain;
 }
 .icon.sprite-stock_action_sell {
-  width: 16px;
-  height: 16px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-14.8-14l.7 2h13.1l-1.8 8H6.9L4.4 2H2V0H0v2h2l.2 1zM6.5 14h10l.4-2H6.1l.4 2z'/%3E%3C/svg%3E") no-repeat center;
-  background-size: contain;
+    width: 16px;
+    height: 16px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M7 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-14.8-14l.7 2h13.1l-1.8 8H6.9L4.4 2H2V0H0v2h2l.2 1zM6.5 14h10l.4-2H6.1l.4 2z'/%3E%3C/svg%3E")
+        no-repeat center;
+    background-size: contain;
 }
 .icon.sprite-stock_action_consumption {
-  width: 16px;
-  height: 16px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z'/%3E%3C/svg%3E") no-repeat center;
-  background-size: contain;
+    width: 16px;
+    height: 16px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23337ab7' d='M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z'/%3E%3C/svg%3E")
+        no-repeat center;
+    background-size: contain;
 }
 .icon.sprite-stock_stocktaking {
-  width: 14px;
-  height: 14px;
-  display: inline-block;
-  vertical-align: middle;
-  background: currentColor;
-  -webkit-mask-size: contain;
-  mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  mask-position: center;
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    vertical-align: middle;
+    background: currentColor;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
 }
 
 /* Settings sprites — sprite sheet positions */
 .icon.sprite-settings_blue {
-  background-position: -2278px -1080px;
-  width: 17px;
-  height: 17px;
+    background-position: -2278px -1080px;
+    width: 17px;
+    height: 17px;
 }
 .icon.sprite-settings_branch {
-  background-position: -2278px -1211px;
-  width: 19px;
-  height: 19px;
+    background-position: -2278px -1211px;
+    width: 19px;
+    height: 19px;
 }
 .icon.sprite-settings_calendar {
-  background-position: -2278px -1280px;
-  width: 20px;
-  height: 20px;
+    background-position: -2278px -1280px;
+    width: 20px;
+    height: 20px;
 }
 .icon.sprite-settings_employees {
-  background-position: -2278px -1694px;
-  width: 17px;
-  height: 20px;
+    background-position: -2278px -1694px;
+    width: 17px;
+    height: 20px;
 }
 .icon.sprite-settings_notifications_nav {
-  background-position: -2482px -338px;
-  width: 19px;
-  height: 17px;
+    background-position: -2482px -338px;
+    width: 19px;
+    height: 17px;
 }
 .icon.sprite-settings_payment_methods {
-  background-position: -2482px -685px;
-  width: 19px;
-  height: 18px;
+    background-position: -2482px -685px;
+    width: 19px;
+    height: 18px;
 }
 .icon.sprite-settings_sms_nav {
-  background-position: -2482px -1502px;
-  width: 19px;
-  height: 16px;
+    background-position: -2482px -1502px;
+    width: 19px;
+    height: 16px;
 }
 .icon.sprite-settings_services {
-  background-position: -2482px -1433px;
-  width: 16px;
-  height: 19px;
+    background-position: -2482px -1433px;
+    width: 16px;
+    height: 19px;
 }
 .icon.sprite-breadcrumbs_settings {
-  background-position: -119px -614px;
-  width: 16px;
-  height: 16px;
+    background-position: -119px -614px;
+    width: 16px;
+    height: 16px;
 }
 .icon.sprite-extension_star_black {
-  background-position: -850px -1043px;
-  width: 19px;
-  height: 17px;
+    background-position: -850px -1043px;
+    width: 19px;
+    height: 17px;
 }
 .icon.sprite-settings_customer_groups {
-  background-position: -2278px -1350px;
-  width: 16px;
-  height: 18px;
+    background-position: -2278px -1350px;
+    width: 16px;
+    height: 18px;
 }
 .icon.sprite-settings_customer_origins {
-  background-position: -2278px -1418px;
-  width: 15px;
-  height: 21px;
+    background-position: -2278px -1418px;
+    width: 15px;
+    height: 21px;
 }
 .icon.sprite-settings_cut_logo {
-  background-position: -2278px -1560px;
-  width: 16px;
-  height: 16px;
+    background-position: -2278px -1560px;
+    width: 16px;
+    height: 16px;
 }
 .icon.sprite-settings_data_protection {
-  background-position: -2278px -1626px;
-  width: 18px;
-  height: 18px;
+    background-position: -2278px -1626px;
+    width: 18px;
+    height: 18px;
 }
 .icon.sprite-settings_extra_fields {
-  background-position: -2278px -1764px;
-  width: 21px;
-  height: 20px;
+    background-position: -2278px -1764px;
+    width: 21px;
+    height: 20px;
 }
 .icon.sprite-settings_label_visits {
-  background-position: -2482px -66px;
-  width: 18px;
-  height: 18px;
+    background-position: -2482px -66px;
+    width: 18px;
+    height: 18px;
 }
 .icon.sprite-settings_phone_records_nav {
-  background-position: -2482px -753px;
-  width: 17px;
-  height: 20px;
+    background-position: -2482px -753px;
+    width: 17px;
+    height: 20px;
 }
 .icon.sprite-settings_prepay {
-  background-position: -2482px -823px;
-  width: 19px;
-  height: 18px;
+    background-position: -2482px -823px;
+    width: 19px;
+    height: 18px;
 }
 .icon.sprite-settings_product_purchase_prices {
-  background-position: -2482px -959px;
-  width: 18px;
-  height: 17px;
+    background-position: -2482px -959px;
+    width: 18px;
+    height: 17px;
 }
 
 /* General sprite sheet positions */
 .icon.sprite-active_blue {
-  background-position: 0 -64px;
-  width: 14px;
-  height: 14px;
+    background-position: 0 -64px;
+    width: 14px;
+    height: 14px;
 }
 .icon.sprite-add_customer_save {
-  background-position: 0 -460px;
-  width: 15px;
-  height: 15px;
+    background-position: 0 -460px;
+    width: 15px;
+    height: 15px;
 }
 .icon.sprite-advanced_sms_options {
-  background-position: 0 -942px;
-  width: 21px;
-  height: 21px;
+    background-position: 0 -942px;
+    width: 21px;
+    height: 21px;
 }
 .icon.sprite-all_employees {
-  background-position: 0 -1153px;
-  width: 26px;
-  height: 17px;
+    background-position: 0 -1153px;
+    width: 26px;
+    height: 17px;
 }
 .icon.sprite-breadcrumbs_communication,
 .icon.sprite-breadcrumbs_communication_set {
-  background-position: -119px -138px;
-  width: 22px;
-  height: 17px;
+    background-position: -119px -138px;
+    width: 22px;
+    height: 17px;
 }
 .icon.sprite-breadcrumbs_customers {
-  background-position: -119px -205px;
-  width: 22px;
-  height: 21px;
+    background-position: -119px -205px;
+    width: 22px;
+    height: 21px;
 }
 .icon.sprite-breadcrumbs_extensions {
-  background-position: -119px -341px;
-  width: 19px;
-  height: 19px;
+    background-position: -119px -341px;
+    width: 19px;
+    height: 19px;
 }
 .icon.sprite-breadcrumbs_help {
-  background-position: -119px -410px;
-  width: 18px;
-  height: 18px;
+    background-position: -119px -410px;
+    width: 18px;
+    height: 18px;
 }
 .icon.sprite-breadcrumbs_services {
-  background-position: -119px -543px;
-  width: 18px;
-  height: 21px;
+    background-position: -119px -543px;
+    width: 18px;
+    height: 21px;
 }
 .icon.sprite-breadcrumbs_statistics {
-  background-position: -119px -680px;
-  width: 18px;
-  height: 17px;
+    background-position: -119px -680px;
+    width: 18px;
+    height: 17px;
 }
 .icon.sprite-breadcrumbs_stock {
-  background-position: -119px -747px;
-  width: 21px;
-  height: 17px;
+    background-position: -119px -747px;
+    width: 21px;
+    height: 17px;
 }
 .icon.sprite-calendar_employees {
-  background-position: -119px -1088px;
-  width: 17px;
-  height: 18px;
+    background-position: -119px -1088px;
+    width: 17px;
+    height: 18px;
 }
 .icon.sprite-client_absent_on {
-  background-position: -238px -476px;
-  width: 21px;
-  height: 22px;
+    background-position: -238px -476px;
+    width: 21px;
+    height: 22px;
 }
 .icon.sprite-customer_card {
-  background-position: -238px -997px;
-  width: 21px;
-  height: 18px;
+    background-position: -238px -997px;
+    width: 21px;
+    height: 18px;
 }
 .icon.sprite-customer_dashboard {
-  background-position: -238px -1065px;
-  width: 17px;
-  height: 17px;
+    background-position: -238px -1065px;
+    width: 17px;
+    height: 17px;
 }
 .icon.sprite-customer_description {
-  background-position: -238px -1132px;
-  width: 12px;
-  height: 15px;
+    background-position: -238px -1132px;
+    width: 12px;
+    height: 15px;
 }
 .icon.sprite-customer_email {
-  background-position: -238px -1197px;
-  width: 15px;
-  height: 12px;
+    background-position: -238px -1197px;
+    width: 15px;
+    height: 12px;
 }
 .icon.sprite-customer_female {
-  background-position: -238px -1259px;
-  width: 20px;
-  height: 21px;
+    background-position: -238px -1259px;
+    width: 20px;
+    height: 21px;
 }
 .icon.sprite-customer_files {
-  background-position: -238px -1330px;
-  width: 20px;
-  height: 18px;
+    background-position: -238px -1330px;
+    width: 20px;
+    height: 18px;
 }
 .icon.sprite-customer_history_visits {
-  background-position: -238px -1469px;
-  width: 19px;
-  height: 20px;
+    background-position: -238px -1469px;
+    width: 19px;
+    height: 20px;
 }
 .icon.sprite-customer_male {
-  background-position: -238px -1739px;
-  width: 21px;
-  height: 22px;
+    background-position: -238px -1739px;
+    width: 21px;
+    height: 22px;
 }
 .icon.sprite-customer_personal_data {
-  background-position: -442px 0;
-  width: 21px;
-  height: 19px;
+    background-position: -442px 0;
+    width: 21px;
+    height: 19px;
 }
 .icon.sprite-customer_photo_gallery {
-  background-position: -442px -69px;
-  width: 21px;
-  height: 18px;
+    background-position: -442px -69px;
+    width: 21px;
+    height: 18px;
 }
 .icon.sprite-customer_statistics {
-  background-position: -442px -137px;
-  width: 17px;
-  height: 18px;
+    background-position: -442px -137px;
+    width: 17px;
+    height: 18px;
 }
 .icon.sprite-customer_telephone {
-  background-position: -442px -205px;
-  width: 16px;
-  height: 18px;
-  top: -1px;
+    background-position: -442px -205px;
+    width: 16px;
+    height: 18px;
+    top: -1px;
 }
 .icon.sprite-customer_unknown_sex {
-  background-position: -442px -273px;
-  width: 20px;
-  height: 21px;
+    background-position: -442px -273px;
+    width: 20px;
+    height: 21px;
 }
 .icon.sprite-delete {
-  background-position: -442px -1676px;
-  width: 12px;
-  height: 19px;
+    background-position: -442px -1676px;
+    width: 12px;
+    height: 19px;
 }
 .icon.sprite-filter {
-  background-position: -850px -1314px;
-  width: 14px;
-  height: 15px;
+    background-position: -850px -1314px;
+    width: 14px;
+    height: 15px;
 }
 .icon.sprite-filter_cancellation_visits {
-  background-position: -850px -1588px;
-  width: 13px;
-  height: 19px;
+    background-position: -850px -1588px;
+    width: 13px;
+    height: 19px;
 }
 .icon.sprite-filter_handled_employees {
-  background-position: -850px -1797px;
-  width: 17px;
-  height: 18px;
+    background-position: -850px -1797px;
+    width: 17px;
+    height: 18px;
 }
 .icon.sprite-filter_less {
-  background-position: -850px -1932px;
-  width: 13px;
-  height: 2px;
-  top: -1px;
+    background-position: -850px -1932px;
+    width: 13px;
+    height: 2px;
+    top: -1px;
 }
 .icon.sprite-filter_more {
-  background-position: -1054px -66px;
-  width: 14px;
-  height: 15px;
+    background-position: -1054px -66px;
+    width: 14px;
+    height: 15px;
 }
 .icon.sprite-filter_purchased_services {
-  background-position: -1054px -276px;
-  width: 16px;
-  height: 19px;
+    background-position: -1054px -276px;
+    width: 16px;
+    height: 19px;
 }
 .icon.sprite-filter_visit_salon {
-  background-position: -1054px -485px;
-  width: 13px;
-  height: 20px;
+    background-position: -1054px -485px;
+    width: 13px;
+    height: 20px;
 }
 .icon.sprite-group {
-  background-position: -1258px -1277px;
-  width: 21px;
-  height: 20px;
+    background-position: -1258px -1277px;
+    width: 21px;
+    height: 20px;
 }
 .icon.sprite-group_recent_added {
-  background-position: -1258px -1347px;
-  width: 19px;
-  height: 24px;
-  top: 2px;
+    background-position: -1258px -1347px;
+    width: 19px;
+    height: 24px;
+    top: 2px;
 }
 .icon.sprite-group_today {
-  background-position: -1258px -1484px;
-  width: 20px;
-  height: 20px;
-  top: -1px;
+    background-position: -1258px -1484px;
+    width: 20px;
+    height: 20px;
+    top: -1px;
 }
 .icon.sprite-info_tip {
-  background-position: -1462px -576px;
-  width: 21px;
-  height: 21px;
+    background-position: -1462px -576px;
+    width: 21px;
+    height: 21px;
 }
 .icon.sprite-opinions {
-  background-position: -1870px -613px;
-  width: 19px;
-  height: 19px;
+    background-position: -1870px -613px;
+    width: 19px;
+    height: 19px;
 }
 .icon.sprite-stock_value_report {
-  background-position: -3094px -143px;
-  width: 17px;
-  height: 23px;
+    background-position: -3094px -143px;
+    width: 17px;
+    height: 23px;
 }
 .icon.sprite-register_activity {
-  background-position: -2074px -484px;
-  width: 22px;
-  height: 14px;
+    background-position: -2074px -484px;
+    width: 22px;
+    height: 14px;
 }
 .icon.sprite-schedule_copy {
-  background-position: -2074px -1158px;
-  width: 15px;
-  height: 18px;
+    background-position: -2074px -1158px;
+    width: 15px;
+    height: 18px;
 }
 .icon.sprite-schedule_dayoff {
-  background-position: -2074px -1294px;
-  width: 17px;
-  height: 17px;
+    background-position: -2074px -1294px;
+    width: 17px;
+    height: 17px;
 }
 .icon.sprite-schedule_employees {
-  background-position: -2074px -1497px;
-  width: 19px;
-  height: 21px;
+    background-position: -2074px -1497px;
+    width: 19px;
+    height: 21px;
 }
 .icon.sprite-schedule_inactive {
-  background-position: -2074px -1768px;
-  width: 13px;
-  height: 16px;
+    background-position: -2074px -1768px;
+    width: 13px;
+    height: 16px;
 }
 .icon.sprite-schedule_report {
-  background-position: -2278px -137px;
-  width: 16px;
-  height: 22px;
+    background-position: -2278px -137px;
+    width: 16px;
+    height: 22px;
 }
 .icon.sprite-schedule_template {
-  background-position: -2278px -209px;
-  width: 15px;
-  height: 13px;
+    background-position: -2278px -209px;
+    width: 15px;
+    height: 13px;
 }
 .icon.sprite-stock_products {
-  background-position: -2890px -1317px;
-  width: 20px;
-  height: 22px;
+    background-position: -2890px -1317px;
+    width: 20px;
+    height: 22px;
 }
 .icon.sprite-tips {
-  background-position: -3094px -541px;
-  width: 22px;
-  height: 16px;
+    background-position: -3094px -541px;
+    width: 22px;
+    height: 16px;
 }
 .icon.sprite-user_group {
-  background-position: -3094px -955px;
-  width: 16px;
-  height: 18px;
-  top: -1px;
+    background-position: -3094px -955px;
+    width: 16px;
+    height: 18px;
+    top: -1px;
 }

--- a/apps/panel/src/types.ts
+++ b/apps/panel/src/types.ts
@@ -2,6 +2,7 @@ export interface Client {
     id: number;
     name: string;
     phone?: string;
+    email?: string;
 }
 
 export type Role = 'client' | 'employee' | 'receptionist' | 'admin';

--- a/apps/panel/src/types.ts
+++ b/apps/panel/src/types.ts
@@ -949,6 +949,13 @@ export interface ProductSaleItem {
     discountCents?: number;
 }
 
+export interface UsageItem {
+    productId: number;
+    productName: string;
+    quantity: number;
+    unit: string;
+}
+
 export interface FinalizeAppointmentRequest {
     paymentMethod: PaymentMethod;
     paidAmountCents: number;
@@ -956,6 +963,7 @@ export interface FinalizeAppointmentRequest {
     discountCents?: number;
     products?: ProductSaleItem[];
     note?: string;
+    usageItems?: { productId: number; quantity: number; unit?: string }[];
 }
 
 export interface FinalizationSummary {

--- a/apps/panel/src/types.ts
+++ b/apps/panel/src/types.ts
@@ -23,7 +23,9 @@ export type AppointmentStatus =
     | 'in_progress'
     | 'cancelled'
     | 'completed'
-    | 'no_show';
+    | 'no_show'
+    | 'online_pending'
+    | 'rescheduled_pending';
 
 export interface Appointment {
     id: number;

--- a/apps/panel/src/types.ts
+++ b/apps/panel/src/types.ts
@@ -46,6 +46,13 @@ export interface Appointment {
     internalNote?: string;
 }
 
+export interface Formula {
+    id: number;
+    description: string;
+    date: string;
+    appointment?: { id: number };
+}
+
 export type PriceType = 'fixed' | 'from';
 
 export interface Service {

--- a/backend/salonbw-backend/src/appointments/appointment.entity.ts
+++ b/backend/salonbw-backend/src/appointments/appointment.entity.ts
@@ -21,6 +21,8 @@ export enum AppointmentStatus {
     Cancelled = 'cancelled',
     Completed = 'completed',
     NoShow = 'no_show',
+    OnlinePending = 'online_pending',
+    RescheduledPending = 'rescheduled_pending',
 }
 
 export enum PaymentMethod {

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -450,4 +450,26 @@ export class AppointmentsController {
     ): Promise<Appointment> {
         return this.appointmentsService.updateNotes(id, body.internalNote);
     }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin, Role.Receptionist, Role.Employee)
+    @Get(':id/usage')
+    @ApiBearerAuth()
+    @ApiOperation({
+        summary: 'Get suggested material usage from service recipe',
+    })
+    @ApiResponse({
+        status: 200,
+        description: 'Usage suggestions derived from service recipe items',
+    })
+    async getUsageSuggestions(@Param('id', ParseIntPipe) id: number): Promise<
+        {
+            productId: number;
+            productName: string;
+            quantity: number;
+            unit: string;
+        }[]
+    > {
+        return this.appointmentsService.getUsageSuggestions(id);
+    }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -120,6 +120,7 @@ export class AppointmentsController {
                 service: { id: body.serviceId } as SalonService,
                 serviceVariantId: body.serviceVariantId,
                 startTime: new Date(body.startTime),
+                reservedOnline: !isStaff ? true : undefined,
             },
             { id: user.userId } as User,
         );

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -356,6 +356,31 @@ export class AppointmentsController {
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin, Role.Receptionist, Role.Employee)
+    @Get('online-pending-count')
+    @ApiBearerAuth()
+    @ApiOperation({
+        summary: 'Count online-pending appointments',
+        description:
+            'Admin and Receptionist see the total count. ' +
+            'Employee sees only their own online-pending appointments.',
+    })
+    @ApiResponse({
+        status: 200,
+        description: 'Count of online-pending appointments',
+        schema: { type: 'object', properties: { count: { type: 'number' } } },
+    })
+    async countOnlinePending(
+        @CurrentUser() user: { userId: number; role: Role },
+    ): Promise<{ count: number }> {
+        const isEmployeeOnly = user.role === Role.Employee;
+        const count = await this.appointmentsService.countOnlinePending(
+            isEmployeeOnly ? user.userId : undefined,
+        );
+        return { count };
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Admin, Role.Employee)
     @Get(':id/conflicts')
     @ApiBearerAuth()

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -437,4 +437,17 @@ export class AppointmentsController {
             id: user.userId,
         } as User);
     }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Admin, Role.Receptionist, Role.Employee)
+    @Patch(':id/notes')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Update internal note on appointment' })
+    @ApiResponse({ status: 200, type: Appointment })
+    async updateNotes(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() body: { internalNote: string | null },
+    ): Promise<Appointment> {
+        return this.appointmentsService.updateNotes(id, body.internalNote);
+    }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.module.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.module.ts
@@ -6,6 +6,7 @@ import { AppointmentsController } from './appointments.controller';
 import { CommissionsModule } from '../commissions/commissions.module';
 import { Service as SalonService } from '../services/service.entity';
 import { ServiceVariant } from '../services/entities/service-variant.entity';
+import { ServiceRecipeItem } from '../services/entities/service-recipe-item.entity';
 import { User } from '../users/user.entity';
 import { LogsModule } from '../logs/logs.module';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -19,6 +20,7 @@ import { LoyaltyModule } from '../loyalty/loyalty.module';
             Appointment,
             SalonService,
             ServiceVariant,
+            ServiceRecipeItem,
             User,
         ]),
         CommissionsModule,

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -844,8 +844,12 @@ export class AppointmentsService {
                     },
                     user,
                 );
-            } catch {
+            } catch (err) {
                 // Non-fatal: usage deduction failure does not roll back finalization
+                console.error(
+                    `[finalize] usage deduction failed for appointment ${id}:`,
+                    err,
+                );
             }
         }
 
@@ -931,7 +935,7 @@ export class AppointmentsService {
             .map((item) => ({
                 productId: item.product!.id,
                 productName: item.product!.name,
-                quantity: Math.max(1, Math.round(item.quantity ?? 1)),
+                quantity: Math.max(0.01, +(item.quantity ?? 1).toFixed(2)),
                 unit: item.unit ?? 'op.',
             }));
     }

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -24,6 +24,7 @@ import { CommissionsService } from '../commissions/commissions.service';
 import { Role } from '../users/role.enum';
 import { Service as SalonService } from '../services/service.entity';
 import { ServiceVariant } from '../services/entities/service-variant.entity';
+import { ServiceRecipeItem } from '../services/entities/service-recipe-item.entity';
 import { User } from '../users/user.entity';
 import { LogService } from '../logs/log.service';
 import { LogAction } from '../logs/log-action.enum';
@@ -44,6 +45,8 @@ export class AppointmentsService {
         private readonly servicesRepository: Repository<SalonService>,
         @InjectRepository(ServiceVariant)
         private readonly serviceVariantsRepository: Repository<ServiceVariant>,
+        @InjectRepository(ServiceRecipeItem)
+        private readonly recipeItemsRepository: Repository<ServiceRecipeItem>,
         @InjectRepository(User)
         private readonly usersRepository: Repository<User>,
         private readonly commissionsService: CommissionsService,
@@ -814,6 +817,40 @@ export class AppointmentsService {
             },
         );
 
+        // Deduct materials used during the service from warehouse stock
+        if (dto.usageItems && dto.usageItems.length > 0 && this.retailService) {
+            const clientName = [
+                appointment.client.firstName,
+                appointment.client.lastName,
+            ]
+                .filter((part) => Boolean(part && part.trim()))
+                .join(' ')
+                .trim();
+            try {
+                await this.retailService.createUsage(
+                    {
+                        items: dto.usageItems.map((item) => ({
+                            productId: item.productId,
+                            quantity: item.quantity,
+                            unit: item.unit,
+                        })),
+                        employeeId: appointment.employee.id,
+                        appointmentId: appointment.id,
+                        clientName:
+                            clientName.length > 0
+                                ? clientName
+                                : (appointment.client.name ??
+                                  null ??
+                                  undefined),
+                        scope: 'completed',
+                    },
+                    user,
+                );
+            } catch {
+                // Non-fatal: usage deduction failure does not roll back finalization
+            }
+        }
+
         const updated = await this.findOne(id);
         if (updated) {
             this.metrics?.incAppointmentCompleted();
@@ -860,5 +897,34 @@ export class AppointmentsService {
         appointment.internalNote =
             internalNote === null ? undefined : internalNote;
         return this.appointmentsRepository.save(appointment);
+    }
+
+    async getUsageSuggestions(
+        id: number,
+    ): Promise<
+        {
+            productId: number;
+            productName: string;
+            quantity: number;
+            unit: string;
+        }[]
+    > {
+        const appointment = await this.appointmentsRepository.findOne({
+            where: { id },
+            relations: ['service'],
+        });
+        if (!appointment?.service?.id) return [];
+        const items = await this.recipeItemsRepository.find({
+            where: { serviceId: appointment.service.id },
+            relations: ['product'],
+        });
+        return items
+            .filter((item) => item.product && (item.quantity ?? 0) > 0)
+            .map((item) => ({
+                productId: item.product!.id,
+                productName: item.product!.name,
+                quantity: Math.max(1, Math.round(item.quantity ?? 1)),
+                unit: item.unit ?? 'op.',
+            }));
     }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -839,9 +839,7 @@ export class AppointmentsService {
                         clientName:
                             clientName.length > 0
                                 ? clientName
-                                : (appointment.client.name ??
-                                  null ??
-                                  undefined),
+                                : (appointment.client.name || undefined),
                         scope: 'completed',
                     },
                     user,
@@ -897,6 +895,16 @@ export class AppointmentsService {
         appointment.internalNote =
             internalNote === null ? undefined : internalNote;
         return this.appointmentsRepository.save(appointment);
+    }
+
+    async countOnlinePending(employeeId?: number): Promise<number> {
+        const where: FindOptionsWhere<Appointment> = {
+            status: AppointmentStatus.OnlinePending,
+        };
+        if (employeeId !== undefined) {
+            where.employee = { id: employeeId };
+        }
+        return this.appointmentsRepository.count({ where });
     }
 
     async getUsageSuggestions(

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -198,6 +198,9 @@ export class AppointmentsService {
             data.endTime = this.computeEnd(data.startTime, service.duration);
         }
         await this.assertNoConflict(employee.id, data.startTime, data.endTime);
+        if (data.reservedOnline) {
+            data.status = AppointmentStatus.OnlinePending;
+        }
         const appointment = this.appointmentsRepository.create(data);
         const saved = await this.appointmentsRepository.save(appointment);
         const result = await this.findOne(saved.id);
@@ -463,9 +466,15 @@ export class AppointmentsService {
         if (!appointment) {
             return null;
         }
-        if (appointment.status !== AppointmentStatus.Scheduled) {
+        const reschedulableStatuses = [
+            AppointmentStatus.Scheduled,
+            AppointmentStatus.Confirmed,
+            AppointmentStatus.OnlinePending,
+            AppointmentStatus.RescheduledPending,
+        ];
+        if (!reschedulableStatuses.includes(appointment.status)) {
             throw new BadRequestException(
-                'Only scheduled appointments can be rescheduled',
+                'Only scheduled or confirmed appointments can be rescheduled',
             );
         }
         if (!startTime || isNaN(startTime.getTime())) {
@@ -498,10 +507,18 @@ export class AppointmentsService {
             newEnd,
             id,
         );
+        // When staff reschedules a confirmed appointment, flag it so the
+        // client can accept the new time before it moves back to confirmed.
+        const newStatus =
+            appointment.status === AppointmentStatus.Confirmed
+                ? AppointmentStatus.RescheduledPending
+                : appointment.status;
+
         await this.appointmentsRepository.update(id, {
             startTime,
             endTime: newEnd,
             serviceVariantId: appointment.serviceVariantId ?? null,
+            status: newStatus,
         });
         const updated = await this.findOne(id);
         if (updated) {
@@ -624,12 +641,15 @@ export class AppointmentsService {
             return this.completeAppointment(id, user);
         }
 
-        if (
-            appointment.status === AppointmentStatus.Cancelled ||
-            appointment.status === AppointmentStatus.Completed
-        ) {
+        const terminalStatuses = [
+            AppointmentStatus.Cancelled,
+            AppointmentStatus.Completed,
+            AppointmentStatus.NoShow,
+            AppointmentStatus.InProgress,
+        ];
+        if (terminalStatuses.includes(appointment.status)) {
             throw new BadRequestException(
-                'Cannot change status for cancelled or completed appointment',
+                `Cannot change status from ${appointment.status}`,
             );
         }
 
@@ -645,6 +665,12 @@ export class AppointmentsService {
             [AppointmentStatus.Confirmed]: [
                 AppointmentStatus.InProgress,
                 AppointmentStatus.NoShow,
+            ],
+            // Staff can confirm or cancel an online booking request
+            [AppointmentStatus.OnlinePending]: [AppointmentStatus.Confirmed],
+            // Client can confirm the new time or cancel after staff reschedule
+            [AppointmentStatus.RescheduledPending]: [
+                AppointmentStatus.Confirmed,
             ],
             [AppointmentStatus.InProgress]: [],
             [AppointmentStatus.NoShow]: [],

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -846,4 +846,19 @@ export class AppointmentsService {
 
         return updated;
     }
+
+    async updateNotes(
+        id: number,
+        internalNote: string | null,
+    ): Promise<Appointment> {
+        const appointment = await this.appointmentsRepository.findOne({
+            where: { id },
+        });
+        if (!appointment) {
+            throw new BadRequestException('Appointment not found');
+        }
+        appointment.internalNote =
+            internalNote === null ? undefined : internalNote;
+        return this.appointmentsRepository.save(appointment);
+    }
 }

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -781,41 +781,40 @@ export class AppointmentsService {
                     user,
                     manager,
                 );
-
-                // Process product sales (upselling) if any
-                if (
-                    dto.products &&
-                    dto.products.length > 0 &&
-                    this.retailService
-                ) {
-                    for (const productSale of dto.products) {
-                        const customerName = [
-                            appointment.client.firstName,
-                            appointment.client.lastName,
-                        ]
-                            .filter((part) => Boolean(part && part.trim()))
-                            .join(' ')
-                            .trim();
-                        await this.retailService.createSale(
-                            {
-                                productId: productSale.productId,
-                                quantity: productSale.quantity,
-                                unitPriceCents: productSale.unitPriceCents,
-                                discountCents: productSale.discountCents,
-                                employeeId: appointment.employee.id,
-                                appointmentId: appointment.id,
-                                clientId: appointment.client.id,
-                                clientName:
-                                    customerName.length > 0
-                                        ? customerName
-                                        : (appointment.client.name ?? null),
-                            },
-                            user,
-                        );
-                    }
-                }
             },
         );
+
+        // Process product sales (upselling) after main transaction commits.
+        // createSale uses its own transaction so it cannot join the outer one;
+        // running it post-commit prevents partial-sale state when the outer
+        // transaction rolls back.
+        if (dto.products && dto.products.length > 0 && this.retailService) {
+            const customerName = [
+                appointment.client.firstName,
+                appointment.client.lastName,
+            ]
+                .filter((part) => Boolean(part && part.trim()))
+                .join(' ')
+                .trim();
+            for (const productSale of dto.products) {
+                await this.retailService.createSale(
+                    {
+                        productId: productSale.productId,
+                        quantity: productSale.quantity,
+                        unitPriceCents: productSale.unitPriceCents,
+                        discountCents: productSale.discountCents,
+                        employeeId: appointment.employee.id,
+                        appointmentId: appointment.id,
+                        clientId: appointment.client.id,
+                        clientName:
+                            customerName.length > 0
+                                ? customerName
+                                : (appointment.client.name ?? null),
+                    },
+                    user,
+                );
+            }
+        }
 
         // Deduct materials used during the service from warehouse stock
         if (dto.usageItems && dto.usageItems.length > 0 && this.retailService) {
@@ -839,7 +838,7 @@ export class AppointmentsService {
                         clientName:
                             clientName.length > 0
                                 ? clientName
-                                : (appointment.client.name || undefined),
+                                : appointment.client.name || undefined,
                         scope: 'completed',
                     },
                     user,
@@ -911,9 +910,7 @@ export class AppointmentsService {
         return this.appointmentsRepository.count({ where });
     }
 
-    async getUsageSuggestions(
-        id: number,
-    ): Promise<
+    async getUsageSuggestions(id: number): Promise<
         {
             productId: number;
             productName: string;

--- a/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
+++ b/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsDateString, IsOptional } from 'class-validator';
+import { IsInt, IsDateString, IsOptional, IsBoolean } from 'class-validator';
 
 export class CreateAppointmentDto {
     @ApiProperty()
@@ -32,6 +32,7 @@ export class CreateAppointmentDto {
         description:
             'Set to true when client books online — creates appointment with online_pending status',
     })
+    @IsBoolean()
     @IsOptional()
     reservedOnline?: boolean;
 }

--- a/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
+++ b/backend/salonbw-backend/src/appointments/dto/create-appointment.dto.ts
@@ -26,4 +26,12 @@ export class CreateAppointmentDto {
     @IsInt()
     @IsOptional()
     clientId?: number;
+
+    @ApiProperty({
+        required: false,
+        description:
+            'Set to true when client books online — creates appointment with online_pending status',
+    })
+    @IsOptional()
+    reservedOnline?: boolean;
 }

--- a/backend/salonbw-backend/src/appointments/dto/finalize-appointment.dto.ts
+++ b/backend/salonbw-backend/src/appointments/dto/finalize-appointment.dto.ts
@@ -11,6 +11,22 @@ import {
 import { Type } from 'class-transformer';
 import { PaymentMethod } from '../appointment.entity';
 
+export class UsageItemDto {
+    @ApiProperty({ description: 'Product ID' })
+    @IsNumber()
+    productId: number;
+
+    @ApiProperty({ description: 'Quantity used', minimum: 1 })
+    @IsNumber()
+    @Min(1)
+    quantity: number;
+
+    @ApiProperty({ description: 'Unit (e.g. ml, g, op.)', required: false })
+    @IsString()
+    @IsOptional()
+    unit?: string;
+}
+
 export class ProductSaleItemDto {
     @ApiProperty({ description: 'Product ID' })
     @IsNumber()
@@ -94,4 +110,16 @@ export class FinalizeAppointmentDto {
     @IsString()
     @IsOptional()
     note?: string;
+
+    @ApiProperty({
+        description:
+            'Materials used during the service (deducted from warehouse)',
+        required: false,
+        type: [UsageItemDto],
+    })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => UsageItemDto)
+    @IsOptional()
+    usageItems?: UsageItemDto[];
 }

--- a/backend/salonbw-backend/src/appointments/test-context.ts
+++ b/backend/salonbw-backend/src/appointments/test-context.ts
@@ -6,6 +6,7 @@ import { AppointmentsService } from './appointments.service';
 import { Role } from '../users/role.enum';
 import { Service as SalonService, PriceType } from '../services/service.entity';
 import { ServiceVariant } from '../services/entities/service-variant.entity';
+import { ServiceRecipeItem } from '../services/entities/service-recipe-item.entity';
 import { User } from '../users/user.entity';
 import { CommissionsService } from '../commissions/commissions.service';
 import { LogService } from '../logs/log.service';
@@ -101,6 +102,7 @@ export function createAppointmentsTestContext(): AppointmentsTestContext {
     const mockUsersRepo = createUsersRepo(users);
     const mockServicesRepo = createServicesRepo(services);
     const mockServiceVariantsRepo = createServiceVariantsRepo();
+    const mockRecipeItemsRepo = createRecipeItemsRepo();
     const mockAppointmentsRepo = createAppointmentsRepo(
         appointments,
         services,
@@ -156,6 +158,7 @@ export function createAppointmentsTestContext(): AppointmentsTestContext {
         mockAppointmentsRepo,
         mockServicesRepo,
         mockServiceVariantsRepo,
+        mockRecipeItemsRepo,
         mockUsersRepo,
         mockCommissionsService,
         mockLogService,
@@ -213,6 +216,12 @@ function createServiceVariantsRepo() {
             [{ where: { id: number } } | undefined]
         >(() => Promise.resolve(null)),
     } as unknown as jest.Mocked<Repository<ServiceVariant>>;
+}
+
+function createRecipeItemsRepo() {
+    return {
+        find: jest.fn(() => Promise.resolve([])),
+    } as unknown as jest.Mocked<Repository<ServiceRecipeItem>>;
 }
 
 function createAppointmentsRepo(

--- a/backend/salonbw-backend/src/formulas/formulas.service.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.service.ts
@@ -37,8 +37,13 @@ export class FormulasService {
         if (appointment.employee.id !== userId) {
             throw new ForbiddenException();
         }
-        if (appointment.status !== AppointmentStatus.Completed) {
-            throw new BadRequestException('Appointment not completed');
+        if (
+            appointment.status !== AppointmentStatus.Completed &&
+            appointment.status !== AppointmentStatus.InProgress
+        ) {
+            throw new BadRequestException(
+                'Appointment must be in progress or completed to add a formula',
+            );
         }
         const formula = this.formulasRepository.create({
             description: data.description,

--- a/backend/salonbw-backend/src/migrations/1760960000000-AddOnlinePendingAppointmentStatuses.ts
+++ b/backend/salonbw-backend/src/migrations/1760960000000-AddOnlinePendingAppointmentStatuses.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOnlinePendingAppointmentStatuses1760960000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the existing CHECK constraint on appointments.status and recreate it
+        // with the two new values: 'online_pending' and 'rescheduled_pending'.
+        // The constraint name follows TypeORM's auto-naming convention.
+        await queryRunner.query(`
+            ALTER TABLE "appointments"
+            DROP CONSTRAINT IF EXISTS "CHK_appointments_status"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "appointments"
+            ADD CONSTRAINT "CHK_appointments_status"
+            CHECK ("status" IN (
+                'scheduled', 'confirmed', 'in_progress',
+                'cancelled', 'completed', 'no_show',
+                'online_pending', 'rescheduled_pending'
+            ))
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "appointments"
+            DROP CONSTRAINT IF EXISTS "CHK_appointments_status"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "appointments"
+            ADD CONSTRAINT "CHK_appointments_status"
+            CHECK ("status" IN (
+                'scheduled', 'confirmed', 'in_progress',
+                'cancelled', 'completed', 'no_show'
+            ))
+        `);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds two new appointment statuses: `online_pending` (client booked online, awaiting salon confirmation) and `rescheduled_pending` (staff moved the appointment, client must accept)
- DB migration drops/recreates the `CHK_appointments_status` constraint with all 8 values
- Backend: `create()` sets `online_pending` when `reservedOnline=true`; `updateStatus()` handles transitions from new statuses; `updateStartTime()` sets `rescheduled_pending` when a confirmed appointment is rescheduled by staff
- Panel `AppointmentStatus` union type extended with the two new values
- `EventCard`: orange ring + "Oczekuje na potwierdzenie" / yellow ring + "Przeniesiona — wymaga akceptacji"
- `AppointmentDrawer`: confirm/cancel actions + contextual info text for pending statuses
- `ClientAppointmentHistoryView`: status badges, warning border, accept-reschedule button
- `calendar.tsx`: wires up `onAcceptReschedule` → `PATCH /appointments/:id/status { status: 'confirmed' }`

## Test plan

- [ ] Book an appointment with `reservedOnline: true` → status is `online_pending` in the calendar
- [ ] Staff opens the drawer → sees "Potwierdź rezerwację" button → click → status becomes `confirmed`
- [ ] Staff reschedules a `confirmed` appointment → status becomes `rescheduled_pending`
- [ ] Client views `/calendar?view=client` → sees yellow-bordered card with "Zaakceptuj nowy termin" button → click → status becomes `confirmed`
- [ ] Run migration on staging DB and verify no constraint violations

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_