### PR TITLE
fix(panel): hide hamburger on desktop, replace Versum logo with salon logo

### DIFF
--- a/apps/panel/src/components/salon/SalonTopbar.tsx
+++ b/apps/panel/src/components/salon/SalonTopbar.tsx
@@ -98,10 +98,11 @@ export default function SalonTopbar() {
                         href={topbar.brand.href}
                         title="przejdź do pulpitu"
                     >
-                        <SalonIcon id="svg-logo" className="svg-logo" />
-                        <SalonIcon
-                            id="svg-dashboard-ico"
-                            className="svg-dashboard-ico"
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                            src="/images/logo.svg"
+                            alt="Salon BW"
+                            className="salon-topbar-logo"
                         />
                     </Link>
                 </div>

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -2155,23 +2155,7 @@ tr.customer-row:hover .customers-drag-handle {
     color: #818488;
 }
 
-.navbar .brand a .svg-logo {
-    width: 95px;
-    height: 13px;
-    margin-right: 8px;
-}
-
-.navbar .brand a .svg-dashboard-ico {
-    display: none;
-    width: 18px;
-    height: 13px;
-}
-
-.navbar:hover .svg-dashboard-ico {
-    display: block !important;
-}
-
-.salon-topbar-logo {
+.navbar .brand a .salon-topbar-logo {
     height: 28px;
     width: auto;
     display: block;
@@ -2216,9 +2200,6 @@ tr.customer-row:hover .customers-drag-handle {
     background: transparent;
     border: none;
     padding: 9px 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
 }
 
 .navbar .navbar-toggle .icon-bar {
@@ -6275,6 +6256,8 @@ body.salonbw-sidebar-open .salonbw-nav-overlay {
         display: flex;
         align-items: center;
         justify-content: center;
+        flex-direction: column;
+        gap: 4px;
     }
 
     /* --- Sidebar wrapper: no left padding (mainnav is fixed/overlaid) --- */


### PR DESCRIPTION
## Summary

- **Hamburger hidden on desktop**: `.navbar .navbar-toggle { display: flex }` was overriding `.navbar .menu-toggler { display: none }` (same CSS specificity, later rule won). Removed `display`/`flex-direction`/`gap` from the default `.navbar-toggle` rule; `flex-direction: column; gap: 4px` moved to the mobile media query where the toggler is actually shown.
- **Salon logo instead of Versum wordmark**: `svg-logo` SVG sprite contained the Versum wordmark paths. Replaced `<SalonIcon id="svg-logo">` in `SalonTopbar` with ``&lt;img src="/images/logo.svg"&gt;`` using `.salon-topbar-logo` class (`height: 28px, width: auto`).
- **Removed dead CSS**: `.svg-logo`, `.svg-dashboard-ico`, and `.navbar:hover .svg-dashboard-ico` rules that referred to the now-removed sprite usage.

## Test plan

- [ ] Desktop (>767px): hamburger icon not visible in topbar
- [ ] Mobile (≤767px): hamburger visible and opens sidebar on click
- [ ] Salon logo (`/images/logo.svg`) visible in topbar on both desktop and mobile — no "Versum" text

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_