### PR TITLE
fix(bootstrap5): complete BS3 class cleanup — components, CSS shims, services CSV

### DIFF
--- a/apps/panel/src/components/customers/CustomerCard.tsx
+++ b/apps/panel/src/components/customers/CustomerCard.tsx
@@ -100,13 +100,13 @@ export default function CustomerCard({ customer, onClose, onUpdate }: Props) {
                             <div className="text-end ms-auto">
                                 <div className="btn-group">
                                     <button
-                                        className="btn btn-default btn-sm"
+                                        className="btn btn-outline-secondary btn-sm"
                                         onClick={onClose}
                                     >
                                         <i className="fa fa-arrow-left me-2"></i>
                                         Wróć
                                     </button>
-                                    <button className="btn btn-default btn-sm ms-2">
+                                    <button className="btn btn-outline-secondary btn-sm ms-2">
                                         <i className="fa fa-pencil me-2"></i>
                                         Edytuj
                                     </button>

--- a/apps/panel/src/components/customers/CustomerCommunicationTab.tsx
+++ b/apps/panel/src/components/customers/CustomerCommunicationTab.tsx
@@ -83,7 +83,7 @@ export default function CustomerCommunicationTab({ customer }: Props) {
                     <div className="customer-communication-actions">
                         <Link
                             href={`/customers/${customer.id}/edit`}
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                         >
                             Edytuj
                         </Link>
@@ -273,14 +273,14 @@ export default function CustomerCommunicationTab({ customer }: Props) {
                 <div className="customer-communication-history-switcher">
                     <button
                         type="button"
-                        className={`btn btn-xs ${historyChannel === 'sms' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${historyChannel === 'sms' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => setHistoryChannel('sms')}
                     >
                         SMS
                     </button>
                     <button
                         type="button"
-                        className={`btn btn-xs ${historyChannel === 'email' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${historyChannel === 'email' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => setHistoryChannel('email')}
                     >
                         Email

--- a/apps/panel/src/components/customers/CustomerFilesTab.tsx
+++ b/apps/panel/src/components/customers/CustomerFilesTab.tsx
@@ -117,7 +117,7 @@ export default function CustomerFilesTab({ customerId }: Props) {
                                     ),
                                 )}
                             </select>
-                            <label className="btn btn-primary btn-xs m-0">
+                            <label className="btn btn-primary btn-sm m-0">
                                 dodaj plik
                                 <input
                                     type="file"
@@ -143,7 +143,7 @@ export default function CustomerFilesTab({ customerId }: Props) {
                                 <button
                                     type="button"
                                     onClick={() => setFilterCategory('all')}
-                                    className={`btn btn-xs ${filterCategory === 'all' ? 'btn-primary' : 'btn-default'}`}
+                                    className={`btn btn-sm ${filterCategory === 'all' ? 'btn-primary' : 'btn-outline-secondary'}`}
                                 >
                                     wszystkie
                                 </button>
@@ -157,7 +157,7 @@ export default function CustomerFilesTab({ customerId }: Props) {
                                                     key as CustomerFileCategory,
                                                 )
                                             }
-                                            className={`btn btn-xs ${filterCategory === key ? 'btn-primary' : 'btn-default'}`}
+                                            className={`btn btn-sm ${filterCategory === key ? 'btn-primary' : 'btn-outline-secondary'}`}
                                         >
                                             {config.label.toLowerCase()}
                                         </button>
@@ -241,7 +241,7 @@ export default function CustomerFilesTab({ customerId }: Props) {
                                                                         file.downloadUrl,
                                                                     )
                                                                 }
-                                                                className="btn btn-default btn-xs"
+                                                                className="btn btn-outline-secondary btn-sm"
                                                                 title="Pobierz plik"
                                                                 aria-label="Pobierz plik"
                                                             >
@@ -254,7 +254,7 @@ export default function CustomerFilesTab({ customerId }: Props) {
                                                                         file.id,
                                                                     )
                                                                 }
-                                                                className="btn btn-danger btn-xs"
+                                                                className="btn btn-danger btn-sm"
                                                                 title="Usuń plik"
                                                                 aria-label="Usuń plik"
                                                                 disabled={

--- a/apps/panel/src/components/customers/CustomerGalleryTab.tsx
+++ b/apps/panel/src/components/customers/CustomerGalleryTab.tsx
@@ -30,7 +30,7 @@ export default function CustomerGalleryTab({ customerId }: Props) {
                 <div className="salonbw-widget">
                     <div className="salonbw-widget__header flex-between">
                         <span>galeria zdjęć</span>
-                        <label className="btn btn-primary btn-xs m-0">
+                        <label className="btn btn-primary btn-sm m-0">
                             dodaj zdjęcie
                             <input
                                 type="file"
@@ -142,7 +142,7 @@ export default function CustomerGalleryTab({ customerId }: Props) {
                             <div className="modal-footer">
                                 <button
                                     type="button"
-                                    className="btn btn-default btn-sm"
+                                    className="btn btn-outline-secondary btn-sm"
                                     onClick={() => setSelectedImageId(null)}
                                 >
                                     zamknij

--- a/apps/panel/src/components/customers/CustomerHistoryTab.tsx
+++ b/apps/panel/src/components/customers/CustomerHistoryTab.tsx
@@ -180,7 +180,10 @@ export default function CustomerHistoryTab({ customerId }: Props) {
     return (
         <div className="customer-history-tab customer-history-tab--salonbw">
             <div className="customer-history-toolbar">
-                <button type="button" className="btn btn-default btn-xs">
+                <button
+                    type="button"
+                    className="btn btn-outline-secondary btn-sm"
+                >
                     filtruj
                 </button>
             </div>
@@ -189,7 +192,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                 <div className="customer-history-filters">
                     <button
                         type="button"
-                        className={`btn btn-xs ${status === 'all' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${status === 'all' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => {
                             setStatus('all');
                             setPage(1);
@@ -199,7 +202,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                     </button>
                     <button
                         type="button"
-                        className={`btn btn-xs ${status === 'upcoming' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${status === 'upcoming' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => {
                             setStatus('upcoming');
                             setPage(1);
@@ -209,7 +212,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                     </button>
                     <button
                         type="button"
-                        className={`btn btn-xs ${status === 'completed' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${status === 'completed' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => {
                             setStatus('completed');
                             setPage(1);
@@ -219,7 +222,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                     </button>
                     <button
                         type="button"
-                        className={`btn btn-xs ${status === 'cancelled' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${status === 'cancelled' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => {
                             setStatus('cancelled');
                             setPage(1);
@@ -229,7 +232,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                     </button>
                     <button
                         type="button"
-                        className={`btn btn-xs ${status === 'no_show' ? 'btn-primary' : 'btn-default'}`}
+                        className={`btn btn-sm ${status === 'no_show' ? 'btn-primary' : 'btn-outline-secondary'}`}
                         onClick={() => {
                             setStatus('no_show');
                             setPage(1);
@@ -499,7 +502,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                     <div className="btn-group">
                         <button
                             type="button"
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                             disabled={page <= 1}
                             onClick={() => setPage((p) => Math.max(1, p - 1))}
                         >
@@ -507,7 +510,7 @@ export default function CustomerHistoryTab({ customerId }: Props) {
                         </button>
                         <button
                             type="button"
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                             disabled={page >= totalPages}
                             onClick={() =>
                                 setPage((p) => Math.min(totalPages, p + 1))

--- a/apps/panel/src/components/customers/CustomerNotesTab.tsx
+++ b/apps/panel/src/components/customers/CustomerNotesTab.tsx
@@ -129,7 +129,7 @@ export default function CustomerNotesTab({ customerId }: Props) {
                 <div className="customer-comments-actions">
                     <button
                         type="button"
-                        className="btn btn-primary btn-xs"
+                        className="btn btn-primary btn-sm"
                         onClick={() => void handleAdd()}
                         disabled={!content.trim() || create.isPending}
                     >
@@ -217,14 +217,14 @@ function NoteRow({
             <div className="customer-comment-controls">
                 <button
                     type="button"
-                    className="btn btn-default btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                     onClick={() => void onTogglePin()}
                 >
                     {note.isPinned ? 'ukryj z alertów' : 'pokaż w alertach'}
                 </button>
                 <button
                     type="button"
-                    className="btn btn-default btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                     onClick={() => void onDelete()}
                 >
                     usuń

--- a/apps/panel/src/components/customers/CustomerPersonalDataTab.tsx
+++ b/apps/panel/src/components/customers/CustomerPersonalDataTab.tsx
@@ -92,7 +92,7 @@ export default function CustomerPersonalDataTab({ customer, onUpdate }: Props) {
             <div className="customer-new-actions customer-new-actions--sticky">
                 <button
                     type="button"
-                    className="btn btn-primary btn-xs"
+                    className="btn btn-primary btn-sm"
                     onClick={() => void handleSave()}
                     disabled={!isDirty || isSaving}
                 >
@@ -100,7 +100,7 @@ export default function CustomerPersonalDataTab({ customer, onUpdate }: Props) {
                 </button>
                 <button
                     type="button"
-                    className="btn btn-default btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                     onClick={handleReset}
                     disabled={!isDirty || isSaving}
                 >

--- a/apps/panel/src/components/customers/CustomerReviewsTab.tsx
+++ b/apps/panel/src/components/customers/CustomerReviewsTab.tsx
@@ -135,7 +135,7 @@ export default function CustomerReviewsTab({ customerId }: Props) {
                                 <div className="btn-">
                                     <button
                                         onClick={() => setFilterSource('all')}
-                                        className={`btn btn-xs ${filterSource === 'all' ? 'btn-primary' : 'btn-default'}`}
+                                        className={`btn btn-sm ${filterSource === 'all' ? 'btn-primary' : 'btn-outline-secondary'}`}
                                     >
                                         Wszystkie
                                     </button>
@@ -153,7 +153,7 @@ export default function CustomerReviewsTab({ customerId }: Props) {
                                                             key as ReviewSource,
                                                         )
                                                     }
-                                                    className={`btn btn-xs ${filterSource === key ? 'btn-primary' : 'btn-default'}`}
+                                                    className={`btn btn-sm ${filterSource === key ? 'btn-primary' : 'btn-outline-secondary'}`}
                                                 >
                                                     {config.label} ({count})
                                                 </button>

--- a/apps/panel/src/components/customers/CustomerSidebar.tsx
+++ b/apps/panel/src/components/customers/CustomerSidebar.tsx
@@ -36,7 +36,7 @@ export default function CustomerSidebar({
         <div className="salonbw-sidebar">
             {/* Search */}
             <div className="salonbw-sidebar__search">
-                <div className="form-group mb-0">
+                <div className="mb-0">
                     <input
                         type="text"
                         placeholder="Szukaj klientów..."
@@ -56,7 +56,7 @@ export default function CustomerSidebar({
                         {onCreateGroup && (
                             <button
                                 onClick={onCreateGroup}
-                                className="btn btn-link btn-xs p-0 text-salonbw-blue"
+                                className="btn btn-link btn-sm p-0 text-salonbw-blue"
                             >
                                 + dodaj
                             </button>
@@ -156,10 +156,10 @@ export default function CustomerSidebar({
 
                     {showAdvancedFilters && (
                         <div className="salonbw-sidebar__filters">
-                            <div className="form-group mb-0">
+                            <div className="mb-0">
                                 <label
                                     htmlFor="filter-gender"
-                                    className="control-label salonbw-label-xs"
+                                    className="form-label salonbw-label-xs"
                                 >
                                     Płeć
                                 </label>
@@ -187,7 +187,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-age-min"
-                                        className="control-label salonbw-label-xs"
+                                        className="form-label salonbw-label-xs"
                                     >
                                         Wiek od
                                     </label>
@@ -211,7 +211,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-age-max"
-                                        className="control-label small mb-4"
+                                        className="form-label small mb-4"
                                     >
                                         do
                                     </label>
@@ -238,7 +238,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-spent-min"
-                                        className="control-label salonbw-label-xs"
+                                        className="form-label salonbw-label-xs"
                                     >
                                         Wydane od
                                     </label>
@@ -262,7 +262,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-spent-max"
-                                        className="control-label salonbw-label-xs"
+                                        className="form-label salonbw-label-xs"
                                     >
                                         do
                                     </label>
@@ -329,7 +329,7 @@ export default function CustomerSidebar({
                                         limit: filters.limit,
                                     })
                                 }
-                                className="btn btn-default btn-xs btn-block mt-5"
+                                className="btn btn-outline-secondary btn-sm d-block mt-5"
                             >
                                 Wyczyść filtry
                             </button>

--- a/apps/panel/src/components/customers/CustomerStatisticsTab.tsx
+++ b/apps/panel/src/components/customers/CustomerStatisticsTab.tsx
@@ -276,14 +276,14 @@ export default function CustomerStatisticsTab({ customerId }: Props) {
                 <div className="customer-stats-lists__tabs">
                     <button
                         type="button"
-                        className={`btn btn-default btn-xs ${activeList === 'services' ? 'active' : ''}`}
+                        className={`btn btn-outline-secondary btn-sm ${activeList === 'services' ? 'active' : ''}`}
                         onClick={() => setActiveList('services')}
                     >
                         wykonane usługi {favoriteServiceRows.length}
                     </button>
                     <button
                         type="button"
-                        className={`btn btn-default btn-xs ${activeList === 'products' ? 'active' : ''}`}
+                        className={`btn btn-outline-secondary btn-sm ${activeList === 'products' ? 'active' : ''}`}
                         onClick={() => setActiveList('products')}
                     >
                         zakupione produkty {favoriteProductRows.length}

--- a/apps/panel/src/components/customers/CustomerSummaryTab.tsx
+++ b/apps/panel/src/components/customers/CustomerSummaryTab.tsx
@@ -442,7 +442,7 @@ export default function CustomerSummaryTab({
                             </div>
                             <div className="salonbw-widget__content form-horizontal">
                                 <div className="form-">
-                                    <label className="control-label">
+                                    <label className="form-label">
                                         Telefon
                                     </label>
                                     <div className="control-content">
@@ -450,17 +450,13 @@ export default function CustomerSummaryTab({
                                     </div>
                                 </div>
                                 <div className="form-">
-                                    <label className="control-label">
-                                        E-mail
-                                    </label>
+                                    <label className="form-label">E-mail</label>
                                     <div className="control-content">
                                         {customer.email || '-'}
                                     </div>
                                 </div>
                                 <div className="form-">
-                                    <label className="control-label">
-                                        Adres
-                                    </label>
+                                    <label className="form-label">Adres</label>
                                     <div className="control-content">
                                         {[
                                             customer.address,
@@ -472,7 +468,7 @@ export default function CustomerSummaryTab({
                                     </div>
                                 </div>
                                 <div className="form-">
-                                    <label className="control-label">
+                                    <label className="form-label">
                                         Klient od
                                     </label>
                                     <div className="control-content">
@@ -482,7 +478,7 @@ export default function CustomerSummaryTab({
 
                                 {/* Grupy klienta - jak w source UI */}
                                 <div className="form-">
-                                    <label className="control-label">
+                                    <label className="form-label">
                                         należy do grup
                                     </label>
                                     <div className="control-content">
@@ -663,7 +659,7 @@ export default function CustomerSummaryTab({
                             <div className="modal-footer">
                                 <button
                                     type="button"
-                                    className="btn btn-default"
+                                    className="btn btn-outline-secondary"
                                     onClick={() =>
                                         setShowAddToGroupModal(false)
                                     }

--- a/apps/panel/src/components/help/HelpContactPage.tsx
+++ b/apps/panel/src/components/help/HelpContactPage.tsx
@@ -236,7 +236,7 @@ export default function HelpContactPage() {
                         target="_blank"
                         rel="noreferrer"
                         href={SALONBW_KNOWLEDGE_BASE_URL}
-                        className="button button-blue"
+                        className="btn btn-primary"
                     >
                         Przejdź do Bazy Wiedzy »
                     </a>
@@ -265,7 +265,7 @@ export default function HelpContactPage() {
                     <ol>
                         <li className="control-group text required physical_help_query">
                             <label
-                                className="text required control-label"
+                                className="text required form-label"
                                 htmlFor="physical_help_query"
                             >
                                 Pytanie
@@ -285,7 +285,7 @@ export default function HelpContactPage() {
                         </li>
                         <li className="control-group email required physical_help_email">
                             <label
-                                className="email required control-label"
+                                className="email required form-label"
                                 htmlFor="physical_help_email"
                             >
                                 Adres email
@@ -322,7 +322,7 @@ export default function HelpContactPage() {
                         </li>
                         <li className="control-group file optional physical_help_attachment">
                             <label
-                                className="file optional control-label"
+                                className="file optional form-label"
                                 htmlFor="physical_help_attachment"
                             >
                                 Załącznik

--- a/apps/panel/src/components/salon/modals/CreateCalendarViewModal.tsx
+++ b/apps/panel/src/components/salon/modals/CreateCalendarViewModal.tsx
@@ -90,7 +90,7 @@ export default function CreateCalendarViewModal({
                         <ul className="calendar-view-form-list">
                             <li>
                                 <label
-                                    className="control-label"
+                                    className="form-label"
                                     htmlFor="calendar_view_name"
                                 >
                                     Nazwa
@@ -143,7 +143,7 @@ export default function CreateCalendarViewModal({
                         </button>
                         <button
                             type="button"
-                            className="btn btn-default"
+                            className="btn btn-outline-secondary"
                             onClick={onCancel}
                             disabled={submitting}
                         >

--- a/apps/panel/src/components/salon/modals/CreateCustomerGroupModal.tsx
+++ b/apps/panel/src/components/salon/modals/CreateCustomerGroupModal.tsx
@@ -60,11 +60,8 @@ export default function CreateCustomerGroupModal({
                         <h4 className="modal-title">Nowa grupa klientów</h4>
                     </div>
                     <div className="modal-body modal-body-scroll">
-                        <div className="form-group">
-                            <label
-                                className="control-label"
-                                htmlFor="group_name"
-                            >
+                        <div className="mb-3">
+                            <label className="form-label" htmlFor="group_name">
                                 Nazwa grupy
                             </label>
                             <input
@@ -83,9 +80,9 @@ export default function CreateCustomerGroupModal({
                                 autoFocus
                             />
                         </div>
-                        <div className="form-group">
+                        <div className="mb-3">
                             <label
-                                className="control-label"
+                                className="form-label"
                                 htmlFor="group_description"
                             >
                                 Opis (opcjonalnie)
@@ -105,8 +102,8 @@ export default function CreateCustomerGroupModal({
                                 aria-label="Opis grupy"
                             />
                         </div>
-                        <div className="form-group">
-                            <label className="control-label">Kolor</label>
+                        <div className="mb-3">
+                            <label className="form-label">Kolor</label>
                             <div className="salonbw-color-picker">
                                 {colorOptions.map((color) => (
                                     <button
@@ -129,7 +126,7 @@ export default function CreateCustomerGroupModal({
                     <div className="modal-footer">
                         <button
                             type="button"
-                            className="btn btn-default"
+                            className="btn btn-outline-secondary"
                             onClick={onClose}
                         >
                             Anuluj

--- a/apps/panel/src/components/salon/modals/CreateCustomerModal.tsx
+++ b/apps/panel/src/components/salon/modals/CreateCustomerModal.tsx
@@ -51,8 +51,8 @@ export default function CreateCustomerModal({
                         <h4 className="modal-title">Dodaj klienta</h4>
                     </div>
                     <div className="modal-body">
-                        <div className="form-group">
-                            <label className="control-label">Imię</label>
+                        <div className="mb-3">
+                            <label className="form-label">Imię</label>
                             <input
                                 className="form-control"
                                 value={form.firstName}
@@ -67,8 +67,8 @@ export default function CreateCustomerModal({
                                 autoFocus
                             />
                         </div>
-                        <div className="form-group">
-                            <label className="control-label">Nazwisko</label>
+                        <div className="mb-3">
+                            <label className="form-label">Nazwisko</label>
                             <input
                                 className="form-control"
                                 value={form.lastName}
@@ -82,8 +82,8 @@ export default function CreateCustomerModal({
                                 aria-label="Nazwisko"
                             />
                         </div>
-                        <div className="form-group">
-                            <label className="control-label">Email</label>
+                        <div className="mb-3">
+                            <label className="form-label">Email</label>
                             <input
                                 className="form-control"
                                 type="email"
@@ -97,8 +97,8 @@ export default function CreateCustomerModal({
                                 aria-label="Email"
                             />
                         </div>
-                        <div className="form-group">
-                            <label className="control-label">Telefon</label>
+                        <div className="mb-3">
+                            <label className="form-label">Telefon</label>
                             <input
                                 className="form-control"
                                 value={form.phone}
@@ -115,7 +115,7 @@ export default function CreateCustomerModal({
                     <div className="modal-footer">
                         <button
                             type="button"
-                            className="btn btn-default"
+                            className="btn btn-outline-secondary"
                             onClick={onClose}
                         >
                             Anuluj

--- a/apps/panel/src/components/salon/modals/ManageCalendarViewsModal.tsx
+++ b/apps/panel/src/components/salon/modals/ManageCalendarViewsModal.tsx
@@ -76,7 +76,7 @@ export default function ManageCalendarViewsModal({
                                             <div className="calendar-view-drafts__actions">
                                                 <button
                                                     type="button"
-                                                    className="btn btn-link btn-xs"
+                                                    className="btn btn-link btn-sm"
                                                     onClick={() =>
                                                         onEdit(view.id)
                                                     }
@@ -85,7 +85,7 @@ export default function ManageCalendarViewsModal({
                                                 </button>
                                                 <button
                                                     type="button"
-                                                    className="btn btn-link btn-xs text-danger"
+                                                    className="btn btn-link btn-sm text-danger"
                                                     onClick={() =>
                                                         onDelete(view.id)
                                                     }
@@ -112,7 +112,7 @@ export default function ManageCalendarViewsModal({
                         </Link>
                         <button
                             type="button"
-                            className="btn btn-default"
+                            className="btn btn-outline-secondary"
                             onClick={onClose}
                         >
                             zamknij

--- a/apps/panel/src/components/salon/modals/ManageCategoriesModal.tsx
+++ b/apps/panel/src/components/salon/modals/ManageCategoriesModal.tsx
@@ -88,7 +88,7 @@ export default function ManageCategoriesModal({ type, onClose }: Props) {
                         <div className="modal-footer">
                             <button
                                 type="button"
-                                className="btn btn-default btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                                 onClick={onClose}
                             >
                                 zamknij
@@ -182,7 +182,7 @@ function ManageProductCategoriesModal({ onClose }: { onClose: () => void }) {
                         <form onSubmit={(e) => void handleCreate(e)}>
                             <div className="form-">
                                 <label
-                                    className="control-label"
+                                    className="form-label"
                                     htmlFor="new_category_name"
                                 >
                                     Dodaj kategorię
@@ -198,7 +198,7 @@ function ManageProductCategoriesModal({ onClose }: { onClose: () => void }) {
                             </div>
                             <div className="form-">
                                 <label
-                                    className="control-label"
+                                    className="form-label"
                                     htmlFor="new_category_parent"
                                 >
                                     Kategoria nadrzędna
@@ -227,7 +227,7 @@ function ManageProductCategoriesModal({ onClose }: { onClose: () => void }) {
                             </div>
                             <button
                                 type="submit"
-                                className="btn btn-primary btn-xs"
+                                className="btn btn-primary btn-sm"
                                 disabled={!newName.trim() || isBusy}
                             >
                                 {createCategory.isPending
@@ -271,7 +271,7 @@ function ManageProductCategoriesModal({ onClose }: { onClose: () => void }) {
                     <div className="modal-footer">
                         <button
                             type="button"
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                             onClick={onClose}
                         >
                             zamknij
@@ -312,10 +312,7 @@ function CategoryEditorRow({
             style={{ borderColor: '#e6eaee' }}
         >
             <div className="form-">
-                <label
-                    className="control-label"
-                    htmlFor={`cat_name_${draft.id}`}
-                >
+                <label className="form-label" htmlFor={`cat_name_${draft.id}`}>
                     Nazwa
                 </label>
                 <input
@@ -330,7 +327,7 @@ function CategoryEditorRow({
             </div>
             <div className="form-">
                 <label
-                    className="control-label"
+                    className="form-label"
                     htmlFor={`cat_parent_${draft.id}`}
                 >
                     Kategoria nadrzędna
@@ -363,7 +360,7 @@ function CategoryEditorRow({
             <div className="row row-cols-1 row-cols-sm-2 g-2">
                 <div className="form-">
                     <label
-                        className="control-label"
+                        className="form-label"
                         htmlFor={`cat_sort_order_${draft.id}`}
                     >
                         Kolejność
@@ -384,7 +381,7 @@ function CategoryEditorRow({
                 </div>
                 <div className="form-">
                     <label
-                        className="control-label"
+                        className="form-label"
                         htmlFor={`cat_active_${draft.id}`}
                     >
                         Aktywna
@@ -410,7 +407,7 @@ function CategoryEditorRow({
             <div className="d-flex gap-2">
                 <button
                     type="button"
-                    className="btn btn-default btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                     onClick={() => void onSave(state)}
                     disabled={isBusy || !state.name.trim()}
                 >
@@ -418,7 +415,7 @@ function CategoryEditorRow({
                 </button>
                 <button
                     type="button"
-                    className="btn btn-danger btn-xs"
+                    className="btn btn-danger btn-sm"
                     onClick={() => void onDelete(state.id, state.name)}
                     disabled={isBusy}
                 >

--- a/apps/panel/src/components/salon/modals/ManageCustomerGroupsModal.tsx
+++ b/apps/panel/src/components/salon/modals/ManageCustomerGroupsModal.tsx
@@ -129,7 +129,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                         <form onSubmit={(e) => void handleCreate(e)}>
                             <div className="form-">
                                 <label
-                                    className="control-label"
+                                    className="form-label"
                                     htmlFor="new_group_name"
                                 >
                                     Dodaj nową grupę
@@ -150,7 +150,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                             </div>
                             <div className="form-">
                                 <label
-                                    className="control-label"
+                                    className="form-label"
                                     htmlFor="new_group_desc"
                                 >
                                     Opis (opcjonalnie)
@@ -170,7 +170,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                                 />
                             </div>
                             <div className="form-">
-                                <label className="control-label">Kolor</label>
+                                <label className="form-label">Kolor</label>
                                 <div className="salonbw-color-picker">
                                     {colorOptions.map((color) => {
                                         return (
@@ -197,7 +197,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                             <div className="d-flex gap-2">
                                 <button
                                     type="submit"
-                                    className="btn btn-primary btn-xs"
+                                    className="btn btn-primary btn-sm"
                                     disabled={isBusy || !newGroup.name.trim()}
                                 >
                                     {create.isPending
@@ -206,7 +206,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                                 </button>
                                 <button
                                     type="button"
-                                    className="btn btn-default btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                     onClick={() =>
                                         setNewGroup({
                                             name: '',
@@ -276,7 +276,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                                                 <div className="btn-">
                                                     <button
                                                         type="button"
-                                                        className="btn btn-default btn-xs"
+                                                        className="btn btn-outline-secondary btn-sm"
                                                         onClick={() =>
                                                             void handleSave(
                                                                 g.id,
@@ -291,7 +291,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        className="btn btn-danger btn-xs"
+                                                        className="btn btn-danger btn-sm"
                                                         onClick={() =>
                                                             void handleDelete(
                                                                 g.id,
@@ -306,7 +306,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
 
                                             <div className="form-">
                                                 <label
-                                                    className="control-label"
+                                                    className="form-label"
                                                     htmlFor={`group_name_${g.id}`}
                                                 >
                                                     Nazwa
@@ -331,7 +331,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
 
                                             <div className="form-">
                                                 <label
-                                                    className="control-label"
+                                                    className="form-label"
                                                     htmlFor={`group_desc_${g.id}`}
                                                 >
                                                     Opis
@@ -357,7 +357,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                                             </div>
 
                                             <div className="form-">
-                                                <label className="control-label">
+                                                <label className="form-label">
                                                     Kolor
                                                 </label>
                                                 <div className="salonbw-color-picker">
@@ -413,7 +413,7 @@ export default function ManageCustomerGroupsModal({ onClose }: Props) {
                     <div className="modal-footer">
                         <button
                             type="button"
-                            className="btn btn-default"
+                            className="btn btn-outline-secondary"
                             onClick={onClose}
                             disabled={isBusy}
                         >

--- a/apps/panel/src/components/salon/modals/SelectorModal.tsx
+++ b/apps/panel/src/components/salon/modals/SelectorModal.tsx
@@ -68,7 +68,7 @@ export default function SelectorModal({
                     <div className="modal-footer">
                         <button
                             type="button"
-                            className="btn btn-default"
+                            className="btn btn-outline-secondary"
                             onClick={onClose}
                         >
                             Anuluj

--- a/apps/panel/src/components/salon/navs/CalendarNav.tsx
+++ b/apps/panel/src/components/salon/navs/CalendarNav.tsx
@@ -113,14 +113,14 @@ export default function CalendarNav() {
             <div className="nav-header flex-between">
                 <button
                     onClick={() => changeMonth(-1)}
-                    className="btn btn-xs btn-link p-0"
+                    className="btn btn-sm btn-link p-0"
                 >
                     &lt;
                 </button>
                 <span>{monthYear}</span>
                 <button
                     onClick={() => changeMonth(1)}
-                    className="btn btn-xs btn-link p-0"
+                    className="btn btn-sm btn-link p-0"
                 >
                     &gt;
                 </button>

--- a/apps/panel/src/components/services/CategoryFormModal.tsx
+++ b/apps/panel/src/components/services/CategoryFormModal.tsx
@@ -120,10 +120,10 @@ export default function CategoryFormModal({
 
                     <form className="form-horizontal" onSubmit={handleSubmit}>
                         <div className="modal-body py-20">
-                            <div className="form-group">
+                            <div className="mb-3">
                                 <label
                                     htmlFor="category_name"
-                                    className="col-sm-3 control-label"
+                                    className="col-sm-3 form-label"
                                 >
                                     Nazwa kategorii *
                                 </label>
@@ -144,10 +144,10 @@ export default function CategoryFormModal({
                                 </div>
                             </div>
 
-                            <div className="form-group">
+                            <div className="mb-3">
                                 <label
                                     htmlFor="category_description"
-                                    className="col-sm-3 control-label"
+                                    className="col-sm-3 form-label"
                                 >
                                     Opis
                                 </label>
@@ -167,10 +167,10 @@ export default function CategoryFormModal({
                                 </div>
                             </div>
 
-                            <div className="form-group">
+                            <div className="mb-3">
                                 <label
                                     htmlFor="category_parent"
-                                    className="col-sm-3 control-label"
+                                    className="col-sm-3 form-label"
                                 >
                                     Kategoria nadrzędna
                                 </label>
@@ -201,8 +201,8 @@ export default function CategoryFormModal({
                                 </div>
                             </div>
 
-                            <div className="form-group">
-                                <label className="col-sm-3 control-label">
+                            <div className="mb-3">
+                                <label className="col-sm-3 form-label">
                                     Kolor
                                 </label>
                                 <div className="col-sm-9">
@@ -259,7 +259,7 @@ export default function CategoryFormModal({
                                 </div>
                             </div>
 
-                            <div className="form-group">
+                            <div className="mb-3">
                                 <div className="col-sm-offset-3 col-sm-9">
                                     <div className="checkbox">
                                         <label>
@@ -285,7 +285,7 @@ export default function CategoryFormModal({
                             <button
                                 type="button"
                                 onClick={onClose}
-                                className="btn btn-default"
+                                className="btn btn-outline-secondary"
                             >
                                 Anuluj
                             </button>

--- a/apps/panel/src/components/services/ManageCategoriesModal.tsx
+++ b/apps/panel/src/components/services/ManageCategoriesModal.tsx
@@ -89,7 +89,7 @@ export default function ManageCategoriesModal({
                     </div>
                     <div className="btn-group">
                         <button
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                             onClick={() => handleEdit(category)}
                             title="Edytuj kategorię"
                             aria-label="Edytuj kategorię"
@@ -97,7 +97,7 @@ export default function ManageCategoriesModal({
                             <i className="fa fa-pencil"></i>
                         </button>
                         <button
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                             onClick={() => handleAdd(category.id)}
                             title="Dodaj podkategorię"
                             aria-label="Dodaj podkategorię"
@@ -105,7 +105,7 @@ export default function ManageCategoriesModal({
                             <i className="fa fa-plus"></i>
                         </button>
                         <button
-                            className="btn btn-default btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                             onClick={() => {
                                 void handleDelete(category.id, category.name);
                             }}
@@ -164,7 +164,7 @@ export default function ManageCategoriesModal({
                     </div>
                     <div className="modal-footer">
                         <button
-                            className="btn btn-default float-start"
+                            className="btn btn-outline-secondary float-start"
                             onClick={() => handleAdd(null)}
                         >
                             <i className="fa fa-plus me-2"></i>

--- a/apps/panel/src/components/services/ServiceFormModal.tsx
+++ b/apps/panel/src/components/services/ServiceFormModal.tsx
@@ -174,11 +174,8 @@ export default function ServiceFormModal({
 
     const renderBasicTab = () => (
         <div className="tab-pane active py-20">
-            <div className="form-group">
-                <label
-                    htmlFor="service_name"
-                    className="col-sm-3 control-label"
-                >
+            <div className="mb-3">
+                <label htmlFor="service_name" className="col-sm-3 form-label">
                     Nazwa usługi *
                 </label>
                 <div className="col-sm-9">
@@ -196,10 +193,10 @@ export default function ServiceFormModal({
                 </div>
             </div>
 
-            <div className="form-group">
+            <div className="mb-3">
                 <label
                     htmlFor="service_category"
-                    className="col-sm-3 control-label"
+                    className="col-sm-3 form-label"
                 >
                     Kategoria
                 </label>
@@ -227,10 +224,10 @@ export default function ServiceFormModal({
                 </div>
             </div>
 
-            <div className="form-group">
+            <div className="mb-3">
                 <label
                     htmlFor="service_duration"
-                    className="col-sm-3 control-label"
+                    className="col-sm-3 form-label"
                 >
                     Czas trwania *
                 </label>
@@ -259,11 +256,8 @@ export default function ServiceFormModal({
                 </div>
             </div>
 
-            <div className="form-group">
-                <label
-                    htmlFor="service_price"
-                    className="col-sm-3 control-label"
-                >
+            <div className="mb-3">
+                <label htmlFor="service_price" className="col-sm-3 form-label">
                     Cena (PLN) *
                 </label>
                 <div className="col-sm-4">
@@ -283,7 +277,7 @@ export default function ServiceFormModal({
                             }
                             required
                         />
-                        <span className="input-group-addon">zł</span>
+                        <span className="input-group-text">zł</span>
                     </div>
                 </div>
                 <div className="col-sm-5">
@@ -305,8 +299,8 @@ export default function ServiceFormModal({
                 </div>
             </div>
 
-            <div className="form-group">
-                <label htmlFor="service_vat" className="col-sm-3 control-label">
+            <div className="mb-3">
+                <label htmlFor="service_vat" className="col-sm-3 form-label">
                     Stawka VAT
                 </label>
                 <div className="col-sm-4">
@@ -328,12 +322,12 @@ export default function ServiceFormModal({
                             className="form-control"
                             placeholder="23"
                         />
-                        <span className="input-group-addon">%</span>
+                        <span className="input-group-text">%</span>
                     </div>
                 </div>
             </div>
 
-            <div className="form-group">
+            <div className="mb-3">
                 <div className="col-sm-offset-3 col-sm-9">
                     <div className="checkbox">
                         <label>
@@ -372,10 +366,10 @@ export default function ServiceFormModal({
 
     const renderDescriptionTab = () => (
         <div className="tab-pane active py-20">
-            <div className="form-group">
+            <div className="mb-3">
                 <label
                     htmlFor="service_desc_private"
-                    className="col-sm-3 control-label"
+                    className="col-sm-3 form-label"
                 >
                     Opis (prywatny)
                 </label>
@@ -395,10 +389,10 @@ export default function ServiceFormModal({
                     />
                 </div>
             </div>
-            <div className="form-group">
+            <div className="mb-3">
                 <label
                     htmlFor="service_desc_public"
-                    className="col-sm-3 control-label"
+                    className="col-sm-3 form-label"
                 >
                     Opis publiczny
                 </label>
@@ -527,7 +521,7 @@ export default function ServiceFormModal({
                                                         )
                                                     }
                                                 />
-                                                <span className="input-group-addon">
+                                                <span className="input-group-text">
                                                     zł
                                                 </span>
                                             </div>
@@ -535,7 +529,7 @@ export default function ServiceFormModal({
                                         <td className="text-end">
                                             <button
                                                 type="button"
-                                                className="btn btn-xs btn-default"
+                                                className="btn btn-sm btn-outline-secondary"
                                                 onClick={() =>
                                                     handleRemoveEmployee(
                                                         assignment.employeeId,
@@ -557,7 +551,7 @@ export default function ServiceFormModal({
             <div className="mt-15">
                 <button
                     type="button"
-                    className="btn btn-default btn-sm"
+                    className="btn btn-outline-secondary btn-sm"
                     onClick={() => setIsEmployeeSelectorOpen(true)}
                 >
                     + dodaj pracownika
@@ -663,7 +657,7 @@ export default function ServiceFormModal({
                             <button
                                 type="button"
                                 onClick={onClose}
-                                className="btn btn-default"
+                                className="btn btn-outline-secondary"
                             >
                                 Anuluj
                             </button>

--- a/apps/panel/src/components/services/ServiceVariantsModal.tsx
+++ b/apps/panel/src/components/services/ServiceVariantsModal.tsx
@@ -147,7 +147,7 @@ export default function ServiceVariantsModal({
                                             <button
                                                 type="button"
                                                 onClick={() => handleOpenForm()}
-                                                className="btn btn-primary btn-xs"
+                                                className="btn btn-primary btn-sm"
                                             >
                                                 dodaj wariant
                                             </button>
@@ -224,7 +224,7 @@ export default function ServiceVariantsModal({
                                                                                     variant,
                                                                                 )
                                                                             }
-                                                                            className="btn btn-default btn-xs me-1"
+                                                                            className="btn btn-outline-secondary btn-sm me-1"
                                                                         >
                                                                             edytuj
                                                                         </button>
@@ -235,7 +235,7 @@ export default function ServiceVariantsModal({
                                                                                     variant.id,
                                                                                 )
                                                                             }
-                                                                            className="btn btn-default btn-xs"
+                                                                            className="btn btn-outline-secondary btn-sm"
                                                                         >
                                                                             usuń
                                                                         </button>
@@ -260,7 +260,7 @@ export default function ServiceVariantsModal({
                                         </h5>
 
                                         <div className="control-group">
-                                            <label className="control-label">
+                                            <label className="form-label">
                                                 Nazwa wariantu *
                                             </label>
                                             <div className="controls">
@@ -283,7 +283,7 @@ export default function ServiceVariantsModal({
                                         </div>
 
                                         <div className="control-group">
-                                            <label className="control-label">
+                                            <label className="form-label">
                                                 Opis (opcjonalnie)
                                             </label>
                                             <div className="controls">
@@ -308,7 +308,7 @@ export default function ServiceVariantsModal({
                                         </div>
 
                                         <div className="control-group">
-                                            <label className="control-label">
+                                            <label className="form-label">
                                                 Czas trwania (min) *
                                             </label>
                                             <div className="controls">
@@ -335,7 +335,7 @@ export default function ServiceVariantsModal({
                                         </div>
 
                                         <div className="control-group">
-                                            <label className="control-label">
+                                            <label className="form-label">
                                                 Cena (zł) *
                                             </label>
                                             <div className="controls">
@@ -392,7 +392,7 @@ export default function ServiceVariantsModal({
                                         <div className="form-actions bg-none border-top p-20-0">
                                             <button
                                                 type="button"
-                                                className="btn btn-default mr-10"
+                                                className="btn btn-outline-secondary mr-10"
                                                 onClick={handleCancelForm}
                                             >
                                                 anuluj
@@ -424,7 +424,7 @@ export default function ServiceVariantsModal({
                         <div className="modal-footer">
                             <button
                                 type="button"
-                                className="btn btn-default"
+                                className="btn btn-outline-secondary"
                                 onClick={onClose}
                             >
                                 zamknij

--- a/apps/panel/src/components/settings/ActivityLogRoute.tsx
+++ b/apps/panel/src/components/settings/ActivityLogRoute.tsx
@@ -191,7 +191,7 @@ export default function ActivityLogRoute({
                 <div className="settings-employee-activity-page">
                     <div>
                         <button
-                            className="button"
+                            className="btn btn-outline-secondary"
                             id="filters_toggle"
                             type="button"
                             onClick={() => {
@@ -340,7 +340,7 @@ export default function ActivityLogRoute({
                                         </div>
                                         <div className="col-sm-12 filter settings-employee-activity-page__filter-actions">
                                             <button
-                                                className="button button-blue"
+                                                className="btn btn-primary"
                                                 type="submit"
                                             >
                                                 zastosuj
@@ -372,7 +372,7 @@ export default function ActivityLogRoute({
                                         </div>
                                         <button
                                             type="button"
-                                            className="btn btn-default"
+                                            className="btn btn-outline-secondary"
                                             onClick={() =>
                                                 void activityLogs.refetch()
                                             }

--- a/apps/panel/src/components/settings/BranchIdentityForm.tsx
+++ b/apps/panel/src/components/settings/BranchIdentityForm.tsx
@@ -189,7 +189,7 @@ export default function BranchIdentityForm() {
                 </p>
                 <button
                     type="button"
-                    className="btn btn-default"
+                    className="btn btn-outline-secondary"
                     onClick={() => void refetch()}
                 >
                     spróbuj ponownie
@@ -214,7 +214,7 @@ export default function BranchIdentityForm() {
             <ol>
                 <li className="control-group">
                     <label
-                        className="string required control-label"
+                        className="string required form-label"
                         htmlFor="branch-name"
                     >
                         Nazwa
@@ -238,7 +238,7 @@ export default function BranchIdentityForm() {
                 </li>
                 <li className="control-group">
                     <label
-                        className="email optional control-label"
+                        className="email optional form-label"
                         htmlFor="branch-email"
                     >
                         Email
@@ -260,7 +260,7 @@ export default function BranchIdentityForm() {
                     </div>
                 </li>
                 <li className="control-group">
-                    <label className="string optional control-label">
+                    <label className="string optional form-label">
                         Numer telefonu
                     </label>
                     <div className="controls phones">
@@ -306,7 +306,7 @@ export default function BranchIdentityForm() {
                 </li>
                 <li className="control-group">
                     <label
-                        className="string optional control-label"
+                        className="string optional form-label"
                         htmlFor="branch-website"
                     >
                         Adres strony internetowej
@@ -329,7 +329,7 @@ export default function BranchIdentityForm() {
                 </li>
                 <li className="control-group">
                     <label
-                        className="string optional control-label"
+                        className="string optional form-label"
                         htmlFor="branch-facebook"
                     >
                         Facebook
@@ -346,7 +346,7 @@ export default function BranchIdentityForm() {
                 </li>
                 <li className="control-group">
                     <label
-                        className="string optional control-label"
+                        className="string optional form-label"
                         htmlFor="branch-instagram"
                     >
                         Instagram
@@ -363,7 +363,7 @@ export default function BranchIdentityForm() {
                 </li>
                 <li className="control-group">
                     <label
-                        className="file optional control-label"
+                        className="file optional form-label"
                         htmlFor="branch-logo-url"
                     >
                         Logo

--- a/apps/panel/src/components/settings/CalendarSettingsForm.tsx
+++ b/apps/panel/src/components/settings/CalendarSettingsForm.tsx
@@ -160,7 +160,7 @@ export default function CalendarSettingsForm() {
                 <div>Nie udało się pobrać ustawień kalendarza.</div>
                 <button
                     type="button"
-                    className="btn btn-default"
+                    className="btn btn-outline-secondary"
                     onClick={() => void refetch()}
                 >
                     odśwież
@@ -208,7 +208,7 @@ export default function CalendarSettingsForm() {
                     <ol>
                         <li className="control-group">
                             <label
-                                className="select optional control-label"
+                                className="select optional form-label"
                                 htmlFor="setting-calendar-default-view"
                             >
                                 Domyślny widok kalendarza
@@ -237,7 +237,7 @@ export default function CalendarSettingsForm() {
                         </li>
                         <li className="control-group">
                             <label
-                                className="select optional control-label"
+                                className="select optional form-label"
                                 htmlFor="setting-calendar-from"
                             >
                                 Pokaż godziny od
@@ -261,7 +261,7 @@ export default function CalendarSettingsForm() {
                         </li>
                         <li className="control-group">
                             <label
-                                className="select optional control-label"
+                                className="select optional form-label"
                                 htmlFor="setting-calendar-to"
                             >
                                 Pokaż godziny do
@@ -287,7 +287,7 @@ export default function CalendarSettingsForm() {
                         </li>
                         <li className="control-group">
                             <label
-                                className="select optional control-label"
+                                className="select optional form-label"
                                 htmlFor="setting-first-visible-hour"
                             >
                                 Przewiń kalendarz do godziny
@@ -311,7 +311,7 @@ export default function CalendarSettingsForm() {
                         </li>
                         <li className="control-group">
                             <label
-                                className="string required control-label"
+                                className="string required form-label"
                                 htmlFor="setting-slot-length"
                             >
                                 Podział godziny
@@ -341,7 +341,7 @@ export default function CalendarSettingsForm() {
                         </li>
                         <li className="control-group">
                             <label
-                                className="select optional control-label"
+                                className="select optional form-label"
                                 htmlFor="setting-days-while-editable"
                             >
                                 Ograniczenie wprowadzania zmian wstecz
@@ -405,7 +405,7 @@ export default function CalendarSettingsForm() {
                         </li>
                         <li className="control-group">
                             <label
-                                className="select optional control-label"
+                                className="select optional form-label"
                                 htmlFor="setting-customer-naming-order"
                             >
                                 Kolejność wyświetlania danych klienta

--- a/apps/panel/src/components/settings/CustomerGroupsListPage.tsx
+++ b/apps/panel/src/components/settings/CustomerGroupsListPage.tsx
@@ -210,7 +210,7 @@ export default function CustomerGroupsListPage() {
                 <div id="general-actions">
                     <button
                         type="button"
-                        className="button"
+                        className="btn btn-outline-secondary"
                         onClick={() => {
                             setDraftGroups(groups);
                             setReorderMode(true);
@@ -223,7 +223,7 @@ export default function CustomerGroupsListPage() {
                     </button>
                     <button
                         type="button"
-                        className="button button-blue"
+                        className="btn btn-primary"
                         onClick={() =>
                             void sort
                                 .mutateAsync(flattenForSort(draftTree))
@@ -237,7 +237,7 @@ export default function CustomerGroupsListPage() {
                     </button>
                     <button
                         type="button"
-                        className="button"
+                        className="btn btn-outline-secondary"
                         onClick={() => {
                             setDraftGroups(groups);
                             setReorderMode(false);
@@ -248,11 +248,14 @@ export default function CustomerGroupsListPage() {
                     >
                         anuluj
                     </button>
-                    <Link className="button" href="/customers">
+                    <Link
+                        className="btn btn-outline-secondary"
+                        href="/customers"
+                    >
                         wróć do listy klientów
                     </Link>
                     <Link
-                        className="button button-blue"
+                        className="btn btn-primary"
                         href="/settings/customer_groups/new"
                     >
                         dodaj grupę
@@ -267,7 +270,7 @@ export default function CustomerGroupsListPage() {
                     <div>Nie udało się pobrać grup klientów.</div>
                     <button
                         type="button"
-                        className="btn btn-default"
+                        className="btn btn-outline-secondary"
                         onClick={() => void refetch()}
                     >
                         odśwież
@@ -323,9 +326,9 @@ export default function CustomerGroupsListPage() {
                                 <h4 className="modal-title">Edycja grupy</h4>
                             </div>
                             <div className="modal-body">
-                                <div className="form-group">
+                                <div className="mb-3">
                                     <label
-                                        className="control-label"
+                                        className="form-label"
                                         htmlFor="customer-group-edit-name"
                                     >
                                         Nazwa
@@ -339,9 +342,9 @@ export default function CustomerGroupsListPage() {
                                         }
                                     />
                                 </div>
-                                <div className="form-group">
+                                <div className="mb-3">
                                     <label
-                                        className="control-label"
+                                        className="form-label"
                                         htmlFor="customer-group-edit-parent"
                                     >
                                         Grupa nadrzędna
@@ -375,7 +378,7 @@ export default function CustomerGroupsListPage() {
                             <div className="modal-footer">
                                 <button
                                     type="button"
-                                    className="btn btn-default"
+                                    className="btn btn-outline-secondary"
                                     onClick={() => setEditingGroup(null)}
                                 >
                                     anuluj

--- a/apps/panel/src/components/settings/EventRemindersPage.tsx
+++ b/apps/panel/src/components/settings/EventRemindersPage.tsx
@@ -203,7 +203,7 @@ export default function EventRemindersPage() {
                     <div className="btn-group float-end">
                         <button
                             type="button"
-                            className="btn btn-default dropdown-toggle"
+                            className="btn btn-outline-secondary dropdown-toggle"
                             data-toggle="dropdown"
                         >
                             więcej
@@ -218,7 +218,7 @@ export default function EventRemindersPage() {
                     </div>
                     <button
                         type="button"
-                        className="btn button-blue float-end"
+                        className="btn btn-primary float-end"
                         style={{ marginRight: '8px' }}
                         onClick={() => void openEdit()}
                     >
@@ -265,8 +265,8 @@ export default function EventRemindersPage() {
                         onSubmit={(event) => void handleSave(event)}
                     >
                         <h3>Edytuj przypomnienie</h3>
-                        <div className="form-group">
-                            <label className="control-label">Status</label>
+                        <div className="mb-3">
+                            <label className="form-label">Status</label>
                             <div>
                                 <label className="radio-inline">
                                     <input
@@ -298,11 +298,8 @@ export default function EventRemindersPage() {
                                 </label>
                             </div>
                         </div>
-                        <div className="form-group">
-                            <label
-                                htmlFor="timingHours"
-                                className="control-label"
-                            >
+                        <div className="mb-3">
+                            <label htmlFor="timingHours" className="form-label">
                                 Czas wysyłki
                             </label>
                             <select
@@ -328,10 +325,10 @@ export default function EventRemindersPage() {
                                 <option value={48}>Dwa dni przed wizytą</option>
                             </select>
                         </div>
-                        <div className="form-group">
+                        <div className="mb-3">
                             <label
                                 htmlFor="preferredChannel"
-                                className="control-label"
+                                className="form-label"
                             >
                                 Preferowany kanał
                             </label>
@@ -354,11 +351,8 @@ export default function EventRemindersPage() {
                                 <option value="both">SMS i e-mail</option>
                             </select>
                         </div>
-                        <div className="form-group">
-                            <label
-                                htmlFor="smsTemplate"
-                                className="control-label"
-                            >
+                        <div className="mb-3">
+                            <label htmlFor="smsTemplate" className="form-label">
                                 Treść SMS
                             </label>
                             <textarea
@@ -374,10 +368,10 @@ export default function EventRemindersPage() {
                                 }
                             />
                         </div>
-                        <div className="form-group">
+                        <div className="mb-3">
                             <label
                                 htmlFor="emailSubject"
-                                className="control-label"
+                                className="form-label"
                             >
                                 Temat e-maila
                             </label>
@@ -394,10 +388,10 @@ export default function EventRemindersPage() {
                                 }
                             />
                         </div>
-                        <div className="form-group">
+                        <div className="mb-3">
                             <label
                                 htmlFor="emailTemplate"
-                                className="control-label"
+                                className="form-label"
                             >
                                 Treść e-maila
                             </label>
@@ -414,10 +408,10 @@ export default function EventRemindersPage() {
                                 }
                             />
                         </div>
-                        <div className="form-group">
+                        <div className="mb-3">
                             <button
                                 type="submit"
-                                className="btn button-blue"
+                                className="btn btn-primary"
                                 disabled={updateReminderSettings.isPending}
                             >
                                 {updateReminderSettings.isPending
@@ -426,7 +420,7 @@ export default function EventRemindersPage() {
                             </button>
                             <button
                                 type="button"
-                                className="btn btn-default"
+                                className="btn btn-outline-secondary"
                                 style={{ marginLeft: '8px' }}
                                 onClick={() => void closeEdit()}
                                 disabled={updateReminderSettings.isPending}
@@ -489,7 +483,7 @@ export default function EventRemindersPage() {
                 <div className="reminder-how-it-works">
                     <button
                         type="button"
-                        className="btn btn-default"
+                        className="btn btn-outline-secondary"
                         onClick={() => setHowItWorksOpen((v) => !v)}
                     >
                         Jak to działa?{' '}

--- a/apps/panel/src/components/settings/NewCustomerGroupPage.tsx
+++ b/apps/panel/src/components/settings/NewCustomerGroupPage.tsx
@@ -65,7 +65,7 @@ export default function NewCustomerGroupPage() {
                 <ol>
                     <li className="control-group">
                         <label
-                            className="string required control-label"
+                            className="string required form-label"
                             htmlFor="physical-customers-group-name"
                         >
                             Nazwa
@@ -85,7 +85,7 @@ export default function NewCustomerGroupPage() {
                     </li>
                     <li className="control-group">
                         <label
-                            className="select optional control-label"
+                            className="select optional form-label"
                             htmlFor="physical-customers-group-parent-id"
                         >
                             Grupa nadrzędna

--- a/apps/panel/src/components/settings/PaymentConfigurationPage.tsx
+++ b/apps/panel/src/components/settings/PaymentConfigurationPage.tsx
@@ -90,7 +90,7 @@ export default function PaymentConfigurationPage() {
                     <div>Nie udało się pobrać ustawień płatności.</div>
                     <button
                         type="button"
-                        className="btn btn-default"
+                        className="btn btn-outline-secondary"
                         onClick={() => void refetch()}
                     >
                         odśwież
@@ -112,7 +112,7 @@ export default function PaymentConfigurationPage() {
                     primary={
                         <button
                             type="button"
-                            className={`btn ${isEnabled ? 'btn-default' : 'btn-primary'}`}
+                            className={`btn ${isEnabled ? 'btn-outline-secondary' : 'btn-primary'}`}
                             disabled={updatePaymentConfiguration.isPending}
                             onClick={() =>
                                 void saveConfiguration({

--- a/apps/panel/src/components/settings/SmsSettingsPage.tsx
+++ b/apps/panel/src/components/settings/SmsSettingsPage.tsx
@@ -168,7 +168,7 @@ export default function SmsSettingsPage() {
                 <div>Nie udało się pobrać ustawień SMS.</div>
                 <button
                     type="button"
-                    className="btn btn-default"
+                    className="btn btn-outline-secondary"
                     onClick={() => void refetch()}
                 >
                     odśwież

--- a/apps/panel/src/components/settings/TimetableEmployeesPage.tsx
+++ b/apps/panel/src/components/settings/TimetableEmployeesPage.tsx
@@ -341,7 +341,7 @@ export default function TimetableEmployeesPage() {
                 <div>Nie udało się pobrać grafików pracowników.</div>
                 <button
                     type="button"
-                    className="btn btn-default"
+                    className="btn btn-outline-secondary"
                     onClick={() => void refetch()}
                 >
                     odśwież
@@ -369,7 +369,7 @@ export default function TimetableEmployeesPage() {
                     <div className="date">
                         <div className="button-group">
                             <Link
-                                className="button"
+                                className="btn btn-outline-secondary"
                                 href={{
                                     pathname: '/settings/timetable/employees',
                                     query: {
@@ -387,7 +387,7 @@ export default function TimetableEmployeesPage() {
                                 <span className="fc-icon fc-icon-left-single-arrow" />
                             </Link>
                             <Link
-                                className="button"
+                                className="btn btn-outline-secondary"
                                 href={{
                                     pathname: '/settings/timetable/employees',
                                     query: {
@@ -442,7 +442,7 @@ export default function TimetableEmployeesPage() {
                             <Link
                                 className={
                                     kind === 'day'
-                                        ? 'button button-blue'
+                                        ? 'btn btn-primary'
                                         : 'button'
                                 }
                                 href={{
@@ -464,7 +464,7 @@ export default function TimetableEmployeesPage() {
                             <Link
                                 className={
                                     kind === 'week'
-                                        ? 'button button-blue'
+                                        ? 'btn btn-primary'
                                         : 'button'
                                 }
                                 href={{

--- a/apps/panel/src/components/settings/TimetableTemplatesPage.tsx
+++ b/apps/panel/src/components/settings/TimetableTemplatesPage.tsx
@@ -341,7 +341,7 @@ export default function TimetableTemplatesPage() {
                 <div>Nie udało się pobrać szablonów grafików.</div>
                 <button
                     type="button"
-                    className="btn btn-default"
+                    className="btn btn-outline-secondary"
                     onClick={() => void refetch()}
                 >
                     odśwież
@@ -369,7 +369,7 @@ export default function TimetableTemplatesPage() {
                     <div className="buttons">
                         <button
                             type="button"
-                            className="button button-blue"
+                            className="btn btn-primary"
                             onClick={() => void handleAdd()}
                         >
                             Dodaj szablon

--- a/apps/panel/src/components/statistics/StatisticsToolbar.tsx
+++ b/apps/panel/src/components/statistics/StatisticsToolbar.tsx
@@ -27,7 +27,7 @@ export default function StatisticsToolbar({
                 <div className="float-start statistics_date">
                     <button
                         type="button"
-                        className="button button-link button_prev mr-s"
+                        className="btn btn-link button_prev mr-s"
                         onClick={onPrev}
                         aria-label="Poprzedni dzień"
                     >
@@ -62,7 +62,7 @@ export default function StatisticsToolbar({
                     </div>
                     <button
                         type="button"
-                        className="button button-link button_next ml-s"
+                        className="btn btn-link button_next ml-s"
                         onClick={onNext}
                         aria-label="Następny dzień"
                     >
@@ -77,7 +77,7 @@ export default function StatisticsToolbar({
                 {onExcel ? (
                     <button
                         type="button"
-                        className="button"
+                        className="btn btn-outline-secondary"
                         onClick={onExcel}
                         disabled={excelDisabled}
                     >
@@ -91,7 +91,7 @@ export default function StatisticsToolbar({
                 {onPrint ? (
                     <button
                         type="button"
-                        className="button button-link statistics-print-button"
+                        className="btn btn-link statistics-print-button"
                         onClick={onPrint}
                         aria-label="Drukuj"
                     >

--- a/apps/panel/src/components/warehouse/ProductViewShell.tsx
+++ b/apps/panel/src/components/warehouse/ProductViewShell.tsx
@@ -22,19 +22,22 @@ export default function ProductViewShell({
 }: ProductViewShellProps) {
     const actions = (
         <div className="products-card-actions">
-            <Link href="/sales/new" className="btn btn-default btn-xs">
+            <Link
+                href="/sales/new"
+                className="btn btn-outline-secondary btn-sm"
+            >
                 sprzedaj
             </Link>
-            <Link href="/use/new" className="btn btn-default btn-xs">
+            <Link href="/use/new" className="btn btn-outline-secondary btn-sm">
                 zużyj
             </Link>
             <Link
                 href={`/products/${productId}/edit`}
-                className="btn btn-default btn-xs"
+                className="btn btn-outline-secondary btn-sm"
             >
                 edytuj
             </Link>
-            <Link href="/products/new" className="btn btn-primary btn-xs">
+            <Link href="/products/new" className="btn btn-primary btn-sm">
                 dodaj produkt
             </Link>
         </div>

--- a/apps/panel/src/pages/communication/[id].tsx
+++ b/apps/panel/src/pages/communication/[id].tsx
@@ -333,7 +333,7 @@ export default function CommunicationDetailPage() {
                             jak i email. Wybierz właściwy typ wiadomości:
                             <div className="mt-m">
                                 <Link
-                                    className="button"
+                                    className="btn btn-outline-secondary"
                                     href={getCommunicationHref(id!, 'sms')}
                                 >
                                     otwórz jako SMS
@@ -384,7 +384,7 @@ export default function CommunicationDetailPage() {
                                     </ul>
                                     <br />
                                     <Link
-                                        className="button"
+                                        className="btn btn-outline-secondary"
                                         href={`/calendar?event=${sms.appointment.id}`}
                                     >
                                         Pokaż wizytę w kalendarzu
@@ -692,7 +692,7 @@ export default function CommunicationDetailPage() {
                                                         </button>
                                                         <button
                                                             type="button"
-                                                            className="button"
+                                                            className="btn btn-outline-secondary"
                                                             onClick={
                                                                 handleModifySelectedTemplate
                                                             }

--- a/apps/panel/src/pages/customers/[id]/edit.tsx
+++ b/apps/panel/src/pages/customers/[id]/edit.tsx
@@ -172,7 +172,7 @@ export default function CustomerEditPage() {
                                         href={
                                             `/customers/${customer.id}` as Route
                                         }
-                                        className="btn btn-outline-secondary btn-xs"
+                                        className="btn btn-outline-secondary btn-sm"
                                     >
                                         wróć do karty klienta
                                     </Link>

--- a/apps/panel/src/pages/customers/new.tsx
+++ b/apps/panel/src/pages/customers/new.tsx
@@ -242,7 +242,7 @@ export default function NewCustomerPage() {
                             <div className="customer-new-actions customer-new-actions--sticky">
                                 <button
                                     type="submit"
-                                    className="btn btn-primary btn-xs"
+                                    className="btn btn-primary btn-sm"
                                     onClick={() => setSubmitMode('view')}
                                     disabled={
                                         create.isPending ||
@@ -258,7 +258,7 @@ export default function NewCustomerPage() {
                                 </button>
                                 <button
                                     type="submit"
-                                    className="btn btn-outline-secondary btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                     onClick={() => setSubmitMode('next')}
                                     disabled={create.isPending}
                                 >
@@ -266,7 +266,7 @@ export default function NewCustomerPage() {
                                 </button>
                                 <Link
                                     href={'/customers' as Route}
-                                    className="btn btn-outline-secondary btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                 >
                                     wróć do listy
                                 </Link>

--- a/apps/panel/src/pages/deliveries/[id].tsx
+++ b/apps/panel/src/pages/deliveries/[id].tsx
@@ -48,7 +48,7 @@ export default function DeliveryDetailsPage() {
                 <div className="btn-group">
                     <Link
                         href="/deliveries/history"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         historia dostaw
                     </Link>
@@ -57,14 +57,14 @@ export default function DeliveryDetailsPage() {
                         <>
                             <button
                                 type="button"
-                                className="btn btn-primary btn-xs"
+                                className="btn btn-primary btn-sm"
                                 onClick={() => void receive()}
                             >
                                 przyjmij dostawę
                             </button>
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                                 onClick={() => void cancel()}
                             >
                                 anuluj

--- a/apps/panel/src/pages/deliveries/new.tsx
+++ b/apps/panel/src/pages/deliveries/new.tsx
@@ -119,7 +119,7 @@ export default function WarehouseDeliveryCreatePage() {
             actions={
                 <Link
                     href="/deliveries/history"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                 >
                     historia dostaw
                 </Link>
@@ -216,7 +216,7 @@ export default function WarehouseDeliveryCreatePage() {
                                     <td>
                                         <button
                                             type="button"
-                                            className="btn btn-outline-secondary btn-xs"
+                                            className="btn btn-outline-secondary btn-sm"
                                             onClick={() => removeLine(index)}
                                         >
                                             usuń
@@ -231,14 +231,14 @@ export default function WarehouseDeliveryCreatePage() {
                 <div className="warehouse-actions-row">
                     <button
                         type="button"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                         onClick={addLine}
                     >
                         dodaj kolejną pozycję
                     </button>
                     <Link
                         href="/products/new"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         dodaj nowy produkt
                     </Link>
@@ -272,7 +272,7 @@ export default function WarehouseDeliveryCreatePage() {
                             </select>
                             <Link
                                 href="/suppliers"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                             >
                                 dodaj dostawcę
                             </Link>
@@ -320,13 +320,13 @@ export default function WarehouseDeliveryCreatePage() {
                 <div className="warehouse-entry-actions">
                     <Link
                         href="/deliveries/history"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         anuluj
                     </Link>
                     <button
                         type="button"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                         onClick={() => void saveDraftAndExit()}
                         disabled={
                             createDelivery.isPending ||
@@ -339,7 +339,7 @@ export default function WarehouseDeliveryCreatePage() {
                     </button>
                     <button
                         type="button"
-                        className="btn btn-primary btn-xs"
+                        className="btn btn-primary btn-sm"
                         onClick={() => void submit()}
                         disabled={
                             createDelivery.isPending ||

--- a/apps/panel/src/pages/extension/tools/[id].tsx
+++ b/apps/panel/src/pages/extension/tools/[id].tsx
@@ -311,7 +311,7 @@ function ExtensionToolContent() {
                                     {tool.status === 'Aktywny' &&
                                         tool.settingsUrl && (
                                             <a
-                                                className="button"
+                                                className="btn btn-outline-secondary"
                                                 href={tool.settingsUrl}
                                             >
                                                 <div className="icon sprite-settings_blue" />

--- a/apps/panel/src/pages/inventory/[id].tsx
+++ b/apps/panel/src/pages/inventory/[id].tsx
@@ -57,14 +57,14 @@ export default function InventoryDetailsPage() {
                 <div className="btn-group">
                     <Link
                         href="/inventory"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         historia inwentaryzacji
                     </Link>
                     {data?.status === 'draft' ? (
                         <button
                             type="button"
-                            className="btn btn-primary btn-xs"
+                            className="btn btn-primary btn-sm"
                             onClick={() => void start()}
                         >
                             rozpocznij
@@ -73,7 +73,7 @@ export default function InventoryDetailsPage() {
                     {data?.status === 'in_progress' ? (
                         <button
                             type="button"
-                            className="btn btn-primary btn-xs"
+                            className="btn btn-primary btn-sm"
                             onClick={() => void complete()}
                         >
                             zakończ

--- a/apps/panel/src/pages/inventory/new.tsx
+++ b/apps/panel/src/pages/inventory/new.tsx
@@ -31,7 +31,7 @@ export default function InventoryNewPage() {
             actions={
                 <Link
                     href="/inventory"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                 >
                     wróć do historii
                 </Link>
@@ -67,7 +67,7 @@ export default function InventoryNewPage() {
             <div className="warehouse-entry-actions warehouse-new-screen">
                 <button
                     type="button"
-                    className="btn btn-primary btn-xs"
+                    className="btn btn-primary btn-sm"
                     onClick={() => void create()}
                     disabled={createMutation.isPending}
                 >
@@ -77,7 +77,7 @@ export default function InventoryNewPage() {
                 </button>
                 <Link
                     href="/inventory"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                 >
                     anuluj
                 </Link>

--- a/apps/panel/src/pages/manufacturers/index.tsx
+++ b/apps/panel/src/pages/manufacturers/index.tsx
@@ -35,7 +35,7 @@ export default function WarehouseManufacturersPage() {
             heading="Magazyn / Producenci"
             activeTab="deliveries"
             actions={
-                <Link href="/products/new" className="btn btn-primary btn-xs">
+                <Link href="/products/new" className="btn btn-primary btn-sm">
                     dodaj produkt
                 </Link>
             }

--- a/apps/panel/src/pages/orders/[id].tsx
+++ b/apps/panel/src/pages/orders/[id].tsx
@@ -41,7 +41,7 @@ export default function WarehouseOrderDetailsPage() {
                 <div className="btn-group">
                     <Link
                         href="/orders/history"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         historia zamówień
                     </Link>
@@ -49,7 +49,7 @@ export default function WarehouseOrderDetailsPage() {
                         <>
                             <button
                                 type="button"
-                                className="btn btn-primary btn-xs"
+                                className="btn btn-primary btn-sm"
                                 onClick={() =>
                                     orderId
                                         ? void sendMutation.mutateAsync(orderId)
@@ -60,7 +60,7 @@ export default function WarehouseOrderDetailsPage() {
                             </button>
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                                 onClick={() =>
                                     orderId
                                         ? void cancelMutation.mutateAsync(
@@ -77,7 +77,7 @@ export default function WarehouseOrderDetailsPage() {
                         <>
                             <button
                                 type="button"
-                                className="btn btn-primary btn-xs"
+                                className="btn btn-primary btn-sm"
                                 onClick={() =>
                                     orderId
                                         ? void receiveMutation.mutateAsync(
@@ -90,7 +90,7 @@ export default function WarehouseOrderDetailsPage() {
                             </button>
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                                 onClick={() =>
                                     orderId
                                         ? void cancelMutation.mutateAsync(

--- a/apps/panel/src/pages/orders/new.tsx
+++ b/apps/panel/src/pages/orders/new.tsx
@@ -86,7 +86,7 @@ export default function WarehouseOrderCreatePage() {
             actions={
                 <Link
                     href="/orders/history"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                 >
                     historia zamówień
                 </Link>
@@ -188,7 +188,7 @@ export default function WarehouseOrderCreatePage() {
                                     <td>
                                         <button
                                             type="button"
-                                            className="btn btn-outline-secondary btn-xs"
+                                            className="btn btn-outline-secondary btn-sm"
                                             onClick={() =>
                                                 setLines((current) =>
                                                     current.filter(
@@ -210,14 +210,14 @@ export default function WarehouseOrderCreatePage() {
                 <div className="warehouse-actions-row">
                     <button
                         type="button"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                         onClick={addLine}
                     >
                         dodaj kolejną pozycję
                     </button>
                     <Link
                         href="/products/new"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         dodaj nowy produkt
                     </Link>
@@ -251,7 +251,7 @@ export default function WarehouseOrderCreatePage() {
                             </select>
                             <Link
                                 href="/suppliers"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                             >
                                 dodaj dostawcę
                             </Link>
@@ -283,7 +283,7 @@ export default function WarehouseOrderCreatePage() {
                             </span>
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                                 onClick={() => setNotesEnabled(true)}
                             >
                                 dodaj uwagi
@@ -293,13 +293,13 @@ export default function WarehouseOrderCreatePage() {
                     <div className="warehouse-entry-actions">
                         <Link
                             href="/orders/history"
-                            className="btn btn-outline-secondary btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                         >
                             anuluj
                         </Link>
                         <button
                             type="button"
-                            className="btn btn-primary btn-xs"
+                            className="btn btn-primary btn-sm"
                             onClick={() => void submit()}
                             disabled={createMutation.isPending}
                         >

--- a/apps/panel/src/pages/products/[id]/edit.tsx
+++ b/apps/panel/src/pages/products/[id]/edit.tsx
@@ -333,7 +333,7 @@ export default function EditProductPage() {
                             <div className="product-form__actions">
                                 <button
                                     type="submit"
-                                    className="btn btn-primary btn-xs"
+                                    className="btn btn-primary btn-sm"
                                     disabled={isSaving}
                                 >
                                     {isSaving
@@ -342,7 +342,7 @@ export default function EditProductPage() {
                                 </button>
                                 <Link
                                     href={`/products/${productId ?? ''}`}
-                                    className="btn btn-outline-secondary btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                 >
                                     anuluj
                                 </Link>

--- a/apps/panel/src/pages/products/commissions/[id].tsx
+++ b/apps/panel/src/pages/products/commissions/[id].tsx
@@ -71,7 +71,7 @@ export default function ProductCommissionsPage() {
                     <div className="products-commissions__actions">
                         <button
                             type="button"
-                            className="btn btn-primary btn-xs"
+                            className="btn btn-primary btn-sm"
                             onClick={() => void save()}
                             disabled={updateMutation.isPending}
                         >

--- a/apps/panel/src/pages/products/index.tsx
+++ b/apps/panel/src/pages/products/index.tsx
@@ -320,7 +320,7 @@ export default function WarehouseProductsPage() {
                 <button
                     type="button"
                     onClick={exportProductsCsv}
-                    className="button"
+                    className="btn btn-outline-secondary"
                 >
                     <div
                         className="icon sprite-exel_blue mr-xs"

--- a/apps/panel/src/pages/products/new.tsx
+++ b/apps/panel/src/pages/products/new.tsx
@@ -271,14 +271,14 @@ export default function NewProductPage() {
                         <div className="product-form__actions">
                             <button
                                 type="submit"
-                                className="btn btn-primary btn-xs"
+                                className="btn btn-primary btn-sm"
                                 disabled={isSaving}
                             >
                                 {isSaving ? 'zapisywanie...' : 'dodaj produkt'}
                             </button>
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary btn-xs"
+                                className="btn btn-outline-secondary btn-sm"
                                 onClick={() => void router.push('/products')}
                             >
                                 wróć do listy

--- a/apps/panel/src/pages/sales/history/[id].tsx
+++ b/apps/panel/src/pages/sales/history/[id].tsx
@@ -155,16 +155,16 @@ export default function WarehouseSaleDetailsPage() {
                 <div className="btn-group">
                     <Link
                         href="/sales/history"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         historia sprzedaży
                     </Link>
-                    <Link href="/sales/new" className="btn btn-primary btn-xs">
+                    <Link href="/sales/new" className="btn btn-primary btn-sm">
                         dodaj sprzedaż
                     </Link>
                     <button
                         type="button"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         drukuj
                     </button>
@@ -449,7 +449,7 @@ export default function WarehouseSaleDetailsPage() {
                             <div className="btn-group">
                                 <button
                                     type="button"
-                                    className="btn btn-outline-secondary btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                     disabled={voidMutation.isPending}
                                     onClick={() => void handleAction('void')}
                                 >
@@ -457,7 +457,7 @@ export default function WarehouseSaleDetailsPage() {
                                 </button>
                                 <button
                                     type="button"
-                                    className="btn btn-outline-secondary btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                     disabled={refundMutation.isPending}
                                     onClick={() => void handleAction('refund')}
                                 >
@@ -465,7 +465,7 @@ export default function WarehouseSaleDetailsPage() {
                                 </button>
                                 <button
                                     type="button"
-                                    className="btn btn-primary btn-xs"
+                                    className="btn btn-primary btn-sm"
                                     disabled={correctionMutation.isPending}
                                     onClick={() =>
                                         void handleAction('correction')

--- a/apps/panel/src/pages/sales/new.tsx
+++ b/apps/panel/src/pages/sales/new.tsx
@@ -159,7 +159,7 @@ export default function WarehouseSaleCreatePage() {
             actions={
                 <Link
                     href="/sales/history"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                 >
                     historia sprzedaży
                 </Link>
@@ -282,7 +282,7 @@ export default function WarehouseSaleCreatePage() {
                                     <td>
                                         <button
                                             type="button"
-                                            className="btn btn-outline-secondary btn-xs"
+                                            className="btn btn-outline-secondary btn-sm"
                                             onClick={() => removeLine(index)}
                                         >
                                             usuń
@@ -297,14 +297,14 @@ export default function WarehouseSaleCreatePage() {
                 <div className="warehouse-actions-row">
                     <button
                         type="button"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                         onClick={addLine}
                     >
                         dodaj kolejną pozycję
                     </button>
                     <Link
                         href="/products/new"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         dodaj nowy produkt
                     </Link>
@@ -326,7 +326,7 @@ export default function WarehouseSaleCreatePage() {
                                 />
                                 <Link
                                     href="/customers/new"
-                                    className="btn btn-outline-secondary btn-xs"
+                                    className="btn btn-outline-secondary btn-sm"
                                 >
                                     nowy klient
                                 </Link>
@@ -428,13 +428,13 @@ export default function WarehouseSaleCreatePage() {
                     <div className="warehouse-actions-row">
                         <Link
                             href="/sales/history"
-                            className="btn btn-outline-secondary btn-xs"
+                            className="btn btn-outline-secondary btn-sm"
                         >
                             anuluj
                         </Link>
                         <button
                             type="button"
-                            className="btn btn-primary btn-xs"
+                            className="btn btn-primary btn-sm"
                             onClick={() => void submit()}
                             disabled={createMutation.isPending}
                         >

--- a/apps/panel/src/pages/services/[id]/index.tsx
+++ b/apps/panel/src/pages/services/[id]/index.tsx
@@ -229,7 +229,7 @@ export default function ServiceDetailsPage() {
                         <button
                             type="button"
                             onClick={() => setIsEditModalOpen(true)}
-                            className="button"
+                            className="btn btn-outline-secondary"
                             disabled={!summaryData || user?.role !== 'admin'}
                         >
                             edytuj

--- a/apps/panel/src/pages/services/index.tsx
+++ b/apps/panel/src/pages/services/index.tsx
@@ -417,7 +417,7 @@ function ServicesPageContent({ role }: { role: Role }) {
                                 e.preventDefault();
                                 downloadCsvPriceList();
                             }}
-                            className="button"
+                            className="btn btn-outline-secondary"
                         >
                             <div
                                 className="icon sprite-exel_blue mr-xs"

--- a/apps/panel/src/pages/services/new.tsx
+++ b/apps/panel/src/pages/services/new.tsx
@@ -834,7 +834,7 @@ function NewServicePageContent() {
                                         <div className="mt-m">
                                             <button
                                                 type="button"
-                                                className="button"
+                                                className="btn btn-outline-secondary"
                                                 onClick={addVariant}
                                             >
                                                 dodaj kolejny wariant
@@ -1200,7 +1200,7 @@ function NewServicePageContent() {
                                                 </table>
                                                 <button
                                                     type="button"
-                                                    className="button"
+                                                    className="btn btn-outline-secondary"
                                                     onClick={addRecipeItem}
                                                 >
                                                     dodaj kolejną pozycję
@@ -1232,7 +1232,7 @@ function NewServicePageContent() {
                         </button>
                         <button
                             type="button"
-                            className="button"
+                            className="btn btn-outline-secondary"
                             disabled={isSaving}
                             onClick={() =>
                                 void handleSubmit('save_and_add_another')

--- a/apps/panel/src/pages/settings/categories.tsx
+++ b/apps/panel/src/pages/settings/categories.tsx
@@ -103,7 +103,7 @@ function renderCategoryRows(
                         <span className="btn-group">
                             <button
                                 type="button"
-                                className="btn btn-xs btn-outline-secondary"
+                                className="btn btn-sm btn-outline-secondary"
                                 disabled={index === 0}
                                 onClick={() =>
                                     options.onMove(category.id, 'up')
@@ -113,7 +113,7 @@ function renderCategoryRows(
                             </button>
                             <button
                                 type="button"
-                                className="btn btn-xs btn-outline-secondary"
+                                className="btn btn-sm btn-outline-secondary"
                                 disabled={index === siblings - 1}
                                 onClick={() =>
                                     options.onMove(category.id, 'down')
@@ -126,19 +126,19 @@ function renderCategoryRows(
                         <span className="btn-group">
                             <Link
                                 href={`/settings/categories/${category.id}/edit`}
-                                className="btn btn-xs btn-outline-secondary"
+                                className="btn btn-sm btn-outline-secondary"
                             >
                                 edytuj
                             </Link>
                             <Link
                                 href={`/settings/categories/new?parent_id=${category.id}`}
-                                className="btn btn-xs btn-outline-secondary"
+                                className="btn btn-sm btn-outline-secondary"
                             >
                                 dodaj podkategorię
                             </Link>
                             <button
                                 type="button"
-                                className="btn btn-xs btn-outline-secondary"
+                                className="btn btn-sm btn-outline-secondary"
                                 disabled={options.deletingId === category.id}
                                 onClick={() => options.onDelete(category)}
                             >

--- a/apps/panel/src/pages/settings/customer_origins.tsx
+++ b/apps/panel/src/pages/settings/customer_origins.tsx
@@ -232,7 +232,7 @@ export default function SettingsCustomerOriginsPage() {
                                                                         </button>
                                                                         <button
                                                                             type="button"
-                                                                            className="btn btn-xs btn-outline-secondary"
+                                                                            className="btn btn-sm btn-outline-secondary"
                                                                             onClick={() =>
                                                                                 setEditingId(
                                                                                     null,
@@ -246,7 +246,7 @@ export default function SettingsCustomerOriginsPage() {
                                                                     <span className="btn-group">
                                                                         <button
                                                                             type="button"
-                                                                            className="btn btn-xs btn-outline-secondary"
+                                                                            className="btn btn-sm btn-outline-secondary"
                                                                             onClick={() => {
                                                                                 setEditingId(
                                                                                     origin.id,
@@ -260,7 +260,7 @@ export default function SettingsCustomerOriginsPage() {
                                                                         </button>
                                                                         <button
                                                                             type="button"
-                                                                            className="btn btn-xs btn-outline-secondary"
+                                                                            className="btn btn-sm btn-outline-secondary"
                                                                             onClick={() =>
                                                                                 deleteOrigin.mutate(
                                                                                     origin.id,

--- a/apps/panel/src/pages/settings/data_protection.tsx
+++ b/apps/panel/src/pages/settings/data_protection.tsx
@@ -153,7 +153,7 @@ export default function SettingsDataProtectionPage() {
                             >
                                 <div className="actions">
                                     <Link
-                                        className="button"
+                                        className="btn btn-outline-secondary"
                                         href="/settings/data-protection/logs"
                                     >
                                         Rejestr aktywności pracowników

--- a/apps/panel/src/pages/settings/employees/commissions/index.tsx
+++ b/apps/panel/src/pages/settings/employees/commissions/index.tsx
@@ -100,7 +100,7 @@ export default function SettingsEmployeeCommissionsPage() {
                                             <td style={{ textAlign: 'right' }}>
                                                 <Link
                                                     href={`/settings/employees/commissions/${emp.id}`}
-                                                    className="btn btn-xs btn-outline-secondary"
+                                                    className="btn btn-sm btn-outline-secondary"
                                                 >
                                                     edytuj
                                                 </Link>

--- a/apps/panel/src/pages/settings/extra_fields.tsx
+++ b/apps/panel/src/pages/settings/extra_fields.tsx
@@ -488,7 +488,7 @@ export default function SettingsExtraFieldsPage() {
                                                                 </button>
                                                                 <button
                                                                     type="button"
-                                                                    className="btn btn-xs btn-outline-secondary"
+                                                                    className="btn btn-sm btn-outline-secondary"
                                                                     onClick={() =>
                                                                         setEditForm(
                                                                             null,
@@ -530,7 +530,7 @@ export default function SettingsExtraFieldsPage() {
                                                             <span className="btn-group">
                                                                 <button
                                                                     type="button"
-                                                                    className="btn btn-xs btn-outline-secondary"
+                                                                    className="btn btn-sm btn-outline-secondary"
                                                                     onClick={() =>
                                                                         openEditForm(
                                                                             field,
@@ -541,7 +541,7 @@ export default function SettingsExtraFieldsPage() {
                                                                 </button>
                                                                 <button
                                                                     type="button"
-                                                                    className="btn btn-xs btn-outline-secondary"
+                                                                    className="btn btn-sm btn-outline-secondary"
                                                                     onClick={() =>
                                                                         deleteField.mutate(
                                                                             field.id,

--- a/apps/panel/src/pages/settings/timetable/employees/[id].tsx
+++ b/apps/panel/src/pages/settings/timetable/employees/[id].tsx
@@ -526,7 +526,7 @@ export default function SettingsTimetableEmployeeDetailPage() {
                                 <div className="date">
                                     <div className="button-group">
                                         <Link
-                                            className="button"
+                                            className="btn btn-outline-secondary"
                                             href={{
                                                 pathname:
                                                     '/settings/timetable/employees/[id]',
@@ -541,7 +541,7 @@ export default function SettingsTimetableEmployeeDetailPage() {
                                             <span className="fc-icon fc-icon-left-single-arrow" />
                                         </Link>
                                         <Link
-                                            className="button"
+                                            className="btn btn-outline-secondary"
                                             href={{
                                                 pathname:
                                                     '/settings/timetable/employees/[id]',
@@ -587,7 +587,7 @@ export default function SettingsTimetableEmployeeDetailPage() {
                                 <div className="buttons">
                                     <Link
                                         href={`/settings/employees/${id}`}
-                                        className="button"
+                                        className="btn btn-outline-secondary"
                                     >
                                         powrót do pracownika
                                     </Link>

--- a/apps/panel/src/pages/statistics/commissions.tsx
+++ b/apps/panel/src/pages/statistics/commissions.tsx
@@ -358,7 +358,7 @@ export default function CommissionsPage() {
                     </div>
                     <button
                         type="button"
-                        className="button"
+                        className="btn btn-outline-secondary"
                         onClick={downloadCommissionCsv}
                     >
                         <div

--- a/apps/panel/src/pages/stock-alerts/index.tsx
+++ b/apps/panel/src/pages/stock-alerts/index.tsx
@@ -14,7 +14,7 @@ export default function WarehouseLowStockPage() {
             heading="Magazyn / Niski stan magazynowy"
             activeTab="deliveries"
             actions={
-                <Link href="/deliveries/new" className="btn btn-primary btn-xs">
+                <Link href="/deliveries/new" className="btn btn-primary btn-sm">
                     dodaj dostawę
                 </Link>
             }

--- a/apps/panel/src/pages/use/history/[id].tsx
+++ b/apps/panel/src/pages/use/history/[id].tsx
@@ -23,7 +23,7 @@ export default function WarehouseUsageDetailsPage() {
             actions={
                 <Link
                     href="/use/history"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                 >
                     historia zużycia
                 </Link>

--- a/apps/panel/src/pages/use/new.tsx
+++ b/apps/panel/src/pages/use/new.tsx
@@ -97,13 +97,13 @@ export default function WarehouseUsageCreatePage() {
                 <>
                     <Link
                         href="/use/history"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         historia zużycia
                     </Link>
                     <Link
                         href="/use/planned"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         planowane zużycie
                     </Link>
@@ -161,7 +161,7 @@ export default function WarehouseUsageCreatePage() {
                                 <td>
                                     <button
                                         type="button"
-                                        className="btn btn-outline-secondary btn-xs"
+                                        className="btn btn-outline-secondary btn-sm"
                                         onClick={() => removeLine(index)}
                                     >
                                         usuń
@@ -176,7 +176,7 @@ export default function WarehouseUsageCreatePage() {
             <div className="warehouse-actions-row">
                 <button
                     type="button"
-                    className="btn btn-outline-secondary btn-xs"
+                    className="btn btn-outline-secondary btn-sm"
                     onClick={addLine}
                 >
                     dodaj kolejną pozycję
@@ -229,7 +229,7 @@ export default function WarehouseUsageCreatePage() {
             <div className="warehouse-actions-row">
                 <button
                     type="button"
-                    className="btn btn-primary btn-xs"
+                    className="btn btn-primary btn-sm"
                     onClick={() => void submit()}
                     disabled={createMutation.isPending}
                 >

--- a/apps/panel/src/pages/use/planned.tsx
+++ b/apps/panel/src/pages/use/planned.tsx
@@ -20,13 +20,13 @@ export default function WarehouseUsagePlannedPage() {
                 <>
                     <Link
                         href="/use/new?scope=planned"
-                        className="btn btn-primary btn-xs"
+                        className="btn btn-primary btn-sm"
                     >
                         dodaj planowane zużycie
                     </Link>
                     <Link
                         href="/use/history"
-                        className="btn btn-outline-secondary btn-xs"
+                        className="btn btn-outline-secondary btn-sm"
                     >
                         historia zużycia
                     </Link>

--- a/apps/panel/src/server/calendarViewsRuntime.ts
+++ b/apps/panel/src/server/calendarViewsRuntime.ts
@@ -180,8 +180,8 @@ export function renderCalendarViewsIndex(
 <div class='calendar-view-drafts__meta'>${escapeHtml(names)}</div>
 </div>
 <div class='calendar-view-drafts__actions'>
-<a class='btn btn-link btn-xs' data-calendar-view-form-link title='Edytuj widok' href='/salonblackandwhite/calendar/views/${view.id}/edit'>edytuj</a>
-<a class='btn btn-link btn-xs text-danger' data-destroy-calendar-view data-confirmation-message='Czy na pewno chcesz usunąć ten widok?' href='/api/runtime/calendar-views/${view.id}'>usuń</a>
+<a class='btn btn-link btn-sm' data-calendar-view-form-link title='Edytuj widok' href='/salonblackandwhite/calendar/views/${view.id}/edit'>edytuj</a>
+<a class='btn btn-link btn-sm text-danger' data-destroy-calendar-view data-confirmation-message='Czy na pewno chcesz usunąć ten widok?' href='/api/runtime/calendar-views/${view.id}'>usuń</a>
 </div>
 </div>
 </div>`;
@@ -221,7 +221,7 @@ export function renderCalendarViewForm(options: {
 ${errorHtml}
 <ul class="calendar-view-form-list">
 <li>
-<label class="control-label" for="calendar_view_name">Nazwa</label>
+<label class="form-label" for="calendar_view_name">Nazwa</label>
 <input id="calendar_view_name" class="form-control" name="name" value="${escapeHtml(options.value?.name ?? '')}" autofocus />
 </li>
 </ul>

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -74,23 +74,6 @@ body.e2e-body {
     color: #7d8790;
 }
 
-.btn-default {
-    background: #fff;
-    border: 1px solid var(--salon-border);
-    color: #4d565e;
-}
-
-.btn-default:hover {
-    background: #f7f8f9;
-}
-
-.btn-xs {
-    padding: 4px 9px;
-    font-size: 12px;
-    line-height: 1.2;
-    border-radius: 2px;
-}
-
 .btn-group {
     display: inline-flex;
     gap: 6px;
@@ -459,16 +442,6 @@ body.e2e-body {
     margin-top: 16px;
 }
 
-.form-group {
-    margin: 0 0 12px;
-}
-
-.control-label {
-    display: block;
-    font-size: 11px;
-    color: #6b7680;
-    margin: 0 0 6px;
-}
 
 .form-control {
     width: 100%;
@@ -3877,41 +3850,6 @@ body.e2e-customers #customers_main .breadcrumb .glyphicon {
     color: #313140;
 }
 
-/* --- SalonBW buttons --- */
-.button {
-    display: inline-block;
-    padding: 4px 10px;
-    font-size: 13px;
-    line-height: 18.2px;
-    color: #56aef0;
-    background: transparent;
-    border: 1px solid transparent;
-    cursor: pointer;
-    text-decoration: none;
-    vertical-align: middle;
-    box-sizing: border-box;
-}
-.button.button-blue {
-    color: #fff;
-    background: #56aef0;
-    border-color: #56aef0;
-}
-.button:hover {
-    text-decoration: none;
-    opacity: 0.9;
-}
-/* Edit-style button (outlined) used in detail toolbars */
-.buttons-row .button {
-    color: #56aef0;
-    background: #fff;
-    border: 1px solid #56aef0;
-    padding: 4px 10px;
-}
-.buttons-row .button.button-blue {
-    color: #fff;
-    background: #56aef0;
-}
-
 /* --- table-bordered (list tables) --- */
 .table-bordered {
     border-collapse: collapse;
@@ -4187,10 +4125,6 @@ h2.column_row small {
     border-right: 4px solid transparent;
     border-left: 4px solid transparent;
 }
-.button-small {
-    padding: 2px 8px;
-    font-size: 12px;
-}
 .box-rows .link-more {
     display: block;
     margin-top: 8px;
@@ -4404,15 +4338,7 @@ body.settings-dashboard-landing .main-content > .inner {
     margin-bottom: 14px;
 }
 
-.settings-detail-layout .simple_form.edit_branch .control-label {
-    color: #686868;
-    flex: 0 0 118px;
-    font-size: 13px;
-    font-weight: 400;
-    line-height: 18px;
-    margin: 0;
-    padding-top: 7px;
-}
+
 
 .settings-detail-layout .simple_form.edit_branch .controls {
     align-items: flex-start;
@@ -4631,15 +4557,7 @@ body.settings-dashboard-landing .main-content > .inner {
     margin-bottom: 14px;
 }
 
-.settings-calendar-page .simple_form.edit_setting .control-label {
-    color: #686868;
-    flex: 0 0 180px;
-    font-size: 13px;
-    font-weight: 400;
-    line-height: 18px;
-    margin: 0;
-    padding-top: 7px;
-}
+
 
 .settings-calendar-page .simple_form.edit_setting .controls {
     align-items: flex-start;
@@ -4890,16 +4808,7 @@ body.settings-dashboard-landing .main-content > .inner {
     margin-bottom: 14px;
 }
 
-.settings-customer-group-form-page
-    .simple_form.new_physical_customers_group
-    .control-label {
-    color: #686868;
-    flex: 0 0 118px;
-    font-size: 13px;
-    line-height: 18px;
-    margin: 0;
-    padding-top: 7px;
-}
+
 
 .settings-customer-group-form-page
     .simple_form.new_physical_customers_group
@@ -5630,12 +5539,6 @@ body.settings-dashboard-landing .main-content > .inner {
         display: block;
     }
 
-    .settings-detail-layout .simple_form.edit_branch .control-label {
-        display: block;
-        margin-bottom: 6px;
-        padding-top: 0;
-    }
-
     .settings-detail-layout .simple_form.edit_branch .controls {
         display: block;
     }
@@ -5647,12 +5550,6 @@ body.settings-dashboard-landing .main-content > .inner {
 
     .settings-calendar-page .simple_form.edit_setting li.control-group {
         display: block;
-    }
-
-    .settings-calendar-page .simple_form.edit_setting .control-label {
-        display: block;
-        margin-bottom: 6px;
-        padding-top: 0;
     }
 
     .settings-calendar-page .simple_form.edit_setting .controls {
@@ -5699,13 +5596,6 @@ body.settings-dashboard-landing .main-content > .inner {
         display: block;
     }
 
-    .settings-customer-group-form-page
-        .simple_form.new_physical_customers_group
-        .control-label {
-        display: block;
-        margin-bottom: 6px;
-        padding-top: 0;
-    }
 }
 
 /* Body-scoped (1,3,1) overrides the body#extension .main-content .inner (1,2,1) rule.
@@ -6341,19 +6231,6 @@ body.e2e-extension .main-content .inner.extension_info {
 
 .data-protection-limits__input {
     width: 90px;
-}
-
-.button-link {
-    background: none;
-    border: 0;
-    color: #2575ed;
-    cursor: pointer;
-    padding: 0;
-}
-
-.button-link[disabled] {
-    color: #8ca7d9;
-    cursor: default;
 }
 
 /* ========================================
@@ -7736,15 +7613,6 @@ body.salonbw-sidebar-open .salonbw-nav-overlay {
     color: #28a745;
 }
 
-/* Secondary button (Versum button-default = outlined .button) */
-.button-default {
-    color: #6c757d;
-    background: transparent;
-    border: 1px solid #dee2e6;
-}
-.button.button-default:hover {
-    background: #f8f9fa;
-}
 
 /* Sprite icon placeholders (fallback when sprite sheet not available) */
 .icon.sprite-pencil::before {

--- a/apps/panel/src/styles/salon-theme.css
+++ b/apps/panel/src/styles/salon-theme.css
@@ -36,41 +36,6 @@ body {
     cursor: not-allowed;
 }
 
-.button-blue {
-    background: #56aef0;
-    color: #fff;
-    border: 1px solid #56aef0;
-    display: inline-block;
-    padding: 6px 12px;
-    cursor: pointer;
-    font-size: 13px;
-    line-height: 1.42857;
-    text-decoration: none;
-}
-.button-blue:hover {
-    filter: brightness(0.95);
-    color: #fff;
-    text-decoration: none;
-}
-
-.button {
-    display: inline-block;
-    padding: 6px 12px;
-    cursor: pointer;
-    font-size: 13px;
-    text-decoration: none;
-}
-.button-link {
-    background: transparent;
-    color: var(--salon-accent);
-    border: none;
-    padding: 6px 12px;
-    cursor: pointer;
-}
-.button-link:hover {
-    text-decoration: underline;
-}
-
 /* --- Sections (PanelSection wrapper) --- */
 .salon-section {
     padding: 15px 20px;


### PR DESCRIPTION
## Summary

Finishes the Bootstrap 3 → Bootstrap 5 class migration across the entire panel codebase.

### Components cleanup (36 files)
- `btn-default` → `btn-outline-secondary`
- `btn-xs` → `btn-sm`
- `btn-block` → `d-block`
- `button-blue` → `btn btn-primary`
- `button-link` → `btn btn-link`
- `control-label` → `form-label`
- `form-group` → `mb-3` (`form-group mb-0` → `mb-0`)
- `input-group-addon` → `input-group-text`
- bare `className="button"` → `btn btn-outline-secondary`

### Remaining pages (23 files)
Batch of pages missed in PR #1344: `btn-xs` → `btn-sm` in manufacturers, sales, deliveries, orders, customers, inventory, products, use/planned, stock-alerts, settings.

### Server template (`calendarViewsRuntime.ts`)
Fixed `btn-xs` and `control-label` in HTML template strings.

### CSS shim removal (170 lines deleted)
`salon-shell.css` and `salon-theme.css` — removed all dead shim definitions:
- `.btn-default`, `.btn-xs`, `.form-group`, `.control-label` (all occurrences incl. media queries)
- `.button`, `.button-blue`, `.button-link`, `.button-small`, `.button-default`
- All `.buttons-row .button*` variants

### Services price list (`uslugi.csv`)
Added real salon price list CSV (23 women's + 14 men's services with variants).
Run import in production: `IMPORT_SERVICES_CSV=../../../uslugi.csv pnpm import:services`

## Test plan
- [ ] Lint / typecheck passes
- [ ] All buttons render correctly (primary, secondary, link)
- [ ] Form labels and spacing intact
- [ ] No visual regressions in settings, customers, services, warehouse pages

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_