### PR TITLE
fix: reservedOnline=true in booking wizard + employee WhatsApp alert

### DIFF
--- a/apps/panel/src/pages/booking.tsx
+++ b/apps/panel/src/pages/booking.tsx
@@ -168,6 +168,7 @@ export default function BookingPage() {
                     serviceId: selectedService.id,
                     employeeId: selectedSlot.employeeId,
                     startTime: selectedSlot.time,
+                    reservedOnline: true,
                 }),
             });
             setCreatedAppointmentId(result.id);

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -220,8 +220,8 @@ export class AppointmentsService {
             entity: 'appointment',
             id: result.id,
         });
+        const { date, time } = this.formatDate(result.startTime);
         if (client.phone && client.receiveNotifications) {
-            const { date, time } = this.formatDate(result.startTime);
             try {
                 await this.whatsappService.sendBookingConfirmation(
                     client.phone,
@@ -235,6 +235,29 @@ export class AppointmentsService {
             console.warn(
                 'Client has no phone number or notifications disabled; skipping booking confirmation',
             );
+        }
+        if (
+            result.status === AppointmentStatus.OnlinePending &&
+            employee.phone
+        ) {
+            const clientName = [client.firstName, client.lastName]
+                .filter(Boolean)
+                .join(' ')
+                .trim();
+            try {
+                await this.whatsappService.sendNewOnlineBookingAlert(
+                    employee.phone,
+                    clientName || client.name || 'Klient',
+                    result.service.name,
+                    date,
+                    time,
+                );
+            } catch (error) {
+                console.error(
+                    'Failed to send online booking alert to employee',
+                    error,
+                );
+            }
         }
         return result;
     }

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -113,4 +113,19 @@ export class WhatsappService {
     async sendFollowUp(to: string, date: string, time: string): Promise<void> {
         await this.sendTemplate(to, 'follow_up', [date, time]);
     }
+
+    async sendNewOnlineBookingAlert(
+        to: string,
+        clientName: string,
+        serviceName: string,
+        date: string,
+        time: string,
+    ): Promise<void> {
+        await this.sendTemplate(to, 'new_online_booking_alert', [
+            clientName,
+            serviceName,
+            date,
+            time,
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary

- **booking.tsx**: `reservedOnline: true` was missing from the POST `/appointments` body — client bookings via the wizard landed in `scheduled` instead of `online_pending`, breaking the whole confirmation flow
- **appointments.service.ts**: after creating an `online_pending` appointment, send a WhatsApp alert to the assigned employee so staff are notified immediately without checking the panel
- **whatsapp.service.ts**: new `sendNewOnlineBookingAlert()` method using template `new_online_booking_alert` with params `[clientName, serviceName, date, time]` — template must be registered in Meta Business Manager before going live

## Test plan

- [ ] Book an appointment via `/booking` as a client → appointment status in DB is `online_pending` (not `scheduled`)
- [ ] Staff opens calendar → sees the `online_pending` badge count in topbar
- [ ] Staff opens AppointmentDrawer → "Potwierdź rezerwację" button present
- [ ] Confirm → status becomes `confirmed`, client receives booking confirmation WhatsApp
- [ ] Register `new_online_booking_alert` template in Meta Business Manager and verify employee receives alert on booking

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_