### PR TITLE
fix(panel): unify sidenav content structure across all modules

### DIFF
--- a/apps/panel/src/components/salon/navs/ClientDetailNav.tsx
+++ b/apps/panel/src/components/salon/navs/ClientDetailNav.tsx
@@ -94,7 +94,7 @@ export default function ClientDetailNav({
     return (
         <div className="show_action_content client-detail-nav">
             <div className="column_row">
-                <h4>Karta klienta</h4>
+                <div className="nav-header">KARTA KLIENTA</div>
                 <div className="tree">
                     <Link
                         href={`/customers/${customerId}`}

--- a/apps/panel/src/components/salon/navs/ClientsNav.tsx
+++ b/apps/panel/src/components/salon/navs/ClientsNav.tsx
@@ -149,7 +149,7 @@ export default function ClientsNav() {
                 >
                     <div className="index_action_content">
                         <div className="customer_groups column_row">
-                            <h4>Grupy klientów</h4>
+                            <div className="nav-header">GRUPY KLIENTÓW</div>
                             <div className="tree" id="groups">
                                 <a
                                     className={`root ${activeQuickGroup === 'all' ? 'active' : ''}`}
@@ -315,7 +315,7 @@ export default function ClientsNav() {
                             className={`column_row ${currentGroupId ? '' : 'hidden'}`}
                             id="filter_boxes_container"
                         >
-                            <h4>Kryteria wyszukiwania</h4>
+                            <div className="nav-header">KRYTERIA WYSZUKIWANIA</div>
                             <div id="filter_boxes">
                                 {groups
                                     ?.filter((g) => currentGroupId === g.id)
@@ -344,7 +344,7 @@ export default function ClientsNav() {
                         </div>
 
                         <div className="column_row" id="search_criteria">
-                            <h4>Wybierz kryteria</h4>
+                            <div className="nav-header">WYBIERZ KRYTERIA</div>
                             <div className="list_container">
                                 <ul
                                     className="simple-list"

--- a/apps/panel/src/components/salon/navs/EmployeesNav.tsx
+++ b/apps/panel/src/components/salon/navs/EmployeesNav.tsx
@@ -12,7 +12,7 @@ export default function EmployeesNav() {
     return (
         <div className="sidenav" id="sidenav">
             <div className="column_row tree">
-                <h4>Pracownicy</h4>
+                <div className="nav-header">PRACOWNICY</div>
                 <Link
                     className={`root ${isActive('/settings/employees') ? 'active' : ''}`.trim()}
                     href="/settings/employees"

--- a/apps/panel/src/components/salon/navs/NewCustomerNav.tsx
+++ b/apps/panel/src/components/salon/navs/NewCustomerNav.tsx
@@ -40,9 +40,10 @@ export default function NewCustomerNav({
     title = 'NOWY KLIENT',
 }: NewCustomerNavProps) {
     return (
+        <div className="sidenav" id="sidenav">
         <div className="show_action_content client-detail-nav">
             <div className="column_row">
-                <h4>{title}</h4>
+                <div className="nav-header">{title}</div>
                 <div className="tree">
                     <ul>
                         {tabs.map((tab) => (
@@ -73,6 +74,7 @@ export default function NewCustomerNav({
                     </ul>
                 </div>
             </div>
+        </div>
         </div>
     );
 }

--- a/apps/panel/src/components/salon/navs/StatisticsNav.tsx
+++ b/apps/panel/src/components/salon/navs/StatisticsNav.tsx
@@ -100,27 +100,15 @@ export default function StatisticsNav() {
         <div className="column_row tree">
             <ul id="statistics_menu_list">
                 {REPORTS.map((item) => (
-                    <li key={item.id}>
-                        <Link
-                            href={item.href}
-                            className={isActive(item.href) ? 'active' : ''}
-                            title={item.label}
-                        >
+                    <li key={item.id} className={isActive(item.href) ? 'active' : ''}>
+                        <Link href={item.href} title={item.label}>
                             {item.label}
                         </Link>
                         {item.children ? (
                             <ul>
                                 {item.children.map((child) => (
-                                    <li key={child.id}>
-                                        <Link
-                                            href={child.href}
-                                            className={
-                                                isActive(child.href)
-                                                    ? 'active'
-                                                    : ''
-                                            }
-                                            title={child.label}
-                                        >
+                                    <li key={child.id} className={isActive(child.href) ? 'active' : ''}>
+                                        <Link href={child.href} title={child.label}>
                                             {child.label}
                                         </Link>
                                     </li>


### PR DESCRIPTION
## Summary

- **`NewCustomerNav`** — added `.sidenav` wrapper. Component is rendered via `useSetSecondaryNav` (not `SalonSecondaryNav`), which places it inside a plain `<div>` — without the wrapper, `/customers/new` and `/customers/[id]/edit` had no sidenav background/border styling
- **`EmployeesNav`, `ClientDetailNav`, `ClientsNav`** — replaced `<h4>` section headings with `<div class="nav-header">` to match the standard 11px uppercase grey style used consistently by `SettingsNav`, `WarehouseNav`, `CommunicationNav`
- **`StatisticsNav`** — moved `.active` class from `<Link>` (`<a>` element) to parent `<li>`, so the `salon-shell.css` rule `.sidenav .tree li.active > a` correctly highlights the active report link (was silently broken)

## Test plan

- [ ] `/customers/new` — sidenav should have white background + border (`.sidenav` styling)
- [ ] `/customers/[id]/edit` — same
- [ ] `/employees` — "PRACOWNICY" heading should be 11px uppercase grey, not large bold h4
- [ ] `/customers/[id]` — "KARTA KLIENTA" heading should be 11px uppercase grey
- [ ] `/customers` — "GRUPY KLIENTÓW" / "KRYTERIA WYSZUKIWANIA" headings should be 11px uppercase grey
- [ ] `/statistics` — clicking any report should visibly highlight it in the sidenav (was not working before)
- [ ] `/statistics/employees` etc. — child links also highlight correctly

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_