### PR TITLE
fix(panel): use dedicated pending-count endpoint for topbar badge

### DIFF
--- a/apps/panel/src/hooks/useAppointments.ts
+++ b/apps/panel/src/hooks/useAppointments.ts
@@ -143,13 +143,10 @@ export function usePendingBookingsCount() {
     const query = useQuery({
         queryKey: ['pending-bookings-count'],
         queryFn: async () => {
-            const response = await apiFetch<
-                LocalAppointment[] | { items?: LocalAppointment[] }
-            >(`/appointments?status=online_pending`);
-            if (Array.isArray(response)) {
-                return response.length;
-            }
-            return Array.isArray(response.items) ? response.items.length : 0;
+            const response = await apiFetch<{ count: number }>(
+                `/appointments/online-pending-count`,
+            );
+            return response.count ?? 0;
         },
         enabled: isStaff,
         refetchInterval: 2 * 60 * 1000,


### PR DESCRIPTION
## Summary

- Replace `GET /appointments?status=online_pending` (fetches full objects, counts array) with the dedicated `GET /appointments/online-pending-count` endpoint that returns `{ count: number }` directly from a DB `COUNT()` query
- Fixes silent role bug: old endpoint scoped Employee to their own appointments only (`employeeId: user.userId`), so online_pending appointments assigned to other employees were invisible; the dedicated endpoint handles role scoping on the API side

## Why badge shows 0 right now

The counter itself is correct — it shows 0 because:
1. Production API hasn't been deployed with the `online_pending` DB migration yet
2. No clients have booked through the new `/booking` wizard yet

Once the API is redeployed and clients start booking, the badge will update every 2 minutes.

## Test plan

- [ ] Log in as admin — tasks icon badge should show count of online_pending appointments
- [ ] Check browser Network tab: request should go to `/appointments/online-pending-count`, not `/appointments?status=online_pending`
- [ ] Create a test online_pending appointment via API, verify badge increments within 2 minutes

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_