### PR TITLE
End-to-end workflow fixes: notifications, dashboard KPIs, pending queue

### DIFF
--- a/apps/panel/src/__tests__/AdminDashboard.test.tsx
+++ b/apps/panel/src/__tests__/AdminDashboard.test.tsx
@@ -5,12 +5,22 @@ jest.mock('@/hooks/useDashboard', () => ({
     useDashboard: jest.fn(() => ({
         loading: false,
         data: {
+            clientCount: 42,
+            employeeCount: 3,
+            todayAppointments: 4,
+            onlinePendingCount: 0,
+            revenueToday: 300,
+            revenueThisMonth: 4200,
+            completedThisMonth: 40,
             upcomingAppointments: [
                 {
                     id: 1,
                     startTime: '2026-03-12T10:00:00.000Z',
-                    client: { id: 2, name: 'Jan Kowalski' },
-                    service: { id: 3, name: 'Strzyżenie' },
+                    clientName: 'Jan Kowalski',
+                    clientPhone: '+48 600 000 001',
+                    serviceName: 'Strzyżenie',
+                    employeeName: 'Aleksandra',
+                    status: 'scheduled',
                 },
             ],
         },
@@ -66,7 +76,7 @@ describe('AdminDashboard', () => {
 
         expect(screen.getByText('4')).toBeInTheDocument();
         expect(screen.getByText('2')).toBeInTheDocument();
-        expect(screen.getByText('300,00 zł')).toBeInTheDocument();
+        expect(screen.getAllByText('300,00 zł').length).toBeGreaterThan(0);
         expect(screen.getAllByText('+100%')).toHaveLength(3);
         expect(screen.getByText('Jan Kowalski')).toBeInTheDocument();
         expect(screen.queryByText('pokaż obrót')).not.toBeInTheDocument();

--- a/apps/panel/src/components/calendar/AppointmentDrawer.tsx
+++ b/apps/panel/src/components/calendar/AppointmentDrawer.tsx
@@ -132,6 +132,15 @@ export default function AppointmentDrawer({
     const [formulas, setFormulas] = useState<Formula[]>([]);
     const [formulasLoaded, setFormulasLoaded] = useState(false);
 
+    interface UsageHistoryEntry {
+        id: number;
+        usedAt: string;
+        appointmentId: number | null;
+        items: { productName: string; quantity: number; unit: string }[];
+    }
+    const [usageHistory, setUsageHistory] = useState<UsageHistoryEntry[]>([]);
+    const [historyLoaded, setHistoryLoaded] = useState(false);
+
     const title =
         mode === 'create' ? 'Nowa wizyta' : `Wizyta #${appointment?.id ?? ''}`;
 
@@ -183,6 +192,8 @@ export default function AppointmentDrawer({
         setFormulaError(null);
         setFormulas([]);
         setFormulasLoaded(false);
+        setUsageHistory([]);
+        setHistoryLoaded(false);
 
         if (mode === 'edit' && appointment) {
             setStartTime(toLocalDateTimeInput(new Date(appointment.startTime)));
@@ -193,16 +204,24 @@ export default function AppointmentDrawer({
             setError(null);
 
             const clientId = appointment.client?.id;
-            const canShowFormulas =
-                appointment.status === 'in_progress' ||
-                appointment.status === 'completed';
-            if (clientId && canShowFormulas) {
+            if (clientId) {
+                // Load formulas for all statuses so employee can check history before starting
                 apiFetch<Formula[]>(`/customers/${clientId}/formulas`)
                     .then((data) => {
-                        setFormulas(data.slice(0, 3));
+                        setFormulas(data.slice(0, 5));
                         setFormulasLoaded(true);
                     })
                     .catch(() => setFormulasLoaded(true));
+
+                // Load material usage history
+                apiFetch<UsageHistoryEntry[]>(
+                    `/customers/${clientId}/usage-history`,
+                )
+                    .then((data) => {
+                        setUsageHistory(data.slice(0, 5));
+                        setHistoryLoaded(true);
+                    })
+                    .catch(() => setHistoryLoaded(true));
             }
             return;
         }
@@ -860,6 +879,96 @@ export default function AppointmentDrawer({
                         </div>
                     ) : null}
 
+                    {/* ── Client history: formulas + materials ────────── */}
+                    {isEditMode &&
+                        (formulasLoaded || historyLoaded) &&
+                        (formulas.length > 0 || usageHistory.length > 0) && (
+                            <div className="rounded border p-2">
+                                <strong className="d-block mb-2">
+                                    Historia klienta
+                                </strong>
+
+                                {formulas.length > 0 && (
+                                    <div className="mb-3">
+                                        <div className="small fw-medium text-muted mb-1">
+                                            Poprzednie receptury
+                                        </div>
+                                        <div className="d-flex flex-column gap-1">
+                                            {formulas.map((f) => (
+                                                <div
+                                                    key={f.id}
+                                                    className="small bg-light rounded px-2 py-1"
+                                                >
+                                                    <div
+                                                        className="text-muted mb-0"
+                                                        style={{
+                                                            fontSize: '0.7rem',
+                                                        }}
+                                                    >
+                                                        {new Date(
+                                                            f.date,
+                                                        ).toLocaleDateString(
+                                                            'pl-PL',
+                                                        )}
+                                                    </div>
+                                                    <div>{f.description}</div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+
+                                {usageHistory.length > 0 && (
+                                    <div>
+                                        <div className="small fw-medium text-muted mb-1">
+                                            Użyte materiały (poprzednie wizyty)
+                                        </div>
+                                        <div className="d-flex flex-column gap-1">
+                                            {usageHistory.map((entry) => (
+                                                <div
+                                                    key={entry.id}
+                                                    className="small bg-light rounded px-2 py-1"
+                                                >
+                                                    <div
+                                                        className="text-muted mb-1"
+                                                        style={{
+                                                            fontSize: '0.7rem',
+                                                        }}
+                                                    >
+                                                        {new Date(
+                                                            entry.usedAt,
+                                                        ).toLocaleDateString(
+                                                            'pl-PL',
+                                                        )}
+                                                    </div>
+                                                    {entry.items.map(
+                                                        (item, i) => (
+                                                            <div
+                                                                key={i}
+                                                                className="d-flex justify-content-between"
+                                                            >
+                                                                <span>
+                                                                    {
+                                                                        item.productName
+                                                                    }
+                                                                </span>
+                                                                <span className="text-muted">
+                                                                    {
+                                                                        item.quantity
+                                                                    }{' '}
+                                                                    {item.unit}
+                                                                </span>
+                                                            </div>
+                                                        ),
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+
                     {canShowFormulaSection ? (
                         <div className="rounded border p-2">
                             <strong className="d-block mb-2">
@@ -937,36 +1046,6 @@ export default function AppointmentDrawer({
                                         : 'Zapisz formularz'}
                                 </button>
                             </div>
-
-                            {formulasLoaded && formulas.length > 0 && (
-                                <div>
-                                    <div className="small fw-medium text-muted mb-1">
-                                        Poprzednie formularze klienta
-                                    </div>
-                                    <div className="d-flex flex-column gap-1">
-                                        {formulas.map((f) => (
-                                            <div
-                                                key={f.id}
-                                                className="small bg-light rounded px-2 py-1"
-                                            >
-                                                <div
-                                                    className="text-muted mb-0"
-                                                    style={{
-                                                        fontSize: '0.75rem',
-                                                    }}
-                                                >
-                                                    {new Date(
-                                                        f.date,
-                                                    ).toLocaleDateString(
-                                                        'pl-PL',
-                                                    )}
-                                                </div>
-                                                <div>{f.description}</div>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                            )}
                         </div>
                     ) : null}
 

--- a/apps/panel/src/components/calendar/FinalizationModal.tsx
+++ b/apps/panel/src/components/calendar/FinalizationModal.tsx
@@ -48,6 +48,7 @@ export default function FinalizationModal({
     const [productSales, setProductSales] = useState<ProductSaleItem[]>([]);
     const [showProductPicker, setShowProductPicker] = useState(false);
     const [usageItems, setUsageItems] = useState<UsageItem[]>([]);
+    const [showUsagePicker, setShowUsagePicker] = useState(false);
     const [uiError, setUiError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
     const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -56,7 +57,7 @@ export default function FinalizationModal({
     const { data: productsResponse } = useQuery<ProductsResponse>({
         queryKey: ['products'],
         queryFn: () => apiFetch<ProductsResponse>('/products'),
-        enabled: open && showProductPicker,
+        enabled: open && (showProductPicker || showUsagePicker),
     });
     const products = useMemo<Product[]>(
         () =>
@@ -145,6 +146,7 @@ export default function FinalizationModal({
         setProductSales([]);
         setUsageItems([]);
         setShowProductPicker(false);
+        setShowUsagePicker(false);
         setUiError(null);
         setSuccessMessage(null);
         onClose();
@@ -234,6 +236,23 @@ export default function FinalizationModal({
 
     const removeProduct = (productId: number) => {
         setProductSales(productSales.filter((p) => p.productId !== productId));
+    };
+
+    const addUsageMaterial = (productId: number) => {
+        const product = products.find((p) => p.id === productId);
+        if (!product) return;
+        const existing = usageItems.find((u) => u.productId === productId);
+        if (existing) return;
+        setUsageItems((prev) => [
+            ...prev,
+            {
+                productId,
+                productName: product.name,
+                quantity: 1,
+                unit: 'op.',
+            },
+        ]);
+        setShowUsagePicker(false);
     };
 
     const updateProductQuantity = (productId: number, quantity: number) => {
@@ -495,67 +514,118 @@ export default function FinalizationModal({
                 </div>
 
                 {/* Materials used */}
-                {usageItems.length > 0 && (
-                    <div className="mb-3">
-                        <label className="d-block small fw-medium text-body mb-2">
+                <div className="mb-3">
+                    <div className="d-flex justify-content-between align-items-center mb-2">
+                        <label className="small fw-medium text-body mb-0">
                             Użyte materiały
                         </label>
-                        <div className="d-flex flex-column gap-2">
-                            {usageItems.map((item, idx) => (
-                                <div
-                                    key={item.productId}
-                                    className="d-flex align-items-center gap-2 bg-light rounded px-2 py-1"
-                                >
-                                    <span className="flex-fill small">
-                                        {item.productName}
-                                    </span>
-                                    <input
-                                        type="number"
-                                        min="1"
-                                        step="1"
-                                        value={item.quantity}
-                                        onChange={(e) => {
-                                            const qty =
-                                                parseInt(e.target.value) || 1;
-                                            setUsageItems((prev) =>
-                                                prev.map((it, i) =>
-                                                    i === idx
-                                                        ? {
-                                                              ...it,
-                                                              quantity:
-                                                                  Math.max(
-                                                                      1,
-                                                                      qty,
-                                                                  ),
-                                                          }
-                                                        : it,
-                                                ),
-                                            );
-                                        }}
-                                        className="form-control form-control-sm"
-                                        style={{ width: '70px' }}
-                                    />
-                                    <span className="small text-muted">
-                                        {item.unit}
-                                    </span>
-                                    <button
-                                        type="button"
-                                        className="text-danger small"
-                                        onClick={() =>
-                                            setUsageItems((prev) =>
-                                                prev.filter(
-                                                    (_, i) => i !== idx,
-                                                ),
-                                            )
-                                        }
-                                    >
-                                        ×
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
+                        <button
+                            type="button"
+                            onClick={() => setShowUsagePicker(!showUsagePicker)}
+                            className="small text-primary"
+                        >
+                            {showUsagePicker ? 'Ukryj' : '+ Dodaj materiał'}
+                        </button>
                     </div>
-                )}
+
+                    {showUsagePicker && (
+                        <div
+                            className="border border-secondary border-opacity-25 rounded-3 p-2 mb-2 overflow-y-auto"
+                            style={{ maxHeight: '200px' }}
+                        >
+                            {products.length === 0 ? (
+                                <p className="small text-muted text-center py-2">
+                                    Brak produktów
+                                </p>
+                            ) : (
+                                <div className="d-flex flex-column gap-1">
+                                    {products
+                                        .filter(
+                                            (p) =>
+                                                !usageItems.some(
+                                                    (u) => u.productId === p.id,
+                                                ),
+                                        )
+                                        .map((product) => (
+                                            <button
+                                                key={product.id}
+                                                type="button"
+                                                onClick={() =>
+                                                    addUsageMaterial(product.id)
+                                                }
+                                                className="w-100 text-start px-2 py-1 small rounded d-flex justify-content-between"
+                                            >
+                                                <span>{product.name}</span>
+                                                <span className="text-muted">
+                                                    stan: {product.stock ?? '–'}
+                                                </span>
+                                            </button>
+                                        ))}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {usageItems.length > 0 && (
+                        <div>
+                            <div className="d-flex flex-column gap-2">
+                                {usageItems.map((item, idx) => (
+                                    <div
+                                        key={item.productId}
+                                        className="d-flex align-items-center gap-2 bg-light rounded px-2 py-1"
+                                    >
+                                        <span className="flex-fill small">
+                                            {item.productName}
+                                        </span>
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            step="1"
+                                            value={item.quantity}
+                                            onChange={(e) => {
+                                                const qty =
+                                                    parseInt(e.target.value) ||
+                                                    1;
+                                                setUsageItems((prev) =>
+                                                    prev.map((it, i) =>
+                                                        i === idx
+                                                            ? {
+                                                                  ...it,
+                                                                  quantity:
+                                                                      Math.max(
+                                                                          1,
+                                                                          qty,
+                                                                      ),
+                                                              }
+                                                            : it,
+                                                    ),
+                                                );
+                                            }}
+                                            className="form-control form-control-sm"
+                                            style={{ width: '70px' }}
+                                        />
+                                        <span className="small text-muted">
+                                            {item.unit}
+                                        </span>
+                                        <button
+                                            type="button"
+                                            className="text-danger small"
+                                            onClick={() =>
+                                                setUsageItems((prev) =>
+                                                    prev.filter(
+                                                        (_, i) => i !== idx,
+                                                    ),
+                                                )
+                                            }
+                                        >
+                                            ×
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
 
                 {/* Note */}
                 <div className="mb-3">

--- a/apps/panel/src/components/dashboard/AdminDashboard.tsx
+++ b/apps/panel/src/components/dashboard/AdminDashboard.tsx
@@ -241,58 +241,53 @@ export default function AdminDashboard() {
             </div>
 
             <div className="salonbw-dashboard__grid">
-                <div className="salonbw-dashboard__section">
-                    <div className="salonbw-dashboard__section-header">
-                        <h2>więcej aktywności</h2>
-                        <Link
-                            href="/settings/employees/activity-logs"
-                            className="salonbw-link"
-                        >
-                            więcej
-                        </Link>
+                {/* Pending online bookings — most urgent action */}
+                {(dashboardData?.onlinePendingCount ?? 0) > 0 && (
+                    <div
+                        className="salonbw-dashboard__section"
+                        style={{
+                            gridColumn: '1 / -1',
+                            borderLeft: '4px solid #f59e0b',
+                        }}
+                    >
+                        <div className="salonbw-dashboard__section-header">
+                            <h2>
+                                <span className="badge bg-warning text-dark me-2">
+                                    {dashboardData?.onlinePendingCount}
+                                </span>
+                                Rezerwacje online czekające na potwierdzenie
+                            </h2>
+                            <Link
+                                href="/appointments?status=online_pending"
+                                className="btn btn-sm btn-warning"
+                            >
+                                Zarządzaj
+                            </Link>
+                        </div>
+                        <p className="small text-muted mb-0">
+                            Klienci zarezerwowali wizyty online. Potwierdź lub
+                            odrzuć — po potwierdzeniu klient otrzyma
+                            powiadomienie WhatsApp.
+                        </p>
                     </div>
-                    <div className="salonbw-activity-list">
-                        {dashboardData?.upcomingAppointments
-                            ?.slice(0, 5)
-                            .map((appointment) => (
-                                <div
-                                    key={appointment.id}
-                                    className="salonbw-activity-item"
-                                >
-                                    <div className="salonbw-activity-item__avatar">
-                                        {appointment.client?.name?.charAt(0) ||
-                                            '?'}
-                                    </div>
-                                    <div className="salonbw-activity-item__content">
-                                        <div className="salonbw-activity-item__title">
-                                            Wizyta:{' '}
-                                            {appointment.client?.name ||
-                                                'Unknown'}
-                                        </div>
-                                        <div className="salonbw-activity-item__meta">
-                                            {format(
-                                                new Date(appointment.startTime),
-                                                'd MMMM, HH:mm',
-                                                { locale: pl },
-                                            )}
-                                        </div>
-                                    </div>
-                                </div>
-                            )) || (
-                            <div className="salonbw-activity-item salonbw-activity-item--empty">
-                                Brak aktywności
-                            </div>
-                        )}
-                    </div>
-                </div>
+                )}
 
                 <div className="salonbw-dashboard__section">
                     <div className="salonbw-dashboard__section-header">
-                        <h2>najbliższe zaplanowane wizyty</h2>
+                        <h2>najbliższe wizyty</h2>
+                        <Link href="/calendar" className="salonbw-link">
+                            kalendarz
+                        </Link>
                     </div>
                     <div className="salonbw-appointments-list">
-                        {dashboardData?.upcomingAppointments
-                            ?.slice(0, 5)
+                        {(dashboardData?.upcomingAppointments ?? []).length ===
+                            0 && (
+                            <div className="salonbw-appointment-item salonbw-appointment-item--empty">
+                                Brak zaplanowanych wizyt
+                            </div>
+                        )}
+                        {(dashboardData?.upcomingAppointments ?? [])
+                            .slice(0, 6)
                             .map((appointment) => (
                                 <div
                                     key={appointment.id}
@@ -303,47 +298,126 @@ export default function AdminDashboard() {
                                             new Date(appointment.startTime),
                                             'HH:mm',
                                         )}
+                                        <div className="small text-muted">
+                                            {format(
+                                                new Date(appointment.startTime),
+                                                'd MMM',
+                                                { locale: pl },
+                                            )}
+                                        </div>
                                     </div>
                                     <div className="salonbw-appointment-item__details">
                                         <div className="salonbw-appointment-item__client">
-                                            {appointment.client?.name ||
-                                                'Unknown'}
+                                            {appointment.clientName || '—'}
+                                            {appointment.clientPhone && (
+                                                <a
+                                                    href={`tel:${appointment.clientPhone}`}
+                                                    className="ms-2 small text-muted"
+                                                    onClick={(e) =>
+                                                        e.stopPropagation()
+                                                    }
+                                                >
+                                                    {appointment.clientPhone}
+                                                </a>
+                                            )}
                                         </div>
                                         <div className="salonbw-appointment-item__service">
-                                            {appointment.service?.name ||
-                                                'Unknown'}
+                                            {appointment.serviceName}
+                                            {appointment.employeeName && (
+                                                <span className="text-muted ms-1">
+                                                    · {appointment.employeeName}
+                                                </span>
+                                            )}
                                         </div>
                                     </div>
+                                    {appointment.status ===
+                                        'online_pending' && (
+                                        <span className="badge bg-warning text-dark ms-auto">
+                                            Oczekuje
+                                        </span>
+                                    )}
                                 </div>
-                            )) || (
-                            <div className="salonbw-appointment-item salonbw-appointment-item--empty">
-                                Brak zaplanowanych wizyt
-                            </div>
-                        )}
+                            ))}
                     </div>
                     <Link
-                        href="/calendar"
+                        href="/appointments"
                         className="salonbw-dashboard__section-footer"
                     >
-                        kalendarz wizyt
+                        lista wszystkich wizyt
                     </Link>
                 </div>
 
                 <div className="salonbw-dashboard__section">
                     <div className="salonbw-dashboard__section-header">
-                        <h2>zadania</h2>
-                        <div className="salonbw-dashboard__section-actions">
-                            <button type="button" className="salonbw-icon-btn">
-                                +
-                            </button>
-                            <button type="button" className="salonbw-icon-btn">
-                                •••
-                            </button>
+                        <h2>podsumowanie miesiąca</h2>
+                        <Link href="/statistics" className="salonbw-link">
+                            szczegóły
+                        </Link>
+                    </div>
+                    <div className="salonbw-appointments-list">
+                        <div className="salonbw-appointment-item">
+                            <div className="salonbw-appointment-item__details">
+                                <div className="salonbw-appointment-item__client">
+                                    Przychód (dzisiaj)
+                                </div>
+                                <div className="salonbw-appointment-item__service text-muted small">
+                                    z zakończonych wizyt
+                                </div>
+                            </div>
+                            <div className="fw-bold">
+                                {formatMoney(
+                                    dashboardData?.revenueToday ??
+                                        stats?.todayRevenue ??
+                                        0,
+                                )}
+                            </div>
+                        </div>
+                        <div className="salonbw-appointment-item">
+                            <div className="salonbw-appointment-item__details">
+                                <div className="salonbw-appointment-item__client">
+                                    Przychód (ten miesiąc)
+                                </div>
+                                <div className="salonbw-appointment-item__service text-muted small">
+                                    z zakończonych wizyt
+                                </div>
+                            </div>
+                            <div className="fw-bold">
+                                {formatMoney(
+                                    dashboardData?.revenueThisMonth ??
+                                        stats?.monthRevenue ??
+                                        0,
+                                )}
+                            </div>
+                        </div>
+                        <div className="salonbw-appointment-item">
+                            <div className="salonbw-appointment-item__details">
+                                <div className="salonbw-appointment-item__client">
+                                    Zakończone wizyty (ten miesiąc)
+                                </div>
+                            </div>
+                            <div className="fw-bold">
+                                {dashboardData?.completedThisMonth ??
+                                    stats?.monthAppointments ??
+                                    0}
+                            </div>
+                        </div>
+                        <div className="salonbw-appointment-item">
+                            <div className="salonbw-appointment-item__details">
+                                <div className="salonbw-appointment-item__client">
+                                    Łączna liczba klientów
+                                </div>
+                            </div>
+                            <div className="fw-bold">
+                                {dashboardData?.clientCount ?? 0}
+                            </div>
                         </div>
                     </div>
-                    <div className="salonbw-empty-state">
-                        Brak zadań do wykonania
-                    </div>
+                    <Link
+                        href="/statistics"
+                        className="salonbw-dashboard__section-footer"
+                    >
+                        pełne statystyki
+                    </Link>
                 </div>
             </div>
         </div>

--- a/apps/panel/src/components/dashboard/ClientDashboard.tsx
+++ b/apps/panel/src/components/dashboard/ClientDashboard.tsx
@@ -1,28 +1,71 @@
+'use client';
+
+import Link from 'next/link';
 import { useClientDashboard } from '@/hooks/useDashboard';
-import StatsWidget from '@/components/StatsWidget';
+
+const STATUS_LABELS: Record<string, string> = {
+    scheduled: 'Zaplanowana',
+    confirmed: 'Potwierdzona',
+    in_progress: 'W trakcie',
+    completed: 'Zrealizowana',
+    cancelled: 'Anulowana',
+    no_show: 'Nieobecność',
+    online_pending: 'Oczekuje',
+    rescheduled_pending: 'Zmiana terminu',
+};
+
+const STATUS_CLASS: Record<string, string> = {
+    scheduled: 'badge bg-secondary',
+    confirmed: 'badge bg-primary',
+    in_progress: 'badge bg-warning text-dark',
+    completed: 'badge bg-success',
+    cancelled: 'badge bg-danger',
+    no_show: 'badge bg-dark',
+    online_pending: 'badge bg-warning text-dark',
+    rescheduled_pending: 'badge bg-info text-dark',
+};
+
+function statusLabel(status: string) {
+    return STATUS_LABELS[status] ?? status;
+}
+
+function statusClass(status: string) {
+    return STATUS_CLASS[status] ?? 'badge bg-secondary';
+}
 
 export default function ClientDashboard() {
     const { data, loading, error } = useClientDashboard();
 
     if (loading) {
-        return <div className="p-3">Loading dashboard...</div>;
+        return (
+            <div className="salonbw-dashboard">
+                <div className="salonbw-dashboard__loading">
+                    Ładowanie pulpitu...
+                </div>
+            </div>
+        );
     }
 
     if (error) {
         return (
-            <div className="p-3 text-danger">
-                Error loading dashboard: {error.message}
+            <div className="salonbw-dashboard">
+                <div className="alert alert-danger">
+                    Błąd ładowania danych: {error.message}
+                </div>
             </div>
         );
     }
 
     if (!data) {
-        return <div className="p-3">No data available</div>;
+        return (
+            <div className="salonbw-dashboard">
+                <div className="salonbw-dashboard__empty">Brak danych</div>
+            </div>
+        );
     }
 
-    const formatDate = (dateStr: string) => {
-        const date = new Date(dateStr);
-        return date.toLocaleDateString('pl-PL', {
+    const formatDate = (dateStr: string) =>
+        new Date(dateStr).toLocaleDateString('pl-PL', {
             weekday: 'long',
             year: 'numeric',
             month: 'long',
@@ -30,120 +73,179 @@ export default function ClientDashboard() {
             hour: '2-digit',
             minute: '2-digit',
         });
-    };
 
     return (
-        <div className="gap-3">
-            <h1 className="fs-3 fw-bold">Your Dashboard</h1>
+        <div className="salonbw-dashboard">
+            <div className="salonbw-dashboard__header">
+                <h1 className="salonbw-dashboard__title">Mój panel</h1>
+                <Link
+                    href="/booking"
+                    className="salonbw-btn salonbw-btn--primary"
+                >
+                    Zarezerwuj wizytę
+                </Link>
+            </div>
 
-            {/* Upcoming Appointment */}
-            <section className="bg-white rounded-3 shadow p-4">
-                <h2 className="fs-5 fw-semibold mb-3">Upcoming Appointment</h2>
-                {data.upcomingAppointment ? (
-                    <div className="border-start-4 border-primary ps-3">
-                        <p className="fs-5 fw-medium">
-                            {data.upcomingAppointment.serviceName}
-                        </p>
-                        <p className="text-muted">
-                            {formatDate(data.upcomingAppointment.startTime)}
-                        </p>
-                        <p className="small text-muted">
-                            with {data.upcomingAppointment.employeeName}
-                        </p>
+            {/* Nearest appointment */}
+            <div className="salonbw-dashboard__grid">
+                <div className="salonbw-dashboard__section">
+                    <div className="salonbw-dashboard__section-header">
+                        <h2>Nadchodząca wizyta</h2>
                     </div>
-                ) : (
-                    <p className="text-muted">
-                        No upcoming appointments scheduled
-                    </p>
-                )}
-            </section>
+                    {data.upcomingAppointment ? (
+                        <div className="salonbw-appointments-list">
+                            <div className="salonbw-appointment-item salonbw-appointment-item--upcoming">
+                                <div className="salonbw-appointment-item__details">
+                                    <div className="salonbw-appointment-item__client">
+                                        {data.upcomingAppointment.serviceName}
+                                    </div>
+                                    <div className="salonbw-appointment-item__service text-muted small">
+                                        {formatDate(
+                                            data.upcomingAppointment.startTime,
+                                        )}
+                                    </div>
+                                    {data.upcomingAppointment.employeeName && (
+                                        <div className="salonbw-appointment-item__service text-muted small">
+                                            specjalista:{' '}
+                                            {
+                                                data.upcomingAppointment
+                                                    .employeeName
+                                            }
+                                        </div>
+                                    )}
+                                </div>
+                                {data.upcomingAppointment.status && (
+                                    <span
+                                        className={statusClass(
+                                            data.upcomingAppointment.status,
+                                        )}
+                                    >
+                                        {statusLabel(
+                                            data.upcomingAppointment.status,
+                                        )}
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="salonbw-appointments-list">
+                            <div className="salonbw-appointment-item salonbw-appointment-item--empty">
+                                Brak zaplanowanych wizyt
+                            </div>
+                        </div>
+                    )}
+                    <Link
+                        href="/booking"
+                        className="salonbw-dashboard__section-footer"
+                    >
+                        zarezerwuj nową wizytę
+                    </Link>
+                </div>
 
-            {/* Stats */}
-            <section className="-cols-1 gap-3">
-                <StatsWidget
-                    title="Completed Appointments"
-                    value={data.completedCount}
-                    loading={false}
-                />
-                <StatsWidget
-                    title="Services Used"
-                    value={data.serviceHistory.length}
-                    loading={false}
-                />
-            </section>
+                {/* Monthly summary */}
+                <div className="salonbw-dashboard__section">
+                    <div className="salonbw-dashboard__section-header">
+                        <h2>Moje statystyki</h2>
+                    </div>
+                    <div className="salonbw-appointments-list">
+                        <div className="salonbw-appointment-item">
+                            <div className="salonbw-appointment-item__details">
+                                <div className="salonbw-appointment-item__client">
+                                    Zrealizowane wizyty
+                                </div>
+                            </div>
+                            <div className="fw-bold">{data.completedCount}</div>
+                        </div>
+                        <div className="salonbw-appointment-item">
+                            <div className="salonbw-appointment-item__details">
+                                <div className="salonbw-appointment-item__client">
+                                    Różne usługi
+                                </div>
+                            </div>
+                            <div className="fw-bold">
+                                {data.serviceHistory.length}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-            {/* Service History */}
-            <section className="bg-white rounded-3 shadow p-4">
-                <h2 className="fs-5 fw-semibold mb-3">
-                    Your Favorite Services
-                </h2>
-                {data.serviceHistory.length > 0 ? (
-                    <ul className="gap-2">
+            {/* Favourite services */}
+            {data.serviceHistory.length > 0 && (
+                <div className="salonbw-dashboard__section mt-3">
+                    <div className="salonbw-dashboard__section-header">
+                        <h2>Ulubione usługi</h2>
+                    </div>
+                    <div className="salonbw-appointments-list">
                         {data.serviceHistory.slice(0, 5).map((service) => (
-                            <li
+                            <div
                                 key={service.id}
-                                className="d-flex justify-content-between align-items-center py-2 border-bottom last:border-0"
+                                className="salonbw-appointment-item"
                             >
-                                <span>{service.name}</span>
-                                <span className="text-muted small">
+                                <div className="salonbw-appointment-item__details">
+                                    <div className="salonbw-appointment-item__client">
+                                        {service.name}
+                                    </div>
+                                </div>
+                                <div className="text-muted small">
                                     {service.count}{' '}
-                                    {service.count === 1 ? 'visit' : 'visits'}
-                                </span>
-                            </li>
+                                    {service.count === 1
+                                        ? 'wizyta'
+                                        : service.count < 5
+                                          ? 'wizyty'
+                                          : 'wizyt'}
+                                </div>
+                            </div>
                         ))}
-                    </ul>
-                ) : (
-                    <p className="text-muted">No service history yet</p>
-                )}
-            </section>
+                    </div>
+                </div>
+            )}
 
-            {/* Recent Appointments */}
-            <section className="bg-white rounded-3 shadow p-4">
-                <h2 className="fs-5 fw-semibold mb-3">Recent Appointments</h2>
+            {/* Recent appointments */}
+            <div className="salonbw-dashboard__section mt-3">
+                <div className="salonbw-dashboard__section-header">
+                    <h2>Ostatnie wizyty</h2>
+                </div>
                 {data.recentAppointments.length > 0 ? (
-                    <div className="overflow-x-auto">
-                        <table className="w-100 small">
-                            <thead>
-                                <tr className="border-bottom">
-                                    <th className="text-start py-2">Service</th>
-                                    <th className="text-start py-2">Date</th>
-                                    <th className="text-start py-2">Status</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {data.recentAppointments.map((apt) => (
-                                    <tr key={apt.id} className="border-bottom">
-                                        <td className="py-2">
-                                            {apt.serviceName}
-                                        </td>
-                                        <td className="py-2">
-                                            {new Date(
-                                                apt.startTime,
-                                            ).toLocaleDateString('pl-PL')}
-                                        </td>
-                                        <td className="py-2">
-                                            <span
-                                                className={`px-2 py-1 rounded small ${
-                                                    apt.status === 'completed'
-                                                        ? 'bg-success bg-opacity-10 text-success'
-                                                        : apt.status ===
-                                                            'cancelled'
-                                                          ? 'bg-danger bg-opacity-10 text-danger'
-                                                          : 'bg-primary bg-opacity-10 text-primary'
-                                                }`}
-                                            >
-                                                {apt.status}
-                                            </span>
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
+                    <div className="salonbw-appointments-list">
+                        {data.recentAppointments.map((apt) => (
+                            <div
+                                key={apt.id}
+                                className="salonbw-appointment-item"
+                            >
+                                <div className="salonbw-appointment-item__time">
+                                    {new Date(apt.startTime).toLocaleDateString(
+                                        'pl-PL',
+                                        {
+                                            day: 'numeric',
+                                            month: 'short',
+                                        },
+                                    )}
+                                </div>
+                                <div className="salonbw-appointment-item__details">
+                                    <div className="salonbw-appointment-item__client">
+                                        {apt.serviceName}
+                                    </div>
+                                    {apt.employeeName && (
+                                        <div className="salonbw-appointment-item__service text-muted small">
+                                            {apt.employeeName}
+                                        </div>
+                                    )}
+                                </div>
+                                <span className={statusClass(apt.status)}>
+                                    {statusLabel(apt.status)}
+                                </span>
+                            </div>
+                        ))}
                     </div>
                 ) : (
-                    <p className="text-muted">No appointments yet</p>
+                    <div className="salonbw-appointments-list">
+                        <div className="salonbw-appointment-item salonbw-appointment-item--empty">
+                            Brak historii wizyt
+                        </div>
+                    </div>
                 )}
-            </section>
+            </div>
         </div>
     );
 }

--- a/apps/panel/src/components/salon/SalonTopbar.tsx
+++ b/apps/panel/src/components/salon/SalonTopbar.tsx
@@ -115,7 +115,7 @@ export default function SalonTopbar() {
                     {onlinePendingCount > 0 ? (
                         <li className="d-flex align-items-center">
                             <Link
-                                href="/calendar"
+                                href="/appointments?status=online_pending"
                                 className="link d-flex align-items-center gap-1 px-2"
                                 title="Wizyty oczekujące na potwierdzenie"
                             >

--- a/apps/panel/src/components/salon/SalonTopbar.tsx
+++ b/apps/panel/src/components/salon/SalonTopbar.tsx
@@ -55,6 +55,18 @@ export default function SalonTopbar() {
         document.body.classList.toggle('salonbw-sidebar-open');
     };
 
+    const closeSidebar = () => {
+        if (typeof document !== 'undefined') {
+            document.body.classList.remove('salonbw-sidebar-open');
+        }
+    };
+
+    useEffect(() => {
+        const handleRouteChange = () => closeSidebar();
+        router.events.on('routeChangeStart', handleRouteChange);
+        return () => router.events.off('routeChangeStart', handleRouteChange);
+    }, [router.events]);
+
     const handleLogout = (event: MouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
         void logout().then(() => {
@@ -63,247 +75,259 @@ export default function SalonTopbar() {
     };
 
     return (
-        <div
-            className="navbar navbar-default navbar-static-top d-flex"
-            id="navbar"
-        >
-            <div className="notification-bar-container"></div>
-            <div>
-                {topbar.menuToggler.enabled ? (
-                    <a
-                        aria-label="Menu"
-                        className="menu-toggler navbar-toggle"
-                        href="#"
-                        id="menu-toggler"
-                        onClick={handleMenuTogglerClick}
-                    >
-                        <span className="icon-bar"></span>
-                        <span className="icon-bar"></span>
-                        <span className="icon-bar"></span>
-                    </a>
-                ) : null}
-                <div className="brand">
-                    <Link
-                        aria-label="Przejdź do pulpitu"
-                        href={topbar.brand.href}
-                        title="przejdź do pulpitu"
-                    >
-                        <img
-                            src="/images/logo.svg"
-                            alt="Salon Black &amp; White"
-                            className="salon-topbar-logo"
-                        />
-                    </Link>
-                </div>
-            </div>
-            <div className="ml-auto">
-                <ul className="navbar-right simple-list d-flex">
-                    <li className="d-flex">
-                        <div className="omnibox-wrapper">
-                            <input
-                                className="omnibox"
-                                data-search-url={topbar.search.searchUrl}
-                                id="omnibox"
-                                placeholder={topbar.search.placeholder}
-                            />
-                            <div
-                                className="dropdown-menu"
-                                id="omnibox-results"
-                            ></div>
-                        </div>
-                    </li>
-                    {onlinePendingCount > 0 ? (
-                        <li className="d-flex align-items-center">
-                            <Link
-                                href="/appointments?status=online_pending"
-                                className="link d-flex align-items-center gap-1 px-2"
-                                title="Wizyty oczekujące na potwierdzenie"
-                            >
-                                <span className="badge bg-warning text-dark">
-                                    {onlinePendingCount}
-                                </span>
-                                <span className="d-none d-md-inline small">
-                                    oczekujące
-                                </span>
-                            </Link>
-                        </li>
-                    ) : null}
-                    {topbar.notifications.enabled ? (
-                        <li
-                            className="notification_center"
-                            id="notification_center_navbar"
-                        >
-                            <a
-                                className="link e2e-notification-center-navbar"
-                                href="#"
-                                onClick={(event) => event.preventDefault()}
-                            >
-                                <div
-                                    className={`notification_center_icon${topbar.notifications.unreadCount ? ' notifications_unread' : ''}`}
-                                    data-unread_notifications={
-                                        topbar.notifications.unreadCount ?? 0
-                                    }
-                                    id="notification_center_navbar_icon"
-                                >
-                                    <SalonIcon
-                                        id="svg-notifications"
-                                        className="svg-notifications"
-                                    />
-                                </div>
-                            </a>
-                        </li>
-                    ) : null}
-                    {topbar.tasks.enabled ? (
-                        <li className="all_complete tasks_tooltip">
-                            <a
-                                aria-expanded="false"
-                                className="link"
-                                href="#"
-                                title="Twoje zadania"
-                                onClick={(event) => event.preventDefault()}
-                            >
-                                <div
-                                    className="assigned_tasks"
-                                    data-assigned_tasks={
-                                        topbar.tasks.count ?? 0
-                                    }
-                                >
-                                    <SalonIcon
-                                        id="svg-todo"
-                                        className="svg-todo"
-                                    />
-                                </div>
-                            </a>
-                            <div className="dropdown_cover"></div>
-                            <div
-                                className="dropdown-menu-tasks"
-                                id="dropdownTasks"
-                                role="menu"
-                            ></div>
-                        </li>
-                    ) : null}
-                    <li
-                        ref={helpMenuRef}
-                        className={`dropdown help_tooltip right-menu${helpMenuOpen ? ' open' : ''}`}
-                    >
+        <>
+            {/* Mobile overlay — closes sidebar when tapped */}
+            <div
+                className="salonbw-nav-overlay"
+                aria-hidden="true"
+                onClick={closeSidebar}
+            />
+            <div
+                className="navbar navbar-default navbar-static-top d-flex"
+                id="navbar"
+            >
+                <div className="notification-bar-container"></div>
+                <div>
+                    {topbar.menuToggler.enabled ? (
                         <a
-                            className="ai-center d-flex dropdown-toggle"
-                            data-toggle="dropdown"
+                            aria-label="Menu"
+                            className="menu-toggler navbar-toggle"
                             href="#"
-                            onClick={(event) => {
-                                event.preventDefault();
-                                setHelpMenuOpen((value) => !value);
-                            }}
+                            id="menu-toggler"
+                            onClick={handleMenuTogglerClick}
                         >
-                            <div className="d-inline-block jQ_nav_chat_notification">
-                                <SalonIcon
-                                    id="svg-help"
-                                    className="svg-help mr-xs"
-                                />
-                            </div>
-                            <div className="d-none d-md-inline">
-                                <span>Pomoc</span>
-                            </div>
+                            <span className="icon-bar"></span>
+                            <span className="icon-bar"></span>
+                            <span className="icon-bar"></span>
                         </a>
-                        <ul className="dropdown-menu larger-dropdown-menu nav-help">
-                            {topbar.help.showChat ? (
-                                <>
-                                    <li className="main-menu-li">
-                                        <a
-                                            id="chat_widget"
-                                            href="#"
-                                            style={{ cursor: 'pointer' }}
-                                            onClick={(event) =>
-                                                event.preventDefault()
-                                            }
-                                        >
-                                            <div className="jQ_chat_notification">
-                                                <SalonIcon
-                                                    id="svg-help"
-                                                    className="svg-chat"
-                                                />
-                                            </div>
-                                            <span>Czat z konsultantem</span>
-                                        </a>
-                                    </li>
-                                    <li className="divider"></li>
-                                </>
-                            ) : null}
-                            <li className="main-menu-li">
-                                <Link href={topbar.help.contactFormHref}>
-                                    <SalonIcon
-                                        id="svg-message"
-                                        className="svg-message"
-                                    />
-                                    <span>Formularz kontaktowy</span>
+                    ) : null}
+                    <div className="brand">
+                        <Link
+                            aria-label="Przejdź do pulpitu"
+                            href={topbar.brand.href}
+                            title="przejdź do pulpitu"
+                        >
+                            <img
+                                src="/images/logo.svg"
+                                alt="Salon Black &amp; White"
+                                className="salon-topbar-logo"
+                            />
+                        </Link>
+                    </div>
+                </div>
+                <div className="ml-auto">
+                    <ul className="navbar-right simple-list d-flex">
+                        <li className="d-flex">
+                            <div className="omnibox-wrapper">
+                                <input
+                                    className="omnibox"
+                                    data-search-url={topbar.search.searchUrl}
+                                    id="omnibox"
+                                    placeholder={topbar.search.placeholder}
+                                />
+                                <div
+                                    className="dropdown-menu"
+                                    id="omnibox-results"
+                                ></div>
+                            </div>
+                        </li>
+                        {onlinePendingCount > 0 ? (
+                            <li className="d-flex align-items-center">
+                                <Link
+                                    href="/appointments?status=online_pending"
+                                    className="link d-flex align-items-center gap-1 px-2"
+                                    title="Wizyty oczekujące na potwierdzenie"
+                                >
+                                    <span className="badge bg-warning text-dark">
+                                        {onlinePendingCount}
+                                    </span>
+                                    <span className="d-none d-md-inline small">
+                                        oczekujące
+                                    </span>
                                 </Link>
                             </li>
-                            {topbar.help.knowledgeBaseHref ? (
-                                <>
-                                    <li className="divider"></li>
-                                    <li className="main-menu-li">
-                                        <a
-                                            href={topbar.help.knowledgeBaseHref}
-                                            target="_blank"
-                                            rel="noreferrer"
-                                        >
-                                            <span>Baza wiedzy</span>
-                                        </a>
-                                    </li>
-                                </>
-                            ) : null}
-                        </ul>
-                    </li>
-                    <li
-                        ref={userMenuRef}
-                        className={`dropdown right-menu${userMenuOpen ? ' open' : ''}`}
-                    >
-                        <a
-                            className="dropdown-toggle e2e-nav-user-dropdown"
-                            data-toggle="dropdown"
-                            href="#"
-                            onClick={(event) => {
-                                event.preventDefault();
-                                setUserMenuOpen((value) => !value);
-                            }}
-                        >
-                            <div className="border-color">
-                                <div className="color1">
-                                    {topbar.user.initials}
-                                </div>
-                            </div>
-                        </a>
-                        <ul className="dropdown-menu larger-dropdown-menu">
-                            <li className="main-menu-li">
+                        ) : null}
+                        {topbar.notifications.enabled ? (
+                            <li
+                                className="notification_center"
+                                id="notification_center_navbar"
+                            >
                                 <a
-                                    className="profil"
-                                    href={topbar.user.profileHref}
+                                    className="link e2e-notification-center-navbar"
+                                    href="#"
+                                    onClick={(event) => event.preventDefault()}
                                 >
-                                    {topbar.user.avatarUrl ? (
-                                        <img
-                                            alt="Avatar"
-                                            className="avatar"
-                                            src={topbar.user.avatarUrl}
+                                    <div
+                                        className={`notification_center_icon${topbar.notifications.unreadCount ? ' notifications_unread' : ''}`}
+                                        data-unread_notifications={
+                                            topbar.notifications.unreadCount ??
+                                            0
+                                        }
+                                        id="notification_center_navbar_icon"
+                                    >
+                                        <SalonIcon
+                                            id="svg-notifications"
+                                            className="svg-notifications"
                                         />
-                                    ) : null}
-                                    <strong>{topbar.user.fullName}</strong>
-                                    {topbar.user.roleLabel}
+                                    </div>
                                 </a>
                             </li>
-                            <li className="divider"></li>
-                            <li className="main-menu-li">
+                        ) : null}
+                        {topbar.tasks.enabled ? (
+                            <li className="all_complete tasks_tooltip">
                                 <a
-                                    className="e2e-user-logout"
-                                    href={topbar.user.logoutHref || '#'}
-                                    onClick={handleLogout}
+                                    aria-expanded="false"
+                                    className="link"
+                                    href="#"
+                                    title="Twoje zadania"
+                                    onClick={(event) => event.preventDefault()}
                                 >
-                                    Wyloguj
+                                    <div
+                                        className="assigned_tasks"
+                                        data-assigned_tasks={
+                                            topbar.tasks.count ?? 0
+                                        }
+                                    >
+                                        <SalonIcon
+                                            id="svg-todo"
+                                            className="svg-todo"
+                                        />
+                                    </div>
                                 </a>
+                                <div className="dropdown_cover"></div>
+                                <div
+                                    className="dropdown-menu-tasks"
+                                    id="dropdownTasks"
+                                    role="menu"
+                                ></div>
                             </li>
-                        </ul>
-                    </li>
-                </ul>
+                        ) : null}
+                        <li
+                            ref={helpMenuRef}
+                            className={`dropdown help_tooltip right-menu${helpMenuOpen ? ' open' : ''}`}
+                        >
+                            <a
+                                className="ai-center d-flex dropdown-toggle"
+                                data-toggle="dropdown"
+                                href="#"
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    setHelpMenuOpen((value) => !value);
+                                }}
+                            >
+                                <div className="d-inline-block jQ_nav_chat_notification">
+                                    <SalonIcon
+                                        id="svg-help"
+                                        className="svg-help mr-xs"
+                                    />
+                                </div>
+                                <div className="d-none d-md-inline">
+                                    <span>Pomoc</span>
+                                </div>
+                            </a>
+                            <ul className="dropdown-menu larger-dropdown-menu nav-help">
+                                {topbar.help.showChat ? (
+                                    <>
+                                        <li className="main-menu-li">
+                                            <a
+                                                id="chat_widget"
+                                                href="#"
+                                                style={{ cursor: 'pointer' }}
+                                                onClick={(event) =>
+                                                    event.preventDefault()
+                                                }
+                                            >
+                                                <div className="jQ_chat_notification">
+                                                    <SalonIcon
+                                                        id="svg-help"
+                                                        className="svg-chat"
+                                                    />
+                                                </div>
+                                                <span>Czat z konsultantem</span>
+                                            </a>
+                                        </li>
+                                        <li className="divider"></li>
+                                    </>
+                                ) : null}
+                                <li className="main-menu-li">
+                                    <Link href={topbar.help.contactFormHref}>
+                                        <SalonIcon
+                                            id="svg-message"
+                                            className="svg-message"
+                                        />
+                                        <span>Formularz kontaktowy</span>
+                                    </Link>
+                                </li>
+                                {topbar.help.knowledgeBaseHref ? (
+                                    <>
+                                        <li className="divider"></li>
+                                        <li className="main-menu-li">
+                                            <a
+                                                href={
+                                                    topbar.help
+                                                        .knowledgeBaseHref
+                                                }
+                                                target="_blank"
+                                                rel="noreferrer"
+                                            >
+                                                <span>Baza wiedzy</span>
+                                            </a>
+                                        </li>
+                                    </>
+                                ) : null}
+                            </ul>
+                        </li>
+                        <li
+                            ref={userMenuRef}
+                            className={`dropdown right-menu${userMenuOpen ? ' open' : ''}`}
+                        >
+                            <a
+                                className="dropdown-toggle e2e-nav-user-dropdown"
+                                data-toggle="dropdown"
+                                href="#"
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    setUserMenuOpen((value) => !value);
+                                }}
+                            >
+                                <div className="border-color">
+                                    <div className="color1">
+                                        {topbar.user.initials}
+                                    </div>
+                                </div>
+                            </a>
+                            <ul className="dropdown-menu larger-dropdown-menu">
+                                <li className="main-menu-li">
+                                    <a
+                                        className="profil"
+                                        href={topbar.user.profileHref}
+                                    >
+                                        {topbar.user.avatarUrl ? (
+                                            <img
+                                                alt="Avatar"
+                                                className="avatar"
+                                                src={topbar.user.avatarUrl}
+                                            />
+                                        ) : null}
+                                        <strong>{topbar.user.fullName}</strong>
+                                        {topbar.user.roleLabel}
+                                    </a>
+                                </li>
+                                <li className="divider"></li>
+                                <li className="main-menu-li">
+                                    <a
+                                        className="e2e-user-logout"
+                                        href={topbar.user.logoutHref || '#'}
+                                        onClick={handleLogout}
+                                    >
+                                        Wyloguj
+                                    </a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
             </div>
-        </div>
+        </>
     );
 }

--- a/apps/panel/src/pages/appointments.tsx
+++ b/apps/panel/src/pages/appointments.tsx
@@ -190,7 +190,7 @@ export default function AppointmentsPage() {
                 />
 
                 <div className="column_row mb-3">
-                    <div className="d-flex flex-wrap gap-2 align-items-end">
+                    <div className="salonbw-filters d-flex flex-wrap gap-2 align-items-end">
                         <div>
                             <label className="form-label mb-1 small">Od</label>
                             <input
@@ -230,7 +230,6 @@ export default function AppointmentsPage() {
                                     );
                                     handleFilterChange();
                                 }}
-                                style={{ minWidth: 160 }}
                             >
                                 <option value="">Wszystkie statusy</option>
                                 {ALL_STATUSES.map((s) => (
@@ -240,7 +239,7 @@ export default function AppointmentsPage() {
                                 ))}
                             </select>
                         </div>
-                        <div className="flex-grow-1" style={{ minWidth: 180 }}>
+                        <div className="flex-grow-1">
                             <label className="form-label mb-1 small">
                                 Klient / telefon
                             </label>

--- a/apps/panel/src/pages/appointments.tsx
+++ b/apps/panel/src/pages/appointments.tsx
@@ -4,7 +4,8 @@ import Link from 'next/link';
 import SalonShell from '@/components/salon/SalonShell';
 import SalonBreadcrumbs from '@/components/salon/SalonBreadcrumbs';
 import { useAuth } from '@/contexts/AuthContext';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@/contexts/ToastContext';
 import type { Appointment, AppointmentStatus, ServiceVariant } from '@/types';
 
 interface AppointmentWithVariant extends Appointment {
@@ -64,14 +65,17 @@ const ALL_STATUSES: AppointmentStatus[] = [
 export default function AppointmentsPage() {
     const { role, apiFetch } = useAuth();
     const router = useRouter();
+    const queryClient = useQueryClient();
+    const toast = useToast();
 
     const today = new Date();
     const thirtyDaysAgo = new Date(today);
     thirtyDaysAgo.setDate(today.getDate() - 30);
 
+    const initialStatus = (router.query.status as AppointmentStatus) || '';
     const [from, setFrom] = useState(isoDate(thirtyDaysAgo));
     const [to, setTo] = useState(isoDate(today));
-    const [status, setStatus] = useState<AppointmentStatus | ''>('');
+    const [status, setStatus] = useState<AppointmentStatus | ''>(initialStatus);
     const [search, setSearch] = useState('');
     const [searchInput, setSearchInput] = useState('');
     const [page, setPage] = useState(1);
@@ -115,6 +119,55 @@ export default function AppointmentsPage() {
         const dateStr = isoDate(d);
         void router.push(`/calendar?date=${dateStr}&appointmentId=${appt.id}`);
     };
+
+    const [actionLoading, setActionLoading] = useState<number | null>(null);
+
+    const handleConfirm = useCallback(
+        async (e: React.MouseEvent, appt: AppointmentWithVariant) => {
+            e.stopPropagation();
+            setActionLoading(appt.id);
+            try {
+                await apiFetch(`/appointments/${appt.id}/status`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ status: 'confirmed' }),
+                });
+                toast.success(
+                    'Wizyta potwierdzona — klient otrzyma powiadomienie WhatsApp',
+                );
+                void queryClient.invalidateQueries({
+                    queryKey: ['appointments-list'],
+                });
+            } catch {
+                toast.error('Błąd potwierdzenia wizyty');
+            } finally {
+                setActionLoading(null);
+            }
+        },
+        [apiFetch, toast, queryClient],
+    );
+
+    const handleReject = useCallback(
+        async (e: React.MouseEvent, appt: AppointmentWithVariant) => {
+            e.stopPropagation();
+            if (!confirm('Odrzucić rezerwację i anulować wizytę?')) return;
+            setActionLoading(appt.id);
+            try {
+                await apiFetch(`/appointments/${appt.id}/cancel`, {
+                    method: 'PATCH',
+                });
+                toast.success('Rezerwacja odrzucona');
+                void queryClient.invalidateQueries({
+                    queryKey: ['appointments-list'],
+                });
+            } catch {
+                toast.error('Błąd anulowania wizyty');
+            } finally {
+                setActionLoading(null);
+            }
+        },
+        [apiFetch, toast, queryClient],
+    );
 
     if (!role) return null;
 
@@ -354,15 +407,57 @@ export default function AppointmentsPage() {
                                         className="text-end"
                                         style={{ whiteSpace: 'nowrap' }}
                                     >
-                                        <button
-                                            className="btn btn-sm btn-outline-secondary"
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                openInCalendar(appt);
-                                            }}
-                                        >
-                                            Otwórz
-                                        </button>
+                                        <div className="d-flex gap-1 justify-content-end">
+                                            {appt.status ===
+                                                'online_pending' && (
+                                                <>
+                                                    <button
+                                                        className="btn btn-sm btn-success"
+                                                        disabled={
+                                                            actionLoading ===
+                                                            appt.id
+                                                        }
+                                                        onClick={(e) =>
+                                                            void handleConfirm(
+                                                                e,
+                                                                appt,
+                                                            )
+                                                        }
+                                                        title="Potwierdź rezerwację — klient otrzyma WhatsApp"
+                                                    >
+                                                        {actionLoading ===
+                                                        appt.id
+                                                            ? '...'
+                                                            : '✓ Potwierdź'}
+                                                    </button>
+                                                    <button
+                                                        className="btn btn-sm btn-outline-danger"
+                                                        disabled={
+                                                            actionLoading ===
+                                                            appt.id
+                                                        }
+                                                        onClick={(e) =>
+                                                            void handleReject(
+                                                                e,
+                                                                appt,
+                                                            )
+                                                        }
+                                                        title="Odrzuć rezerwację"
+                                                    >
+                                                        ✕
+                                                    </button>
+                                                </>
+                                            )}
+                                            <button
+                                                className="btn btn-sm btn-outline-secondary"
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    openInCalendar(appt);
+                                                }}
+                                            >
+                                                Otwórz
+                                            </button>
+                                        </div>
                                     </td>
                                 </tr>
                             ))}

--- a/apps/panel/src/pages/customers/index.tsx
+++ b/apps/panel/src/pages/customers/index.tsx
@@ -389,45 +389,47 @@ export default function ClientsPage() {
                                     className="column_row details_container"
                                     id="customers_list"
                                 >
-                                    <table className="list-table">
-                                        <thead>
-                                            <tr>
-                                                <th>Klient</th>
-                                                <th>Kontakt</th>
-                                                <th className="hidden-xs">
-                                                    Ostatnia wizyta
-                                                </th>
-                                                <th
-                                                    className="text-right hidden-xs"
-                                                    aria-label="Akcje"
-                                                />
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {filteredCustomers.map(
-                                                (customer, i) => (
-                                                    <DraggableCustomerRow
-                                                        key={customer.id}
-                                                        customer={customer}
-                                                        isDragging={
-                                                            draggedCustomer?.id ===
-                                                            customer.id
-                                                        }
-                                                        rowClass={
-                                                            i % 2 === 0
-                                                                ? 'odd'
-                                                                : 'even'
-                                                        }
-                                                        onOpen={(id) =>
-                                                            void router.push(
-                                                                `/customers/${id}` as Route,
-                                                            )
-                                                        }
+                                    <div className="list-table-responsive">
+                                        <table className="list-table">
+                                            <thead>
+                                                <tr>
+                                                    <th>Klient</th>
+                                                    <th>Kontakt</th>
+                                                    <th className="hidden-xs">
+                                                        Ostatnia wizyta
+                                                    </th>
+                                                    <th
+                                                        className="text-right hidden-xs"
+                                                        aria-label="Akcje"
                                                     />
-                                                ),
-                                            )}
-                                        </tbody>
-                                    </table>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {filteredCustomers.map(
+                                                    (customer, i) => (
+                                                        <DraggableCustomerRow
+                                                            key={customer.id}
+                                                            customer={customer}
+                                                            isDragging={
+                                                                draggedCustomer?.id ===
+                                                                customer.id
+                                                            }
+                                                            rowClass={
+                                                                i % 2 === 0
+                                                                    ? 'odd'
+                                                                    : 'even'
+                                                            }
+                                                            onOpen={(id) =>
+                                                                void router.push(
+                                                                    `/customers/${id}` as Route,
+                                                                )
+                                                            }
+                                                        />
+                                                    ),
+                                                )}
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             </>
                         )}

--- a/apps/panel/src/pages/dashboard/index.tsx
+++ b/apps/panel/src/pages/dashboard/index.tsx
@@ -12,7 +12,7 @@ const ClientDashboard = dynamic<
 >(() => import('@/components/dashboard/ClientDashboard'), {
     ssr: false,
     loading: () => (
-        <div className="p-4 small text-muted">Loading dashboard...</div>
+        <div className="p-4 small text-muted">Ładowanie pulpitu...</div>
     ),
 });
 
@@ -21,7 +21,7 @@ const AdminDashboard = dynamic<ComponentProps<typeof AdminDashboardComponent>>(
     {
         ssr: false,
         loading: () => (
-            <div className="p-4 small text-muted">Loading dashboard...</div>
+            <div className="p-4 small text-muted">Ładowanie pulpitu...</div>
         ),
     },
 );
@@ -41,7 +41,7 @@ export default function DashboardPage() {
             case 'receptionist':
                 return <AdminDashboard />;
             default:
-                return <div>Please log in to view your dashboard</div>;
+                return null;
         }
     };
 

--- a/apps/panel/src/pages/employees/index.tsx
+++ b/apps/panel/src/pages/employees/index.tsx
@@ -19,7 +19,9 @@ const EmployeeForm = dynamic<ComponentProps<typeof EmployeeFormComponent>>(
     {
         ssr: false,
         loading: () => (
-            <div className="salonbw-loading">Ładowanie formularza pracownika…</div>
+            <div className="salonbw-loading">
+                Ładowanie formularza pracownika…
+            </div>
         ),
     },
 );

--- a/apps/panel/src/pages/employees/index.tsx
+++ b/apps/panel/src/pages/employees/index.tsx
@@ -19,7 +19,7 @@ const EmployeeForm = dynamic<ComponentProps<typeof EmployeeFormComponent>>(
     {
         ssr: false,
         loading: () => (
-            <div className="salonbw-loading">Loading employee form…</div>
+            <div className="salonbw-loading">Ładowanie formularza pracownika…</div>
         ),
     },
 );

--- a/apps/panel/src/pages/reviews/index.tsx
+++ b/apps/panel/src/pages/reviews/index.tsx
@@ -17,7 +17,7 @@ const ReviewForm = dynamic<ComponentProps<typeof ReviewFormComponent>>(
     {
         ssr: false,
         loading: () => (
-            <div className="salonbw-loading">Loading review form…</div>
+            <div className="salonbw-loading">Ładowanie formularza opinii…</div>
         ),
     },
 );

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -6340,3 +6340,151 @@ body.e2e-extension .main-content .inner.extension_info {
     color: #8ca7d9;
     cursor: default;
 }
+
+/* ========================================
+   Mobile Nav Overlay
+   ======================================== */
+
+.salonbw-nav-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 1040;
+}
+
+body.salonbw-sidebar-open .salonbw-nav-overlay {
+    display: block;
+}
+
+/* ========================================
+   Mobile Responsive Layout
+   ======================================== */
+
+@media (max-width: 767px) {
+    /* --- Topbar: remove mainnav offset, keep hamburger visible --- */
+    .navbar.navbar-default {
+        padding-left: 48px;
+    }
+
+    .navbar .menu-toggler {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    /* --- Sidebar wrapper: no left padding (mainnav is fixed/overlaid) --- */
+    #sidebar,
+    .sidebar {
+        padding-left: 0;
+        flex-direction: column;
+        width: 100%;
+    }
+
+    /* --- Mainnav: hidden off-screen by default, slides in when open --- */
+    #mainnav,
+    .mainnav {
+        transform: translateX(-100%);
+        transition: transform 0.25s ease;
+        z-index: 1050;
+        top: var(--salon-topbar-h);
+        height: calc(100vh - var(--salon-topbar-h));
+    }
+
+    /* Overlay behind open mainnav */
+    body.salonbw-sidebar-open::after {
+        content: '';
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.45);
+        z-index: 1040;
+    }
+
+    /* Open state: slide mainnav in */
+    body.salonbw-sidebar-open #mainnav,
+    body.salonbw-sidebar-open .mainnav {
+        transform: translateX(0);
+    }
+
+    /* --- Sidenav: full-width strip above content --- */
+    #sidenav,
+    .sidenav {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid var(--salon-border);
+        max-height: 200px;
+        overflow-y: auto;
+        padding: 6px 8px;
+    }
+
+    /* --- Main content: no left margin offset --- */
+    #main-container,
+    .main-container {
+        flex-direction: column;
+    }
+
+    .main-content .inner {
+        padding: 12px;
+    }
+}
+
+/* ========================================
+   Mobile Table Scroll
+   ======================================== */
+
+@media (max-width: 767px) {
+    /* Wrap any bare table without an existing scroll container */
+    .list-table-responsive {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* Appointments filter bar: stack vertically */
+    .salonbw-filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .salonbw-filters > * {
+        min-width: 0 !important;
+        width: 100%;
+    }
+
+    /* Stat cards: single column on mobile */
+    .salonbw-dashboard__stats {
+        grid-template-columns: 1fr;
+    }
+
+    /* Dashboard grid: single column */
+    .salonbw-dashboard__grid {
+        grid-template-columns: 1fr;
+    }
+
+    /* Form grids: single column */
+    .product-form__row,
+    .warehouse-form-grid,
+    .salon-column-row {
+        grid-template-columns: 1fr !important;
+        flex-direction: column;
+    }
+
+    .salon-column {
+        max-width: 100% !important;
+        width: 100%;
+    }
+
+    /* Appointment drawer / modals: full-width on mobile */
+    .salonbw-drawer {
+        width: 100% !important;
+        max-width: 100% !important;
+        border-radius: 0;
+    }
+
+    /* Tables: allow horizontal scroll */
+    .salonbw-table-wrap,
+    .data_table_wrapper,
+    .data-table-wrapper {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}

--- a/apps/panel/src/types.ts
+++ b/apps/panel/src/types.ts
@@ -290,11 +290,26 @@ export interface Review {
     createdAt?: string;
 }
 
+export interface UpcomingAppointmentItem {
+    id: number;
+    startTime: string;
+    endTime?: string;
+    status: AppointmentStatus;
+    clientName: string;
+    clientPhone?: string;
+    serviceName: string;
+    employeeName: string;
+}
+
 export interface DashboardResponse {
     clientCount: number;
     employeeCount: number;
     todayAppointments: number;
-    upcomingAppointments: Appointment[];
+    onlinePendingCount: number;
+    revenueToday: number;
+    revenueThisMonth: number;
+    completedThisMonth: number;
+    upcomingAppointments: UpcomingAppointmentItem[];
 }
 
 export interface ClientDashboardResponse {
@@ -303,6 +318,7 @@ export interface ClientDashboardResponse {
         serviceName: string;
         startTime: string;
         employeeName: string;
+        status?: string;
     } | null;
     completedCount: number;
     serviceHistory: { id: number; name: string; count: number }[];
@@ -311,6 +327,7 @@ export interface ClientDashboardResponse {
         serviceName: string;
         startTime: string;
         status: string;
+        employeeName?: string;
     }[];
 }
 

--- a/backend/salonbw-backend/src/appointments/appointments.service.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.ts
@@ -5,6 +5,7 @@ import {
     ForbiddenException,
     Inject,
     forwardRef,
+    Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -39,6 +40,8 @@ import { Log } from '../logs/log.entity';
 
 @Injectable()
 export class AppointmentsService {
+    private readonly logger = new Logger(AppointmentsService.name);
+
     constructor(
         @InjectRepository(Appointment)
         private readonly appointmentsRepository: Repository<Appointment>,
@@ -161,11 +164,22 @@ export class AppointmentsService {
         search?: string;
         page?: number;
         limit?: number;
-    }): Promise<{ items: Appointment[]; total: number; page: number; pageSize: number }> {
+    }): Promise<{
+        items: Appointment[];
+        total: number;
+        page: number;
+        pageSize: number;
+    }> {
         const page = params.page ?? 1;
         const pageSize = Math.min(params.limit ?? 50, 200);
 
-        const buildWhere = (extraClientWhere?: FindOptionsWhere<{ firstName?: string; lastName?: string; phone?: string }>): FindOptionsWhere<Appointment> => {
+        const buildWhere = (
+            extraClientWhere?: FindOptionsWhere<{
+                firstName?: string;
+                lastName?: string;
+                phone?: string;
+            }>,
+        ): FindOptionsWhere<Appointment> => {
             const where: FindOptionsWhere<Appointment> = {};
             if (params.employeeId) where.employee = { id: params.employeeId };
             if (params.status) where.status = params.status;
@@ -180,7 +194,9 @@ export class AppointmentsService {
             return where;
         };
 
-        let whereCondition: FindOptionsWhere<Appointment> | FindOptionsWhere<Appointment>[];
+        let whereCondition:
+            | FindOptionsWhere<Appointment>
+            | FindOptionsWhere<Appointment>[];
         if (params.search) {
             const term = `%${params.search}%`;
             whereCondition = [
@@ -582,6 +598,24 @@ export class AppointmentsService {
                 startTime: updated.startTime,
                 endTime: updated.endTime,
             });
+            // Notify client about rescheduled appointment
+            if (newStatus === AppointmentStatus.RescheduledPending) {
+                const client = updated.client;
+                if (client?.phone && client.receiveNotifications) {
+                    const { date, time } = this.formatDate(updated.startTime);
+                    try {
+                        await this.whatsappService.sendRescheduleNotification(
+                            client.phone,
+                            date,
+                            time,
+                        );
+                    } catch {
+                        this.logger.warn(
+                            'Failed to send reschedule WhatsApp notification',
+                        );
+                    }
+                }
+            }
         }
         return updated;
     }
@@ -749,6 +783,47 @@ export class AppointmentsService {
                 previousStatus: appointment.status,
                 status: targetStatus,
             });
+
+            // Notify client when their online booking is confirmed by salon
+            if (
+                appointment.status === AppointmentStatus.OnlinePending &&
+                targetStatus === AppointmentStatus.Confirmed
+            ) {
+                const client = updated.client;
+                if (client?.phone && client.receiveNotifications) {
+                    const { date, time } = this.formatDate(updated.startTime);
+                    try {
+                        await this.whatsappService.sendBookingConfirmed(
+                            client.phone,
+                            date,
+                            time,
+                        );
+                    } catch {
+                        this.logger.warn(
+                            'Failed to send booking confirmed WhatsApp',
+                        );
+                    }
+                }
+            }
+
+            // Notify client when their appointment is rescheduled by staff
+            if (targetStatus === AppointmentStatus.RescheduledPending) {
+                const client = updated.client;
+                if (client?.phone && client.receiveNotifications) {
+                    const { date, time } = this.formatDate(updated.startTime);
+                    try {
+                        await this.whatsappService.sendRescheduleNotification(
+                            client.phone,
+                            date,
+                            time,
+                        );
+                    } catch {
+                        this.logger.warn(
+                            'Failed to send reschedule WhatsApp notification',
+                        );
+                    }
+                }
+            }
         }
         return updated;
     }

--- a/backend/salonbw-backend/src/dashboard/dashboard.service.ts
+++ b/backend/salonbw-backend/src/dashboard/dashboard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Between, MoreThan } from 'typeorm';
+import { Repository, Between, MoreThan, In } from 'typeorm';
 import { User } from '../users/user.entity';
 import { Role } from '../users/role.enum';
 import {
@@ -20,12 +20,10 @@ export class DashboardService {
     ) {}
 
     async getSummary(): Promise<DashboardSummaryDto> {
-        const clientCount = await this.usersRepository.count({
-            where: { role: Role.Client },
-        });
-        const employeeCount = await this.usersRepository.count({
-            where: { role: Role.Employee },
-        });
+        const [clientCount, employeeCount] = await Promise.all([
+            this.usersRepository.count({ where: { role: Role.Client } }),
+            this.usersRepository.count({ where: { role: Role.Employee } }),
+        ]);
 
         const now = new Date();
         const startOfDay = new Date(now);
@@ -33,61 +31,129 @@ export class DashboardService {
         const endOfDay = new Date(now);
         endOfDay.setHours(23, 59, 59, 999);
 
-        const todayAppointments = await this.appointmentsRepository.count({
-            where: {
-                startTime: Between(startOfDay, endOfDay),
-                status: AppointmentStatus.Scheduled,
-            },
-        });
+        const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
 
-        const upcomingAppointments = await this.appointmentsRepository.find({
-            where: {
-                startTime: MoreThan(now),
-                status: AppointmentStatus.Scheduled,
-            },
-            order: { startTime: 'ASC' },
-            take: 5,
-        });
+        const activeStatuses = [
+            AppointmentStatus.Scheduled,
+            AppointmentStatus.Confirmed,
+            AppointmentStatus.InProgress,
+            AppointmentStatus.OnlinePending,
+        ];
+
+        // Run all DB queries in parallel
+        const [
+            todayActive,
+            onlinePending,
+            upcomingAppointments,
+            completedToday,
+            completedThisMonth,
+        ] = await Promise.all([
+            this.appointmentsRepository.count({
+                where: {
+                    startTime: Between(startOfDay, endOfDay),
+                    status: In(activeStatuses),
+                },
+            }),
+            this.appointmentsRepository.count({
+                where: { status: AppointmentStatus.OnlinePending },
+            }),
+            this.appointmentsRepository.find({
+                where: {
+                    startTime: MoreThan(now),
+                    status: In([
+                        AppointmentStatus.Scheduled,
+                        AppointmentStatus.Confirmed,
+                        AppointmentStatus.OnlinePending,
+                    ]),
+                },
+                relations: ['client', 'service', 'employee'],
+                order: { startTime: 'ASC' },
+                take: 8,
+            }),
+            this.appointmentsRepository.find({
+                where: {
+                    startTime: Between(startOfDay, endOfDay),
+                    status: AppointmentStatus.Completed,
+                },
+                select: ['id', 'paidAmount'],
+            }),
+            this.appointmentsRepository.find({
+                where: {
+                    startTime: Between(startOfMonth, endOfDay),
+                    status: AppointmentStatus.Completed,
+                },
+                select: ['id', 'paidAmount'],
+            }),
+        ]);
+
+        const revenueToday = completedToday.reduce(
+            (sum, a) => sum + (Number(a.paidAmount) || 0),
+            0,
+        );
+        const revenueThisMonth = completedThisMonth.reduce(
+            (sum, a) => sum + (Number(a.paidAmount) || 0),
+            0,
+        );
 
         return {
             clientCount,
             employeeCount,
-            todayAppointments,
-            upcomingAppointments,
+            todayAppointments: todayActive,
+            onlinePendingCount: onlinePending,
+            revenueToday,
+            revenueThisMonth,
+            completedThisMonth: completedThisMonth.length,
+            upcomingAppointments: upcomingAppointments.map((a) => ({
+                id: a.id,
+                startTime: a.startTime,
+                endTime: a.endTime,
+                status: a.status,
+                clientName: a.client?.name ?? '',
+                clientPhone: (a.client as any)?.phone ?? '',
+                serviceName: a.service?.name ?? '',
+                employeeName: a.employee?.name ?? '',
+            })),
         };
     }
 
     async getClientSummary(userId: number): Promise<ClientDashboardDto> {
         const now = new Date();
 
-        // Get next upcoming appointment for this client
         const upcomingAppointment = await this.appointmentsRepository.findOne({
             where: {
                 client: { id: userId },
                 startTime: MoreThan(now),
-                status: AppointmentStatus.Scheduled,
+                status: In([
+                    AppointmentStatus.Scheduled,
+                    AppointmentStatus.Confirmed,
+                    AppointmentStatus.OnlinePending,
+                    AppointmentStatus.RescheduledPending,
+                ]),
             },
             relations: ['service', 'employee'],
             order: { startTime: 'ASC' },
         });
 
-        // Count completed appointments
-        const completedCount = await this.appointmentsRepository.count({
-            where: {
-                client: { id: userId },
-                status: AppointmentStatus.Completed,
-            },
-        });
+        const [completedCount, allAppointments, recentAppointments] =
+            await Promise.all([
+                this.appointmentsRepository.count({
+                    where: {
+                        client: { id: userId },
+                        status: AppointmentStatus.Completed,
+                    },
+                }),
+                this.appointmentsRepository.find({
+                    where: { client: { id: userId } },
+                    relations: ['service'],
+                }),
+                this.appointmentsRepository.find({
+                    where: { client: { id: userId } },
+                    relations: ['service', 'employee'],
+                    order: { startTime: 'DESC' },
+                    take: 10,
+                }),
+            ]);
 
-        // Get all appointments for service history aggregation
-        const allAppointments = await this.appointmentsRepository.find({
-            where: {
-                client: { id: userId },
-            },
-            relations: ['service'],
-        });
-
-        // Aggregate services used with counts
         const serviceMap = new Map<
             number,
             { id: number; name: string; count: number }
@@ -110,16 +176,6 @@ export class DashboardService {
             (a, b) => b.count - a.count,
         );
 
-        // Get recent appointments (last 10)
-        const recentAppointments = await this.appointmentsRepository.find({
-            where: {
-                client: { id: userId },
-            },
-            relations: ['service'],
-            order: { startTime: 'DESC' },
-            take: 10,
-        });
-
         return {
             upcomingAppointment: upcomingAppointment
                 ? {
@@ -130,6 +186,7 @@ export class DashboardService {
                           upcomingAppointment.employee?.name ??
                           upcomingAppointment.employee?.email ??
                           '',
+                      status: upcomingAppointment.status,
                   }
                 : null,
             completedCount,
@@ -139,6 +196,7 @@ export class DashboardService {
                 serviceName: apt.service?.name ?? '',
                 startTime: apt.startTime,
                 status: apt.status,
+                employeeName: apt.employee?.name ?? '',
             })),
         };
     }

--- a/backend/salonbw-backend/src/dashboard/dto/client-dashboard.dto.ts
+++ b/backend/salonbw-backend/src/dashboard/dto/client-dashboard.dto.ts
@@ -15,6 +15,10 @@ export class UpcomingAppointmentDto {
 
     @ApiProperty({ description: 'Employee name' })
     employeeName: string;
+
+    @ApiProperty({ description: 'Appointment status', required: false })
+    @IsOptional()
+    status?: string;
 }
 
 export class ServiceHistoryItemDto {
@@ -43,6 +47,10 @@ export class RecentAppointmentDto {
 
     @ApiProperty({ description: 'Appointment status' })
     status: string;
+
+    @ApiProperty({ description: 'Employee name', required: false })
+    @IsOptional()
+    employeeName?: string;
 }
 
 export class ClientDashboardDto {

--- a/backend/salonbw-backend/src/dashboard/dto/dashboard-summary.dto.ts
+++ b/backend/salonbw-backend/src/dashboard/dto/dashboard-summary.dto.ts
@@ -1,15 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-    IsString,
-    IsNumber,
-    IsBoolean,
-    IsOptional,
-    IsNotEmpty,
-    IsDateString,
-    IsArray,
-    ValidateNested,
-} from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsNumber, IsNotEmpty, IsArray, IsOptional } from 'class-validator';
 
 export class DashboardSummaryDto {
     @IsNumber()
@@ -25,10 +15,38 @@ export class DashboardSummaryDto {
     @IsNumber()
     @IsNotEmpty()
     @ApiProperty({
-        description: 'Number of appointments scheduled for today',
+        description: 'Active appointments today (all non-cancelled statuses)',
         example: 5,
     })
     todayAppointments: number;
+
+    @IsNumber()
+    @ApiProperty({
+        description: 'Online bookings waiting for confirmation',
+        example: 2,
+    })
+    onlinePendingCount: number;
+
+    @IsNumber()
+    @ApiProperty({
+        description: 'Revenue from completed appointments today (PLN)',
+        example: 480,
+    })
+    revenueToday: number;
+
+    @IsNumber()
+    @ApiProperty({
+        description: 'Revenue from completed appointments this month (PLN)',
+        example: 8400,
+    })
+    revenueThisMonth: number;
+
+    @IsNumber()
+    @ApiProperty({
+        description: 'Completed appointments this month',
+        example: 120,
+    })
+    completedThisMonth: number;
 
     @IsArray()
     @IsNotEmpty()

--- a/backend/salonbw-backend/src/formulas/customer-formulas.controller.ts
+++ b/backend/salonbw-backend/src/formulas/customer-formulas.controller.ts
@@ -18,11 +18,15 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../users/role.enum';
 import { FormulasService } from './formulas.service';
 import { Formula } from './formula.entity';
+import { RetailService } from '../retail/retail.service';
 
 @ApiTags('formulas')
 @Controller('customers')
 export class CustomerFormulasController {
-    constructor(private readonly formulasService: FormulasService) {}
+    constructor(
+        private readonly formulasService: FormulasService,
+        private readonly retailService: RetailService,
+    ) {}
 
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(Role.Client, Role.Admin)
@@ -42,5 +46,15 @@ export class CustomerFormulasController {
     @ApiResponse({ status: 200, type: Formula, isArray: true })
     findForCustomer(@Param('id', ParseIntPipe) id: number): Promise<Formula[]> {
         return this.formulasService.findForClient(id);
+    }
+
+    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    @Roles(Role.Employee, Role.Admin)
+    @Get(':id/usage-history')
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Get material usage history for customer' })
+    @ApiResponse({ status: 200, description: 'Usage history per appointment' })
+    findUsageHistory(@Param('id', ParseIntPipe) id: number) {
+        return this.retailService.getUsageHistoryForClient(id);
     }
 }

--- a/backend/salonbw-backend/src/formulas/formulas.module.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.module.ts
@@ -5,9 +5,10 @@ import { FormulasService } from './formulas.service';
 import { AppointmentFormulasController } from './appointment-formulas.controller';
 import { CustomerFormulasController } from './customer-formulas.controller';
 import { Appointment } from '../appointments/appointment.entity';
+import { RetailModule } from '../retail/retail.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Formula, Appointment])],
+    imports: [TypeOrmModule.forFeature([Formula, Appointment]), RetailModule],
     providers: [FormulasService],
     controllers: [AppointmentFormulasController, CustomerFormulasController],
 })

--- a/backend/salonbw-backend/src/notifications/whatsapp.service.ts
+++ b/backend/salonbw-backend/src/notifications/whatsapp.service.ts
@@ -128,4 +128,28 @@ export class WhatsappService {
             time,
         ]);
     }
+
+    async sendBookingConfirmed(
+        to: string,
+        date: string,
+        time: string,
+    ): Promise<void> {
+        await this.sendTemplate(to, 'booking_confirmed', [date, time]);
+    }
+
+    async sendRescheduleNotification(
+        to: string,
+        date: string,
+        time: string,
+    ): Promise<void> {
+        await this.sendTemplate(to, 'appointment_rescheduled', [date, time]);
+    }
+
+    async sendCancellationNotification(
+        to: string,
+        date: string,
+        time: string,
+    ): Promise<void> {
+        await this.sendTemplate(to, 'appointment_cancelled', [date, time]);
+    }
 }

--- a/backend/salonbw-backend/src/retail/retail.service.ts
+++ b/backend/salonbw-backend/src/retail/retail.service.ts
@@ -1346,6 +1346,33 @@ export class RetailService {
         return query.getMany();
     }
 
+    async getUsageHistoryForClient(clientId: number): Promise<
+        {
+            id: number;
+            usedAt: Date;
+            appointmentId: number | null;
+            items: { productName: string; quantity: number; unit: string }[];
+        }[]
+    > {
+        if (!(await this.hasTable('public.warehouse_usages'))) return [];
+        const usages = await this.warehouseUsages.find({
+            where: { clientId },
+            relations: ['items'],
+            order: { usedAt: 'DESC' },
+            take: 10,
+        });
+        return usages.map((u) => ({
+            id: u.id,
+            usedAt: u.usedAt,
+            appointmentId: u.appointmentId,
+            items: (u.items ?? []).map((i) => ({
+                productName: i.productName,
+                quantity: Number(i.quantity),
+                unit: i.unit,
+            })),
+        }));
+    }
+
     async getUsageDetails(id: number) {
         if (!(await this.hasTable('public.warehouse_usages'))) {
             throw new NotFoundException(`Usage ${id} not found`);


### PR DESCRIPTION
## Summary

### Critical workflow gap fixed: WhatsApp notifications

**Before:** When reception confirmed a client's online booking (`online_pending → confirmed`), the client received **no notification**. They booked, got a "booking received" message, and then — silence.

**After:** `updateStatus()` now sends `sendBookingConfirmed` WhatsApp to the client on confirmation. Similarly, `sendRescheduleNotification` fires when staff reschedules a confirmed appointment (creating `rescheduled_pending`).

New WhatsApp methods added: `sendBookingConfirmed`, `sendRescheduleNotification`, `sendCancellationNotification`.

### Dashboard — real KPIs

**Before:** `GET /dashboard` returned only `clientCount`, `employeeCount`, `todayAppointments` (counting **only `scheduled`** status), and a flat appointment list with nested client/service objects.

**After:**
- `todayAppointments` counts all active statuses: scheduled + confirmed + in_progress + online_pending
- New fields: `revenueToday`, `revenueThisMonth`, `completedThisMonth`, `onlinePendingCount`
- Upcoming appointments use flat format: `clientName`, `clientPhone`, `serviceName`, `employeeName`, `status`
- All DB queries run in parallel (`Promise.all`)
- Client dashboard also shows `online_pending` and `rescheduled_pending` in upcoming appointment

### Frontend improvements

- **Topbar badge** now links to `/appointments?status=online_pending` (was `/calendar`) for direct access to the approval queue
- **AdminDashboard**: pending bookings alert banner with count + "Zarządzaj" button when online bookings need confirmation
- **AdminDashboard**: monthly summary section showing revenue today/month, completed count, total clients
- **AdminDashboard**: upcoming appointments show client phone (clickable `tel:` link) and employee name
- **Appointments list**: pre-fills status filter from `?status=` URL query param
- **Appointments list**: quick ✓ Confirm / ✕ Reject buttons on `online_pending` rows — no need to open the full calendar drawer

## End-to-end flow (after this PR)

1. Client books online → status `online_pending` → employee gets WhatsApp alert
2. Reception sees orange badge in topbar → clicks → filtered appointments list opens
3. Reception clicks ✓ Confirm → status `confirmed` → **client gets WhatsApp confirmation**
4. Employee sees appointment in calendar → starts → finalizes → inventory deducted

## Test plan

- [ ] Book appointment online as client — verify `online_pending` status
- [ ] Reception sees badge in topbar, clicks → `/appointments?status=online_pending`
- [ ] Click ✓ Potwierdź — appointment changes to `confirmed`, toast shown
- [ ] Client receives WhatsApp `booking_confirmed` template
- [ ] AdminDashboard shows revenue today/month from real data
- [ ] AdminDashboard shows pending bookings alert banner when count > 0
- [ ] Staff reschedules a confirmed appointment → client gets `appointment_rescheduled` WhatsApp

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_