### PR TITLE
fix(tests): add isAuthenticated+initialized to follow-up page auth mock

### DIFF
--- a/apps/panel/src/__tests__/statisticsFollowUpPage.test.tsx
+++ b/apps/panel/src/__tests__/statisticsFollowUpPage.test.tsx
@@ -7,6 +7,8 @@ const apiFetchProxy = (...args: unknown[]) => apiFetchMock(...args);
 jest.mock('@/contexts/AuthContext', () => ({
     useAuth: () => ({
         role: 'admin',
+        isAuthenticated: true,
+        initialized: true,
         apiFetch: apiFetchProxy,
     }),
 }));


### PR DESCRIPTION
## Summary

- `statisticsFollowUpPage.test.tsx` — 5 tests were failing because the `useAuth` mock returned only `role` and `apiFetch`, but `RouteGuard` also checks `isAuthenticated` and `initialized`
- Without `initialized: true`, RouteGuard returns the loading fallback (`null`) → component renders as empty `<div />`
- Fix: add `isAuthenticated: true, initialized: true` to the mock

## Test plan

- [ ] `statisticsFollowUpPage` suite: 5/5 passing locally
- [ ] CI `Frontend (dashboard)` → Panel tests: green

https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lid2gmXKgezt8b5x3dZBSk)_