### PR TITLE
fix: stale pending badge, unbounded proxy body, NaN in employeeIds

### DIFF
--- a/apps/landing/src/pages/api/logs/client.ts
+++ b/apps/landing/src/pages/api/logs/client.ts
@@ -15,7 +15,17 @@ export default async function handler(
         return;
     }
 
-    const body = await readRawBody(req);
+    let body: Uint8Array;
+    try {
+        body = await readRawBody(req);
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'BODY_TOO_LARGE') {
+            res.status(413).json({ error: 'Request body too large' });
+            return;
+        }
+        throw err;
+    }
     const headers: Record<string, string> = {
         'Content-Type': 'application/json',
     };
@@ -60,10 +70,21 @@ export const config = {
     },
 };
 
+const MAX_BODY_BYTES = 64 * 1024; // 64 KB — log payloads should be small
+
 function readRawBody(req: NextApiRequest): Promise<Uint8Array> {
     return new Promise((resolve, reject) => {
         const chunks: Buffer[] = [];
-        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        let totalBytes = 0;
+        req.on('data', (chunk: Buffer) => {
+            totalBytes += chunk.byteLength;
+            if (totalBytes > MAX_BODY_BYTES) {
+                req.destroy();
+                reject(Object.assign(new Error('Request body too large'), { code: 'BODY_TOO_LARGE' }));
+                return;
+            }
+            chunks.push(chunk);
+        });
         req.on('end', () => resolve(Buffer.concat(chunks)));
         req.on('error', reject);
     });

--- a/apps/panel/src/hooks/useAppointments.ts
+++ b/apps/panel/src/hooks/useAppointments.ts
@@ -94,6 +94,9 @@ export function useAppointmentMutations() {
         void queryClient.invalidateQueries({
             queryKey: MY_APPOINTMENTS_QUERY_KEY,
         });
+        void queryClient.invalidateQueries({
+            queryKey: ['pending-bookings-count'],
+        });
     };
 
     const cancelAppointment = useMutation({

--- a/apps/panel/src/pages/api/[...path].ts
+++ b/apps/panel/src/pages/api/[...path].ts
@@ -113,9 +113,19 @@ export default async function handler(
         }
     }
 
-    const body: Uint8Array | undefined = isBodyAllowed
-        ? await readRawBody(req)
-        : undefined;
+    let body: Uint8Array | undefined;
+    if (isBodyAllowed) {
+        try {
+            body = await readRawBody(req);
+        } catch (err) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === 'BODY_TOO_LARGE') {
+                res.status(413).json({ error: 'Request body too large' });
+                return;
+            }
+            throw err;
+        }
+    }
 
     // Some upstream stacks (Passenger/proxies) can be sensitive to chunked uploads.
     // When we buffer the full request body, we can safely set Content-Length.
@@ -179,10 +189,19 @@ export const config = {
     },
 };
 
+const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
+
 function readRawBody(req: NextApiRequest): Promise<Uint8Array> {
     return new Promise((resolve, reject) => {
         const chunks: Buffer[] = [];
+        let totalBytes = 0;
         req.on('data', (chunk: Buffer) => {
+            totalBytes += chunk.byteLength;
+            if (totalBytes > MAX_BODY_BYTES) {
+                req.destroy();
+                reject(Object.assign(new Error('Request body too large'), { code: 'BODY_TOO_LARGE' }));
+                return;
+            }
             chunks.push(chunk);
         });
         req.on('end', () => resolve(Buffer.concat(chunks)));

--- a/backend/salonbw-backend/src/calendar/dto/calendar-query.dto.ts
+++ b/backend/salonbw-backend/src/calendar/dto/calendar-query.dto.ts
@@ -34,9 +34,11 @@ export class CalendarQueryDto {
 
         const entries = Array.isArray(value) ? value : String(value).split(',');
 
-        return entries.map((entry) =>
-            typeof entry === 'number' ? entry : parseInt(String(entry), 10),
-        );
+        return entries.map((entry) => {
+            if (typeof entry === 'number') return entry;
+            const n = parseInt(String(entry).trim(), 10);
+            return isNaN(n) ? entry : n; // keep original string so @IsNumber rejects it
+        });
     })
     employeeIds?: number[];
 


### PR DESCRIPTION
## Summary

Three bugs found during code review of recent commits:

- **`useAppointments`**: `invalidateAppointments()` didn't invalidate `['pending-bookings-count']` — after confirming/rejecting a pending appointment, the topbar badge stayed stale until the next 2-minute poll. Fixed by adding the missing invalidation.

- **`readRawBody` (panel proxy + landing logs)**: Both handlers buffered unlimited request bodies in memory. The landing `/api/logs/client` endpoint is public (no auth), so any client could POST a multi-GB payload and OOM the process. Panel proxy capped at **10 MB**, landing logs at **64 KB** (log payloads should be small). Returns 413 when exceeded.

- **`calendar-query.dto` employeeIds Transform**: `parseInt('abc', 10)` returns `NaN`, which `@IsNumber` correctly rejects — but `NaN` was silently placed in the output array first. Now the original non-numeric string is preserved so class-validator produces a clear, typed validation error instead of operating on `NaN`.

## Test plan

- [ ] Confirm a pending appointment in ReceptionView → topbar badge decrements immediately (no 2-min wait)
- [ ] POST a 100 KB payload to `/api/logs/client` → 413 response
- [ ] POST a 20 MB payload to `/api/[...path]` → 413 response
- [ ] `GET /calendar/events?date=2026-05-28&employeeIds=1,abc` → 400 validation error with clear message

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_