### PR TITLE
fix(landing): stop hero "Black & White" text jumping on slide change

### DIFF
--- a/apps/landing/src/components/HeroSlider.tsx
+++ b/apps/landing/src/components/HeroSlider.tsx
@@ -83,7 +83,7 @@ export default function HeroSlider({ slides }: HeroSliderProps) {
 
             {/* Content — centred vertically */}
             <div className="absolute inset-0 z-20 flex flex-col items-center justify-center px-4">
-                <div key={currentSlide} className="max-w-3xl mx-auto text-center text-white">
+                <div className="max-w-3xl mx-auto text-center text-white">
                     {/* Academy eyebrow */}
                     <p
                         className="hero-tag mb-3 uppercase text-xs md:text-sm"


### PR DESCRIPTION
## Summary

- `key={currentSlide}` on the hero content wrapper caused React to unmount and remount the entire content div on every slide transition (including the 5.5s auto-play).
- Each remount restarted all CSS animations — including `fadeUp` on `.hero-tag` (`Black & White` in Tangerine font), making it visibly jump up from below every 5.5 seconds.
- Users noticed it especially while hovering over the "Umów wizytę" button.
- Fix: remove `key={currentSlide}`. Text content (`data[currentSlide]?.title`) already updates reactively — no remount needed.

## Test plan

- [ ] Open landing hero — "Black & White" text is stable during auto-play slide transitions
- [ ] Hover over "Umów wizytę" button — no text jumping
- [ ] Slide title/description still updates correctly on slide change

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_