### PR TITLE
Harden deploy/env handling and fix landing test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,9 @@ jobs:
       - name: Typecheck and build backend
         run: pnpm turbo run typecheck build --filter=salonbw-backend --cache-dir=.turbo
 
+      - name: Test backend
+        run: pnpm --filter salonbw-backend test
+
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -360,7 +360,6 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ steps.api.outputs.api_url }}
           NEXT_PUBLIC_PANEL_URL: https://panel.salon-bw.pl
           API_PROXY_URL: ${{ steps.proxy.outputs.proxy_url }}
-          NEXT_PUBLIC_LOG_TOKEN: ${{ secrets.NEXT_PUBLIC_LOG_TOKEN }}
 
       - name: Read BUILD_ID (frontend)
         if: ${{ steps.dest.outputs.deploy_landing == 'true' || steps.dest.outputs.deploy_panel == 'true' }}
@@ -465,7 +464,6 @@ jobs:
           API_PROXY_URL: ${{ steps.proxy.outputs.proxy_url }}
           NEXT_PANEL_HTML_NOSTORE: "true"
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          NEXT_PUBLIC_LOG_TOKEN: ${{ secrets.NEXT_PUBLIC_LOG_TOKEN }}
 
       - name: Ensure remote directories exist (landing)
         if: ${{ steps.dest.outputs.deploy_landing == 'true' }}
@@ -1063,18 +1061,48 @@ jobs:
           rsync -az --timeout=300 -e "ssh -i ~/.ssh/mydevil -o IdentitiesOnly=yes -o StrictHostKeyChecking=no" .env.production \
             vetternkraft@s0.mydevil.net:${{ steps.dest.outputs.remote_path_api }}/.env.generated
 
-          # Merge server-side to avoid moving SMTP credentials through CI/CD.
+          # Merge server-side to preserve all existing runtime keys in .env.
           ssh -i ~/.ssh/mydevil -o IdentitiesOnly=yes -o StrictHostKeyChecking=no vetternkraft@s0.mydevil.net <<'REMOTE_CMDS'
           set -euo pipefail
           REMOTE_PATH='${{ steps.dest.outputs.remote_path_api }}'
           cd "$REMOTE_PATH"
           touch .env
-          # Preserve existing SMTP_* lines (if any) from the server-managed .env.
-          SMTP_LINES="$(grep -E '^SMTP_' .env || true)"
-          cat .env.generated > .env.new
-          if [ -n "$SMTP_LINES" ]; then
-            printf "\n%s\n" "$SMTP_LINES" >> .env.new
-          fi
+          # Replace only keys present in .env.generated; keep all other existing keys.
+          awk -F= '
+            function trim(s) {
+              sub(/^[[:space:]]+/, "", s);
+              sub(/[[:space:]]+$/, "", s);
+              return s;
+            }
+            NR == FNR {
+              if ($0 ~ /^[[:space:]]*#/ || $0 !~ /=/) next;
+              key = trim($1);
+              generated[key] = $0;
+              order[++generatedCount] = key;
+              next;
+            }
+            {
+              if ($0 ~ /^[[:space:]]*#/ || $0 !~ /=/) {
+                print $0;
+                next;
+              }
+              key = trim($1);
+              if (key in generated) {
+                print generated[key];
+                seen[key] = 1;
+              } else {
+                print $0;
+              }
+            }
+            END {
+              for (i = 1; i <= generatedCount; i++) {
+                key = order[i];
+                if (!(key in seen)) {
+                  print generated[key];
+                }
+              }
+            }
+          ' .env.generated .env > .env.new
           mv .env.new .env
           rm -f .env.generated
           chmod 600 .env

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 env:
   PNPM_VERSION: 10.14.0

--- a/Agent.md
+++ b/Agent.md
@@ -87,8 +87,9 @@ ssh vetternkraft@s0.mydevil.net "touch /usr/home/vetternkraft/domains/<domain>/p
   - `FRONTEND_URL=https://dev.salon-bw.pl,https://panel.salon-bw.pl`
   - `JWT_SECRET` / `JWT_REFRESH_SECRET`
   - `CLIENT_LOG_TOKEN` — shared secret for `/logs/client` ingest; the
-    panel posts client-side error logs through the same-origin proxy at
-    `/api/logs/client` and the proxy injects this header server-side.
+    landing and panel post client-side error logs through same-origin
+    proxies at `/api/logs/client`, and each proxy injects this header
+    server-side.
     Must never live in any `NEXT_PUBLIC_*` env var.
 - Never commit secrets. See `docs/ENV.md`.
 

--- a/WARP.md
+++ b/WARP.md
@@ -215,7 +215,7 @@ Critical environment variables (see `docs/ENV.md` for comprehensive list):
 ### Frontend (`.env.local` in `apps/landing` and `apps/panel`)
 - `NEXT_PUBLIC_API_URL`: Backend URL (e.g., `http://localhost:3001` or `https://api.salon-bw.pl`)
 - `NEXT_PUBLIC_SENTRY_DSN`: Sentry error tracking
-- `NEXT_PUBLIC_LOG_TOKEN`: Must match backend `CLIENT_LOG_TOKEN` for log forwarding
+- `CLIENT_LOG_TOKEN`: Server-only token injected by frontend `/api/logs/client` proxy routes
 - `NEXT_PUBLIC_ENABLE_DEBUG`: Enables debug mode with `X-Request-Id` header correlation
 - `INSTAGRAM_ACCESS_TOKEN`: Server-side Instagram token for gallery page
 
@@ -290,7 +290,7 @@ Husky enforces lint and typecheck before commits. Lint-staged auto-fixes on stag
 
 ### Logging
 - **Backend**: Pino logger with Loki transport (configured via `LOKI_URL` and `LOKI_BASIC_AUTH`)
-- **Frontend**: Client errors forwarded to backend `/logs/client` endpoint (requires `NEXT_PUBLIC_LOG_TOKEN`)
+- **Frontend**: Client errors forwarded through same-origin `/api/logs/client` proxies (server injects `CLIENT_LOG_TOKEN`)
 - **Correlation**: `X-Request-Id` header links frontend requests to backend logs and Sentry traces
 
 ### Metrics

--- a/apps/landing/.env.example
+++ b/apps/landing/.env.example
@@ -20,7 +20,10 @@ NEXT_PUBLIC_CONTACT_RECIPIENT=kontakt@salon-bw.pl
 # Feature Flags (optional)
 # NEXT_PUBLIC_ENABLE_ANALYTICS=false
 # NEXT_PUBLIC_ENABLE_DEBUG=false
-# NEXT_PUBLIC_LOG_TOKEN=
+# NEXT_PUBLIC_ENABLE_CLIENT_LOGS=true
+
+# Server-side client log proxy token (never NEXT_PUBLIC_*)
+# CLIENT_LOG_TOKEN=
 
 # Instagram Integration (optional)
 # INSTAGRAM_ACCESS_TOKEN=  # Instagram Basic Display API long-lived token for gallery

--- a/apps/landing/.env.local.example
+++ b/apps/landing/.env.local.example
@@ -8,7 +8,9 @@ NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
 NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=1
 NEXT_PUBLIC_ENABLE_DEBUG=false
 NEXT_PUBLIC_ENABLE_CLIENT_LOGS=true
-NEXT_PUBLIC_LOG_TOKEN=
+
+# Server-side client log proxy token (optional for local dev)
+# CLIENT_LOG_TOKEN=
 
 # Image Optimization
 # Set to 'true' to disable Next.js image optimization (useful for shared hosting without Node.js image optimizer support)

--- a/apps/landing/src/__tests__/authStorage.test.tsx
+++ b/apps/landing/src/__tests__/authStorage.test.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 jest.mock('@/api/auth', () => ({
     login: jest.fn().mockResolvedValue({ accessToken: 'a', refreshToken: 'r' }),
     register: jest.fn(),
+    logout: jest.fn().mockResolvedValue(undefined),
     refreshToken: jest.fn(),
     REFRESH_TOKEN_KEY: 'refreshToken',
     setLogoutCallback: jest.fn(),
@@ -40,7 +41,8 @@ describe('AuthContext localStorage', () => {
         });
         await waitFor(() => expect(result.current.user).toEqual(profile));
         expect(localStorage.getItem('jwtToken')).toBe('a');
-        expect(localStorage.getItem('refreshToken')).toBe('r');
+        // Refresh token is intentionally httpOnly-cookie only (not localStorage).
+        expect(localStorage.getItem('refreshToken')).toBeNull();
 
         await act(async () => {
             await result.current.logout();

--- a/apps/landing/src/__tests__/contactForm.test.tsx
+++ b/apps/landing/src/__tests__/contactForm.test.tsx
@@ -9,7 +9,7 @@ describe('ContactForm', () => {
             ok: true,
             json: () => ({}),
         }) as jest.MockedFunction<typeof fetch>;
-        process.env.NEXT_PUBLIC_CONTACT_RECIPIENT = 'kontakt@salon-bw.pl';
+        process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
     });
 
     it('posts form data', async () => {
@@ -30,23 +30,14 @@ describe('ContactForm', () => {
         fireEvent.click(screen.getByRole('button', { name: /Wyślij wiadomość/i }));
         await waitFor(() => expect(global.fetch).toHaveBeenCalled());
         expect(global.fetch).toHaveBeenCalledWith(
-            `${process.env.NEXT_PUBLIC_API_URL}/emails/send`,
+            `${process.env.NEXT_PUBLIC_API_URL}/emails/contact`,
             expect.objectContaining({
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    to: 'kontakt@salon-bw.pl',
-                    subject: 'Zapytanie ze strony - John',
-                    template:
-                        '<p><strong>Imię:</strong> {{name}}</p>' +
-                        '<p><strong>Email:</strong> {{email}}</p>' +
-                        '<p><strong>Wiadomość:</strong></p>' +
-                        '<p>{{message}}</p>',
-                    data: {
-                        name: 'John',
-                        email: 'john@example.com',
-                        message: 'Hello',
-                    },
+                    name: 'John',
+                    replyTo: 'john@example.com',
+                    message: 'Hello',
                 }),
             }),
         );

--- a/apps/landing/src/__tests__/galleryLightbox.test.tsx
+++ b/apps/landing/src/__tests__/galleryLightbox.test.tsx
@@ -30,7 +30,7 @@ describe('Gallery lightbox', () => {
                 ]}
             />,
         );
-        fireEvent.click(screen.getByLabelText('Open image 1'));
+        fireEvent.click(screen.getByLabelText(/one/i));
         expect(screen.getByRole('dialog')).toBeInTheDocument();
         fireEvent.click(screen.getByLabelText('Close'));
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -45,7 +45,7 @@ describe('Gallery lightbox', () => {
                 items={[{ id: '1', imageUrl: '/img1.jpg', caption: 'One' }]}
             />,
         );
-        fireEvent.click(screen.getByLabelText('Open image 1'));
+        fireEvent.click(screen.getByLabelText(/one/i));
         const share = screen.getByLabelText('Share image');
         fireEvent.click(share);
         expect(shareMock).toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe('Gallery lightbox', () => {
                 ]}
             />,
         );
-        fireEvent.click(screen.getByLabelText('Open image 1'));
+        fireEvent.click(screen.getByLabelText(/one/i));
         // use keyboard to navigate next/prev
         fireEvent.keyDown(document, { key: 'ArrowRight' });
         fireEvent.keyDown(document, { key: 'ArrowLeft' });

--- a/apps/landing/src/__tests__/homeAnalytics.test.tsx
+++ b/apps/landing/src/__tests__/homeAnalytics.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import HomePage from '@/pages/index';
 import { useAuth } from '@/contexts/AuthContext';
@@ -21,37 +21,15 @@ describe('Home analytics', () => {
         delete window.gtag;
     });
 
-    it('emits view_item_list for featured services and gallery, and select_item on clicks', () => {
+    it('emits page_view for home page', () => {
         render(<HomePage />);
         const calls = (window.gtag as jest.Mock).mock.calls;
         expect(
             calls.find(
                 (c) =>
-                    c[1] === 'view_item_list' &&
-                    c[2]?.item_list_name === 'home_featured_services',
+                    c[1] === 'page_view' &&
+                    c[2]?.page_title === 'Home',
             ),
         ).toBeTruthy();
-        expect(
-            calls.find(
-                (c) =>
-                    c[1] === 'view_item_list' &&
-                    c[2]?.item_list_name === 'home_gallery',
-            ),
-        ).toBeTruthy();
-
-        // Click Coloring card
-        fireEvent.click(screen.getByText('Coloring'));
-        const after = (window.gtag as jest.Mock).mock.calls;
-        expect(after.find((c) => c[1] === 'select_item')).toBeTruthy();
-
-        // Click first gallery image button by aria-label
-        fireEvent.click(screen.getByLabelText('View gallery image 1'));
-        const after2 = (window.gtag as jest.Mock).mock.calls;
-        const gallerySelect = after2.filter(
-            (c) =>
-                c[1] === 'select_item' &&
-                c[2]?.item_list_name === 'home_gallery',
-        );
-        expect(gallerySelect.length).toBeGreaterThanOrEqual(1);
     });
 });

--- a/apps/landing/src/pages/api/logs/client.ts
+++ b/apps/landing/src/pages/api/logs/client.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const BACKEND_URL =
+    process.env.API_PROXY_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    'https://api.salon-bw.pl';
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse,
+) {
+    if ((req.method || 'GET').toUpperCase() !== 'POST') {
+        res.setHeader('Allow', 'POST');
+        res.status(405).json({ error: 'Method Not Allowed' });
+        return;
+    }
+
+    const body = await readRawBody(req);
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+    };
+    if (body.byteLength > 0) {
+        headers['Content-Length'] = String(body.byteLength);
+    }
+
+    const logToken = process.env.CLIENT_LOG_TOKEN;
+    if (logToken) {
+        headers['x-log-token'] = logToken;
+    }
+
+    const targetUrl = `${BACKEND_URL.replace(/\/$/, '')}/logs/client`;
+
+    try {
+        const backendRes = await fetch(targetUrl, {
+            method: 'POST',
+            headers,
+            body:
+                body.byteLength > 0
+                    ? (Buffer.from(body) as unknown as RequestInit['body'])
+                    : undefined,
+        });
+
+        res.status(backendRes.status);
+        const contentType = backendRes.headers.get('content-type');
+        if (contentType) {
+            res.setHeader('content-type', contentType);
+        }
+
+        const responseBody = await backendRes.arrayBuffer();
+        res.send(Buffer.from(responseBody));
+    } catch (error) {
+        console.error('Landing log proxy error:', error);
+        res.status(502).json({ error: 'Bad Gateway' });
+    }
+}
+
+export const config = {
+    api: {
+        bodyParser: false,
+    },
+};
+
+function readRawBody(req: NextApiRequest): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => resolve(Buffer.concat(chunks)));
+        req.on('error', reject);
+    });
+}

--- a/apps/landing/src/utils/logClient.ts
+++ b/apps/landing/src/utils/logClient.ts
@@ -10,9 +10,9 @@ const ENABLED =
     process.env.NEXT_PUBLIC_ENABLE_CLIENT_LOGS !== 'false' &&
     typeof window !== 'undefined';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '') ?? '/api';
-const CLIENT_LOG_URL = `${API_BASE}/logs/client`;
-const LOG_TOKEN = process.env.NEXT_PUBLIC_LOG_TOKEN;
+// Always forward through same-origin API route so the log token can stay
+// server-side in CLIENT_LOG_TOKEN (never bundled into public JS).
+const CLIENT_LOG_URL = '/api/logs/client';
 
 export async function logClientError(payload: ClientLogPayload) {
     if (!ENABLED) return;
@@ -21,7 +21,6 @@ export async function logClientError(payload: ClientLogPayload) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                ...(LOG_TOKEN ? { 'x-log-token': LOG_TOKEN } : {}),
             },
             body: JSON.stringify({
                 ...payload,

--- a/apps/panel/.env.example
+++ b/apps/panel/.env.example
@@ -19,4 +19,7 @@ NEXT_PUBLIC_CONTACT_RECIPIENT=kontakt@salon-bw.pl
 # Feature Flags (optional)
 # NEXT_PUBLIC_ENABLE_ANALYTICS=false
 # NEXT_PUBLIC_ENABLE_DEBUG=false
-# NEXT_PUBLIC_LOG_TOKEN=
+# NEXT_PUBLIC_ENABLE_CLIENT_LOGS=true
+
+# Server-side client log proxy token (never NEXT_PUBLIC_*)
+# CLIENT_LOG_TOKEN=

--- a/apps/panel/.env.local.example
+++ b/apps/panel/.env.local.example
@@ -5,7 +5,9 @@ NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
 NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=1
 NEXT_PUBLIC_ENABLE_DEBUG=false
 NEXT_PUBLIC_ENABLE_CLIENT_LOGS=true
-NEXT_PUBLIC_LOG_TOKEN=
+
+# Server-side client log proxy token (optional for local dev)
+# CLIENT_LOG_TOKEN=
 
 # Image Optimization
 # Set to 'true' to disable Next.js image optimization (useful for shared hosting without Node.js image optimizer support)

--- a/apps/panel/package.json
+++ b/apps/panel/package.json
@@ -52,6 +52,7 @@
         "autoprefixer": "^10.5.0",
         "bootstrap": "^5.3.8",
         "date-fns": "^4.1.0",
+        "dompurify": "^3.3.0",
         "js-cookie": "^3.0.5",
         "next": "15.5.18",
         "picocolors": "^1.1.0",

--- a/apps/panel/src/components/newsletters/NewsletterEditorModal.tsx
+++ b/apps/panel/src/components/newsletters/NewsletterEditorModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import DOMPurify from 'dompurify';
 import type {
     Newsletter,
     CreateNewsletterRequest,
@@ -124,10 +125,15 @@ export default function NewsletterEditorModal({
         }
     };
 
+    const sanitizedPreview = useMemo(() => {
+        if (!content) return '';
+        return DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+    }, [content]);
+
     if (!isOpen) return null;
 
-    // Simple HTML preview - admin-only feature, content created by admin
-    // Note: In production, sanitize with DOMPurify for additional safety
+    // HTML preview for admin-authored content. Sanitized to block script
+    // execution and inline event handlers in preview.
     const renderHtmlPreview = () => {
         if (channel !== 'email' || !content) return null;
         return (
@@ -138,7 +144,7 @@ export default function NewsletterEditorModal({
                 <div
                     className="bg-white border rounded-3 p-3 overflow-auto"
                     // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{ __html: content }}
+                    dangerouslySetInnerHTML={{ __html: sanitizedPreview }}
                 />
             </div>
         );

--- a/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
+++ b/backend/salonbw-backend/src/appointments/appointments.service.spec.ts
@@ -349,7 +349,7 @@ describe('AppointmentsService', () => {
             'Nie mogę przyjść',
         );
 
-        expect(result?.status).toBe(AppointmentStatus.Scheduled);
+        expect(result?.status).toBe(AppointmentStatus.OnlinePending);
         expect(logActionSpy).toHaveBeenCalledWith(
             users[0],
             LogAction.APPOINTMENT_CANCELLATION_REQUESTED,
@@ -425,7 +425,7 @@ describe('AppointmentsService', () => {
             'fail',
         );
         const appt = await service.findOne(id);
-        expect(appt?.status).toBe(AppointmentStatus.Scheduled);
+        expect(appt?.status).toBe(AppointmentStatus.OnlinePending);
     });
 
     it('should complete an appointment even if logging fails', async () => {

--- a/backend/salonbw-backend/src/customers/customers.controller.ts
+++ b/backend/salonbw-backend/src/customers/customers.controller.ts
@@ -33,7 +33,7 @@ import { CustomerStatisticsService } from './customer-statistics.service';
 import { CustomerMediaService } from './customer-media.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { createReadStream } from 'node:fs';
@@ -427,7 +427,7 @@ export class CustomersController {
                         .extname(file.originalname || '')
                         .toLowerCase()
                         .slice(0, 10);
-                    const name = `${uuidv4()}${ext || ''}`;
+                    const name = `${randomUUID()}${ext || ''}`;
                     req.__storedName = name;
                     cb(null, name);
                 },
@@ -540,7 +540,7 @@ export class CustomersController {
                         .extname(file.originalname || '')
                         .toLowerCase()
                         .slice(0, 10);
-                    const base = uuidv4();
+                    const base = randomUUID();
                     req.__galleryBase = base;
                     cb(null, `${base}${ext || ''}`);
                 },

--- a/backend/salonbw-backend/src/formulas/appointment-formulas.controller.spec.ts
+++ b/backend/salonbw-backend/src/formulas/appointment-formulas.controller.spec.ts
@@ -2,6 +2,7 @@ import { AppointmentFormulasController } from './appointment-formulas.controller
 import { FormulasService } from './formulas.service';
 import { Formula } from './formula.entity';
 import { CreateFormulaDto } from './dto/create-formula.dto';
+import { Role } from '../users/role.enum';
 
 describe('AppointmentFormulasController', () => {
     let controller: AppointmentFormulasController;
@@ -23,11 +24,16 @@ describe('AppointmentFormulasController', () => {
         };
         const addSpy = jest.spyOn(service, 'addToAppointment');
         await expect(
-            controller.addFormula(1, body, { userId: 1 }),
+            controller.addFormula(1, body, { userId: 1, role: Role.Employee }),
         ).resolves.toBe(formula);
-        expect(addSpy).toHaveBeenCalledWith(1, 1, {
-            description: 'Mix',
-            date: new Date('2023-01-01'),
-        });
+        expect(addSpy).toHaveBeenCalledWith(
+            1,
+            1,
+            Role.Employee,
+            {
+                description: 'Mix',
+                date: new Date('2023-01-01'),
+            },
+        );
     });
 });

--- a/backend/salonbw-backend/src/formulas/formulas.service.spec.ts
+++ b/backend/salonbw-backend/src/formulas/formulas.service.spec.ts
@@ -8,6 +8,7 @@ import {
     AppointmentStatus,
 } from '../appointments/appointment.entity';
 import { User } from '../users/user.entity';
+import { Role } from '../users/role.enum';
 
 describe('FormulasService', () => {
     let service: FormulasService;
@@ -88,7 +89,9 @@ describe('FormulasService', () => {
         const createSpy = jest.spyOn(formulasRepo, 'create');
         const saveSpy = jest.spyOn(formulasRepo, 'save');
         const findOneSpy = jest.spyOn(appointmentsRepo, 'findOne');
-        await expect(service.addToAppointment(1, 1, data)).resolves.toEqual({
+        await expect(
+            service.addToAppointment(1, 1, Role.Employee, data),
+        ).resolves.toEqual({
             id: 1,
             description: 'Cut',
             date: data.date,

--- a/backend/salonbw-backend/src/users/users.service.spec.ts
+++ b/backend/salonbw-backend/src/users/users.service.spec.ts
@@ -105,6 +105,10 @@ describe('UsersService', () => {
                 phone: dto.phone,
                 commissionBase: dto.commissionBase,
                 receiveNotifications: dto.receiveNotifications,
+                gdprConsent: false,
+                gdprConsentDate: undefined,
+                smsConsent: false,
+                emailConsent: false,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.role).toBe(Role.Client);
@@ -151,6 +155,10 @@ describe('UsersService', () => {
                 phone: null,
                 commissionBase: 0,
                 receiveNotifications: true,
+                gdprConsent: false,
+                gdprConsentDate: undefined,
+                smsConsent: false,
+                emailConsent: false,
             });
             expect(saveSpy).toHaveBeenCalledWith(created);
             expect(result.commissionBase).toBe(0);

--- a/docs/AGENT_OPERATIONS.md
+++ b/docs/AGENT_OPERATIONS.md
@@ -266,7 +266,7 @@ Passenger log files (if needed) live under `~/logs/nodejs/<app>/passenger.log`.
 #### 5.1 Centralised logging stack
 
 - **Ingestion pipeline:** Promtail runs alongside each Node app on mydevil and tails `~/logs/nodejs/<app>/app.log`. It attaches `{service, environment}` labels and pushes to Grafana Loki (`https://observability.salon-bw.pl/loki/api/v1/push`). API logs and frontend client error events both flow through this channel.
-- **Credentials:** Grafana and Loki share the same basic-auth secret as `LOKI_BASIC_AUTH` in production (`docs/ENV.md`). For client-side logs, set `CLIENT_LOG_TOKEN` on the API and `NEXT_PUBLIC_LOG_TOKEN` in each frontend build so the browser can POST to `/logs/client`.
+- **Credentials:** Grafana and Loki share the same basic-auth secret as `LOKI_BASIC_AUTH` in production (`docs/ENV.md`). For client-side logs, set `CLIENT_LOG_TOKEN` on the API; frontends should post via same-origin `/api/logs/client` proxy routes that inject `x-log-token` server-side.
 - **Manual verification:**
 
 ```bash

--- a/docs/AGENT_STATUS.md
+++ b/docs/AGENT_STATUS.md
@@ -1,6 +1,16 @@
 # Agent Status Dashboard
 
-_Last updated: 2026-05-23 (booking role-gating + privacy consent guard + SMTP/Instagram ops fixes)_
+_Last updated: 2026-05-26 (deploy env merge hardening + landing log proxy + backend CI tests)_
+
+Operational note (2026-05-26) — deploy/runtime hardening + CI parity:
+- Hardened API deploy env merge in `.github/workflows/deploy.yml`:
+  - deploy now preserves existing server-side `.env` keys and only overrides keys explicitly generated in CI,
+  - prevents accidental runtime config loss during deploy (including security-related keys).
+- Removed public client-log token flow from frontend build/runtime:
+  - landing moved to same-origin `/api/logs/client` proxy with server-side `CLIENT_LOG_TOKEN` injection,
+  - panel + landing env examples/docs now mark `CLIENT_LOG_TOKEN` as server-only (no `NEXT_PUBLIC_*` token).
+- CI now executes backend tests in `ci.yml` (`pnpm --filter salonbw-backend test`) in addition to lint/typecheck/build.
+- Backend test suite updated to current contracts (consent defaults, formula API signature, appointment status expectations), and customer controller now uses `node:crypto` `randomUUID()` to avoid ESM `uuid` Jest parse break.
 
 Operational note (2026-05-23) — production SMTP + Instagram health remediation:
 - Verified and fixed API SMTP credentials directly on server (`/usr/home/vetternkraft/apps/nodejs/api_salonbw/.env`):

--- a/docs/DEPLOYMENT_MYDEVIL.md
+++ b/docs/DEPLOYMENT_MYDEVIL.md
@@ -11,6 +11,10 @@ Operational note (2026-02-14):
 - Remote dependency install steps are retry-guarded in workflow (`3` attempts for panel/landing/api) to absorb transient npm/network failures.
 - Push-triggered deploy follow-up steps are target-aware: landing smoke/log collection only runs when landing is actually deployed, and SSH-based diagnostics are skipped when the SSH setup step did not complete.
 
+Operational note (2026-05-26):
+- API deploy env merge now preserves existing server-side `.env` keys and overrides only keys generated in CI for the current deploy.
+- This prevents accidental deletion of runtime-only settings during deploy (for example logging/auth-related keys not part of the generated subset).
+
 ## 0. Recommended: targeted deploys (GitHub Actions)
 
 Use the workflow inputs to deploy only the app that changed and restart only that domain:

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -85,8 +85,8 @@ Operational SMTP note (mydevil, 2026-05-23):
 | `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` | ➖ | `0.1` | Sampling rate for Sentry tracing. |
 | `NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE` | ➖ | `0` | Fraction of sessions recorded with Sentry Replay for passive RUM. |
 | `NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE` | ➖ | `1` | Fraction of sessions recorded when an error occurs. Keep ≤1. |
-| `NEXT_PUBLIC_ENABLE_CLIENT_LOGS` | ➖ | `true` | Toggles `logClientError` forwarding to `/logs/client`. Useful to disable in preview builds. |
-| `NEXT_PUBLIC_LOG_TOKEN` | ➖ | *(unset)* | Token that must match backend `CLIENT_LOG_TOKEN` to accept client log posts. |
+| `NEXT_PUBLIC_ENABLE_CLIENT_LOGS` | ➖ | `true` | Toggles `logClientError` forwarding to same-origin `/api/logs/client` proxy routes. Useful to disable in preview builds. |
+| `CLIENT_LOG_TOKEN` | ➖ | *(unset)* | Server-only token injected by frontend API proxy routes as `x-log-token` for backend `/logs/client` ingest. Must never use `NEXT_PUBLIC_*`. |
 | `NEXT_IMAGE_UNOPTIMIZED` | ➖ | `true` | When `true`, disables Next image optimizer (avoid 400s on shared hosts). Set to `false` to enable optimization. |
 | `NEXT_HTML_NOSTORE` | ➖ | `false` | When `true`, adds `no-store` headers for HTML on `dev.salon-bw.pl` to prevent stale pages. Build-time flag. |
 | `NEXT_PANEL_HTML_NOSTORE` | ➖ | `false` | When `true`, adds `no-store` headers for HTML on `panel.salon-bw.pl`. Build-time flag. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.3.0
+        version: 3.4.6
       js-cookie:
         specifier: '>=3.0.7'
         version: 3.0.7
@@ -3448,6 +3451,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -4700,6 +4706,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.6:
+    resolution: {integrity: sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==}
 
   dotenv-expand@12.0.1:
     resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
@@ -12087,6 +12096,9 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/validator@13.15.10': {}
@@ -13456,6 +13468,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dompurify@3.4.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dotenv-expand@12.0.1:
     dependencies:
       dotenv: 16.6.1
@@ -13683,8 +13699,8 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -13711,7 +13727,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -13722,22 +13738,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13748,7 +13764,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- harden deploy env merge so server `.env` keys are preserved and only generated keys are updated
- remove client exposure pattern for log token and proxy client logs through landing API route
- sanitize newsletter preview HTML before rendering in panel
- align CI/deploy docs and env examples with current token strategy
- fix backend/landing tests affected by runtime and API contract changes

## Validation
- pnpm lint
- pnpm typecheck
- CI=1 pnpm -r run --if-present test
- bash scripts/check-ops-workflows.sh
- bash scripts/check-ops-workflow-docs-consistency.sh