### PR TITLE
fix(panel): light sidenav theme + CalendarNav chevron arrows

### DIFF
--- a/apps/panel/src/components/salon/navs/CalendarNav.tsx
+++ b/apps/panel/src/components/salon/navs/CalendarNav.tsx
@@ -110,19 +110,27 @@ export default function CalendarNav() {
     return (
         <>
             {/* Mini Calendar Header */}
-            <div className="nav-header flex-between">
+            <div className="nav-header flex-between" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px 4px' }}>
                 <button
                     onClick={() => changeMonth(-1)}
                     className="btn btn-sm btn-link p-0"
+                    aria-label="Poprzedni miesiąc"
+                    style={{ lineHeight: 1 }}
                 >
-                    &lt;
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M15 18l-6-6 6-6" />
+                    </svg>
                 </button>
-                <span>{monthYear}</span>
+                <span style={{ fontWeight: 600, fontSize: '11px', letterSpacing: '0.05em' }}>{monthYear}</span>
                 <button
                     onClick={() => changeMonth(1)}
                     className="btn btn-sm btn-link p-0"
+                    aria-label="Następny miesiąc"
+                    style={{ lineHeight: 1 }}
                 >
-                    &gt;
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M9 18l6-6-6-6" />
+                    </svg>
                 </button>
             </div>
 

--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -2077,8 +2077,40 @@ h3 {
 /* ============================================================
    LIGHT THEME — unified overrides for all salonbw-* components
    Replaces legacy dark-luxury palette with a clean, light UI.
-   The navbar/sidenav keep their explicit dark colors above.
    ============================================================ */
+
+/* --- Sidenav (secondary nav) — light background matching content area --- */
+#sidenav,
+.sidenav {
+    background: #ffffff;
+    border-right-color: #dee2e6;
+}
+
+#sidenav .nav-header,
+.sidenav .nav-header {
+    color: #7d848c;
+}
+
+#sidenav .nav-list li a,
+.sidenav .nav-list li a {
+    color: #495057;
+}
+
+#sidenav .nav-list li a:hover,
+#sidenav .nav-list li.active a,
+.sidenav .nav-list li a:hover,
+.sidenav .nav-list li.active a {
+    background: #f0f4f8;
+    color: #c5a880;
+}
+
+.sidenav .btn-link {
+    color: #6c757d;
+    text-decoration: none;
+}
+.sidenav .btn-link:hover {
+    color: #212529;
+}
 
 /* --- Component backgrounds & borders --- */
 .salonbw-mass-communication__section,
@@ -2281,11 +2313,23 @@ h3 {
 }
 
 /* --- Employee filter --- */
+.salonbw-employee-filter {
+    flex-direction: column;
+    align-items: stretch;
+}
+.salonbw-employee-filter__item {
+    padding: 4px 0;
+    border-radius: 0;
+}
 .salonbw-employee-filter__item:hover {
-    background: #f0f2f4;
+    background: #f0f4f8;
+    color: #212529;
 }
 .salonbw-employee-filter__name {
     color: #495057;
+}
+.salonbw-checkbox {
+    accent-color: #c5a880;
 }
 
 /* --- Templates --- */


### PR DESCRIPTION
## Summary

- **Sidenav is now light-themed** — overrides the dark `background: #0f0f0f` from the legacy globals.css dark section with `background: #ffffff` and `border-right-color: #dee2e6`, matching the content area instead of the dark topbar
- **Nav-header and nav-list link colors** fixed to be readable on white (was dark text `#3a3430` on dark bg `#0f0f0f`)
- **`.sidenav .btn-link`** overridden to grey (`#6c757d`) so month nav arrows don't appear in Bootstrap's default blue
- **Employee filter layout** — forced `flex-direction: column; align-items: stretch` in light-theme section to override horizontal wrapping from dark section; checkbox `accent-color: #c5a880` (brand gold)
- **CalendarNav month arrows** — replaced raw `<` / `>` text with 14×14 SVG chevron icons + `aria-label` attributes

## Test plan

- [ ] Navigate to `/calendar` — sidenav background should be white, matching content area
- [ ] Month navigation arrows should show as clean chevrons (not `<` `>` text)
- [ ] Employee filter items should be vertical list, each on own row
- [ ] Checkbox tick color should be gold (#c5a880) when checked
- [ ] Navigate to `/services`, `/settings`, `/customers` — sidenav text should be readable (dark on white)
- [ ] `.btn-link` inside sidenav should be grey, not blue

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_