### PR TITLE
style(brand): replace gold accent with silver across landing and panel

### DIFF
--- a/apps/landing/src/components/AboutSpread.tsx
+++ b/apps/landing/src/components/AboutSpread.tsx
@@ -23,7 +23,7 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                         <div>
                             <p
                                 className="text-xs uppercase mb-4"
-                                style={{ color: '#c5a880', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}
+                                style={{ color: '#b4b8be', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}
                             >
                                 {T.founder.eyebrow}
                             </p>
@@ -33,7 +33,7 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                                 style={{
                                     fontFamily: "var(--font-playfair), serif",
                                     fontSize: 'clamp(5rem, 10vw, 9rem)',
-                                    color: '#c5a880',
+                                    color: '#b4b8be',
                                     lineHeight: 0.75,
                                     opacity: 0.25,
                                     marginBottom: '-0.25rem',
@@ -58,7 +58,7 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                                 <footer>
                                     <cite
                                         className="not-italic block"
-                                        style={{ fontFamily: "var(--font-playfair), serif", fontStyle: 'italic', fontSize: '1.5rem', color: '#c5a880', lineHeight: 1.1 }}
+                                        style={{ fontFamily: "var(--font-playfair), serif", fontStyle: 'italic', fontSize: '1.5rem', color: '#b4b8be', lineHeight: 1.1 }}
                                     >
                                         {data.name}
                                     </cite>
@@ -69,8 +69,8 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                             </blockquote>
 
                             <div className="mt-6 flex items-center gap-3">
-                                <div style={{ width: '32px', height: '1px', background: '#c5a880' }} />
-                                <span className="text-xs" style={{ color: '#c5a880', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}>
+                                <div style={{ width: '32px', height: '1px', background: '#b4b8be' }} />
+                                <span className="text-xs" style={{ color: '#b4b8be', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}>
                                     {T.founder.since}
                                 </span>
                             </div>
@@ -81,7 +81,7 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                                     <div key={item.id} className="timeline-item">
                                         <span
                                             className="text-xs font-bold block mb-0.5"
-                                            style={{ color: '#c5a880', fontFamily: "var(--font-open-sans), sans-serif", letterSpacing: '0.1em' }}
+                                            style={{ color: '#b4b8be', fontFamily: "var(--font-open-sans), sans-serif", letterSpacing: '0.1em' }}
                                         >
                                             {T.history.yearMap[item.id as keyof typeof T.history.yearMap]}
                                         </span>
@@ -98,7 +98,7 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                             <div className="relative">
                                 <div
                                     className="absolute"
-                                    style={{ top: '-12px', right: '-12px', left: '12px', bottom: '12px', border: '1px solid #c5a880', borderRadius: '3px', zIndex: 0 }}
+                                    style={{ top: '-12px', right: '-12px', left: '12px', bottom: '12px', border: '1px solid #b4b8be', borderRadius: '3px', zIndex: 0 }}
                                 />
                                 <div
                                     className="relative overflow-hidden"
@@ -114,7 +114,7 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                                         />
                                     ) : (
                                         <div className="w-full h-full flex items-center justify-center" style={{ background: '#e8e2da' }}>
-                                            <span style={{ fontFamily: "var(--font-playfair), serif", fontSize: '3rem', color: '#c5a880' }}>A</span>
+                                            <span style={{ fontFamily: "var(--font-playfair), serif", fontSize: '3rem', color: '#b4b8be' }}>A</span>
                                         </div>
                                     )}
                                 </div>
@@ -133,9 +133,9 @@ export default function AboutSpread({ founder }: { founder?: FounderData }) {
                                 <div key={p.id} className="flex gap-4">
                                     <div
                                         className="shrink-0 w-9 h-9 flex items-center justify-center mt-1"
-                                        style={{ background: 'rgba(197,168,128,0.1)', borderRadius: '2px' }}
+                                        style={{ background: 'rgba(180,184,190,0.1)', borderRadius: '2px' }}
                                     >
-                                        <Icon size={18} strokeWidth={1.5} style={{ color: '#c5a880' }} />
+                                        <Icon size={18} strokeWidth={1.5} style={{ color: '#b4b8be' }} />
                                     </div>
                                     <div>
                                         <h3

--- a/apps/landing/src/components/BookingModal.tsx
+++ b/apps/landing/src/components/BookingModal.tsx
@@ -96,7 +96,7 @@ export default function BookingModal({
         background: 'rgba(255,255,255,0.04)',
         border: `1px solid ${
             focusedField === field
-                ? '#c5a880'
+                ? '#b4b8be'
                 : (field === 'email' && emailError) ||
                     (field === 'password' && passwordError)
                   ? 'rgba(220,60,60,0.6)'
@@ -127,7 +127,7 @@ export default function BookingModal({
                 className="w-full max-w-sm"
                 style={{
                     background: '#0d0d0d',
-                    border: '1px solid rgba(197,168,128,0.2)',
+                    border: '1px solid rgba(180,184,190,0.2)',
                     borderRadius: '3px',
                     overflow: 'hidden',
                     boxShadow: '0 24px 64px rgba(0,0,0,0.7)',
@@ -139,7 +139,7 @@ export default function BookingModal({
                     style={{
                         height: '3px',
                         background:
-                            'linear-gradient(90deg, #c5a880, #e8d5b0, #c5a880)',
+                            'linear-gradient(90deg, #b4b8be, #dce0e4, #b4b8be)',
                     }}
                 />
 
@@ -153,7 +153,7 @@ export default function BookingModal({
                                 fontSize: '0.6rem',
                                 letterSpacing: '0.2em',
                                 textTransform: 'uppercase',
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 marginBottom: '0.5rem',
                             }}
                         >
@@ -209,7 +209,7 @@ export default function BookingModal({
                             style={{
                                 width: '28px',
                                 height: '1px',
-                                background: '#c5a880',
+                                background: '#b4b8be',
                                 marginTop: '1rem',
                                 opacity: 0.6,
                             }}
@@ -236,7 +236,7 @@ export default function BookingModal({
                                     display: 'block',
                                     width: '100%',
                                     padding: '0.85rem 1.5rem',
-                                    background: '#c5a880',
+                                    background: '#b4b8be',
                                     color: '#0d0d0d',
                                     border: 'none',
                                     borderRadius: '2px',
@@ -398,8 +398,8 @@ export default function BookingModal({
                                     width: '100%',
                                     padding: '0.85rem 1.5rem',
                                     background: submitting
-                                        ? '#a8895f'
-                                        : '#c5a880',
+                                        ? '#8e9298'
+                                        : '#b4b8be',
                                     color: '#0d0d0d',
                                     border: 'none',
                                     borderRadius: '2px',
@@ -432,7 +432,7 @@ export default function BookingModal({
                                 <a
                                     href={getPanelUrl('/auth/register')}
                                     style={{
-                                        color: '#c5a880',
+                                        color: '#b4b8be',
                                         textDecoration: 'none',
                                     }}
                                 >

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
             <div className="container mx-auto px-4 md:px-8" style={{ paddingTop: '4rem', paddingBottom: '2.5rem' }}>
                 <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-10 mb-14">
                     <div className="max-w-xs">
-                        <Link href={'/' as Route} className="inline-block mb-4 focus:outline-none focus:ring-2 focus:ring-[#c5a880]" aria-label="Black & White — strona główna">
+                        <Link href={'/' as Route} className="inline-block mb-4 focus:outline-none focus:ring-2 focus:ring-[#b4b8be]" aria-label="Black & White — strona główna">
                             <Image
                                 src="/images/logo.svg"
                                 alt="Black & White"
@@ -44,7 +44,7 @@ export default function Footer() {
                         <button
                             onClick={() => setBookingOpen(true)}
                             type="button"
-                            className="mt-5 text-xs font-semibold uppercase footer-booking-btn focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
+                            className="mt-5 text-xs font-semibold uppercase footer-booking-btn focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                         >
                             {T.nav.booking}
                         </button>
@@ -58,7 +58,7 @@ export default function Footer() {
                                     <li key={link.href}>
                                         <Link
                                             href={link.href as Route}
-                                            className="text-sm footer-link focus:ring-2 focus:ring-[#c5a880]"
+                                            className="text-sm footer-link focus:ring-2 focus:ring-[#b4b8be]"
                                         >
                                             {link.label}
                                         </Link>
@@ -119,7 +119,7 @@ export default function Footer() {
                     <div className="flex gap-5">
                         {[{ href: '/privacy', label: T.footer.privacy }, { href: '/policy', label: T.footer.terms }].map(l => (
                             <Link key={l.href} href={l.href as Route}
-                                className="text-xs footer-link--dim focus:ring-2 focus:ring-[#c5a880]"
+                                className="text-xs footer-link--dim focus:ring-2 focus:ring-[#b4b8be]"
                             >
                                 {l.label}
                             </Link>

--- a/apps/landing/src/components/FounderMessage.tsx
+++ b/apps/landing/src/components/FounderMessage.tsx
@@ -21,7 +21,7 @@ export default function FounderMessage({ founder }: FounderMessageProps) {
                             <div className="relative">
                                 <div
                                     className="absolute"
-                                    style={{ top: '-12px', left: '-12px', right: '12px', bottom: '12px', border: '1px solid #c5a880', borderRadius: '3px', zIndex: 0 }}
+                                    style={{ top: '-12px', left: '-12px', right: '12px', bottom: '12px', border: '1px solid #b4b8be', borderRadius: '3px', zIndex: 0 }}
                                 />
                                 <div className="relative overflow-hidden" style={{ width: '280px', height: '340px', borderRadius: '3px', zIndex: 1 }}>
                                     {data.photo ? (
@@ -34,7 +34,7 @@ export default function FounderMessage({ founder }: FounderMessageProps) {
                                         />
                                     ) : (
                                         <div className="w-full h-full flex items-center justify-center" style={{ background: '#e8e2da' }}>
-                                            <span style={{ fontFamily: "var(--font-playfair), serif", fontSize: '3rem', color: '#c5a880' }}>A</span>
+                                            <span style={{ fontFamily: "var(--font-playfair), serif", fontSize: '3rem', color: '#b4b8be' }}>A</span>
                                         </div>
                                     )}
                                 </div>
@@ -43,18 +43,18 @@ export default function FounderMessage({ founder }: FounderMessageProps) {
 
                         {/* Text */}
                         <div>
-                            <p className="text-xs tracking-widest uppercase mb-4" style={{ color: '#c5a880', letterSpacing: '0.22em', fontFamily: "var(--font-open-sans), sans-serif" }}>
+                            <p className="text-xs tracking-widest uppercase mb-4" style={{ color: '#b4b8be', letterSpacing: '0.22em', fontFamily: "var(--font-open-sans), sans-serif" }}>
                                 {T.founder.eyebrow}
                             </p>
 
-                            <div className="mb-2" style={{ fontFamily: "var(--font-playfair), serif", fontSize: '3.5rem', color: '#c5a880', lineHeight: 0.8, opacity: 0.5 }}>&ldquo;</div>
+                            <div className="mb-2" style={{ fontFamily: "var(--font-playfair), serif", fontSize: '3.5rem', color: '#b4b8be', lineHeight: 0.8, opacity: 0.5 }}>&ldquo;</div>
 
                             <blockquote>
                                 <p className="text-lg leading-relaxed mb-8" style={{ fontFamily: "var(--font-playfair), serif", fontStyle: 'italic', color: '#3a3028' }}>
                                     {data.quote}
                                 </p>
                                 <footer>
-                                    <cite className="not-italic block" style={{ fontFamily: "var(--font-tangerine), cursive", fontSize: '2.4rem', color: '#c5a880', lineHeight: 1.1 }}>
+                                    <cite className="not-italic block" style={{ fontFamily: "var(--font-tangerine), cursive", fontSize: '2.4rem', color: '#b4b8be', lineHeight: 1.1 }}>
                                         {data.name}
                                     </cite>
                                     <span className="text-xs mt-1 block tracking-wider" style={{ color: '#8a7060', letterSpacing: '0.12em' }}>
@@ -64,8 +64,8 @@ export default function FounderMessage({ founder }: FounderMessageProps) {
                             </blockquote>
 
                             <div className="mt-8 flex items-center gap-3">
-                                <div style={{ width: '32px', height: '1px', background: '#c5a880' }} />
-                                <span className="text-xs tracking-widest" style={{ color: '#c5a880', letterSpacing: '0.2em' }}>
+                                <div style={{ width: '32px', height: '1px', background: '#b4b8be' }} />
+                                <span className="text-xs tracking-widest" style={{ color: '#b4b8be', letterSpacing: '0.2em' }}>
                                     {T.founder.since}
                                 </span>
                             </div>

--- a/apps/landing/src/components/HeroSlider.tsx
+++ b/apps/landing/src/components/HeroSlider.tsx
@@ -116,7 +116,7 @@ export default function HeroSlider({ slides }: HeroSliderProps) {
                         <a
                             href={bookingUrl}
                             className="btn-gold inline-block px-10 py-4 text-sm font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-offset-2"
-                            style={{ letterSpacing: '0.12em', borderRadius: '2px', boxShadow: '0 4px 24px rgba(197,168,128,0.4)' }}
+                            style={{ letterSpacing: '0.12em', borderRadius: '2px', boxShadow: '0 4px 24px rgba(180,184,190,0.4)' }}
                         >
                             {T.nav.booking}
                         </a>

--- a/apps/landing/src/components/HistoryAccordion.tsx
+++ b/apps/landing/src/components/HistoryAccordion.tsx
@@ -26,21 +26,21 @@ export default function HistoryAccordion({ items }: HistoryAccordionProps) {
                                 <button
                                     type="button"
                                     onClick={() => toggle(item.id)}
-                                    className="w-full py-6 flex justify-between items-center text-left transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-inset"
+                                    className="w-full py-6 flex justify-between items-center text-left transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-inset"
                                     aria-expanded={isOpen}
                                     aria-controls={`history-content-${item.id}`}
                                 >
                                     <div className="flex items-center gap-5">
-                                        <span className="text-xs font-mono w-10 shrink-0" style={{ color: '#c5a880' }}>
+                                        <span className="text-xs font-mono w-10 shrink-0" style={{ color: '#b4b8be' }}>
                                             {T.history.yearMap[item.id as keyof typeof T.history.yearMap] ?? '—'}
                                         </span>
-                                        <h3 className="text-lg font-semibold" style={{ fontFamily: "var(--font-playfair), serif", color: isOpen ? '#c5a880' : '#ffffff', transition: 'color 0.2s' }}>
+                                        <h3 className="text-lg font-semibold" style={{ fontFamily: "var(--font-playfair), serif", color: isOpen ? '#b4b8be' : '#ffffff', transition: 'color 0.2s' }}>
                                             {item.title}
                                         </h3>
                                     </div>
                                     <svg
                                         className="shrink-0 ml-4 transition-transform duration-300"
-                                        style={{ transform: isOpen ? 'rotate(180deg)' : 'rotate(0)', color: '#c5a880' }}
+                                        style={{ transform: isOpen ? 'rotate(180deg)' : 'rotate(0)', color: '#b4b8be' }}
                                         width={18} height={18} fill="none" stroke="currentColor" viewBox="0 0 24 24"
                                     >
                                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />

--- a/apps/landing/src/components/Navbar.tsx
+++ b/apps/landing/src/components/Navbar.tsx
@@ -55,7 +55,7 @@ export default function Navbar() {
         }
     }, [mobileMenuOpen]);
 
-    const navLinkClass = 'transition duration-200 text-sm tracking-wide font-medium text-gray-800 hover:text-[#c5a880] focus:outline-none focus:ring-2 focus:ring-offset-2';
+    const navLinkClass = 'transition duration-200 text-sm tracking-wide font-medium text-gray-800 hover:text-[#b4b8be] focus:outline-none focus:ring-2 focus:ring-offset-2';
 
     return (
         <>
@@ -74,7 +74,7 @@ export default function Navbar() {
                     {/* Logo */}
                     <Link
                         href={'/' as Route}
-                        className="flex items-center focus:outline-none focus:ring-2 focus:ring-[#c5a880]"
+                        className="flex items-center focus:outline-none focus:ring-2 focus:ring-[#b4b8be]"
                         onClick={() => setMobileMenuOpen(false)}
                         aria-label="Black & White — strona główna"
                     >
@@ -104,7 +104,7 @@ export default function Navbar() {
                                         <Link
                                             href={href as Route}
                                             className={navLinkClass}
-                                            style={active ? { color: '#c5a880', borderBottom: '1px solid #c5a880', paddingBottom: '2px' } : undefined}
+                                            style={active ? { color: '#b4b8be', borderBottom: '1px solid #b4b8be', paddingBottom: '2px' } : undefined}
                                             aria-current={active ? 'page' : undefined}
                                         >
                                             {label}
@@ -141,10 +141,10 @@ export default function Navbar() {
                                     key={code}
                                     type="button"
                                     onClick={() => setLang(code)}
-                                    className="text-xs font-semibold tracking-wider transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-[#c5a880] px-1 py-0.5"
+                                    className="text-xs font-semibold tracking-wider transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-[#b4b8be] px-1 py-0.5"
                                     style={{
-                                        color: lang === code ? '#c5a880' : '#8a7060',
-                                        borderBottom: lang === code ? '1px solid #c5a880' : '1px solid transparent',
+                                        color: lang === code ? '#b4b8be' : '#8a7060',
+                                        borderBottom: lang === code ? '1px solid #b4b8be' : '1px solid transparent',
                                     }}
                                     aria-pressed={lang === code}
                                     aria-label={`Język: ${label}`}
@@ -155,7 +155,7 @@ export default function Navbar() {
                         </div>
 
                         <button
-                            className="btn-gold px-6 py-2.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2"
+                            className="btn-gold px-6 py-2.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2"
                             style={{ color: '#fff', borderRadius: '2px', letterSpacing: '0.14em' }}
                             onClick={() => { trackEvent('begin_checkout', { cta: 'navbar' }); setBookingModalOpen(true); }}
                         >
@@ -165,7 +165,7 @@ export default function Navbar() {
 
                     {/* Mobile Hamburger */}
                     <button
-                        className="md:hidden p-2 rounded focus:outline-none focus:ring-2 focus:ring-[#c5a880]"
+                        className="md:hidden p-2 rounded focus:outline-none focus:ring-2 focus:ring-[#b4b8be]"
                         onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                         aria-label="Toggle menu"
                         aria-expanded={mobileMenuOpen}
@@ -207,7 +207,7 @@ export default function Navbar() {
                                         <Link
                                             href={href as Route}
                                             className="block py-2.5 px-4 text-sm font-medium transition"
-                                            style={{ color: active ? '#c5a880' : undefined }}
+                                            style={{ color: active ? '#b4b8be' : undefined }}
                                             onClick={() => setMobileMenuOpen(false)}
                                             aria-current={active ? 'page' : undefined}
                                         >
@@ -218,11 +218,11 @@ export default function Navbar() {
                             })}
                             {dashboardRoute ? (
                                 <>
-                                    <li><a href={dashboardRoute} className="block py-2.5 px-4 text-gray-800 hover:text-[#c5a880] text-sm font-medium transition">{T.nav.panel}</a></li>
+                                    <li><a href={dashboardRoute} className="block py-2.5 px-4 text-gray-800 hover:text-[#b4b8be] text-sm font-medium transition">{T.nav.panel}</a></li>
                                     <li>
                                         <button
                                             onClick={() => { void handleLogout(); setMobileMenuOpen(false); }}
-                                            className="block w-full text-left py-2.5 px-4 text-gray-800 hover:text-[#c5a880] text-sm font-medium transition"
+                                            className="block w-full text-left py-2.5 px-4 text-gray-800 hover:text-[#b4b8be] text-sm font-medium transition"
                                             type="button"
                                         >
                                             {T.nav.logout}
@@ -234,7 +234,7 @@ export default function Navbar() {
                                     <button
                                         type="button"
                                         onClick={() => { setBookingModalOpen(true); setMobileMenuOpen(false); }}
-                                        className="block w-full text-left py-2.5 px-4 text-gray-800 hover:text-[#c5a880] text-sm font-medium transition"
+                                        className="block w-full text-left py-2.5 px-4 text-gray-800 hover:text-[#b4b8be] text-sm font-medium transition"
                                     >
                                         {T.nav.login}
                                     </button>
@@ -250,7 +250,7 @@ export default function Navbar() {
                                     type="button"
                                     onClick={() => { setLang(code); }}
                                     className="text-xs font-semibold tracking-wider transition-colors duration-150 focus:outline-none"
-                                    style={{ color: lang === code ? '#c5a880' : '#8a7060', borderBottom: lang === code ? '1px solid #c5a880' : '1px solid transparent' }}
+                                    style={{ color: lang === code ? '#b4b8be' : '#8a7060', borderBottom: lang === code ? '1px solid #b4b8be' : '1px solid transparent' }}
                                     aria-pressed={lang === code}
                                 >
                                     {label}
@@ -260,7 +260,7 @@ export default function Navbar() {
 
                         <div className="px-4 mt-4">
                             <button
-                                className="btn-gold block w-full text-center py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880]"
+                                className="btn-gold block w-full text-center py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#b4b8be]"
                                 style={{ color: '#fff', borderRadius: '2px', letterSpacing: '0.14em' }}
                                 onClick={() => { setMobileMenuOpen(false); trackEvent('begin_checkout', { cta: 'mobile_menu' }); setBookingModalOpen(true); }}
                             >

--- a/apps/landing/src/components/SalonGallery.tsx
+++ b/apps/landing/src/components/SalonGallery.tsx
@@ -121,7 +121,7 @@ export default function SalonGallery({ images }: SalonGalleryProps) {
                 <div className="text-center mt-10">
                     <Link
                         href="/gallery"
-                        className="btn-outline-white inline-block px-8 py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
+                        className="btn-outline-white inline-block px-8 py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                         style={{ borderRadius: '2px', letterSpacing: '0.16em' }}
                     >
                         {g.viewAll}

--- a/apps/landing/src/components/SectionHeader.tsx
+++ b/apps/landing/src/components/SectionHeader.tsx
@@ -13,7 +13,7 @@ export default function SectionHeader({ eyebrow, title, subtitle, dark = false, 
         <div className={isLeft ? 'mb-14' : 'text-center mb-14'}>
             <p
                 className="text-xs uppercase mb-3"
-                style={{ color: '#c5a880', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}
+                style={{ color: '#b4b8be', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}
             >
                 {eyebrow}
             </p>
@@ -23,7 +23,7 @@ export default function SectionHeader({ eyebrow, title, subtitle, dark = false, 
             >
                 {title}
             </Tag>
-            <div className={isLeft ? 'mt-4' : 'mx-auto mt-4'} style={{ width: '40px', height: '2px', background: '#c5a880' }} />
+            <div className={isLeft ? 'mt-4' : 'mx-auto mt-4'} style={{ width: '40px', height: '2px', background: '#b4b8be' }} />
             {subtitle && (
                 <p
                     className={`text-sm mt-5 max-w-lg ${isLeft ? '' : 'mx-auto'}`}

--- a/apps/landing/src/components/ServicesTeaser.tsx
+++ b/apps/landing/src/components/ServicesTeaser.tsx
@@ -33,7 +33,7 @@ export default function ServicesTeaser() {
                             <Link
                                 key={title}
                                 href={href}
-                                className={`group relative flex flex-col p-8 md:p-10 overflow-hidden focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-4 ${featured ? 'service-card-dark' : ''}`}
+                                className={`group relative flex flex-col p-8 md:p-10 overflow-hidden focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-4 ${featured ? 'service-card-dark' : ''}`}
                                 style={{
                                     background: featured ? '#0d0d0d' : '#faf9f7',
                                     border: featured ? 'none' : '1px solid #ede9e3',
@@ -62,19 +62,19 @@ export default function ServicesTeaser() {
                                 <span className="service-numeral" aria-hidden="true">{numeral}</span>
 
                                 {featured && (
-                                    <span className="absolute top-4 right-4 text-xs tracking-widest uppercase px-2 py-1 z-10" style={{ color: '#c5a880', border: '1px solid #c5a880', fontSize: '9px', letterSpacing: '0.2em' }}>
+                                    <span className="absolute top-4 right-4 text-xs tracking-widest uppercase px-2 py-1 z-10" style={{ color: '#b4b8be', border: '1px solid #b4b8be', fontSize: '9px', letterSpacing: '0.2em' }}>
                                         {T.services.featured}
                                     </span>
                                 )}
 
-                                <div className="relative z-10 mb-6 w-11 h-11 flex items-center justify-center" style={{ background: featured ? 'rgba(197,168,128,0.15)' : 'rgba(197,168,128,0.1)', borderRadius: '2px' }}>
-                                    <Icon size={22} style={{ color: '#c5a880', strokeWidth: 1.5 }} />
+                                <div className="relative z-10 mb-6 w-11 h-11 flex items-center justify-center" style={{ background: featured ? 'rgba(180,184,190,0.15)' : 'rgba(180,184,190,0.1)', borderRadius: '2px' }}>
+                                    <Icon size={22} style={{ color: '#b4b8be', strokeWidth: 1.5 }} />
                                 </div>
 
                                 <h3 className="relative z-10 text-xl font-bold mb-1" style={{ fontFamily: "var(--font-playfair), serif", color: featured ? '#ffffff' : '#0d0d0d' }}>
                                     {title}
                                 </h3>
-                                <p className="relative z-10 text-xs tracking-wider uppercase mb-4" style={{ color: '#c5a880', letterSpacing: '0.14em' }}>
+                                <p className="relative z-10 text-xs tracking-wider uppercase mb-4" style={{ color: '#b4b8be', letterSpacing: '0.14em' }}>
                                     {subtitle}
                                 </p>
                                 <p className="relative z-10 text-sm leading-relaxed" style={{ color: featured ? 'rgba(255,255,255,0.65)' : '#6b5f52' }}>
@@ -84,14 +84,14 @@ export default function ServicesTeaser() {
                                 {'keyServices' in T.services.items[idx] && T.services.items[idx].keyServices && (
                                     <ul
                                         className="relative z-10 flex-grow flex flex-col justify-between"
-                                        style={{ listStyle: 'none', padding: 0, margin: '1.5rem 0 0', borderTop: '1px solid rgba(197,168,128,0.15)' }}
+                                        style={{ listStyle: 'none', padding: 0, margin: '1.5rem 0 0', borderTop: '1px solid rgba(180,184,190,0.15)' }}
                                     >
                                         {(T.services.items[idx].keyServices as string[]).map((name) => (
                                             <li
                                                 key={name}
                                                 className="flex items-center gap-3"
                                                 style={{
-                                                    borderBottom: '1px solid rgba(197,168,128,0.12)',
+                                                    borderBottom: '1px solid rgba(180,184,190,0.12)',
                                                     padding: '0.65rem 0',
                                                     color: featured ? 'rgba(255,255,255,0.6)' : '#6b5f52',
                                                     fontSize: '0.78rem',
@@ -99,7 +99,7 @@ export default function ServicesTeaser() {
                                                     fontFamily: 'var(--font-open-sans), sans-serif',
                                                 }}
                                             >
-                                                <span style={{ color: '#c5a880', flexShrink: 0, fontSize: '0.9rem' }}>—</span>
+                                                <span style={{ color: '#b4b8be', flexShrink: 0, fontSize: '0.9rem' }}>—</span>
                                                 {name}
                                             </li>
                                         ))}
@@ -107,7 +107,7 @@ export default function ServicesTeaser() {
                                 )}
                                 {!('keyServices' in T.services.items[idx]) && <div className="flex-grow" />}
 
-                                <span className="relative z-10 mt-8 inline-flex items-center gap-2 text-xs font-semibold tracking-widest uppercase transition-all duration-200" style={{ color: '#c5a880', letterSpacing: '0.16em' }}>
+                                <span className="relative z-10 mt-8 inline-flex items-center gap-2 text-xs font-semibold tracking-widest uppercase transition-all duration-200" style={{ color: '#b4b8be', letterSpacing: '0.16em' }}>
                                     {T.services.learnMore}
                                     <svg className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -121,7 +121,7 @@ export default function ServicesTeaser() {
                 <div className="text-center mt-12">
                     <Link
                         href="/services"
-                        className="btn-outline-dark inline-block px-8 py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2"
+                        className="btn-outline-dark inline-block px-8 py-3.5 text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2"
                         style={{ borderRadius: '2px', letterSpacing: '0.16em' }}
                     >
                         {T.services.viewAll}

--- a/apps/landing/src/components/Testimonials.tsx
+++ b/apps/landing/src/components/Testimonials.tsx
@@ -20,7 +20,7 @@ export default function Testimonials() {
                         style={{
                             fontFamily: "var(--font-playfair), serif",
                             fontSize: 'clamp(8rem, 18vw, 14rem)',
-                            color: '#c5a880',
+                            color: '#b4b8be',
                             lineHeight: 0.75,
                             opacity: 0.22,
                             marginBottom: '-0.15em',
@@ -49,7 +49,7 @@ export default function Testimonials() {
                         aria-label={T.testimonials.starsLabel.replace('{n}', String(stars))}
                     >
                         {Array.from({ length: stars }).map((_, i) => (
-                            <svg key={i} className="w-4 h-4" aria-hidden="true" fill="#c5a880" viewBox="0 0 20 20">
+                            <svg key={i} className="w-4 h-4" aria-hidden="true" fill="#b4b8be" viewBox="0 0 20 20">
                                 <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                             </svg>
                         ))}
@@ -69,12 +69,12 @@ export default function Testimonials() {
                             key={t.name}
                             type="button"
                             onClick={() => { if (i !== active) setActive(i); }}
-                            className="focus:outline-none focus:ring-2 focus:ring-[#c5a880]"
+                            className="focus:outline-none focus:ring-2 focus:ring-[#b4b8be]"
                             style={{
                                 width: i === active ? '36px' : '8px',
                                 height: '6px',
                                 borderRadius: '3px',
-                                background: i === active ? '#c5a880' : 'rgba(255,255,255,0.2)',
+                                background: i === active ? '#b4b8be' : 'rgba(255,255,255,0.2)',
                                 transition: 'width 0.45s cubic-bezier(0.34,1.56,0.64,1), background 0.3s',
                                 border: 'none',
                                 cursor: 'pointer',

--- a/apps/landing/src/components/ValuesSection.tsx
+++ b/apps/landing/src/components/ValuesSection.tsx
@@ -61,15 +61,15 @@ export default function ValuesSection() {
                                 tabIndex={isActive ? 0 : -1}
                                 onClick={() => setActive(value.id)}
                                 onKeyDown={e => handleKeyDown(e, value.id)}
-                                className="flex flex-col items-center gap-3 py-5 px-3 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2"
+                                className="flex flex-col items-center gap-3 py-5 px-3 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2"
                                 style={{
                                     background: isActive ? '#0d0d0d' : '#ffffff',
                                     border: isActive ? '1px solid #0d0d0d' : '1px solid #ede9e3',
                                     borderRadius: '3px',
                                 }}
                             >
-                                <div className="w-9 h-9 flex items-center justify-center" style={{ background: isActive ? 'rgba(197,168,128,0.2)' : 'rgba(197,168,128,0.1)', borderRadius: '2px' }}>
-                                    <Icon size={18} strokeWidth={1.5} style={{ color: '#c5a880' }} />
+                                <div className="w-9 h-9 flex items-center justify-center" style={{ background: isActive ? 'rgba(180,184,190,0.2)' : 'rgba(180,184,190,0.1)', borderRadius: '2px' }}>
+                                    <Icon size={18} strokeWidth={1.5} style={{ color: '#b4b8be' }} />
                                 </div>
                                 <span
                                     className="text-center leading-tight"

--- a/apps/landing/src/pages/contact.tsx
+++ b/apps/landing/src/pages/contact.tsx
@@ -66,13 +66,13 @@ export default function ContactPage() {
                                 ].map(({ day, hours, closed }) => (
                                     <div key={day} className="flex justify-between items-center py-2.5" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
                                         <span className="text-sm" style={{ color: 'rgba(255,255,255,0.45)', fontFamily: "var(--font-open-sans), sans-serif" }}>{day}</span>
-                                        <span className="text-sm font-medium" style={{ color: closed ? 'rgba(255,255,255,0.2)' : '#c5a880', fontFamily: "var(--font-open-sans), sans-serif" }}>{hours}</span>
+                                        <span className="text-sm font-medium" style={{ color: closed ? 'rgba(255,255,255,0.2)' : '#b4b8be', fontFamily: "var(--font-open-sans), sans-serif" }}>{hours}</span>
                                     </div>
                                 ))}
                             </div>
 
                             <div className="relative">
-                                <div className="absolute" style={{ inset: 0, border: '1px solid rgba(197,168,128,0.2)', borderRadius: '3px', transform: 'translate(6px, 6px)', zIndex: 0 }} />
+                                <div className="absolute" style={{ inset: 0, border: '1px solid rgba(180,184,190,0.2)', borderRadius: '3px', transform: 'translate(6px, 6px)', zIndex: 0 }} />
                                 <iframe
                                     src={`https://maps.google.com/maps?q=${BUSINESS_INFO.coordinates.lat},${BUSINESS_INFO.coordinates.lng}&z=16&output=embed&hl=pl`}
                                     className="relative w-full"
@@ -88,8 +88,8 @@ export default function ContactPage() {
                         {/* Right: booking CTA + contact form */}
                         <div>
                             {/* Primary CTA */}
-                            <div className="mb-10" style={{ paddingBottom: '2.5rem', borderBottom: '1px solid rgba(197,168,128,0.12)' }}>
-                                <p className="text-xs uppercase mb-3" style={{ color: '#c5a880', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}>
+                            <div className="mb-10" style={{ paddingBottom: '2.5rem', borderBottom: '1px solid rgba(180,184,190,0.12)' }}>
+                                <p className="text-xs uppercase mb-3" style={{ color: '#b4b8be', letterSpacing: '0.12em', fontFamily: "var(--font-open-sans), sans-serif" }}>
                                     {c.bookingTitle}
                                 </p>
                                 <p className="mb-5" style={{ color: 'rgba(255,255,255,0.55)', fontSize: '0.9rem', lineHeight: 1.7, fontFamily: "var(--font-open-sans), sans-serif" }}>

--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -184,7 +184,7 @@ export default function HomePage({ founder, galleryImages }: HomePageProps) {
                             </div>
 
                             <div className="relative self-start">
-                                <div className="absolute" style={{ inset: 0, border: '1px solid rgba(197,168,128,0.25)', borderRadius: '3px', transform: 'translate(8px, 8px)', zIndex: 0 }} />
+                                <div className="absolute" style={{ inset: 0, border: '1px solid rgba(180,184,190,0.25)', borderRadius: '3px', transform: 'translate(8px, 8px)', zIndex: 0 }} />
                                 <iframe
                                     src={`https://maps.google.com/maps?q=${BUSINESS_INFO.coordinates.lat},${BUSINESS_INFO.coordinates.lng}&z=16&output=embed&hl=pl`}
                                     className="relative w-full"

--- a/apps/landing/src/pages/services.tsx
+++ b/apps/landing/src/pages/services.tsx
@@ -118,7 +118,7 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                     <p className="svcs-hero__desc">{s.pageDesc}</p>
                     <button
                         onClick={() => setGeneralBookingOpen(true)}
-                        className="btn-gold text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
+                        className="btn-gold text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                         style={{ color: '#fff', padding: '0.85rem 2.5rem', borderRadius: '2px', letterSpacing: '0.16em' }}
                     >
                         {T.nav.booking}
@@ -201,7 +201,7 @@ export default function ServicesPage({ categories }: ServicesPageProps) {
                         </p>
                         <button
                             onClick={() => setGeneralBookingOpen(true)}
-                            className="btn-gold text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#c5a880] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
+                            className="btn-gold text-xs font-semibold uppercase focus:outline-none focus:ring-2 focus:ring-[#b4b8be] focus:ring-offset-2 focus:ring-offset-[#0d0d0d]"
                             style={{ color: '#fff', padding: '0.85rem 2.5rem', borderRadius: '2px', letterSpacing: '0.16em' }}
                         >
                             {T.nav.booking}

--- a/apps/landing/src/pages/services/balayage.tsx
+++ b/apps/landing/src/pages/services/balayage.tsx
@@ -98,7 +98,7 @@ export default function BalayagePage() {
                 >
                     <p
                         style={{
-                            color: '#c5a880',
+                            color: '#b4b8be',
                             fontSize: '0.7rem',
                             letterSpacing: '0.2em',
                             textTransform: 'uppercase',
@@ -177,7 +177,7 @@ export default function BalayagePage() {
                                 }}
                             >
                                 <span
-                                    style={{ color: '#c5a880', flexShrink: 0 }}
+                                    style={{ color: '#b4b8be', flexShrink: 0 }}
                                 >
                                     —
                                 </span>
@@ -190,7 +190,7 @@ export default function BalayagePage() {
                         <Link
                             href="/services"
                             style={{
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 fontSize: '0.8rem',
                                 letterSpacing: '0.12em',
                                 textTransform: 'uppercase',

--- a/apps/landing/src/pages/services/coloring.tsx
+++ b/apps/landing/src/pages/services/coloring.tsx
@@ -98,7 +98,7 @@ export default function ColoringPage() {
                 >
                     <p
                         style={{
-                            color: '#c5a880',
+                            color: '#b4b8be',
                             fontSize: '0.7rem',
                             letterSpacing: '0.2em',
                             textTransform: 'uppercase',
@@ -175,7 +175,7 @@ export default function ColoringPage() {
                                 }}
                             >
                                 <span
-                                    style={{ color: '#c5a880', flexShrink: 0 }}
+                                    style={{ color: '#b4b8be', flexShrink: 0 }}
                                 >
                                     —
                                 </span>
@@ -188,7 +188,7 @@ export default function ColoringPage() {
                         <Link
                             href="/services"
                             style={{
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 fontSize: '0.8rem',
                                 letterSpacing: '0.12em',
                                 textTransform: 'uppercase',

--- a/apps/landing/src/pages/services/highlights.tsx
+++ b/apps/landing/src/pages/services/highlights.tsx
@@ -98,7 +98,7 @@ export default function HighlightsPage() {
                 >
                     <p
                         style={{
-                            color: '#c5a880',
+                            color: '#b4b8be',
                             fontSize: '0.7rem',
                             letterSpacing: '0.2em',
                             textTransform: 'uppercase',
@@ -176,7 +176,7 @@ export default function HighlightsPage() {
                                 }}
                             >
                                 <span
-                                    style={{ color: '#c5a880', flexShrink: 0 }}
+                                    style={{ color: '#b4b8be', flexShrink: 0 }}
                                 >
                                     —
                                 </span>
@@ -189,7 +189,7 @@ export default function HighlightsPage() {
                         <Link
                             href="/services"
                             style={{
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 fontSize: '0.8rem',
                                 letterSpacing: '0.12em',
                                 textTransform: 'uppercase',

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -3,8 +3,8 @@
 :root {
     --background: #ffffff;
     --foreground: #171717;
-    --brand-gold: #c5a880;
-    --brand-gold-dark: #a8895f;
+    --brand-gold: #b4b8be;
+    --brand-gold-dark: #8e9298;
     --brand-black: #0d0d0d;
 }
 
@@ -53,19 +53,19 @@ h1, h2, h3, h4, h5, h6 {
     color: #fff;
     z-index: 100;
     border-radius: 0.25rem;
-    box-shadow: 0 0 0 2px #c5a880;
+    box-shadow: 0 0 0 2px #b4b8be;
 }
 
 /* Global focus styles for accessibility */
 *:focus-visible {
-    outline: 2px solid #c5a880;
+    outline: 2px solid #b4b8be;
     outline-offset: 2px;
 }
 
 /* Ensure buttons and links are keyboard accessible */
 button:focus-visible,
 a:focus-visible {
-    outline: 2px solid #c5a880;
+    outline: 2px solid #b4b8be;
     outline-offset: 2px;
 }
 
@@ -178,7 +178,7 @@ html {
     letter-spacing: 0.02em;
     margin: 0.05em 0 0.1em;
     line-height: 1;
-    text-shadow: 0 0 60px rgba(197,168,128,0.4);
+    text-shadow: 0 0 60px rgba(180,184,190,0.4);
 }
 .split-hero__heading-line2 {
     display: block;
@@ -303,7 +303,7 @@ html {
     z-index: 2;
     background: rgba(8,8,8,0.82);
     backdrop-filter: blur(12px);
-    border: 1px solid rgba(197,168,128,0.3);
+    border: 1px solid rgba(180,184,190,0.3);
     padding: 1.2rem 1.5rem;
     border-radius: 2px;
     min-width: 200px;
@@ -332,7 +332,7 @@ html {
     color: var(--brand-gold);
     letter-spacing: 0.02em;
     text-decoration: none;
-    border-top: 1px solid rgba(197,168,128,0.2);
+    border-top: 1px solid rgba(180,184,190,0.2);
     padding-top: 0.8rem;
     transition: color 0.2s;
 }
@@ -393,7 +393,7 @@ html {
 .stats-bar__item {
     text-align: center;
     padding: 1.5rem 1rem;
-    border-left: 1px solid rgba(197,168,128,0.15);
+    border-left: 1px solid rgba(180,184,190,0.15);
 }
 .stats-bar__item:first-child { border-left: none; }
 .stats-bar__number {
@@ -580,7 +580,7 @@ html {
     top: 14px;
     width: 1px;
     bottom: 0;
-    background: linear-gradient(to bottom, rgba(197,168,128,0.4), transparent);
+    background: linear-gradient(to bottom, rgba(180,184,190,0.4), transparent);
 }
 .timeline-item:last-child::after { display: none; }
 .timeline-item:last-child { padding-bottom: 0; }
@@ -593,7 +593,7 @@ html {
     font-family: var(--font-playfair), serif;
     font-size: 6rem;
     font-weight: 700;
-    color: rgba(197,168,128,0.08);
+    color: rgba(180,184,190,0.08);
     line-height: 1;
     pointer-events: none;
     user-select: none;
@@ -601,7 +601,7 @@ html {
     z-index: 0;
 }
 .service-card-dark .service-numeral {
-    color: rgba(197,168,128,0.12);
+    color: rgba(180,184,190,0.12);
 }
 
 /* ── Testimonial large quote mark ─────────────────────── */
@@ -612,7 +612,7 @@ html {
     font-family: var(--font-playfair), serif;
     font-size: 8rem;
     line-height: 1;
-    color: rgba(197,168,128,0.10);
+    color: rgba(180,184,190,0.10);
     pointer-events: none;
     user-select: none;
     z-index: 0;
@@ -707,7 +707,7 @@ html {
 .svcs-hero {
     padding: 5rem 1.5rem 4rem;
     text-align: center;
-    border-bottom: 1px solid rgba(197,168,128,0.12);
+    border-bottom: 1px solid rgba(180,184,190,0.12);
 }
 .svcs-hero__eyebrow {
     font-family: var(--font-open-sans), sans-serif;
@@ -749,7 +749,7 @@ html {
     gap: 0.75rem;
     margin-bottom: 1.25rem;
     padding-bottom: 0.9rem;
-    border-bottom: 1px solid rgba(197,168,128,0.15);
+    border-bottom: 1px solid rgba(180,184,190,0.15);
 }
 .svcs-category__title {
     font-family: var(--font-playfair), serif;
@@ -775,7 +775,7 @@ html {
     transition: background 0.15s;
 }
 .svcs-row:last-child { border-bottom: none; }
-.svcs-row:hover { background: rgba(197,168,128,0.04); }
+.svcs-row:hover { background: rgba(180,184,190,0.04); }
 .svcs-row__info { flex: 1; min-width: 0; }
 .svcs-row__name {
     font-size: 0.95rem;
@@ -817,7 +817,7 @@ html {
 }
 .svcs-row__book {
     background: none;
-    border: 1px solid rgba(197,168,128,0.35);
+    border: 1px solid rgba(180,184,190,0.35);
     color: var(--brand-gold);
     font-family: var(--font-open-sans), sans-serif;
     font-size: 0.6rem;
@@ -833,14 +833,14 @@ html {
 }
 .svcs-row__book:hover,
 .svcs-row__book:focus-visible {
-    background: rgba(197,168,128,0.1);
+    background: rgba(180,184,190,0.1);
     border-color: var(--brand-gold);
     outline: none;
 }
 .svcs-bottom-cta {
     text-align: center;
     padding: 5rem 1.5rem;
-    border-top: 1px solid rgba(197,168,128,0.12);
+    border-top: 1px solid rgba(180,184,190,0.12);
     max-width: 860px;
     margin: 0 auto;
 }
@@ -1021,9 +1021,9 @@ html {
     max-width: 860px;
     margin: 0 auto 2.5rem;
     padding: 0.75rem 1.25rem;
-    border: 1px solid rgba(197,168,128,0.2);
+    border: 1px solid rgba(180,184,190,0.2);
     border-radius: 2px;
-    background: rgba(197,168,128,0.04);
+    background: rgba(180,184,190,0.04);
 }
 .ig-fallback__text {
     font-size: 0.8rem;
@@ -1037,7 +1037,7 @@ html {
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--brand-gold);
-    border: 1px solid rgba(197,168,128,0.3);
+    border: 1px solid rgba(180,184,190,0.3);
     border-radius: 2px;
     padding: 0.3rem 0.75rem;
     background: none;
@@ -1046,7 +1046,7 @@ html {
     font-family: var(--font-open-sans), sans-serif;
     white-space: nowrap;
 }
-.ig-fallback__btn:hover { background: rgba(197,168,128,0.08); }
+.ig-fallback__btn:hover { background: rgba(180,184,190,0.08); }
 .ig-fallback__btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .ig-loading {
@@ -1076,7 +1076,7 @@ html {
     margin: 0 auto;
 }
 .faq-item {
-    border-bottom: 1px solid rgba(197,168,128,0.12);
+    border-bottom: 1px solid rgba(180,184,190,0.12);
 }
 .faq-item__trigger {
     width: 100%;
@@ -1152,7 +1152,7 @@ html {
 }
 .contact-form__input {
     background: rgba(255,255,255,0.04);
-    border: 1px solid rgba(197,168,128,0.18);
+    border: 1px solid rgba(180,184,190,0.18);
     border-radius: 2px;
     padding: 0.85rem 1rem;
     color: rgba(255,255,255,0.85);
@@ -1179,7 +1179,7 @@ html {
 }
 .contact-form__success {
     font-size: 0.85rem;
-    color: rgba(197,168,128,0.85);
+    color: rgba(180,184,190,0.85);
     font-family: var(--font-open-sans), sans-serif;
     letter-spacing: 0.04em;
 }
@@ -1245,7 +1245,7 @@ html {
     margin-top: 2.8rem;
     margin-bottom: 1rem;
     padding-bottom: 0.4rem;
-    border-bottom: 1px solid rgba(197,168,128,0.18);
+    border-bottom: 1px solid rgba(180,184,190,0.18);
 }
 .legal-body {
     font-family: var(--font-open-sans), sans-serif;
@@ -1268,7 +1268,7 @@ ol.legal-list { list-style: decimal; }
 .legal-link {
     color: var(--brand-gold);
     text-decoration: none;
-    border-bottom: 1px solid rgba(197,168,128,0.35);
+    border-bottom: 1px solid rgba(180,184,190,0.35);
     transition: border-color 0.2s;
 }
 .legal-link:hover { border-color: var(--brand-gold); }
@@ -1278,14 +1278,14 @@ ol.legal-list { list-style: decimal; }
     color: rgba(255,255,255,0.28);
     margin-top: 3rem;
     padding-top: 1.5rem;
-    border-top: 1px solid rgba(197,168,128,0.1);
+    border-top: 1px solid rgba(180,184,190,0.1);
 }
 
 /* ── blend-mode: multiply — hero gold tint ────────────── */
 .split-hero__gold-tint {
     position: absolute;
     inset: 0;
-    background: rgba(197, 168, 128, 0.45);
+    background: rgba(180, 184, 190, 0.45);
     mix-blend-mode: multiply;
     pointer-events: none;
 }
@@ -1294,7 +1294,7 @@ ol.legal-list { list-style: decimal; }
 .gallery-blend {
     position: absolute;
     inset: 0;
-    background: rgba(197, 168, 128, 0.55);
+    background: rgba(180, 184, 190, 0.55);
     mix-blend-mode: multiply;
     opacity: 0;
     transition: opacity 0.4s ease;

--- a/apps/landing/tailwind.config.ts
+++ b/apps/landing/tailwind.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
                 brand: {
                     black: '#000000',
                     white: '#ffffff',
-                    gold: '#c5a880',
+                    gold: '#b4b8be',
                 },
             },
             fontFamily: {

--- a/apps/panel/src/pages/auth/login.tsx
+++ b/apps/panel/src/pages/auth/login.tsx
@@ -115,7 +115,7 @@ export default function LoginPage() {
         width: '100%',
         padding: '0.85rem 1rem',
         background: 'rgba(255,255,255,0.05)',
-        border: `1px solid ${focusedField === field ? '#c5a880' : touched[field] && errors[field] ? 'rgba(220,60,60,0.7)' : 'rgba(255,255,255,0.12)'}`,
+        border: `1px solid ${focusedField === field ? '#b4b8be' : touched[field] && errors[field] ? 'rgba(220,60,60,0.7)' : 'rgba(255,255,255,0.12)'}`,
         borderRadius: '2px',
         color: '#ffffff',
         fontSize: '0.875rem',
@@ -191,7 +191,7 @@ export default function LoginPage() {
                                 fontSize: '0.6rem',
                                 letterSpacing: '0.2em',
                                 textTransform: 'uppercase',
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 marginBottom: '0.75rem',
                             }}
                         >
@@ -213,7 +213,7 @@ export default function LoginPage() {
                             style={{
                                 width: '32px',
                                 height: '2px',
-                                background: '#c5a880',
+                                background: '#b4b8be',
                                 margin: '1rem auto 0',
                             }}
                         />
@@ -351,7 +351,7 @@ export default function LoginPage() {
                                 display: 'block',
                                 width: '100%',
                                 padding: '0.9rem 1.5rem',
-                                background: submitting ? '#a8895f' : '#c5a880',
+                                background: submitting ? '#8e9298' : '#b4b8be',
                                 color: '#0d0d0d',
                                 border: 'none',
                                 borderRadius: '2px',
@@ -397,7 +397,7 @@ export default function LoginPage() {
                             href="/auth/register"
                             prefetch={false}
                             style={{
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 textDecoration: 'none',
                                 fontWeight: 600,
                             }}

--- a/apps/panel/src/pages/auth/register.tsx
+++ b/apps/panel/src/pages/auth/register.tsx
@@ -124,7 +124,7 @@ export default function RegisterPage() {
         width: '100%',
         padding: '0.85rem 1rem',
         background: 'rgba(255,255,255,0.05)',
-        border: `1px solid ${focusedField === field ? '#c5a880' : touched[field] && errors[field] ? 'rgba(220,60,60,0.7)' : 'rgba(255,255,255,0.12)'}`,
+        border: `1px solid ${focusedField === field ? '#b4b8be' : touched[field] && errors[field] ? 'rgba(220,60,60,0.7)' : 'rgba(255,255,255,0.12)'}`,
         borderRadius: '2px',
         color: '#ffffff',
         fontSize: '0.875rem',
@@ -215,7 +215,7 @@ export default function RegisterPage() {
                                 fontSize: '0.6rem',
                                 letterSpacing: '0.2em',
                                 textTransform: 'uppercase',
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 marginBottom: '0.75rem',
                             }}
                         >
@@ -237,7 +237,7 @@ export default function RegisterPage() {
                             style={{
                                 width: '32px',
                                 height: '2px',
-                                background: '#c5a880',
+                                background: '#b4b8be',
                                 margin: '1rem auto 0',
                             }}
                         />
@@ -402,7 +402,7 @@ export default function RegisterPage() {
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         style={{
-                                            color: '#c5a880',
+                                            color: '#b4b8be',
                                             textDecoration: 'underline',
                                         }}
                                     >
@@ -505,7 +505,7 @@ export default function RegisterPage() {
                                 display: 'block',
                                 width: '100%',
                                 padding: '0.9rem 1.5rem',
-                                background: submitting ? '#a8895f' : '#c5a880',
+                                background: submitting ? '#8e9298' : '#b4b8be',
                                 color: '#0d0d0d',
                                 border: 'none',
                                 borderRadius: '2px',
@@ -550,7 +550,7 @@ export default function RegisterPage() {
                         <Link
                             href="/auth/login"
                             style={{
-                                color: '#c5a880',
+                                color: '#b4b8be',
                                 textDecoration: 'none',
                                 fontWeight: 600,
                             }}

--- a/apps/panel/src/styles/globals.css
+++ b/apps/panel/src/styles/globals.css
@@ -84,7 +84,7 @@ body {
 }
 
 .salonbw-step.active .salonbw-step__number {
-    background: #c5a880;
+    background: #b4b8be;
     color: #0d0d0d;
 }
 
@@ -123,7 +123,7 @@ body {
 }
 
 .salonbw-channel:hover {
-    border-color: #c5a880;
+    border-color: #b4b8be;
 }
 
 .salonbw-channel input {
@@ -131,8 +131,8 @@ body {
 }
 
 .salonbw-channel.active {
-    border-color: #c5a880;
-    background: rgba(197, 168, 128, 0.07);
+    border-color: #b4b8be;
+    background: rgba(180, 184, 190, 0.07);
 }
 
 .salonbw-channel__icon {
@@ -180,13 +180,13 @@ body {
 }
 
 .salonbw-template-item:hover {
-    border-color: #c5a880;
-    background: rgba(197, 168, 128, 0.05);
+    border-color: #b4b8be;
+    background: rgba(180, 184, 190, 0.05);
 }
 
 .salonbw-template-item.active {
-    border-color: #c5a880;
-    background: rgba(197, 168, 128, 0.08);
+    border-color: #b4b8be;
+    background: rgba(180, 184, 190, 0.08);
 }
 
 .salonbw-template-item__name {
@@ -227,8 +227,8 @@ body {
 
 .salonbw-input:focus {
     outline: none;
-    border-color: #c5a880;
-    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
+    border-color: #b4b8be;
+    box-shadow: 0 0 0 2px rgba(180, 184, 190, 0.2);
 }
 
 .salonbw-input--sm {
@@ -253,8 +253,8 @@ body {
 
 .salonbw-textarea:focus {
     outline: none;
-    border-color: #c5a880;
-    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
+    border-color: #b4b8be;
+    box-shadow: 0 0 0 2px rgba(180, 184, 190, 0.2);
 }
 
 .salonbw-char-count {
@@ -287,7 +287,7 @@ body {
     background: #252525;
     border-radius: 4px;
     font-size: 0.75rem;
-    color: #c5a880;
+    color: #b4b8be;
     margin-right: 8px;
     font-family: monospace;
 }
@@ -521,8 +521,8 @@ body {
 
 .salonbw-select:focus {
     outline: none;
-    border-color: #c5a880;
-    box-shadow: 0 0 0 2px rgba(197, 168, 128, 0.2);
+    border-color: #b4b8be;
+    box-shadow: 0 0 0 2px rgba(180, 184, 190, 0.2);
 }
 
 .salonbw-select--inline {
@@ -550,7 +550,7 @@ body {
     border-bottom: 1px solid #252525;
     background: #141414;
     font-weight: 600;
-    color: #c5a880;
+    color: #b4b8be;
     font-size: 0.875rem;
 }
 
@@ -701,7 +701,7 @@ body {
 }
 
 .salonbw-modal__close:hover {
-    color: #c5a880;
+    color: #b4b8be;
     background: #2a2414;
 }
 
@@ -800,7 +800,7 @@ body {
     border-bottom: 1px solid #252525;
     background: #141414;
     font-weight: 600;
-    color: #c5a880;
+    color: #b4b8be;
     font-size: 0.875rem;
 }
 
@@ -884,8 +884,8 @@ body {
 }
 
 .salonbw-status--in-progress {
-    background: rgba(197, 168, 128, 0.15);
-    color: #c5a880;
+    background: rgba(180, 184, 190, 0.15);
+    color: #b4b8be;
 }
 
 .salonbw-status--completed {
@@ -1013,7 +1013,7 @@ body {
 
 .salonbw-icon-btn:hover {
     background: #1e1a14;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 /* Alert */
@@ -1240,7 +1240,7 @@ body {
     border-bottom: 1px solid #252525;
     font-size: 0.875rem;
     font-weight: 600;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 .salonbw-widget__content {
@@ -1492,7 +1492,7 @@ body {
 .salonbw-appointment-item__time {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #c5a880;
+    color: #b4b8be;
     width: 48px;
     flex-shrink: 0;
 }
@@ -1558,7 +1558,7 @@ body {
 }
 
 .fc-col-header-cell-cushion {
-    color: #c5a880 !important;
+    color: #b4b8be !important;
     font-weight: 600 !important;
     font-size: 13px !important;
 }
@@ -1603,7 +1603,7 @@ body {
 }
 
 .fc-daygrid-day.fc-day-today {
-    background: rgba(197, 168, 128, 0.06) !important;
+    background: rgba(180, 184, 190, 0.06) !important;
 }
 
 .fc-daygrid-day-top {
@@ -1643,8 +1643,8 @@ body {
 
 .fc-button-active {
     background: #2a2114 !important;
-    border-color: #c5a880 !important;
-    color: #c5a880 !important;
+    border-color: #b4b8be !important;
+    color: #b4b8be !important;
 }
 
 /* ============================================
@@ -1713,18 +1713,18 @@ body {
 
 .salonbw-mini-cal__day:hover {
     background: #1e1a14;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 .salonbw-mini-cal__day--selected {
-    background: #c5a880 !important;
+    background: #b4b8be !important;
     color: #0d0d0d !important;
 }
 
 .salonbw-mini-cal__day--today {
-    border: 1px solid #c5a880;
+    border: 1px solid #b4b8be;
     font-weight: 600;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 .salonbw-mini-cal__day--other-month {
@@ -1748,8 +1748,8 @@ body {
     --bs-secondary-color: #7a7068;
     --bs-tertiary-color: #5a5450;
     --bs-emphasis-color: #f0e8dc;
-    --bs-link-color: #c5a880;
-    --bs-link-hover-color: #d4b896;
+    --bs-link-color: #b4b8be;
+    --bs-link-hover-color: #c4c8cd;
     --bs-heading-color: #e8e0d5;
     --bs-card-bg: #161616;
     --bs-card-border-color: #252525;
@@ -1762,8 +1762,8 @@ body {
     --bs-dropdown-link-color: #e8e0d5;
     --bs-dropdown-link-hover-bg: #2a2414;
     --bs-table-bg: transparent;
-    --bs-table-striped-bg: rgba(197, 168, 128, 0.04);
-    --bs-table-hover-bg: rgba(197, 168, 128, 0.06);
+    --bs-table-striped-bg: rgba(180, 184, 190, 0.04);
+    --bs-table-hover-bg: rgba(180, 184, 190, 0.06);
     --bs-table-border-color: #252525;
     --bs-modal-bg: #1c1c1c;
     --bs-modal-header-border-color: #252525;
@@ -1773,13 +1773,13 @@ body {
     --bs-nav-tabs-border-color: #252525;
     --bs-nav-tabs-link-active-bg: #161616;
     --bs-nav-tabs-link-active-border-color: #252525;
-    --bs-nav-pills-link-active-bg: #c5a880;
+    --bs-nav-pills-link-active-bg: #b4b8be;
     --bs-pagination-bg: #161616;
     --bs-pagination-border-color: #252525;
-    --bs-pagination-active-bg: #c5a880;
-    --bs-pagination-active-border-color: #c5a880;
+    --bs-pagination-active-bg: #b4b8be;
+    --bs-pagination-active-border-color: #b4b8be;
     --bs-progress-bg: #1e1e1e;
-    --bs-code-color: #c5a880;
+    --bs-code-color: #b4b8be;
 }
 
 /* Topbar */
@@ -1789,11 +1789,11 @@ body {
 }
 
 .navbar .brand a {
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 .navbar .brand a:hover {
-    color: #d4b896;
+    color: #c4c8cd;
 }
 
 .navbar .navbar-right > li > a:not(.button) {
@@ -1822,7 +1822,7 @@ body {
 .sidenav .nav-list li a:hover,
 .sidenav .nav-list li.active a {
     background: #1e1a14;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 /* Main content */
@@ -1856,7 +1856,7 @@ body {
 }
 
 .close:hover {
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 /* Legacy buttons */
@@ -1890,7 +1890,7 @@ body {
 /* Shell table overrides */
 #salonbw-shell-root .salonbw-table th {
     background: #141414;
-    color: #c5a880;
+    color: #b4b8be;
     border-color: #252525;
 }
 
@@ -2047,7 +2047,7 @@ h3 {
 }
 
 .navbar .omnibox:focus {
-    border-color: #c5a880;
+    border-color: #b4b8be;
     box-shadow: none;
 }
 
@@ -2071,7 +2071,7 @@ h3 {
 
 .navbar .dropdown-menu .main-menu-li a:hover {
     background: #2a2414;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 /* ============================================================
@@ -2101,7 +2101,7 @@ h3 {
 .sidenav .nav-list li a:hover,
 .sidenav .nav-list li.active a {
     background: #f0f4f8;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 .sidenav .btn-link {
@@ -2329,7 +2329,7 @@ h3 {
     color: #495057;
 }
 .salonbw-checkbox {
-    accent-color: #c5a880;
+    accent-color: #b4b8be;
 }
 
 /* --- Templates --- */
@@ -2337,12 +2337,12 @@ h3 {
     border-color: #dee2e6;
 }
 .salonbw-template-item:hover {
-    border-color: #c5a880;
-    background: rgba(197, 168, 128, 0.05);
+    border-color: #b4b8be;
+    background: rgba(180, 184, 190, 0.05);
 }
 .salonbw-template-item.active {
-    border-color: #c5a880;
-    background: rgba(197, 168, 128, 0.08);
+    border-color: #b4b8be;
+    background: rgba(180, 184, 190, 0.08);
 }
 
 /* --- Channel selector --- */
@@ -2481,7 +2481,7 @@ h3 {
 }
 
 .fc-daygrid-day.fc-day-today {
-    background: rgba(197, 168, 128, 0.08) !important;
+    background: rgba(180, 184, 190, 0.08) !important;
 }
 
 .fc-col-header-cell {
@@ -2518,8 +2518,8 @@ h3 {
 
 .fc-button-active,
 .fc-button.fc-button-active {
-    background: var(--salon-brand, #c5a880) !important;
-    border-color: var(--salon-brand, #c5a880) !important;
+    background: var(--salon-brand, #b4b8be) !important;
+    border-color: var(--salon-brand, #b4b8be) !important;
     color: #ffffff !important;
 }
 

--- a/apps/panel/src/styles/salon-shell.css
+++ b/apps/panel/src/styles/salon-shell.css
@@ -10,8 +10,8 @@
     --salon-panel-bg: #f8f8f8;
     --salon-text: #1a1a1a;
     --salon-muted: #6b7280;
-    /* brand active/link gold */
-    --salon-accent: #c5a880;
+    /* brand active/link silver */
+    --salon-accent: #b4b8be;
     --salon-mainnav-bg: #0a0a0a;
     --salon-mainnav-active: #060606;
     --salon-green: #2ecc71;
@@ -5065,8 +5065,8 @@ body.settings-dashboard-landing .main-content > .inner {
 }
 
 .sms-settings-page__type-card--active {
-    border-color: #c5a880;
-    box-shadow: 0 10px 25px rgba(197, 168, 128, 0.12);
+    border-color: #b4b8be;
+    box-shadow: 0 10px 25px rgba(180, 184, 190, 0.12);
 }
 
 .sms-settings-page__type-card--inactive {
@@ -5101,7 +5101,7 @@ body.settings-dashboard-landing .main-content > .inner {
 }
 
 .sms-settings-page__type-price {
-    color: #c5a880;
+    color: #b4b8be;
     font-size: 24px;
     font-weight: 600;
     margin-bottom: 12px;

--- a/apps/panel/src/styles/salon-theme.css
+++ b/apps/panel/src/styles/salon-theme.css
@@ -5,9 +5,9 @@
 
 /* --- CSS Variables --- */
 :root {
-    --salon-accent: #c5a880;
-    --salon-brand: #c5a880;
-    --salon-brand-hover: #d4b896;
+    --salon-accent: #b4b8be;
+    --salon-brand: #b4b8be;
+    --salon-brand-hover: #c4c8cd;
     --salon-bg: #ffffff;
     --salon-fg: #1a1a1a;
 }
@@ -127,7 +127,7 @@ body {
 }
 .tree li a:hover {
     background: #1e1a14;
-    color: #c5a880;
+    color: #b4b8be;
 }
 
 /* --- Icon box --- */
@@ -147,7 +147,7 @@ body {
     font-size: 11px;
     font-weight: 600;
     background: #141414;
-    color: #c5a880;
+    color: #b4b8be;
 }
 .table-bordered td {
     font-size: 13px;
@@ -253,7 +253,7 @@ tr.even td {
 /* --- Form accent (focus ring) --- */
 .form-control:focus {
     border-color: var(--salon-brand);
-    box-shadow: 0 0 0 0.2rem rgba(197, 168, 128, 0.25);
+    box-shadow: 0 0 0 0.2rem rgba(180, 184, 190, 0.25);
 }
 
 /* --- Pjax link styling --- */


### PR DESCRIPTION
## Summary

- Replaces all gold color values (`#c5a880` and variants) with cool silver (`#b4b8be`) across both `apps/landing` and `apps/panel`
- Updates all related variants: hover state, transparent rgba versions, gradient tint, and darker submitting state
- Covers 24 files: CSS variables, inline styles in TSX components, and auth pages

## Color mapping

| Old (gold) | New (silver) | Role |
|---|---|---|
| `#c5a880` | `#b4b8be` | primary brand accent |
| `rgba(197, 168, 128, x)` | `rgba(180, 184, 190, x)` | transparent variants |
| `#d4b896` | `#c4c8cd` | hover / lighter state |
| `#e8d5b0` | `#dce0e4` | gradient tint |
| `#a8895f` | `#8e9298` | submitting / darker state |

## Test plan

- [ ] Landing: verify brand accents (buttons, dividers, section headers, testimonials, booking modal) render in silver
- [ ] Panel: verify nav active states, links, form focus rings, auth pages render in silver
- [ ] No visual regressions in dark backgrounds (hero, footer, auth pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)