### PR TITLE
Mobile responsiveness + unified light design + appointments list page

### DIFF
--- a/apps/panel/src/components/calendar/AppointmentDrawer.tsx
+++ b/apps/panel/src/components/calendar/AppointmentDrawer.tsx
@@ -459,7 +459,7 @@ export default function AppointmentDrawer({
         <>
             <div
                 className="position-fixed top-0 end-0 h-100 bg-white border-start shadow-lg"
-                style={{ width: '420px', zIndex: 1100 }}
+                style={{ width: 'min(420px, 100vw)', zIndex: 1100 }}
                 role="dialog"
                 aria-label="Appointment drawer"
             >

--- a/apps/panel/src/pages/_document.tsx
+++ b/apps/panel/src/pages/_document.tsx
@@ -11,6 +11,10 @@ export default function Document(props: CustomDocumentProps) {
     return (
         <Html lang="pl">
             <Head nonce={props.nonce}>
+                <meta
+                    name="viewport"
+                    content="width=device-width, initial-scale=1"
+                />
                 <link rel="preconnect" href="https://fonts.googleapis.com" />
                 <link
                     rel="preconnect"

--- a/apps/panel/src/pages/appointments.tsx
+++ b/apps/panel/src/pages/appointments.tsx
@@ -5,10 +5,14 @@ import SalonShell from '@/components/salon/SalonShell';
 import SalonBreadcrumbs from '@/components/salon/SalonBreadcrumbs';
 import { useAuth } from '@/contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
-import type { Appointment, AppointmentStatus } from '@/types';
+import type { Appointment, AppointmentStatus, ServiceVariant } from '@/types';
+
+interface AppointmentWithVariant extends Appointment {
+    serviceVariant?: ServiceVariant | null;
+}
 
 interface AppointmentPage {
-    items: Appointment[];
+    items: AppointmentWithVariant[];
     total: number;
     page: number;
     pageSize: number;
@@ -83,7 +87,10 @@ export default function AppointmentsPage() {
 
     const { data, isLoading, error } = useQuery<AppointmentPage>({
         queryKey: ['appointments-list', from, to, status, search, page],
-        queryFn: () => apiFetch<AppointmentPage>(`/appointments?${queryParams.toString()}`),
+        queryFn: () =>
+            apiFetch<AppointmentPage>(
+                `/appointments?${queryParams.toString()}`,
+            ),
         enabled: !!role && (role === 'admin' || role === 'receptionist'),
     });
 
@@ -102,7 +109,7 @@ export default function AppointmentsPage() {
 
     const totalPages = data ? Math.ceil(data.total / limit) : 0;
 
-    const openInCalendar = (appt: Appointment) => {
+    const openInCalendar = (appt: AppointmentWithVariant) => {
         if (!appt.startTime) return;
         const d = new Date(appt.startTime);
         const dateStr = isoDate(d);
@@ -137,7 +144,10 @@ export default function AppointmentsPage() {
                                 type="date"
                                 className="form-control form-control-sm"
                                 value={from}
-                                onChange={(e) => { setFrom(e.target.value); handleFilterChange(); }}
+                                onChange={(e) => {
+                                    setFrom(e.target.value);
+                                    handleFilterChange();
+                                }}
                             />
                         </div>
                         <div>
@@ -146,41 +156,67 @@ export default function AppointmentsPage() {
                                 type="date"
                                 className="form-control form-control-sm"
                                 value={to}
-                                onChange={(e) => { setTo(e.target.value); handleFilterChange(); }}
+                                onChange={(e) => {
+                                    setTo(e.target.value);
+                                    handleFilterChange();
+                                }}
                             />
                         </div>
                         <div>
-                            <label className="form-label mb-1 small">Status</label>
+                            <label className="form-label mb-1 small">
+                                Status
+                            </label>
                             <select
                                 className="form-select form-select-sm"
                                 value={status}
-                                onChange={(e) => { setStatus(e.target.value as AppointmentStatus | ''); handleFilterChange(); }}
+                                onChange={(e) => {
+                                    setStatus(
+                                        e.target.value as
+                                            | AppointmentStatus
+                                            | '',
+                                    );
+                                    handleFilterChange();
+                                }}
                                 style={{ minWidth: 160 }}
                             >
                                 <option value="">Wszystkie statusy</option>
                                 {ALL_STATUSES.map((s) => (
-                                    <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+                                    <option key={s} value={s}>
+                                        {STATUS_LABELS[s]}
+                                    </option>
                                 ))}
                             </select>
                         </div>
                         <div className="flex-grow-1" style={{ minWidth: 180 }}>
-                            <label className="form-label mb-1 small">Klient / telefon</label>
+                            <label className="form-label mb-1 small">
+                                Klient / telefon
+                            </label>
                             <div className="input-group input-group-sm">
                                 <input
                                     type="text"
                                     className="form-control"
                                     placeholder="Szukaj..."
                                     value={searchInput}
-                                    onChange={(e) => setSearchInput(e.target.value)}
-                                    onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                                    onChange={(e) =>
+                                        setSearchInput(e.target.value)
+                                    }
+                                    onKeyDown={(e) =>
+                                        e.key === 'Enter' && handleSearch()
+                                    }
                                 />
-                                <button className="btn btn-outline-secondary" onClick={handleSearch}>
+                                <button
+                                    className="btn btn-outline-secondary"
+                                    onClick={handleSearch}
+                                >
                                     Szukaj
                                 </button>
                             </div>
                         </div>
                         <div>
-                            <Link href="/calendar" className="btn btn-sm btn-dark">
+                            <Link
+                                href="/calendar"
+                                className="btn btn-sm btn-dark"
+                            >
                                 + Nowa wizyta
                             </Link>
                         </div>
@@ -189,7 +225,9 @@ export default function AppointmentsPage() {
 
                 <div className="column_row results_info mb-2">
                     <span className="results_title">
-                        {isLoading ? 'Ładowanie...' : `${data?.total ?? 0} wizyt`}
+                        {isLoading
+                            ? 'Ładowanie...'
+                            : `${data?.total ?? 0} wizyt`}
                     </span>
                 </div>
 
@@ -216,15 +254,24 @@ export default function AppointmentsPage() {
                         <tbody>
                             {isLoading && (
                                 <tr>
-                                    <td colSpan={8} className="text-center py-4">
-                                        <div className="spinner-border spinner-border-sm" role="status" />
-                                        {' '}Ładowanie...
+                                    <td
+                                        colSpan={8}
+                                        className="text-center py-4"
+                                    >
+                                        <div
+                                            className="spinner-border spinner-border-sm"
+                                            role="status"
+                                        />{' '}
+                                        Ładowanie...
                                     </td>
                                 </tr>
                             )}
                             {!isLoading && data?.items.length === 0 && (
                                 <tr>
-                                    <td colSpan={8} className="text-center py-4 text-muted">
+                                    <td
+                                        colSpan={8}
+                                        className="text-center py-4 text-muted"
+                                    >
                                         Brak wizyt dla wybranych filtrów.
                                     </td>
                                 </tr>
@@ -243,56 +290,76 @@ export default function AppointmentsPage() {
                                         {appt.client ? (
                                             <Link
                                                 href={`/customers/${appt.client.id}`}
-                                                onClick={(e) => e.stopPropagation()}
+                                                onClick={(e) =>
+                                                    e.stopPropagation()
+                                                }
                                             >
-                                                {appt.client.name || `${(appt.client as any).firstName ?? ''} ${(appt.client as any).lastName ?? ''}`.trim()}
+                                                {appt.client.name}
                                             </Link>
                                         ) : (
-                                            <span className="text-muted">—</span>
+                                            <span className="text-muted">
+                                                —
+                                            </span>
                                         )}
-                                        {(appt.client as any)?.phone && (
+                                        {appt.client?.phone && (
                                             <div className="small text-muted">
-                                                {(appt.client as any).phone}
+                                                {appt.client.phone}
                                             </div>
                                         )}
                                     </td>
                                     <td>
                                         {appt.service?.name ?? '—'}
-                                        {(appt as any).serviceVariant?.name && (
+                                        {appt.serviceVariant?.name && (
                                             <span className="text-muted small ms-1">
-                                                ({(appt as any).serviceVariant.name})
+                                                ({appt.serviceVariant.name})
                                             </span>
                                         )}
                                     </td>
                                     <td>{appt.employee?.name ?? '—'}</td>
                                     <td>
                                         {appt.status && (
-                                            <span className={`badge ${STATUS_BADGE[appt.status] ?? 'bg-secondary'}`}>
-                                                {STATUS_LABELS[appt.status] ?? appt.status}
+                                            <span
+                                                className={`badge ${STATUS_BADGE[appt.status] ?? 'bg-secondary'}`}
+                                            >
+                                                {STATUS_LABELS[appt.status] ??
+                                                    appt.status}
                                             </span>
                                         )}
                                     </td>
                                     <td>
                                         {appt.paymentMethod ? (
                                             <span className="small">
-                                                {appt.paymentMethod === 'cash' ? 'Gotówka' :
-                                                 appt.paymentMethod === 'card' ? 'Karta' :
-                                                 appt.paymentMethod === 'transfer' ? 'Przelew' :
-                                                 appt.paymentMethod}
+                                                {appt.paymentMethod === 'cash'
+                                                    ? 'Gotówka'
+                                                    : appt.paymentMethod ===
+                                                        'card'
+                                                      ? 'Karta'
+                                                      : appt.paymentMethod ===
+                                                          'transfer'
+                                                        ? 'Przelew'
+                                                        : appt.paymentMethod}
                                             </span>
-                                        ) : '—'}
+                                        ) : (
+                                            '—'
+                                        )}
                                     </td>
                                     <td className="text-end">
                                         {appt.paidAmount != null
                                             ? `${Number(appt.paidAmount).toFixed(2)} zł`
                                             : appt.service?.price != null
-                                            ? `${Number(appt.service.price).toFixed(2)} zł`
-                                            : '—'}
+                                              ? `${Number(appt.service.price).toFixed(2)} zł`
+                                              : '—'}
                                     </td>
-                                    <td className="text-end" style={{ whiteSpace: 'nowrap' }}>
+                                    <td
+                                        className="text-end"
+                                        style={{ whiteSpace: 'nowrap' }}
+                                    >
                                         <button
                                             className="btn btn-sm btn-outline-secondary"
-                                            onClick={(e) => { e.stopPropagation(); openInCalendar(appt); }}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                openInCalendar(appt);
+                                            }}
                                         >
                                             Otwórz
                                         </button>
@@ -308,40 +375,50 @@ export default function AppointmentsPage() {
                         <div className="row">
                             <div className="info col-xs-7">
                                 <span>
-                                    Strona {page} z {totalPages}
-                                    {' '}({data?.total} wyników)
+                                    Strona {page} z {totalPages} ({data?.total}{' '}
+                                    wyników)
                                 </span>
                             </div>
                             <div className="form_pagination col-xs-5 d-flex gap-1 justify-content-end">
                                 <button
                                     className="btn btn-sm btn-outline-secondary"
                                     disabled={page <= 1}
-                                    onClick={() => setPage(p => Math.max(1, p - 1))}
+                                    onClick={() =>
+                                        setPage((p) => Math.max(1, p - 1))
+                                    }
                                 >
                                     &laquo; Poprzednia
                                 </button>
-                                {Array.from({ length: Math.min(totalPages, 7) }, (_, i) => {
-                                    const pageNum = totalPages <= 7
-                                        ? i + 1
-                                        : page <= 4
-                                        ? i + 1
-                                        : page >= totalPages - 3
-                                        ? totalPages - 6 + i
-                                        : page - 3 + i;
-                                    return (
-                                        <button
-                                            key={pageNum}
-                                            className={`btn btn-sm ${pageNum === page ? 'btn-dark' : 'btn-outline-secondary'}`}
-                                            onClick={() => setPage(pageNum)}
-                                        >
-                                            {pageNum}
-                                        </button>
-                                    );
-                                })}
+                                {Array.from(
+                                    { length: Math.min(totalPages, 7) },
+                                    (_, i) => {
+                                        const pageNum =
+                                            totalPages <= 7
+                                                ? i + 1
+                                                : page <= 4
+                                                  ? i + 1
+                                                  : page >= totalPages - 3
+                                                    ? totalPages - 6 + i
+                                                    : page - 3 + i;
+                                        return (
+                                            <button
+                                                key={pageNum}
+                                                className={`btn btn-sm ${pageNum === page ? 'btn-dark' : 'btn-outline-secondary'}`}
+                                                onClick={() => setPage(pageNum)}
+                                            >
+                                                {pageNum}
+                                            </button>
+                                        );
+                                    },
+                                )}
                                 <button
                                     className="btn btn-sm btn-outline-secondary"
                                     disabled={page >= totalPages}
-                                    onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                                    onClick={() =>
+                                        setPage((p) =>
+                                            Math.min(totalPages, p + 1),
+                                        )
+                                    }
                                 >
                                     Następna &raquo;
                                 </button>

--- a/apps/panel/src/pages/appointments.tsx
+++ b/apps/panel/src/pages/appointments.tsx
@@ -1,12 +1,355 @@
-import type { GetServerSideProps } from 'next';
+import { useState, useCallback, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import SalonShell from '@/components/salon/SalonShell';
+import SalonBreadcrumbs from '@/components/salon/SalonBreadcrumbs';
+import { useAuth } from '@/contexts/AuthContext';
+import { useQuery } from '@tanstack/react-query';
+import type { Appointment, AppointmentStatus } from '@/types';
 
-export const getServerSideProps: GetServerSideProps = async () => ({
-    redirect: {
-        destination: '/calendar',
-        permanent: false,
-    },
-});
+interface AppointmentPage {
+    items: Appointment[];
+    total: number;
+    page: number;
+    pageSize: number;
+}
 
-export default function AppointmentsAliasPage() {
-    return null;
+const STATUS_LABELS: Record<AppointmentStatus, string> = {
+    scheduled: 'Zaplanowana',
+    confirmed: 'Potwierdzona',
+    in_progress: 'W trakcie',
+    cancelled: 'Anulowana',
+    completed: 'Zakończona',
+    no_show: 'Nieobecność',
+    online_pending: 'Oczekuje',
+    rescheduled_pending: 'Przeniesiona',
+};
+
+const STATUS_BADGE: Record<AppointmentStatus, string> = {
+    scheduled: 'bg-primary',
+    confirmed: 'bg-success',
+    in_progress: 'bg-warning text-dark',
+    cancelled: 'bg-secondary',
+    completed: 'bg-success',
+    no_show: 'bg-danger',
+    online_pending: 'bg-info text-dark',
+    rescheduled_pending: 'bg-warning text-dark',
+};
+
+function formatDateTime(iso: string) {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function isoDate(d: Date) {
+    return d.toISOString().split('T')[0];
+}
+
+const ALL_STATUSES: AppointmentStatus[] = [
+    'scheduled',
+    'confirmed',
+    'in_progress',
+    'completed',
+    'cancelled',
+    'no_show',
+    'online_pending',
+    'rescheduled_pending',
+];
+
+export default function AppointmentsPage() {
+    const { role, apiFetch } = useAuth();
+    const router = useRouter();
+
+    const today = new Date();
+    const thirtyDaysAgo = new Date(today);
+    thirtyDaysAgo.setDate(today.getDate() - 30);
+
+    const [from, setFrom] = useState(isoDate(thirtyDaysAgo));
+    const [to, setTo] = useState(isoDate(today));
+    const [status, setStatus] = useState<AppointmentStatus | ''>('');
+    const [search, setSearch] = useState('');
+    const [searchInput, setSearchInput] = useState('');
+    const [page, setPage] = useState(1);
+    const limit = 50;
+
+    const queryParams = new URLSearchParams();
+    if (from) queryParams.set('from', from);
+    if (to) queryParams.set('to', to + 'T23:59:59');
+    if (status) queryParams.set('status', status);
+    if (search) queryParams.set('search', search);
+    queryParams.set('page', String(page));
+    queryParams.set('limit', String(limit));
+
+    const { data, isLoading, error } = useQuery<AppointmentPage>({
+        queryKey: ['appointments-list', from, to, status, search, page],
+        queryFn: () => apiFetch<AppointmentPage>(`/appointments?${queryParams.toString()}`),
+        enabled: !!role && (role === 'admin' || role === 'receptionist'),
+    });
+
+    const handleSearch = useCallback(() => {
+        setSearch(searchInput);
+        setPage(1);
+    }, [searchInput]);
+
+    const handleFilterChange = useCallback(() => {
+        setPage(1);
+    }, []);
+
+    useEffect(() => {
+        setPage(1);
+    }, [from, to, status]);
+
+    const totalPages = data ? Math.ceil(data.total / limit) : 0;
+
+    const openInCalendar = (appt: Appointment) => {
+        if (!appt.startTime) return;
+        const d = new Date(appt.startTime);
+        const dateStr = isoDate(d);
+        void router.push(`/calendar?date=${dateStr}&appointmentId=${appt.id}`);
+    };
+
+    if (!role) return null;
+
+    if (role !== 'admin' && role !== 'receptionist') {
+        return (
+            <SalonShell role={role}>
+                <div className="inner">
+                    <p>Brak dostępu do listy wizyt.</p>
+                </div>
+            </SalonShell>
+        );
+    }
+
+    return (
+        <SalonShell role={role}>
+            <div className="inner">
+                <SalonBreadcrumbs
+                    iconClass="sprite-breadcrumbs_calendar"
+                    items={[{ label: 'Wizyty', href: '/appointments' }]}
+                />
+
+                <div className="column_row mb-3">
+                    <div className="d-flex flex-wrap gap-2 align-items-end">
+                        <div>
+                            <label className="form-label mb-1 small">Od</label>
+                            <input
+                                type="date"
+                                className="form-control form-control-sm"
+                                value={from}
+                                onChange={(e) => { setFrom(e.target.value); handleFilterChange(); }}
+                            />
+                        </div>
+                        <div>
+                            <label className="form-label mb-1 small">Do</label>
+                            <input
+                                type="date"
+                                className="form-control form-control-sm"
+                                value={to}
+                                onChange={(e) => { setTo(e.target.value); handleFilterChange(); }}
+                            />
+                        </div>
+                        <div>
+                            <label className="form-label mb-1 small">Status</label>
+                            <select
+                                className="form-select form-select-sm"
+                                value={status}
+                                onChange={(e) => { setStatus(e.target.value as AppointmentStatus | ''); handleFilterChange(); }}
+                                style={{ minWidth: 160 }}
+                            >
+                                <option value="">Wszystkie statusy</option>
+                                {ALL_STATUSES.map((s) => (
+                                    <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className="flex-grow-1" style={{ minWidth: 180 }}>
+                            <label className="form-label mb-1 small">Klient / telefon</label>
+                            <div className="input-group input-group-sm">
+                                <input
+                                    type="text"
+                                    className="form-control"
+                                    placeholder="Szukaj..."
+                                    value={searchInput}
+                                    onChange={(e) => setSearchInput(e.target.value)}
+                                    onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                                />
+                                <button className="btn btn-outline-secondary" onClick={handleSearch}>
+                                    Szukaj
+                                </button>
+                            </div>
+                        </div>
+                        <div>
+                            <Link href="/calendar" className="btn btn-sm btn-dark">
+                                + Nowa wizyta
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="column_row results_info mb-2">
+                    <span className="results_title">
+                        {isLoading ? 'Ładowanie...' : `${data?.total ?? 0} wizyt`}
+                    </span>
+                </div>
+
+                {error && (
+                    <div className="alert alert-danger">
+                        Błąd ładowania danych.
+                    </div>
+                )}
+
+                <div className="data_table salonbw-table-wrap">
+                    <table className="table table-bordered table-hover">
+                        <thead>
+                            <tr>
+                                <th>Data</th>
+                                <th>Klient</th>
+                                <th>Usługa</th>
+                                <th>Pracownik</th>
+                                <th>Status</th>
+                                <th>Płatność</th>
+                                <th className="text-end">Kwota</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {isLoading && (
+                                <tr>
+                                    <td colSpan={8} className="text-center py-4">
+                                        <div className="spinner-border spinner-border-sm" role="status" />
+                                        {' '}Ładowanie...
+                                    </td>
+                                </tr>
+                            )}
+                            {!isLoading && data?.items.length === 0 && (
+                                <tr>
+                                    <td colSpan={8} className="text-center py-4 text-muted">
+                                        Brak wizyt dla wybranych filtrów.
+                                    </td>
+                                </tr>
+                            )}
+                            {data?.items.map((appt) => (
+                                <tr
+                                    key={appt.id}
+                                    className="cursor-pointer"
+                                    onClick={() => openInCalendar(appt)}
+                                    style={{ cursor: 'pointer' }}
+                                >
+                                    <td style={{ whiteSpace: 'nowrap' }}>
+                                        {formatDateTime(appt.startTime)}
+                                    </td>
+                                    <td>
+                                        {appt.client ? (
+                                            <Link
+                                                href={`/customers/${appt.client.id}`}
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                {appt.client.name || `${(appt.client as any).firstName ?? ''} ${(appt.client as any).lastName ?? ''}`.trim()}
+                                            </Link>
+                                        ) : (
+                                            <span className="text-muted">—</span>
+                                        )}
+                                        {(appt.client as any)?.phone && (
+                                            <div className="small text-muted">
+                                                {(appt.client as any).phone}
+                                            </div>
+                                        )}
+                                    </td>
+                                    <td>
+                                        {appt.service?.name ?? '—'}
+                                        {(appt as any).serviceVariant?.name && (
+                                            <span className="text-muted small ms-1">
+                                                ({(appt as any).serviceVariant.name})
+                                            </span>
+                                        )}
+                                    </td>
+                                    <td>{appt.employee?.name ?? '—'}</td>
+                                    <td>
+                                        {appt.status && (
+                                            <span className={`badge ${STATUS_BADGE[appt.status] ?? 'bg-secondary'}`}>
+                                                {STATUS_LABELS[appt.status] ?? appt.status}
+                                            </span>
+                                        )}
+                                    </td>
+                                    <td>
+                                        {appt.paymentMethod ? (
+                                            <span className="small">
+                                                {appt.paymentMethod === 'cash' ? 'Gotówka' :
+                                                 appt.paymentMethod === 'card' ? 'Karta' :
+                                                 appt.paymentMethod === 'transfer' ? 'Przelew' :
+                                                 appt.paymentMethod}
+                                            </span>
+                                        ) : '—'}
+                                    </td>
+                                    <td className="text-end">
+                                        {appt.paidAmount != null
+                                            ? `${Number(appt.paidAmount).toFixed(2)} zł`
+                                            : appt.service?.price != null
+                                            ? `${Number(appt.service.price).toFixed(2)} zł`
+                                            : '—'}
+                                    </td>
+                                    <td className="text-end" style={{ whiteSpace: 'nowrap' }}>
+                                        <button
+                                            className="btn btn-sm btn-outline-secondary"
+                                            onClick={(e) => { e.stopPropagation(); openInCalendar(appt); }}
+                                        >
+                                            Otwórz
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                {totalPages > 1 && (
+                    <div className="pagination_container mt-3">
+                        <div className="row">
+                            <div className="info col-xs-7">
+                                <span>
+                                    Strona {page} z {totalPages}
+                                    {' '}({data?.total} wyników)
+                                </span>
+                            </div>
+                            <div className="form_pagination col-xs-5 d-flex gap-1 justify-content-end">
+                                <button
+                                    className="btn btn-sm btn-outline-secondary"
+                                    disabled={page <= 1}
+                                    onClick={() => setPage(p => Math.max(1, p - 1))}
+                                >
+                                    &laquo; Poprzednia
+                                </button>
+                                {Array.from({ length: Math.min(totalPages, 7) }, (_, i) => {
+                                    const pageNum = totalPages <= 7
+                                        ? i + 1
+                                        : page <= 4
+                                        ? i + 1
+                                        : page >= totalPages - 3
+                                        ? totalPages - 6 + i
+                                        : page - 3 + i;
+                                    return (
+                                        <button
+                                            key={pageNum}
+                                            className={`btn btn-sm ${pageNum === page ? 'btn-dark' : 'btn-outline-secondary'}`}
+                                            onClick={() => setPage(pageNum)}
+                                        >
+                                            {pageNum}
+                                        </button>
+                                    );
+                                })}
+                                <button
+                                    className="btn btn-sm btn-outline-secondary"
+                                    disabled={page >= totalPages}
+                                    onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                                >
+                                    Następna &raquo;
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </SalonShell>
+    );
 }

--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -2073,3 +2073,369 @@ h3 {
     background: #2a2414;
     color: #c5a880;
 }
+
+/* ============================================================
+   LIGHT THEME — unified overrides for all salonbw-* components
+   Replaces legacy dark-luxury palette with a clean, light UI.
+   The navbar/sidenav keep their explicit dark colors above.
+   ============================================================ */
+
+/* --- Component backgrounds & borders --- */
+.salonbw-mass-communication__section,
+.salonbw-modal,
+.salonbw-widget,
+.salonbw-stat-card,
+.salonbw-dashboard__section,
+.salonbw-reception-summary,
+.salonbw-reception-table-wrap,
+.salonbw-reception-item,
+.salonbw-panel-sub,
+.salonbw-list-item,
+.salonbw-empty,
+.salonbw-empty-state,
+.salonbw-mini-cal,
+.salonbw-alert,
+.salonbw-variables-help,
+.salonbw-template-item,
+.salonbw-sidebar,
+.salonbw-sidebar-section,
+.salonbw-sidebar__section {
+    background: #ffffff;
+    border-color: #dee2e6;
+}
+
+.salonbw-reception-summary__item,
+.salonbw-reception-summary__item--scheduled,
+.salonbw-reception-summary__item--confirmed,
+.salonbw-reception-summary__item--in-progress,
+.salonbw-reception-summary__item--completed {
+    background: #f8f9fa;
+}
+
+.salonbw-modal__footer,
+.salonbw-modal__header {
+    background: #f8f9fa;
+    border-color: #dee2e6;
+}
+
+/* --- Text --- */
+.salonbw-mass-communication__section h3,
+.salonbw-modal__header h3,
+.salonbw-panel-sub__title,
+.salonbw-reception-item__title,
+.salonbw-dashboard__title,
+.salonbw-stat-card__value,
+.salonbw-dashboard__section-header h2,
+.salonbw-template-item__name,
+.salonbw-reception-empty h3,
+.salonbw-send-result h3,
+.salonbw-activity-item__title,
+.salonbw-appointment-item__client,
+.salonbw-reception-summary__value {
+    color: #212529;
+}
+
+.salonbw-panel-sub__description,
+.salonbw-panel-sub__meta,
+.salonbw-reception-item__meta,
+.salonbw-reception-item__details,
+.salonbw-template-item__preview,
+.salonbw-reception-phone,
+.salonbw-activity-item__meta,
+.salonbw-appointment-item__service,
+.salonbw-reception-empty p,
+.salonbw-reception-no-actions,
+.salonbw-reception-summary__label,
+.salonbw-section-title,
+.salonbw-sidebar__header,
+.salonbw-muted,
+.salonbw-loading,
+.salonbw-mass-communication__subsection h4 {
+    color: #6c757d;
+}
+
+/* --- Tables --- */
+.salonbw-table th,
+.salonbw-reception-table th,
+.salonbw-widget__header {
+    background: #f0f2f4;
+    border-color: #dee2e6;
+    color: #495057;
+}
+
+.salonbw-table td,
+.salonbw-reception-table td {
+    border-color: #dee2e6;
+    color: #212529;
+}
+
+.salonbw-table tr:hover,
+.salonbw-reception-table tbody tr:hover {
+    background: #f8f9fa;
+}
+
+#salonbw-shell-root .salonbw-table th {
+    background: #f0f2f4;
+    color: #495057;
+    border-color: #dee2e6;
+}
+#salonbw-shell-root .salonbw-table td {
+    color: #212529;
+    border-color: #dee2e6;
+}
+#salonbw-shell-root .salonbw-table tr:hover {
+    background: #f8f9fa;
+}
+
+/* --- Form elements --- */
+.salonbw-input,
+.salonbw-textarea,
+.salonbw-select,
+.salonbw-select--inline,
+.salonbw-sidebar__search,
+.salonbw-toolbar-search {
+    background: #ffffff;
+    border-color: #dee2e6;
+    color: #212529;
+}
+
+.salonbw-form-group label {
+    color: #495057;
+}
+
+/* --- Buttons --- */
+.salonbw-toolbar-btn,
+.salonbw-btn--default,
+.salonbw-btn--light,
+.salonbw-btn--secondary {
+    background: #f8f9fa;
+    border-color: #dee2e6;
+    color: #495057;
+}
+.salonbw-toolbar-btn:hover,
+.salonbw-btn--default:hover,
+.salonbw-btn--light:hover,
+.salonbw-btn--secondary:hover {
+    background: #e9ecef;
+    color: #212529;
+}
+
+/* --- Chips/labels --- */
+.salonbw-label-xs {
+    background: #f0f2f4;
+    color: #495057;
+}
+
+/* --- Dividers / section borders --- */
+.salonbw-mass-communication__subsection {
+    border-left-color: #dee2e6;
+}
+.salonbw-mass-communication__footer,
+.salonbw-dashboard__period,
+.salonbw-dashboard__section-header,
+.salonbw-activity-item,
+.salonbw-appointment-item,
+.salonbw-pagination-footer,
+.salonbw-modal__header,
+.salonbw-modal__footer {
+    border-color: #dee2e6;
+}
+.salonbw-dashboard__section-footer {
+    border-top-color: #dee2e6;
+}
+
+/* --- Icon buttons --- */
+.salonbw-icon-btn {
+    color: #6c757d;
+}
+.salonbw-icon-btn:hover {
+    background: #f0f2f4;
+    color: #495057;
+}
+
+/* --- Mini calendar --- */
+.salonbw-mini-cal__weekdays {
+    border-bottom-color: #dee2e6;
+}
+.salonbw-mini-cal__weekdays span {
+    color: #6c757d;
+}
+.salonbw-mini-cal__day {
+    color: #495057;
+}
+.salonbw-mini-cal__day:hover {
+    background: #f0f2f4;
+    color: #212529;
+}
+.salonbw-mini-cal__day--other-month {
+    color: #adb5bd;
+}
+
+/* --- Modal close --- */
+.salonbw-modal__close {
+    color: #6c757d;
+}
+.salonbw-modal__close:hover {
+    background: #e9ecef;
+    color: #212529;
+}
+
+/* --- Employee filter --- */
+.salonbw-employee-filter__item:hover {
+    background: #f0f2f4;
+}
+.salonbw-employee-filter__name {
+    color: #495057;
+}
+
+/* --- Templates --- */
+.salonbw-template-item {
+    border-color: #dee2e6;
+}
+.salonbw-template-item:hover {
+    border-color: #c5a880;
+    background: rgba(197, 168, 128, 0.05);
+}
+.salonbw-template-item.active {
+    border-color: #c5a880;
+    background: rgba(197, 168, 128, 0.08);
+}
+
+/* --- Channel selector --- */
+.salonbw-channel {
+    border-color: #dee2e6;
+}
+.salonbw-checkbox-row {
+    color: #495057;
+}
+
+/* --- Alert --- */
+.salonbw-alert {
+    background: #f8f9fa;
+    border-color: #dee2e6;
+    color: #495057;
+}
+.salonbw-alert-info {
+    background: #e8f4fd;
+    border-color: #bee3f8;
+    color: #0c5460;
+}
+
+/* --- Communication previews --- */
+.communication-reminder-card {
+    background: #ffffff;
+    border-color: #dee2e6;
+    color: #495057;
+}
+.sms_thread .message {
+    background: #f8f9fa;
+    border-color: #dee2e6;
+}
+.sms_thread .message.customer {
+    background: #e8f5f2;
+    border-color: #c3e6cb;
+}
+.communication-preview-sms,
+.communication-preview-email__body {
+    background: #f8f9fa;
+    border-color: #dee2e6;
+    color: #212529;
+}
+.communication-preview-email__subject {
+    color: #212529;
+}
+
+/* --- Calendar view components (drawer) --- */
+.calendar-view-drafts__item {
+    background: #ffffff;
+    border-color: #dee2e6;
+}
+.calendar-view-drafts__title,
+.calendar-view-form-list__heading {
+    color: #212529;
+}
+.calendar-view-drafts__meta {
+    color: #6c757d;
+}
+.calendar-view-checkbox {
+    color: #495057;
+}
+
+/* --- Legacy modal (non-Bootstrap) --- */
+.modal-content {
+    background: #ffffff;
+    border-color: #dee2e6;
+}
+.modal-header {
+    background: #f8f9fa;
+    border-bottom-color: #dee2e6;
+}
+.modal-title {
+    color: #212529;
+    font-family: 'Open Sans', sans-serif;
+}
+.modal-footer {
+    background: #f8f9fa;
+    border-top-color: #dee2e6;
+}
+.close {
+    color: #6c757d;
+}
+.close:hover {
+    color: #212529;
+}
+
+/* --- Legacy btn-default / label-default --- */
+.btn-default {
+    background: #ffffff;
+    border-color: #dee2e6;
+    color: #495057;
+}
+.btn-default:hover {
+    background: #f8f9fa;
+    color: #212529;
+}
+.label-default {
+    background: #f0f2f4;
+    border-color: #dee2e6;
+    color: #6c757d;
+}
+
+/* --- Data table rows --- */
+.data_table .table-bordered tr.odd td {
+    background: #f8f9fa;
+}
+.data_table .table-bordered tr.even td {
+    background: #ffffff;
+}
+
+/* --- Dashboard period button --- */
+.salonbw-dashboard__period-btn {
+    color: #6c757d;
+}
+
+/* --- Mobile: tables scrollable --- */
+@media (max-width: 768px) {
+    .salonbw-reception-view,
+    .salonbw-dashboard__grid,
+    .salonbw-dashboard__stats {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .salonbw-dashboard__stats {
+        grid-template-columns: 1fr;
+    }
+
+    .salonbw-dashboard__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .salonbw-channel-selector {
+        flex-direction: column;
+    }
+
+    .salonbw-form-row {
+        grid-template-columns: 1fr;
+    }
+}

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -2492,7 +2492,7 @@ tr.customer-row:hover .customers-drag-handle {
     display: flex;
     min-height: calc(100vh - var(--salon-topbar-h));
     width: 100%;
-    background: #f7f8f9;
+    background: #ffffff;
 }
 
 /* ========================================
@@ -2699,7 +2699,8 @@ body.e2e-extension .main-content .inner {
 .main-content {
     flex: 1;
     overflow: auto;
-    background: #f1f3f5;
+    background: #ffffff;
+    min-width: 0;
 }
 
 .main-content .inner {
@@ -3300,12 +3301,57 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
         width: 50px;
     }
 
+    #sidebar,
+    .sidebar {
+        padding-left: 50px;
+    }
+
     .sidenav {
         display: none;
     }
 
     .navbar .brand {
         left: 60px;
+    }
+
+    /* Content padding on mobile */
+    .main-content .inner {
+        padding: 12px;
+    }
+
+    .salon-section,
+    .salon-column-row {
+        padding: 10px 12px;
+    }
+
+    /* Table horizontal scroll on mobile */
+    .data_table,
+    .salonbw-table-wrap,
+    .salonbw-reception-table-wrap,
+    .table-bordered-wrap {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* Prevent tables from breaking layout */
+    table {
+        min-width: max-content;
+    }
+
+    /* Stacked column layouts */
+    .salon-column-row .col-md-6,
+    .salon-column-row .col-lg-6 {
+        width: 100%;
+    }
+
+    /* Full-width buttons on mobile */
+    .d-md-none-mobile {
+        display: none !important;
+    }
+
+    /* Topbar omnibox */
+    .navbar .omnibox {
+        max-width: 120px;
     }
 }
 

--- a/backend/salonbw-backend/src/appointments/appointments.controller.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.controller.ts
@@ -46,21 +46,26 @@ export class AppointmentsController {
     @Roles(Role.Admin, Role.Receptionist, Role.Employee, Role.Client)
     @Get()
     @ApiBearerAuth()
-    @ApiOperation({ summary: 'List appointments (admin, optional filters)' })
-    @ApiResponse({ status: 200, type: Appointment, isArray: true })
-    findAll(
+    @ApiOperation({ summary: 'List appointments with filters and pagination' })
+    @ApiResponse({ status: 200, description: 'Paginated appointment list' })
+    async findAll(
         @Query(new ValidationPipe({ transform: true }))
         query: GetAppointmentsDto,
         @CurrentUser() user: { userId: number; role: Role },
-    ): Promise<Appointment[]> {
+    ) {
         if (user.role === Role.Admin || user.role === Role.Receptionist) {
             return this.appointmentsService.findAllInRange({
                 from: query.from ? new Date(query.from) : undefined,
                 to: query.to ? new Date(query.to) : undefined,
                 employeeId: query.employeeId,
+                status: query.status,
+                search: query.search,
+                page: query.page,
+                limit: query.limit,
             });
         }
-        return this.appointmentsService.findForUser(user.userId);
+        const items = await this.appointmentsService.findForUser(user.userId);
+        return { items, total: items.length, page: 1, pageSize: items.length };
     }
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -14,6 +14,7 @@ import {
     Not,
     Between,
     FindOptionsWhere,
+    ILike,
 } from 'typeorm';
 import {
     Appointment,
@@ -152,27 +153,54 @@ export class AppointmentsService {
         return { date, time };
     }
 
-    findAllInRange(params: {
+    async findAllInRange(params: {
         from?: Date;
         to?: Date;
         employeeId?: number;
-    }): Promise<Appointment[]> {
-        const where: FindOptionsWhere<Appointment> & {
-            employee?: { id: number };
-        } = {};
-        if (params.employeeId) where.employee = { id: params.employeeId };
-        if (params.from && params.to) {
-            where.startTime = Between(params.from, params.to);
-        } else if (params.from) {
-            where.startTime = MoreThan(params.from);
-        } else if (params.to) {
-            where.startTime = LessThan(params.to);
+        status?: AppointmentStatus;
+        search?: string;
+        page?: number;
+        limit?: number;
+    }): Promise<{ items: Appointment[]; total: number; page: number; pageSize: number }> {
+        const page = params.page ?? 1;
+        const pageSize = Math.min(params.limit ?? 50, 200);
+
+        const buildWhere = (extraClientWhere?: FindOptionsWhere<{ firstName?: string; lastName?: string; phone?: string }>): FindOptionsWhere<Appointment> => {
+            const where: FindOptionsWhere<Appointment> = {};
+            if (params.employeeId) where.employee = { id: params.employeeId };
+            if (params.status) where.status = params.status;
+            if (extraClientWhere) where.client = extraClientWhere as any;
+            if (params.from && params.to) {
+                where.startTime = Between(params.from, params.to);
+            } else if (params.from) {
+                where.startTime = MoreThan(params.from);
+            } else if (params.to) {
+                where.startTime = LessThan(params.to);
+            }
+            return where;
+        };
+
+        let whereCondition: FindOptionsWhere<Appointment> | FindOptionsWhere<Appointment>[];
+        if (params.search) {
+            const term = `%${params.search}%`;
+            whereCondition = [
+                buildWhere({ firstName: ILike(term) } as any),
+                buildWhere({ lastName: ILike(term) } as any),
+                buildWhere({ phone: ILike(term) } as any),
+            ];
+        } else {
+            whereCondition = buildWhere();
         }
-        return this.appointmentsRepository.find({
-            where,
-            order: { startTime: 'ASC' },
-            relations: ['formulas'],
+
+        const [items, total] = await this.appointmentsRepository.findAndCount({
+            where: whereCondition,
+            order: { startTime: 'DESC' },
+            relations: ['client', 'employee', 'service', 'serviceVariant'],
+            skip: (page - 1) * pageSize,
+            take: pageSize,
         });
+
+        return { items, total, page, pageSize };
     }
 
     async create(data: Partial<Appointment>, user: User): Promise<Appointment> {

--- a/backend/salonbw-backend/src/appointments/dto/get-appointments.dto.ts
+++ b/backend/salonbw-backend/src/appointments/dto/get-appointments.dto.ts
@@ -1,30 +1,46 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsOptional, IsDateString } from 'class-validator';
+import { IsNumber, IsOptional, IsDateString, IsString, IsEnum, Min } from 'class-validator';
 import { Type } from 'class-transformer';
+import { AppointmentStatus } from '../appointment.entity';
 
 export class GetAppointmentsDto {
-    @ApiProperty({
-        required: false,
-        description: 'Start date for filtering appointments (ISO 8601)',
-    })
+    @ApiProperty({ required: false })
     @IsOptional()
     @IsDateString()
     from?: string;
 
-    @ApiProperty({
-        required: false,
-        description: 'End date for filtering appointments (ISO 8601)',
-    })
+    @ApiProperty({ required: false })
     @IsOptional()
     @IsDateString()
     to?: string;
 
-    @ApiProperty({
-        required: false,
-        description: 'Employee ID for filtering appointments',
-    })
+    @ApiProperty({ required: false })
     @IsOptional()
     @Type(() => Number)
     @IsNumber()
     employeeId?: number;
+
+    @ApiProperty({ required: false, enum: AppointmentStatus })
+    @IsOptional()
+    @IsEnum(AppointmentStatus)
+    status?: AppointmentStatus;
+
+    @ApiProperty({ required: false, description: 'Client name or phone search' })
+    @IsOptional()
+    @IsString()
+    search?: string;
+
+    @ApiProperty({ required: false, default: 1 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsNumber()
+    @Min(1)
+    page?: number;
+
+    @ApiProperty({ required: false, default: 50 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsNumber()
+    @Min(1)
+    limit?: number;
 }


### PR DESCRIPTION
## Summary

### Mobile responsiveness + light design
- **Viewport meta tag** — was missing entirely; without it iPhones render the full 980px desktop layout scaled down.
- **AppointmentDrawer** — hardcoded 420px → `min(420px, 100vw)` so it fits on any screen.
- **Main container/content** — backgrounds unified to white (#ffffff).
- **Mobile overrides (salon-shell.css)** — sidebar padding, content inner padding, table horizontal scroll, dashboard grids collapse to single column on mobile.
- **Light theme unification (globals.css)** — all `salonbw-*` components converted from dark luxury palette to clean light Bootstrap 5 defaults. Covers all component backgrounds, borders, text, tables, modals, forms.

### Appointments list page (`/appointments`)
- **New dedicated list page** replacing the redirect to `/calendar`.
- **Filters**: date range (from/to), status dropdown (all 8 statuses), client name/phone search.
- **Pagination**: 50 per page with page navigation.
- **Rows**: date, client (linked to `/customers/:id`), service+variant, employee, status badge, payment method, amount.
- **Click to open**: any row or "Otwórz" button navigates to the calendar on that appointment's date.
- **Backend extended**: `GET /appointments` now accepts `status`, `search`, `page`, `limit` query params and returns `{ items, total, page, pageSize }` instead of a flat array.

## Test plan
- [ ] Open on iPhone — page renders at device width, not scaled down
- [ ] AppointmentDrawer opens full-width on phone
- [ ] All pages use consistent light look
- [ ] Tables scroll horizontally on mobile
- [ ] `/appointments` shows list with filters
- [ ] Date range, status, and search filters all work independently and combined
- [ ] Pagination appears when >50 results
- [ ] Clicking a row opens the calendar on that date

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk