### PR TITLE
fix: final salonbw-* undefined class cleanup across pages and components

### DIFF
--- a/apps/panel/src/components/calendar/ReceptionView.tsx
+++ b/apps/panel/src/components/calendar/ReceptionView.tsx
@@ -81,11 +81,11 @@ const STATUS_CONFIG: Record<AppointmentStatus | string, StatusConfig> = {
 };
 
 const ACTION_LABELS: Record<string, { label: string; className: string }> = {
-    confirm: { label: 'Potwierdź', className: 'salonbw-btn--success' },
-    start: { label: 'Rozpocznij', className: 'salonbw-btn--primary' },
-    finalize: { label: 'Finalizuj', className: 'salonbw-btn--success' },
-    cancel: { label: 'Anuluj', className: 'salonbw-btn--danger' },
-    no_show: { label: 'Nieobecny', className: 'salonbw-btn--warning' },
+    confirm: { label: 'Potwierdź', className: 'btn-success' },
+    start: { label: 'Rozpocznij', className: 'btn-primary' },
+    finalize: { label: 'Finalizuj', className: 'btn-success' },
+    cancel: { label: 'Anuluj', className: 'btn-danger' },
+    no_show: { label: 'Nieobecny', className: 'btn-warning' },
 };
 
 export default function ReceptionView({
@@ -478,7 +478,7 @@ export default function ReceptionView({
                                         <div className="salonbw-reception-actions">
                                             <button
                                                 type="button"
-                                                className="salonbw-btn salonbw-btn--sm salonbw-btn--secondary"
+                                                className="btn btn-sm btn-outline-secondary"
                                                 onClick={() => {
                                                     const customerAlertSeverity =
                                                         appointment.client?.id
@@ -528,7 +528,7 @@ export default function ReceptionView({
                                                               <button
                                                                   key={action}
                                                                   type="button"
-                                                                  className={`salonbw-btn salonbw-btn--sm ${actionConfig.className}`}
+                                                                  className={`btn btn-sm ${actionConfig.className}`}
                                                                   onClick={() =>
                                                                       void handleAction(
                                                                           appointment,

--- a/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
+++ b/apps/panel/src/components/calendar/StaffAppointmentCalendarView.tsx
@@ -73,21 +73,21 @@ const ACTION_CONFIG: Record<
 > = {
     start: {
         label: 'Rozpocznij',
-        className: 'salonbw-btn--primary',
+        className: 'btn-primary',
         nextStatus: 'in_progress',
     },
     finalize: {
         label: 'Finalizuj',
-        className: 'salonbw-btn--success',
+        className: 'btn-success',
     },
     no_show: {
         label: 'No-show',
-        className: 'salonbw-btn--warning',
+        className: 'btn-warning',
         nextStatus: 'no_show',
     },
     cancel: {
         label: 'Anuluj',
-        className: 'salonbw-btn--danger',
+        className: 'btn-danger',
     },
 };
 
@@ -288,7 +288,7 @@ export default function StaffAppointmentCalendarView({
                                         <button
                                             key={action}
                                             type="button"
-                                            className={`salonbw-btn salonbw-btn--sm ${config.className}`}
+                                            className={`btn btn-sm ${config.className}`}
                                             onClick={() =>
                                                 handleAction(
                                                     appointment,
@@ -305,7 +305,7 @@ export default function StaffAppointmentCalendarView({
                                 })}
                                 <button
                                     type="button"
-                                    className="salonbw-btn salonbw-btn--sm salonbw-btn--secondary"
+                                    className="btn btn-sm btn-outline-secondary"
                                     onClick={() =>
                                         onOpenAppointment?.(appointment.id)
                                     }

--- a/apps/panel/src/components/customers/CustomerSidebar.tsx
+++ b/apps/panel/src/components/customers/CustomerSidebar.tsx
@@ -159,7 +159,7 @@ export default function CustomerSidebar({
                             <div className="mb-0">
                                 <label
                                     htmlFor="filter-gender"
-                                    className="form-label salonbw-label-xs"
+                                    className="form-label form-label-xs"
                                 >
                                     Płeć
                                 </label>
@@ -187,7 +187,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-age-min"
-                                        className="form-label salonbw-label-xs"
+                                        className="form-label form-label-xs"
                                     >
                                         Wiek od
                                     </label>
@@ -238,7 +238,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-spent-min"
-                                        className="form-label salonbw-label-xs"
+                                        className="form-label form-label-xs"
                                     >
                                         Wydane od
                                     </label>
@@ -262,7 +262,7 @@ export default function CustomerSidebar({
                                 <div className="col-6">
                                     <label
                                         htmlFor="filter-spent-max"
-                                        className="form-label salonbw-label-xs"
+                                        className="form-label form-label-xs"
                                     >
                                         do
                                     </label>

--- a/apps/panel/src/components/dashboard/AdminDashboard.tsx
+++ b/apps/panel/src/components/dashboard/AdminDashboard.tsx
@@ -157,10 +157,7 @@ export default function AdminDashboard() {
         <div className="salonbw-dashboard">
             <div className="salonbw-dashboard__header">
                 <h1 className="salonbw-dashboard__title">Pulpit</h1>
-                <Link
-                    href="/customers/new"
-                    className="salonbw-btn salonbw-btn--primary"
-                >
+                <Link href="/customers/new" className="btn btn-primary">
                     <i className="salonbw-icon salonbw-icon--plus"></i>
                     Dodaj klienta
                 </Link>
@@ -275,7 +272,7 @@ export default function AdminDashboard() {
                 <div className="salonbw-dashboard__section">
                     <div className="salonbw-dashboard__section-header">
                         <h2>najbliższe wizyty</h2>
-                        <Link href="/calendar" className="salonbw-link">
+                        <Link href="/calendar" className="btn btn-link">
                             kalendarz
                         </Link>
                     </div>
@@ -350,7 +347,7 @@ export default function AdminDashboard() {
                 <div className="salonbw-dashboard__section">
                     <div className="salonbw-dashboard__section-header">
                         <h2>podsumowanie miesiąca</h2>
-                        <Link href="/statistics" className="salonbw-link">
+                        <Link href="/statistics" className="btn btn-link">
                             szczegóły
                         </Link>
                     </div>

--- a/apps/panel/src/components/dashboard/ClientDashboard.tsx
+++ b/apps/panel/src/components/dashboard/ClientDashboard.tsx
@@ -129,10 +129,7 @@ export default function ClientDashboard() {
         <div className="salonbw-dashboard">
             <div className="salonbw-dashboard__header">
                 <h1 className="salonbw-dashboard__title">Mój panel</h1>
-                <Link
-                    href="/booking"
-                    className="salonbw-btn salonbw-btn--primary"
-                >
+                <Link href="/booking" className="btn btn-primary">
                     Zarezerwuj wizytę
                 </Link>
             </div>

--- a/apps/panel/src/pages/appointments.tsx
+++ b/apps/panel/src/pages/appointments.tsx
@@ -190,7 +190,7 @@ export default function AppointmentsPage() {
                 />
 
                 <div className="column_row mb-3">
-                    <div className="salonbw-filters d-flex flex-wrap gap-2 align-items-end">
+                    <div className="d-flex flex-wrap gap-2 align-items-end">
                         <div>
                             <label className="form-label mb-1 small">Od</label>
                             <input

--- a/apps/panel/src/pages/customers/[id].tsx
+++ b/apps/panel/src/pages/customers/[id].tsx
@@ -160,7 +160,7 @@ export default function CustomerDetailPage() {
                                 </p>
                                 <Link
                                     href={'/customers' as Route}
-                                    className="salonbw-btn salonbw-btn--default"
+                                    className="btn btn-outline-secondary"
                                 >
                                     Wróć do listy klientów
                                 </Link>
@@ -186,7 +186,7 @@ export default function CustomerDetailPage() {
                                 <p>Nieprawidłowy identyfikator klienta</p>
                                 <Link
                                     href={'/customers' as Route}
-                                    className="salonbw-btn salonbw-btn--default"
+                                    className="btn btn-outline-secondary"
                                 >
                                     Wróć do listy klientów
                                 </Link>
@@ -196,7 +196,7 @@ export default function CustomerDetailPage() {
                                 <p>Nie udało się załadować danych klienta</p>
                                 <Link
                                     href={'/customers' as Route}
-                                    className="salonbw-btn salonbw-btn--default"
+                                    className="btn btn-outline-secondary"
                                 >
                                     Wróć do listy klientów
                                 </Link>
@@ -334,7 +334,7 @@ export default function CustomerDetailPage() {
                                 <p>Nie znaleziono klienta</p>
                                 <Link
                                     href={'/customers' as Route}
-                                    className="salonbw-btn salonbw-btn--default"
+                                    className="btn btn-outline-secondary"
                                 >
                                     Wróć do listy klientów
                                 </Link>

--- a/apps/panel/src/pages/employees/index.tsx
+++ b/apps/panel/src/pages/employees/index.tsx
@@ -92,7 +92,7 @@ export default function EmployeesPage() {
                     <div className="salonbw-page__toolbar">
                         <button
                             type="button"
-                            className="salonbw-btn salonbw-btn--primary"
+                            className="btn btn-primary"
                             onClick={() => {
                                 setEditing(null);
                                 setOpenForm(true);
@@ -110,7 +110,7 @@ export default function EmployeesPage() {
                             renderActions={(r) => (
                                 <span className="space-x-2">
                                     <button
-                                        className="salonbw-btn salonbw-btn--sm salonbw-btn--light"
+                                        className="btn btn-sm btn-outline-secondary"
                                         onClick={() => {
                                             setEditing(r);
                                             setOpenForm(true);
@@ -119,7 +119,7 @@ export default function EmployeesPage() {
                                         Edytuj
                                     </button>
                                     <button
-                                        className="salonbw-btn salonbw-btn--sm salonbw-btn--danger"
+                                        className="btn btn-sm btn-danger"
                                         onClick={() => void handleDelete(r)}
                                     >
                                         Usuń

--- a/apps/panel/src/pages/extension/index.tsx
+++ b/apps/panel/src/pages/extension/index.tsx
@@ -105,7 +105,7 @@ export default function ExtensionPage() {
                         iconClass="sprite-breadcrumbs_extensions"
                         items={[{ label: 'Dodatki' }]}
                     />
-                    <div className="extensions_boxes versum-extension-grid salonbw-extension-grid">
+                    <div className="extensions_boxes versum-extension-grid">
                         {rows.map((row, rowIndex) => (
                             <div
                                 key={`row-${rowIndex}`}

--- a/apps/panel/src/pages/invoices/index.tsx
+++ b/apps/panel/src/pages/invoices/index.tsx
@@ -44,7 +44,7 @@ export default function InvoicesPage() {
                                             <td>{inv.number}</td>
                                             <td>
                                                 <a
-                                                    className="salonbw-link"
+                                                    className="btn btn-link"
                                                     href={inv.pdfUrl}
                                                     target="_blank"
                                                     rel="noopener noreferrer"

--- a/apps/panel/src/pages/reviews/index.tsx
+++ b/apps/panel/src/pages/reviews/index.tsx
@@ -133,11 +133,11 @@ export default function ReviewsPage() {
                     />
                     <div className="salonbw-page__toolbar">
                         {isAdmin && (
-                            <label className="salonbw-label">
+                            <label className="form-label">
                                 Employee
                                 <input
                                     type="number"
-                                    className="salonbw-input salonbw-input--sm"
+                                    className="form-control form-control-sm"
                                     value={employeeId}
                                     onChange={(e) => {
                                         const n = Number(e.target.value);
@@ -149,7 +149,7 @@ export default function ReviewsPage() {
                         )}
                         <button
                             type="button"
-                            className="salonbw-btn salonbw-btn--primary"
+                            className="btn btn-primary"
                             onClick={() => {
                                 setEditing(null);
                                 setOpenForm(true);
@@ -165,7 +165,7 @@ export default function ReviewsPage() {
                         renderActions={(r) => (
                             <span className="space-x-2">
                                 <button
-                                    className="salonbw-btn salonbw-btn--sm salonbw-btn--light"
+                                    className="btn btn-sm btn-outline-secondary"
                                     onClick={() => {
                                         setEditing(r);
                                         setOpenForm(true);
@@ -174,7 +174,7 @@ export default function ReviewsPage() {
                                     Edytuj
                                 </button>
                                 <button
-                                    className="salonbw-btn salonbw-btn--sm salonbw-btn--danger"
+                                    className="btn btn-sm btn-danger"
                                     onClick={() => void handleDelete(r)}
                                 >
                                     Usuń

--- a/apps/panel/src/pages/statistics/customers.tsx
+++ b/apps/panel/src/pages/statistics/customers.tsx
@@ -58,7 +58,7 @@ export default function ClientsStatisticsPage() {
                     </div>
                     <button
                         type="button"
-                        className="btn btn-outline-secondary salonbw-toolbar-btn"
+                        className="btn btn-outline-secondary"
                         onClick={() => window.print()}
                     >
                         🖨️
@@ -152,7 +152,7 @@ export default function ClientsStatisticsPage() {
                                                             <td>
                                                                 <Link
                                                                     href={`/customers/${client.clientId}`}
-                                                                    className="salonbw-link"
+                                                                    className="btn btn-link"
                                                                 >
                                                                     {
                                                                         client.clientName

--- a/apps/panel/src/pages/statistics/employees.tsx
+++ b/apps/panel/src/pages/statistics/employees.tsx
@@ -174,7 +174,7 @@ export default function EmployeeActivityPage() {
                                                 <td>
                                                     <Link
                                                         href={`${EMPLOYEE_DETAILS_BASE_PATH}/${employee.employeeId}`}
-                                                        className="salonbw-link"
+                                                        className="btn btn-link"
                                                     >
                                                         {employee.employeeName}
                                                     </Link>

--- a/apps/panel/src/pages/statistics/register.tsx
+++ b/apps/panel/src/pages/statistics/register.tsx
@@ -66,10 +66,10 @@ export default function CashRegisterPage() {
                 />
 
                 <div className="salonbw-page__toolbar">
-                    <div className="salonbw-actions">
+                    <div className="d-flex gap-2 align-items-center">
                         <button
                             type="button"
-                            className="salonbw-toolbar-btn btn btn-outline-secondary"
+                            className="btn btn-outline-secondary"
                             onClick={() => navigateDate('prev')}
                         >
                             ◀
@@ -77,13 +77,13 @@ export default function CashRegisterPage() {
                         <input
                             type="date"
                             aria-label="Wybierz datę"
-                            className="form-control salonbw-toolbar-search"
+                            className="form-control"
                             value={selectedDate}
                             onChange={(e) => setSelectedDate(e.target.value)}
                         />
                         <button
                             type="button"
-                            className="salonbw-toolbar-btn btn btn-outline-secondary"
+                            className="btn btn-outline-secondary"
                             onClick={() => navigateDate('next')}
                         >
                             ▶

--- a/apps/panel/src/pages/statistics/services.tsx
+++ b/apps/panel/src/pages/statistics/services.tsx
@@ -81,7 +81,7 @@ export default function ServicesStatisticsPage() {
                     </div>
                     <button
                         type="button"
-                        className="btn btn-outline-secondary salonbw-toolbar-btn"
+                        className="btn btn-outline-secondary"
                         onClick={() => window.print()}
                     >
                         🖨️
@@ -143,7 +143,7 @@ export default function ServicesStatisticsPage() {
                                                 <td>
                                                     <Link
                                                         href={`/services/${service.serviceId}`}
-                                                        className="salonbw-link"
+                                                        className="btn btn-link"
                                                     >
                                                         {service.serviceName}
                                                     </Link>

--- a/apps/panel/src/pages/statistics/tips.tsx
+++ b/apps/panel/src/pages/statistics/tips.tsx
@@ -73,7 +73,7 @@ export default function TipsPage() {
                     </div>
                     <button
                         type="button"
-                        className="btn btn-outline-secondary salonbw-toolbar-btn"
+                        className="btn btn-outline-secondary"
                         onClick={() => window.print()}
                     >
                         🖨️
@@ -153,7 +153,7 @@ export default function TipsPage() {
                                                 <td>
                                                     <Link
                                                         href={`${EMPLOYEE_DETAILS_BASE_PATH}/${employee.employeeId}`}
-                                                        className="salonbw-link"
+                                                        className="btn btn-link"
                                                     >
                                                         {employee.employeeName}
                                                     </Link>

--- a/apps/panel/src/pages/statistics/warehouse/value.tsx
+++ b/apps/panel/src/pages/statistics/warehouse/value.tsx
@@ -105,7 +105,7 @@ export default function WarehouseValuePage() {
                             onClick={() =>
                                 setRefreshToken((value) => value + 1)
                             }
-                            className="salonbw-btn salonbw-btn--default"
+                            className="btn btn-outline-secondary"
                             disabled={isLoading}
                         >
                             {isLoading ? 'Ładowanie...' : 'Odśwież'}


### PR DESCRIPTION
## Summary

- Replace all remaining undefined `salonbw-*` utility classes across 12 pages and 5 components with Bootstrap 5 equivalents
- `salonbw-btn + variants` → `btn btn-{primary,outline-secondary,danger,sm}`
- `salonbw-input` → `form-control`, `salonbw-label` → `form-label`, `salonbw-link` → `btn btn-link`, `salonbw-actions` → `d-flex gap-2 align-items-center`
- Remove noisy salonbw-toolbar-btn/search/filters/extension-grid prefixes (redundant alongside BS5 classes)
- Fix `ReceptionView` + `StaffAppointmentCalendarView`: action config className values changed from `salonbw-btn--{color}` to `btn-{color}`; remove conflicting `btn-outline-secondary` from dynamic compound class

## Test plan

- [ ] `/appointments` — filter buttons and action buttons render correctly
- [ ] `/customers/:id` — sidebar labels, action buttons
- [ ] `/employees` — button styles
- [ ] `/reviews` — action buttons
- [ ] `/statistics/*` — filter inputs and buttons
- [ ] Calendar reception view — action buttons per appointment row use correct colors (primary/success/danger/warning)
- [ ] Staff calendar view — quick action buttons use correct BS5 colors

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_