### PR TITLE
fix(panel): sidenav light theme, topbar cleanup, calendar mobile fix

### DIFF
--- a/apps/panel/src/__tests__/hooksList.test.tsx
+++ b/apps/panel/src/__tests__/hooksList.test.tsx
@@ -76,7 +76,7 @@ describe('list hooks', () => {
     });
 
     it('usePendingBookingsCount counts online pending appointments', async () => {
-        const apiFetch = jest.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]);
+        const apiFetch = jest.fn().mockResolvedValue({ count: 2 });
         mockedUseAuth.mockReturnValue(
             createAuthValue({ apiFetch, role: 'admin' }),
         );
@@ -87,7 +87,7 @@ describe('list hooks', () => {
 
         await waitFor(() => expect(result.current).toBe(2));
         expect(apiFetch).toHaveBeenCalledWith(
-            '/appointments?status=online_pending',
+            '/appointments/online-pending-count',
         );
     });
 });

--- a/apps/panel/src/components/calendar/CalendarHeader.tsx
+++ b/apps/panel/src/components/calendar/CalendarHeader.tsx
@@ -67,17 +67,26 @@ export default function CalendarHeader({
     const formatDateLabel = (short = false) => {
         switch (view) {
             case 'day':
-                return format(date, short ? 'EEE, d MMM' : 'EEEE, d MMMM yyyy', { locale: pl });
+                return format(
+                    date,
+                    short ? 'EEE, d MMM' : 'EEEE, d MMMM yyyy',
+                    { locale: pl },
+                );
             case 'week':
-                return format(date, short ? "'Tydz.' w, MMM yyyy" : "'Tydzień' w, MMMM yyyy", { locale: pl });
+                return format(
+                    date,
+                    short ? "'Tydz.' w, MMM yyyy" : "'Tydzień' w, MMMM yyyy",
+                    { locale: pl },
+                );
             case 'month':
-                return format(date, short ? 'MMM yyyy' : 'MMMM yyyy', { locale: pl });
+                return format(date, short ? 'MMM yyyy' : 'MMMM yyyy', {
+                    locale: pl,
+                });
         }
     };
 
     return (
         <div className="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center justify-content-sm-between border-bottom border-secondary border-opacity-25 bg-white px-3 py-2 gap-2">
-
             {/* Navigation row: Dzisiaj + prev/date/next */}
             <div className="d-flex align-items-center gap-2">
                 <button
@@ -95,15 +104,32 @@ export default function CalendarHeader({
                         aria-label="Poprzedni"
                         style={{ lineHeight: 1 }}
                     >
-                        <svg style={{ width: 20, height: 20 }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                        <svg
+                            style={{ width: 20, height: 20 }}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M15 19l-7-7 7-7"
+                            />
                         </svg>
                     </button>
 
-                    <h2 className="mb-0 fw-semibold text-dark text-capitalize" style={{ fontSize: '0.95rem', whiteSpace: 'nowrap' }}>
+                    <h2
+                        className="mb-0 fw-semibold text-dark text-capitalize"
+                        style={{ fontSize: '0.95rem', whiteSpace: 'nowrap' }}
+                    >
                         {/* Short on xs, full on sm+ */}
-                        <span className="d-inline d-sm-none">{formatDateLabel(true)}</span>
-                        <span className="d-none d-sm-inline">{formatDateLabel(false)}</span>
+                        <span className="d-inline d-sm-none">
+                            {formatDateLabel(true)}
+                        </span>
+                        <span className="d-none d-sm-inline">
+                            {formatDateLabel(false)}
+                        </span>
                     </h2>
 
                     <button
@@ -112,21 +138,38 @@ export default function CalendarHeader({
                         aria-label="Następny"
                         style={{ lineHeight: 1 }}
                     >
-                        <svg style={{ width: 20, height: 20 }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                        <svg
+                            style={{ width: 20, height: 20 }}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M9 5l7 7-7 7"
+                            />
                         </svg>
                     </button>
                 </div>
 
                 {currentTime && (
-                    <span className="d-none d-sm-inline fw-light text-primary" style={{ fontSize: '0.9rem', whiteSpace: 'nowrap' }}>
+                    <span
+                        className="d-none d-sm-inline fw-light text-primary"
+                        style={{ fontSize: '0.9rem', whiteSpace: 'nowrap' }}
+                    >
                         {format(currentTime, 'HH:mm')}
                     </span>
                 )}
             </div>
 
             {/* View toggle: Dzień | Tydzień | Miesiąc */}
-            <div className="btn-group btn-group-sm" role="group" aria-label="Widok kalendarza">
+            <div
+                className="btn-group btn-group-sm"
+                role="group"
+                aria-label="Widok kalendarza"
+            >
                 <button
                     type="button"
                     onClick={() => onViewChange('day')}

--- a/apps/panel/src/components/calendar/CalendarHeader.tsx
+++ b/apps/panel/src/components/calendar/CalendarHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { CalendarView } from '@/types';
 import {
     format,
@@ -62,111 +64,90 @@ export default function CalendarHeader({
         }
     };
 
-    const formatDateLabel = () => {
+    const formatDateLabel = (short = false) => {
         switch (view) {
             case 'day':
-                return format(date, 'EEEE, d MMMM yyyy', { locale: pl });
+                return format(date, short ? 'EEE, d MMM' : 'EEEE, d MMMM yyyy', { locale: pl });
             case 'week':
-                return format(date, "'Tydzień' w, MMMM yyyy", { locale: pl });
+                return format(date, short ? "'Tydz.' w, MMM yyyy" : "'Tydzień' w, MMMM yyyy", { locale: pl });
             case 'month':
-                return format(date, 'MMMM yyyy', { locale: pl });
+                return format(date, short ? 'MMM yyyy' : 'MMMM yyyy', { locale: pl });
         }
     };
 
     return (
-        <div className="d-flex align-items-center justify-content-between border-bottom border-secondary border-opacity-25 bg-white px-3 py-2">
-            <div className="d-flex align-items-center gap-3">
+        <div className="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center justify-content-sm-between border-bottom border-secondary border-opacity-25 bg-white px-3 py-2 gap-2">
+
+            {/* Navigation row: Dzisiaj + prev/date/next */}
+            <div className="d-flex align-items-center gap-2">
                 <button
                     onClick={onTodayClick}
-                    className="rounded-2 border border-secondary border-opacity-50 bg-white px-3 py-1 small fw-medium text-body"
+                    className="btn btn-sm btn-outline-secondary fw-medium"
+                    style={{ whiteSpace: 'nowrap' }}
                 >
                     Dzisiaj
                 </button>
-                <div className="d-flex align-items-center gap-1">
+
+                <div className="d-flex align-items-center flex-grow-1 justify-content-between justify-content-sm-start gap-1">
                     <button
                         onClick={handlePrev}
-                        className="rounded-2 p-1 text-muted"
+                        className="btn btn-sm btn-link text-muted p-1"
                         aria-label="Poprzedni"
+                        style={{ lineHeight: 1 }}
                     >
-                        <svg
-                            className="h-5 w-5"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M15 19l-7-7 7-7"
-                            />
+                        <svg style={{ width: 20, height: 20 }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                         </svg>
                     </button>
+
+                    <h2 className="mb-0 fw-semibold text-dark text-capitalize" style={{ fontSize: '0.95rem', whiteSpace: 'nowrap' }}>
+                        {/* Short on xs, full on sm+ */}
+                        <span className="d-inline d-sm-none">{formatDateLabel(true)}</span>
+                        <span className="d-none d-sm-inline">{formatDateLabel(false)}</span>
+                    </h2>
+
                     <button
                         onClick={handleNext}
-                        className="rounded-2 p-1 text-muted"
+                        className="btn btn-sm btn-link text-muted p-1"
                         aria-label="Następny"
+                        style={{ lineHeight: 1 }}
                     >
-                        <svg
-                            className="h-5 w-5"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M9 5l7 7-7 7"
-                            />
+                        <svg style={{ width: 20, height: 20 }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                         </svg>
                     </button>
                 </div>
-                <div className="d-flex align-items-baseline gap-2">
-                    <h2 className="fs-5 fw-semibold text-dark text-capitalize">
-                        {formatDateLabel()}
-                    </h2>
-                    {currentTime && (
-                        <span className="fs-5 fw-light text-primary">
-                            {format(currentTime, 'HH:mm')}
-                        </span>
-                    )}
-                </div>
+
+                {currentTime && (
+                    <span className="d-none d-sm-inline fw-light text-primary" style={{ fontSize: '0.9rem', whiteSpace: 'nowrap' }}>
+                        {format(currentTime, 'HH:mm')}
+                    </span>
+                )}
             </div>
 
-            <div className="d-flex align-items-center gap-2">
-                <div className="d-flex rounded-2 border border-secondary border-opacity-50 bg-white">
-                    <button
-                        onClick={() => onViewChange('day')}
-                        className={`px-3 py-1 small fw-medium ${
-                            view === 'day'
-                                ? 'bg-primary text-white'
-                                : 'text-body '
-                        } rounded-l-md`}
-                    >
-                        Dzień
-                    </button>
-                    <button
-                        onClick={() => onViewChange('week')}
-                        className={`border-start border-end border-secondary border-opacity-50 px-3 py-1 small fw-medium ${
-                            view === 'week'
-                                ? 'bg-primary text-white'
-                                : 'text-body '
-                        }`}
-                    >
-                        Tydzień
-                    </button>
-                    <button
-                        onClick={() => onViewChange('month')}
-                        className={`px-3 py-1 small fw-medium ${
-                            view === 'month'
-                                ? 'bg-primary text-white'
-                                : 'text-body '
-                        } rounded-r-md`}
-                    >
-                        Miesiąc
-                    </button>
-                </div>
+            {/* View toggle: Dzień | Tydzień | Miesiąc */}
+            <div className="btn-group btn-group-sm" role="group" aria-label="Widok kalendarza">
+                <button
+                    type="button"
+                    onClick={() => onViewChange('day')}
+                    className={`btn btn-sm ${view === 'day' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                >
+                    Dzień
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onViewChange('week')}
+                    className={`btn btn-sm ${view === 'week' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                >
+                    Tydzień
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onViewChange('month')}
+                    className={`btn btn-sm ${view === 'month' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                >
+                    Miesiąc
+                </button>
             </div>
         </div>
     );

--- a/apps/panel/src/components/calendar/CalendarHeader.tsx
+++ b/apps/panel/src/components/calendar/CalendarHeader.tsx
@@ -11,7 +11,7 @@ import {
     subMonths,
 } from 'date-fns';
 import { pl } from 'date-fns/locale';
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface CalendarHeaderProps {
     date: Date;
@@ -19,6 +19,7 @@ interface CalendarHeaderProps {
     onDateChange: (date: Date) => void;
     onViewChange: (view: CalendarView) => void;
     onTodayClick: () => void;
+    extraAction?: React.ReactNode;
 }
 
 export default function CalendarHeader({
@@ -27,6 +28,7 @@ export default function CalendarHeader({
     onDateChange,
     onViewChange,
     onTodayClick,
+    extraAction,
 }: CalendarHeaderProps) {
     const [currentTime, setCurrentTime] = useState<Date | null>(null);
 
@@ -164,33 +166,37 @@ export default function CalendarHeader({
                 )}
             </div>
 
-            {/* View toggle: Dzień | Tydzień | Miesiąc */}
-            <div
-                className="btn-group btn-group-sm"
-                role="group"
-                aria-label="Widok kalendarza"
-            >
-                <button
-                    type="button"
-                    onClick={() => onViewChange('day')}
-                    className={`btn btn-sm ${view === 'day' ? 'btn-primary' : 'btn-outline-secondary'}`}
+            <div className="d-flex align-items-center gap-2">
+                {extraAction}
+
+                {/* View toggle: Dzień | Tydzień | Miesiąc */}
+                <div
+                    className="btn-group btn-group-sm"
+                    role="group"
+                    aria-label="Widok kalendarza"
                 >
-                    Dzień
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onViewChange('week')}
-                    className={`btn btn-sm ${view === 'week' ? 'btn-primary' : 'btn-outline-secondary'}`}
-                >
-                    Tydzień
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onViewChange('month')}
-                    className={`btn btn-sm ${view === 'month' ? 'btn-primary' : 'btn-outline-secondary'}`}
-                >
-                    Miesiąc
-                </button>
+                    <button
+                        type="button"
+                        onClick={() => onViewChange('day')}
+                        className={`btn btn-sm ${view === 'day' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                    >
+                        Dzień
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onViewChange('week')}
+                        className={`btn btn-sm ${view === 'week' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                    >
+                        Tydzień
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onViewChange('month')}
+                        className={`btn btn-sm ${view === 'month' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                    >
+                        Miesiąc
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/apps/panel/src/components/calendar/CalendarView.tsx
+++ b/apps/panel/src/components/calendar/CalendarView.tsx
@@ -202,10 +202,13 @@ export default function CalendarView({
     }, [currentView]);
 
     return (
-        <div className={`d-flex h-100 ${hideSidebar ? '' : 'flex-column '}`}>
+        <div className="d-flex h-100">
             {/* Sidebar matches source layout: Left side filters */}
             {!hideSidebar && (
-                <div className="w-100 flex-flex-shrink-0 border-end border-secondary border-opacity-25 bg-white">
+                <div
+                    className="flex-shrink-0 border-end border-secondary border-opacity-25 bg-white"
+                    style={{ width: 220 }}
+                >
                     <CalendarSidebar
                         employees={employees}
                         selectedEmployeeIds={selectedEmployeeIds}
@@ -299,11 +302,7 @@ export default function CalendarView({
                             slotMaxTime="21:00:00" // source UI usually ends late
                             slotDuration="00:15:00"
                             allDaySlot={false}
-                            headerToolbar={{
-                                left: 'prev,next today',
-                                center: 'title',
-                                right: 'timeGridDay,timeGridWeek,dayGridMonth',
-                            }}
+                            headerToolbar={false}
                             height="auto"
                             contentHeight="auto"
                             nowIndicator

--- a/apps/panel/src/components/salon/navs/CalendarNav.tsx
+++ b/apps/panel/src/components/salon/navs/CalendarNav.tsx
@@ -110,25 +110,59 @@ export default function CalendarNav() {
     return (
         <>
             {/* Mini Calendar Header */}
-            <div className="nav-header flex-between" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px 4px' }}>
+            <div
+                className="nav-header flex-between"
+                style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '8px 12px 4px',
+                }}
+            >
                 <button
                     onClick={() => changeMonth(-1)}
                     className="btn btn-sm btn-link p-0"
                     aria-label="Poprzedni miesiąc"
                     style={{ lineHeight: 1 }}
                 >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
                         <path d="M15 18l-6-6 6-6" />
                     </svg>
                 </button>
-                <span style={{ fontWeight: 600, fontSize: '11px', letterSpacing: '0.05em' }}>{monthYear}</span>
+                <span
+                    style={{
+                        fontWeight: 600,
+                        fontSize: '11px',
+                        letterSpacing: '0.05em',
+                    }}
+                >
+                    {monthYear}
+                </span>
                 <button
                     onClick={() => changeMonth(1)}
                     className="btn btn-sm btn-link p-0"
                     aria-label="Następny miesiąc"
                     style={{ lineHeight: 1 }}
                 >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
                         <path d="M9 18l6-6-6-6" />
                     </svg>
                 </button>

--- a/apps/panel/src/components/salon/navs/ClientsNav.tsx
+++ b/apps/panel/src/components/salon/navs/ClientsNav.tsx
@@ -315,7 +315,9 @@ export default function ClientsNav() {
                             className={`column_row ${currentGroupId ? '' : 'hidden'}`}
                             id="filter_boxes_container"
                         >
-                            <div className="nav-header">KRYTERIA WYSZUKIWANIA</div>
+                            <div className="nav-header">
+                                KRYTERIA WYSZUKIWANIA
+                            </div>
                             <div id="filter_boxes">
                                 {groups
                                     ?.filter((g) => currentGroupId === g.id)

--- a/apps/panel/src/components/salon/navs/NewCustomerNav.tsx
+++ b/apps/panel/src/components/salon/navs/NewCustomerNav.tsx
@@ -41,40 +41,44 @@ export default function NewCustomerNav({
 }: NewCustomerNavProps) {
     return (
         <div className="sidenav" id="sidenav">
-        <div className="show_action_content client-detail-nav">
-            <div className="column_row">
-                <div className="nav-header">{title}</div>
-                <div className="tree">
-                    <ul>
-                        {tabs.map((tab) => (
-                            <li
-                                key={tab.id}
-                                className={
-                                    activeTab === tab.id ? 'active' : undefined
-                                }
-                            >
-                                <a
-                                    href={tab.href}
-                                    className={tab.isLast ? 'last' : undefined}
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        onSelect(tab.id);
-                                    }}
+            <div className="show_action_content client-detail-nav">
+                <div className="column_row">
+                    <div className="nav-header">{title}</div>
+                    <div className="tree">
+                        <ul>
+                            {tabs.map((tab) => (
+                                <li
+                                    key={tab.id}
+                                    className={
+                                        activeTab === tab.id
+                                            ? 'active'
+                                            : undefined
+                                    }
                                 >
-                                    <div className="icon_box">
-                                        <i
-                                            className={`icon ${tab.iconClass}`}
-                                            aria-hidden="true"
-                                        />
-                                    </div>
-                                    {tab.label}
-                                </a>
-                            </li>
-                        ))}
-                    </ul>
+                                    <a
+                                        href={tab.href}
+                                        className={
+                                            tab.isLast ? 'last' : undefined
+                                        }
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            onSelect(tab.id);
+                                        }}
+                                    >
+                                        <div className="icon_box">
+                                            <i
+                                                className={`icon ${tab.iconClass}`}
+                                                aria-hidden="true"
+                                            />
+                                        </div>
+                                        {tab.label}
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
         </div>
     );
 }

--- a/apps/panel/src/components/salon/navs/StatisticsNav.tsx
+++ b/apps/panel/src/components/salon/navs/StatisticsNav.tsx
@@ -100,15 +100,26 @@ export default function StatisticsNav() {
         <div className="column_row tree">
             <ul id="statistics_menu_list">
                 {REPORTS.map((item) => (
-                    <li key={item.id} className={isActive(item.href) ? 'active' : ''}>
+                    <li
+                        key={item.id}
+                        className={isActive(item.href) ? 'active' : ''}
+                    >
                         <Link href={item.href} title={item.label}>
                             {item.label}
                         </Link>
                         {item.children ? (
                             <ul>
                                 {item.children.map((child) => (
-                                    <li key={child.id} className={isActive(child.href) ? 'active' : ''}>
-                                        <Link href={child.href} title={child.label}>
+                                    <li
+                                        key={child.id}
+                                        className={
+                                            isActive(child.href) ? 'active' : ''
+                                        }
+                                    >
+                                        <Link
+                                            href={child.href}
+                                            title={child.label}
+                                        >
                                             {child.label}
                                         </Link>
                                     </li>

--- a/apps/panel/src/pages/calendar.tsx
+++ b/apps/panel/src/pages/calendar.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import type { ParsedUrlQuery } from 'querystring';
 import RouteGuard from '@/components/RouteGuard';
 import SalonShell from '@/components/salon/SalonShell';
 import SalonBreadcrumbs from '@/components/salon/SalonBreadcrumbs';
 import CalendarView from '@/components/calendar/CalendarView';
+import CalendarHeader from '@/components/calendar/CalendarHeader';
 import AppointmentDrawer from '@/components/calendar/AppointmentDrawer';
 import AppointmentQuickModal from '@/components/calendar/AppointmentQuickModal';
 import ReceptionView from '@/components/calendar/ReceptionView';
@@ -1656,28 +1656,45 @@ export default function CalendarPage() {
                         items={[{ label: 'Kalendarz' }]}
                     />
 
-                    <div className="d-flex align-items-center justify-content-between gap-2 px-3 pb-2">
-                        <div className="small text-muted">
-                            Natywny kalendarz Booksy-like (beta). Legacy:{' '}
-                            <Link href="/calendar">/calendar</Link>
-                        </div>
-                        {role !== 'client' ? (
-                            <button
-                                type="button"
-                                className="btn btn-primary btn-sm"
-                                onClick={() =>
-                                    setDrawer({
-                                        open: true,
-                                        mode: 'create',
-                                        appointment: null,
-                                        initialStartTime: new Date(),
-                                    })
-                                }
-                            >
-                                Nowa wizyta
-                            </button>
-                        ) : null}
-                    </div>
+                    {!employeeMode && !clientMode && (
+                        <CalendarHeader
+                            date={currentDate}
+                            view={currentView}
+                            onDateChange={(date) => {
+                                setCurrentDate(date);
+                                updateCalendarQuery({
+                                    date: toDateParam(date),
+                                });
+                            }}
+                            onViewChange={(view) => {
+                                setCurrentView(view);
+                                updateCalendarQuery({ view });
+                            }}
+                            onTodayClick={() => {
+                                const today = new Date();
+                                setCurrentDate(today);
+                                updateCalendarQuery({
+                                    date: toDateParam(today),
+                                });
+                            }}
+                            extraAction={
+                                <button
+                                    type="button"
+                                    className="btn btn-primary btn-sm"
+                                    onClick={() =>
+                                        setDrawer({
+                                            open: true,
+                                            mode: 'create',
+                                            appointment: null,
+                                            initialStartTime: new Date(),
+                                        })
+                                    }
+                                >
+                                    + Wizyta
+                                </button>
+                            }
+                        />
+                    )}
 
                     <div className="px-3 pb-3">
                         {deepLinkError ? (


### PR DESCRIPTION
## Summary

- **Sidenav light theme** — `globals.css` overrides dark background; `nav-header` text/link/hover/active colours unified across all sidenav nav components (`CalendarNav`, `ClientsNav`, `ClientDetailNav`, `EmployeesNav`, `NewCustomerNav`)
- **Employee filter** — column layout + hover/colour fixes in light theme section
- **Topbar cleanup** — disabled non-functional bell (`notifications.enabled = false`), removed hardcoded `MODULE_BADGES` badge on communication, fixed floating help button (was `<button>`, now `<Link href="/helps/new">`)
- **`svg-chat` symbol** — added missing symbol to `SalonSvgSprites.tsx` so the floating help icon renders
- **Pending bookings count** — `usePendingBookingsCount` switched to dedicated `/appointments/online-pending-count` endpoint (returns live DB count, role-scoped)
- **CalendarHeader mobile (iPhone fix)** — replaced no-op Tailwind classes (`h-5 w-5`, `rounded-l-md`) with Bootstrap equivalents; two-row responsive layout (`flex-column flex-sm-row`); shorter date format on xs; clock hidden on mobile

## Test plan

- [ ] Sidenav on all panel pages shows white/light background with grey nav-header text
- [ ] Active nav item is highlighted with gold colour (`#c5a880`)
- [ ] Floating help button navigates to `/helps/new`
- [ ] svg-chat icon visible in floating button
- [ ] Calendar on iPhone (375px): view toggle, prev/next arrows, and date label all visible and tappable
- [ ] Calendar view changes (day/week/month) work on mobile
- [ ] Pending bookings badge hidden when count = 0, shown when > 0

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_