### PR TITLE
fix(deploy): allow admin target in workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ on:
           - probe
           - public
           - dashboard
+          - admin
       environment:
         description: Deployment environment (staging/production)
         required: true


### PR DESCRIPTION
## Summary
- add missing `admin` value to `workflow_dispatch.inputs.target.options` in Deploy workflow
- aligns declared alias support with dispatch input validation

## Validation
- bash scripts/check-ops-workflows.sh
- bash scripts/check-ops-workflow-docs-consistency.sh