### PR TITLE
fix(landing): remove letter-spacing hover on CTA — stops heading reflow

### DIFF
--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -216,13 +216,12 @@ html {
     text-transform: uppercase;
     font-family: var(--font-open-sans), sans-serif;
     border-radius: 1px;
-    transition: background 0.3s, transform 0.3s, letter-spacing 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: background 0.3s, transform 0.3s;
     text-decoration: none;
 }
 .split-hero__cta-primary:hover {
     background: var(--brand-gold-dark);
     transform: translateY(-2px);
-    letter-spacing: 0.32em;
 }
 
 .split-hero__cta-secondary {


### PR DESCRIPTION
## Summary

`.split-hero__cta-primary:hover` animated `letter-spacing` from `0.2em` → `0.32em` with a bounce easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`). This made the button wider on hover, causing a layout reflow that jumped the "Black & White" heading text above it.

- Removed `letter-spacing: 0.32em` from `:hover`
- Removed `letter-spacing` from the `transition` list
- Kept `transform: translateY(-2px)` (compositor-only, no reflow)

## Test plan

- [ ] Hover over "Umów wizytę" button — heading text stays stable
- [ ] Button still has a subtle lift effect (`translateY(-2px)`)

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_