### PR TITLE
Expand data deletion and privacy policy to the real data model

### DIFF
--- a/apps/landing/src/__tests__/dataDeletionContent.test.ts
+++ b/apps/landing/src/__tests__/dataDeletionContent.test.ts
@@ -3,9 +3,33 @@ import { DATA_DELETION } from '@/i18n/dataDeletionContent';
 import type { Language } from '@/i18n/translations';
 
 const localeExpectations: Record<Language, RegExp[]> = {
-    pl: [/Meta/, /Instagram/, /jednego miesiąca/, /kontakt@salon-bw\.pl/],
-    en: [/Meta/, /Instagram/, /one month/, /kontakt@salon-bw\.pl/],
-    de: [/Meta/, /Instagram/, /eines Monats/, /kontakt@salon-bw\.pl/],
+    pl: [
+        /Meta/,
+        /Instagram/,
+        /Google/,
+        /Facebook/,
+        /sesj/,
+        /jednego miesiąca/,
+        /kontakt@salon-bw\.pl/,
+    ],
+    en: [
+        /Meta/,
+        /Instagram/,
+        /Google/,
+        /Facebook/,
+        /sessions/,
+        /one month/,
+        /kontakt@salon-bw\.pl/,
+    ],
+    de: [
+        /Meta/,
+        /Instagram/,
+        /Google/,
+        /Facebook/,
+        /Sitzungen/,
+        /eines Monats/,
+        /kontakt@salon-bw\.pl/,
+    ],
 };
 
 describe.each(Object.keys(localeExpectations) as Language[])(
@@ -15,7 +39,7 @@ describe.each(Object.keys(localeExpectations) as Language[])(
             const doc = DATA_DELETION[lang];
             const renderedContent = JSON.stringify(doc.sections);
 
-            expect(doc.sections).toHaveLength(8);
+            expect(doc.sections).toHaveLength(11);
             expect(doc.effectiveDate).toBe('2026-07-22');
             expect(renderedContent).toContain(
                 'mailto:kontakt@salon-bw.pl',

--- a/apps/landing/src/i18n/dataDeletionContent.ts
+++ b/apps/landing/src/i18n/dataDeletionContent.ts
@@ -25,7 +25,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                     },
                     {
                         type: 'p',
-                        text: 'Obowiązek udostępnienia tej instrukcji wynika z korzystania z logowania Meta (Facebook). Integracja z Instagramem to osobna sprawa — służy wyłącznie do prezentacji treści z naszego firmowego konta salon_bw na stronie i nie przetwarza danych osobowych klientów; jej odrębne zasady opisujemy w punkcie 7.',
+                        text: 'Obowiązek udostępnienia tej instrukcji wynika z korzystania przez nas z usług platformy Meta — aplikacji Instagram obsługującej galerię na stronie oraz, o ile jest udostępnione, logowania przez Facebooka. Sama integracja z Instagramem służy wyłącznie do prezentacji treści z naszego firmowego konta salon_bw i nie przetwarza danych osobowych klientów; jej odrębne zasady opisujemy w punkcie 7.',
                     },
                 ],
             },
@@ -283,7 +283,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                     },
                     {
                         type: 'p',
-                        text: 'The obligation to publish these instructions arises from our use of Meta (Facebook) login. The Instagram integration is a separate matter — it only displays content from our salon_bw business account on the website and does not process clients’ personal data; its separate rules are described in section 7.',
+                        text: 'The obligation to publish these instructions arises from our use of Meta platform services — the Instagram app powering the website gallery and, where made available, Facebook login. The Instagram integration itself only displays content from our salon_bw business account and does not process clients’ personal data; its separate rules are described in section 7.',
                     },
                 ],
             },
@@ -541,7 +541,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                     },
                     {
                         type: 'p',
-                        text: 'Die Pflicht zur Bereitstellung dieser Anleitung ergibt sich aus der Nutzung der Meta-(Facebook-)Anmeldung. Die Instagram-Integration ist eine gesonderte Sache — sie dient ausschließlich der Darstellung von Inhalten unseres Geschäftskontos salon_bw auf der Website und verarbeitet keine personenbezogenen Daten von Kunden; ihre gesonderten Regeln beschreiben wir in Abschnitt 7.',
+                        text: 'Die Pflicht zur Bereitstellung dieser Anleitung ergibt sich aus unserer Nutzung von Diensten der Meta-Plattform — der Instagram-App für die Website-Galerie und, sofern verfügbar, der Facebook-Anmeldung. Die Instagram-Integration selbst dient ausschließlich der Darstellung von Inhalten unseres Geschäftskontos salon_bw und verarbeitet keine personenbezogenen Daten von Kunden; ihre gesonderten Regeln beschreiben wir in Abschnitt 7.',
                     },
                 ],
             },

--- a/apps/landing/src/i18n/dataDeletionContent.ts
+++ b/apps/landing/src/i18n/dataDeletionContent.ts
@@ -219,6 +219,10 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                         type: 'p',
                         text: 'Możemy też zachować minimalny zakres danych na potrzeby przeciwdziałania nadużyciom oraz wykazania zgodności naszych działań z prawem. Jeżeli część danych musi zostać zachowana, poinformujemy o zakresie, podstawie i przewidywanym okresie dalszego przechowywania. Dane te nie będą wykorzystywane do marketingu i zostaną usunięte po upływie wymaganych okresów.',
                     },
+                    {
+                        type: 'p',
+                        text: 'Dodatkowo dane usunięte z systemu mogą przez ograniczony czas (do około 14 dni) pozostawać w automatycznych kopiach zapasowych wykonywanych przez naszego dostawcę hostingu, po czym są cyklicznie nadpisywane. Kopie zapasowe służą wyłącznie przywracaniu systemu po awarii i nie są wykorzystywane do bieżącego przetwarzania danych.',
+                    },
                 ],
             },
             {
@@ -477,6 +481,10 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                         type: 'p',
                         text: 'We may also retain a minimal set of data to prevent abuse and to demonstrate that our actions comply with the law. If any data must be retained, we will explain its scope, the legal basis and the expected retention period. Such data will not be used for marketing and will be deleted once the required periods expire.',
                     },
+                    {
+                        type: 'p',
+                        text: 'In addition, data deleted from the system may remain for a limited time (up to approximately 14 days) in automatic backups made by our hosting provider, after which they are cyclically overwritten. Backups serve solely to restore the system after a failure and are not used for ongoing data processing.',
+                    },
                 ],
             },
             {
@@ -734,6 +742,10 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                     {
                         type: 'p',
                         text: 'Wir können außerdem einen minimalen Datensatz aufbewahren, um Missbrauch vorzubeugen und die Rechtmäßigkeit unserer Tätigkeiten nachzuweisen. Müssen Daten aufbewahrt werden, informieren wir Sie über deren Umfang, Rechtsgrundlage und voraussichtliche Speicherdauer. Diese Daten werden nicht für Marketingzwecke verwendet und nach Ablauf der erforderlichen Fristen gelöscht.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Darüber hinaus können aus dem System gelöschte Daten für begrenzte Zeit (bis zu etwa 14 Tagen) in automatischen Sicherungskopien unseres Hosting-Anbieters verbleiben und werden anschließend zyklisch überschrieben. Sicherungskopien dienen ausschließlich der Systemwiederherstellung nach einem Ausfall und werden nicht für die laufende Datenverarbeitung verwendet.',
                     },
                 ],
             },

--- a/apps/landing/src/i18n/dataDeletionContent.ts
+++ b/apps/landing/src/i18n/dataDeletionContent.ts
@@ -8,45 +8,129 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
     pl: {
         metaTitle: 'Usuwanie danych | Salon Black & White',
         metaDescription:
-            'Instrukcja żądania usunięcia danych z systemu Salon Black & White oraz danych związanych z integracją Meta i Instagram.',
+            'Instrukcja usunięcia konta i danych z systemu Salon Black & White, danych logowania przez Google lub Facebooka oraz danych związanych z integracją Meta i Instagram.',
         ogTitle: 'Usuwanie danych — Salon Black & White',
         ogDescription:
-            'Dowiedz się, jak zażądać usunięcia danych z systemu Salon Black & White i danych związanych z integracją Meta i Instagram.',
+            'Dowiedz się, jak usunąć konto SalonBW i powiązane dane, w tym dane z logowania przez Google lub Facebooka oraz z integracji Meta i Instagram.',
         eyebrow: 'Ochrona danych',
         h1: 'Instrukcja usuwania danych',
-        lead: 'Na tej stronie wyjaśniamy, jak zażądać usunięcia danych osobowych przetwarzanych przez Salon Black & White, w tym danych związanych z korzystaniem z naszych usług Meta i Instagram.',
+        lead: 'Na tej stronie wyjaśniamy, jak usunąć konto klienta Salon Black & White oraz zażądać usunięcia danych osobowych, które przetwarzamy — niezależnie od sposobu założenia konta, w tym danych pobranych przy logowaniu przez Google, Facebooka lub innego dostawcę oraz danych związanych z korzystaniem z usług Meta i Instagram.',
         sections: [
             {
                 heading: '1. Kogo dotyczy ta instrukcja?',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Instrukcja dotyczy klientów i użytkowników serwisu Salon Black & White, systemu rezerwacji oraz osób, których dane mogły zostać przetworzone w związku z integracją salonu z usługami Meta lub Instagram.',
+                        text: 'Instrukcja dotyczy klientów i użytkowników serwisu Salon Black & White oraz systemu rezerwacji, niezależnie od tego, w jaki sposób powstało konto — przez formularz rejestracji z adresem e-mail i hasłem, czy przez logowanie zewnętrzne (Google, Facebook lub inny dostępny dostawca). Dotyczy również osób, których dane mogły zostać przetworzone w związku z integracją salonu z usługami Meta lub Instagram.',
                     },
                     {
                         type: 'p',
-                        text: 'Obecna integracja Instagram służy do wyświetlania mediów z firmowego konta salon_bw. Nie używamy logowania przez Instagram do zakładania kont klientów i nie pobieramy prywatnych wiadomości, kontaktów ani haseł użytkowników Instagrama.',
+                        text: 'Obecna integracja z Instagramem służy wyłącznie do wyświetlania mediów z firmowego konta salon_bw i nie jest logowaniem klienta — jej odrębne zasady opisujemy w punkcie 7.',
                     },
                 ],
             },
             {
-                heading: '2. Jak złożyć żądanie usunięcia danych?',
+                heading: '2. Jakie dane przechowuje SalonBW?',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'W ramach konta klienta i historii korzystania z usług w panelu SalonBW możemy przechowywać następujące kategorie danych:',
+                    },
+                    {
+                        type: 'list',
+                        ordered: false,
+                        items: [
+                            {
+                                lead: 'Dane konta i profilu:',
+                                text: 'imię, nazwisko, nazwa wyświetlana, adres e-mail, rola konta oraz hasło przechowywane wyłącznie w postaci zahaszowanej.',
+                            },
+                            {
+                                lead: 'Dane kontaktowe i adresowe:',
+                                text: 'numer telefonu, adres, miasto i kod pocztowy.',
+                            },
+                            {
+                                lead: 'Dodatkowe dane profilu:',
+                                text: 'data urodzenia, płeć, opis lub notatka, zdjęcie profilowe (awatar).',
+                            },
+                            {
+                                lead: 'Zgody i preferencje komunikacji:',
+                                text: 'zgody RODO i na regulamin (wraz z datami), zgody marketingowe (SMS, WhatsApp, e-mail), ustawienia powiadomień w panelu oraz zapis zmian zgód (rejestr audytowy).',
+                            },
+                            {
+                                lead: 'Historia wizyt i rezerwacji:',
+                                text: 'terminy, wybrane usługi, przypisany pracownik, statusy, kwoty, metody płatności, rabaty i napiwki.',
+                            },
+                            {
+                                lead: 'Notatki, zalecenia i receptury:',
+                                text: 'notatki do wizyt, zalecenia pozabiegowe oraz formuły i receptury (np. koloryzacji) zapisane w profilu.',
+                            },
+                            {
+                                lead: 'Wiadomości i opinie:',
+                                text: 'wątki wiadomości między klientem a salonem oraz oceny i komentarze do wizyt.',
+                            },
+                            {
+                                lead: 'Program lojalnościowy:',
+                                text: 'punkty, historia naliczeń oraz powiązane karty podarunkowe.',
+                            },
+                            {
+                                lead: 'Załączniki:',
+                                text: 'zdjęcia w galerii klienta i pliki dołączone do profilu.',
+                            },
+                            {
+                                lead: 'Dane rozliczeniowe:',
+                                text: 'faktury, paragony oraz dokumentacja sprzedaży produktów.',
+                            },
+                            {
+                                lead: 'Dane techniczne i bezpieczeństwa:',
+                                text: 'tokeny sesji i odświeżania, zapisy prób logowania, logi zdarzeń oraz identyfikatory subskrypcji powiadomień push.',
+                            },
+                            {
+                                lead: 'Historia komunikacji:',
+                                text: 'logi wysłanych wiadomości SMS i e-mail oraz zapisy odbiorców newslettera.',
+                            },
+                            {
+                                lead: 'Identyfikatory logowania zewnętrznego:',
+                                text: 'identyfikator konta u dostawcy (np. Google lub Facebook), jeżeli logowanie zewnętrzne zostało powiązane z kontem — szczegóły w punkcie 3.',
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                heading: '3. Dane pobierane przy logowaniu przez Google, Facebooka lub innego dostawcę',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Jeżeli logujesz się przez Google, Facebooka lub innego dostępnego dostawcę, przy pierwszym logowaniu kopiujemy z Twojego podstawowego profilu wyłącznie: adres e-mail, imię, nazwisko oraz zdjęcie profilowe. Zapisujemy też identyfikator Twojego konta u dostawcy (np. identyfikator Google lub Facebook), aby rozpoznać Cię przy kolejnych logowaniach.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Logowanie zewnętrzne korzysta jedynie z podstawowego zakresu profilu (np. Google: „email” i „profile”; Facebook: „email” i „public_profile”). Nie pobieramy i nie przechowujemy tokenów dostępu dostawcy, list znajomych, wiadomości prywatnych ani haseł.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Skopiowane dane stają się częścią Twojego konta klienta SalonBW i podlegają usunięciu na tych samych zasadach co pozostałe dane profilu (patrz punkty 4 i 5).',
+                    },
+                ],
+            },
+            {
+                heading: '4. Jak złożyć żądanie usunięcia konta lub danych?',
                 blocks: [
                     {
                         type: 'list',
                         ordered: true,
                         items: [
                             {
-                                text: `Wyślij wiadomość na adres ${CONTACT_EMAIL} z tematem „Usunięcie danych – Meta/Instagram” albo „Usunięcie konta SalonBW”.`,
+                                text: `Wyślij wiadomość na adres ${CONTACT_EMAIL} z tematem „Usunięcie konta SalonBW” albo „Usunięcie danych – Meta/Instagram”.`,
                             },
                             {
-                                text: 'Napisz, czy żądanie dotyczy konta klienta SalonBW, danych związanych z Meta/Instagram, czy obu tych zakresów.',
+                                text: 'Napisz, czego dotyczy żądanie: usunięcia całego konta klienta SalonBW (niezależnie od sposobu rejestracji), wybranych danych, czy danych związanych z Meta/Instagram.',
                             },
                             {
-                                text: 'Podaj dane pozwalające odnaleźć konto: imię i nazwisko oraz adres e-mail lub numer telefonu użyty przy rejestracji. Jeżeli żądanie dotyczy integracji Meta/Instagram, możesz dodatkowo podać nazwę użytkownika Instagram.',
+                                text: 'Podaj dane pozwalające odnaleźć konto: imię i nazwisko oraz adres e-mail lub numer telefonu użyty przy rejestracji albo logowaniu zewnętrznym. Jeżeli żądanie dotyczy integracji Meta/Instagram, możesz dodatkowo podać nazwę użytkownika Instagram.',
                             },
                             {
-                                text: 'Wyślij wiadomość z adresu powiązanego z kontem, jeżeli jest to możliwe. Możemy poprosić o dodatkowe potwierdzenie tożsamości, ale nigdy o hasło, token dostępu ani dane logowania do Meta lub Instagram.',
+                                text: 'Wyślij wiadomość z adresu powiązanego z kontem, jeżeli to możliwe. Możemy poprosić o dodatkowe potwierdzenie tożsamości, ale nigdy o hasło, token dostępu ani dane logowania do Google, Facebooka, Meta lub Instagram.',
                             },
                         ],
                     },
@@ -58,47 +142,83 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '3. Co usuniemy?',
+                heading: '5. Co usuniemy przy usunięciu konta?',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Po pozytywnej weryfikacji usuniemy lub zanonimizujemy dane, których nie musimy dalej przechowywać, odpowiednio do zakresu żądania.',
+                        text: 'Po pozytywnej weryfikacji, w zakresie, w jakim nie mamy obowiązku dalszego przechowywania danych (patrz punkt 8), usuniemy lub zanonimizujemy:',
                     },
                     {
                         type: 'list',
                         ordered: false,
                         items: [
                             {
-                                text: 'profil i dane kontaktowe konta klienta SalonBW,',
+                                text: 'konto oraz dane profilu, kontaktowe i adresowe,',
                             },
                             {
-                                text: 'zgody marketingowe i ustawienia komunikacji,',
+                                text: 'zdjęcie profilowe oraz zdjęcia i pliki zapisane w Twoim profilu,',
                             },
                             {
-                                text: 'dane techniczne lub identyfikatory integracji Meta/Instagram zapisane przez Salon Black & White, jeżeli takie dane istnieją,',
+                                text: 'zgody, preferencje komunikacji oraz powiązaną historię wiadomości, opinii, notatek i zaleceń,',
                             },
                             {
-                                text: 'kopie danych pozyskanych z Meta/Instagram i przechowywanych w naszych systemach, jeżeli takie dane istnieją i nie zachodzi obowiązek ich dalszego przechowywania.',
+                                text: 'dane programu lojalnościowego powiązane z kontem,',
+                            },
+                            {
+                                text: 'powiązanie z kontem Google, Facebooka lub innego dostawcy (odłączamy identyfikatory zewnętrzne) oraz kopie podstawowego profilu skopiowane przy logowaniu,',
+                            },
+                            {
+                                text: 'dane techniczne lub identyfikatory integracji Meta/Instagram zapisane przez Salon Black & White, jeżeli takie dane istnieją.',
                             },
                         ],
                     },
+                    {
+                        type: 'p',
+                        text: 'Usunięcie konta unieważnia również aktywne sesje oraz tokeny logowania SalonBW. Po realizacji żądania ponowne korzystanie z systemu rezerwacji wymaga założenia konta od nowa.',
+                    },
                 ],
             },
             {
-                heading: '4. Dane, których nie możemy usunąć od razu',
+                heading: '6. Odłączenie logowania zewnętrznego a usunięcie danych',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Prawo do usunięcia danych nie jest bezwzględne. Niektóre informacje mogą zostać ograniczone i zachowane przez okres wymagany przez prawo, w szczególności dla rozliczeń podatkowych, dokumentacji księgowej, obsługi roszczeń, przeciwdziałania nadużyciom lub wykazania zgodności działań z prawem.',
+                        text: 'Odłączenie aplikacji w ustawieniach konta Google, Facebook lub Meta blokuje przyszłe logowanie tym połączeniem, ale nie usuwa automatycznie odrębnego konta klienta ani danych zapisanych wcześniej w systemie SalonBW. Aby usunąć te dane, złóż żądanie opisane w punkcie 4.',
                     },
                     {
                         type: 'p',
-                        text: 'Jeżeli część danych musi zostać zachowana, poinformujemy o zakresie, podstawie i przewidywanym okresie dalszego przechowywania. Dane te nie będą wykorzystywane do marketingu.',
+                        text: 'Działa to również w drugą stronę: usunięcie konta SalonBW nie usuwa Twojego konta ani danych po stronie Google, Facebooka, Meta czy Instagrama. Tymi danymi zarządzasz bezpośrednio w ustawieniach danego dostawcy. Salon Black & White nie może usunąć danych przechowywanych wyłącznie na serwerach tych usług.',
                     },
                 ],
             },
             {
-                heading: '5. Termin i potwierdzenie realizacji',
+                heading: '7. Instagram — integracja galerii',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Obecna integracja z Instagramem służy wyłącznie do wyświetlania na naszej stronie mediów z firmowego konta salon_bw. Nie używamy logowania przez Instagram do zakładania kont klientów i nie pobieramy prywatnych wiadomości, kontaktów ani haseł użytkowników Instagrama.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Jeżeli w przyszłości udostępnimy logowanie przez Instagram lub innego dostawcę, zaktualizujemy tę stronę oraz Politykę Prywatności, a takie logowanie będzie objęte tymi samymi zasadami usuwania danych co pozostali dostawcy.',
+                    },
+                ],
+            },
+            {
+                heading: '8. Dane, których nie możemy usunąć od razu',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Prawo do usunięcia danych nie jest bezwzględne. Część informacji możemy ograniczyć i zachować przez okres wymagany przepisami, w szczególności: dane rozliczeniowe i księgowe (faktury, paragony, dokumentacja sprzedaży) przez okres wymagany prawem podatkowym, oraz dane niezbędne do ustalenia, dochodzenia lub obrony roszczeń — do czasu ich przedawnienia.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Możemy też zachować minimalny zakres danych na potrzeby przeciwdziałania nadużyciom oraz wykazania zgodności naszych działań z prawem. Jeżeli część danych musi zostać zachowana, poinformujemy o zakresie, podstawie i przewidywanym okresie dalszego przechowywania. Dane te nie będą wykorzystywane do marketingu i zostaną usunięte po upływie wymaganych okresów.',
+                    },
+                ],
+            },
+            {
+                heading: '9. Termin i potwierdzenie realizacji',
                 blocks: [
                     {
                         type: 'p',
@@ -111,20 +231,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '6. Odłączenie aplikacji Meta lub Instagram',
-                blocks: [
-                    {
-                        type: 'p',
-                        text: 'Możesz niezależnie usunąć dostęp aplikacji w ustawieniach swojego konta Meta lub Instagram. Odłączenie aplikacji blokuje przyszły dostęp przy użyciu danego połączenia, ale nie musi automatycznie usuwać odrębnego konta klienta ani danych zapisanych wcześniej w systemie SalonBW. Aby usunąć te dane, złóż żądanie opisane w punkcie 2.',
-                    },
-                    {
-                        type: 'p',
-                        text: 'Treści i dane przechowywane wyłącznie przez Meta lub Instagram, w tym konto Instagram, należy usuwać lub zarządzać nimi bezpośrednio w ustawieniach odpowiedniej usługi. Salon Black & White nie może usunąć danych znajdujących się wyłącznie na serwerach Meta.',
-                    },
-                ],
-            },
-            {
-                heading: '7. Bezpieczeństwo żądania',
+                heading: '10. Bezpieczeństwo żądania',
                 blocks: [
                     {
                         type: 'p',
@@ -133,11 +240,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '8. Administrator i prawa użytkownika',
+                heading: '11. Administrator i prawa użytkownika',
                 blocks: [
                     {
                         type: 'p',
-                        text: `Administratorem danych jest Salon Fryzjerski Black&White Aleksandra Bodora. W sprawach dotyczących danych osobowych skontaktuj się z nami pod adresem ${CONTACT_EMAIL}. Szczegółowe informacje o przetwarzaniu danych znajdują się w Polityce Prywatności. Masz również prawo złożyć skargę do Prezesa Urzędu Ochrony Danych Osobowych.`,
+                        text: `Administratorem danych jest Salon Fryzjerski Black&White Aleksandra Bodora. W sprawach dotyczących danych osobowych skontaktuj się z nami pod adresem ${CONTACT_EMAIL}. Szczegółowe informacje o przetwarzaniu danych, w tym o kategoriach danych i okresach ich przechowywania, znajdują się w Polityce Prywatności. Masz również prawo złożyć skargę do Prezesa Urzędu Ochrony Danych Osobowych.`,
                     },
                     {
                         type: 'link',
@@ -153,13 +260,13 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
     en: {
         metaTitle: 'Data Deletion | Salon Black & White',
         metaDescription:
-            'Instructions for requesting deletion of data from Salon Black & White systems and data connected with Meta and Instagram integrations.',
+            'How to delete your Salon Black & White account and data, including data copied at Google or Facebook login and data connected with Meta and Instagram integrations.',
         ogTitle: 'Data Deletion — Salon Black & White',
         ogDescription:
-            'Learn how to request deletion of data from Salon Black & White systems and data connected with Meta and Instagram integrations.',
+            'Learn how to delete your SalonBW account and related data, including data from Google or Facebook login and from Meta and Instagram integrations.',
         eyebrow: 'Data protection',
         h1: 'Data deletion instructions',
-        lead: 'This page explains how to request deletion of personal data processed by Salon Black & White, including data connected with our use of Meta and Instagram services.',
+        lead: 'This page explains how to delete your Salon Black & White client account and request deletion of the personal data we process — regardless of how the account was created, including data copied at login through Google, Facebook or another provider, and data connected with our use of Meta and Instagram services.',
         reviewNotice:
             'English is a convenience translation. The legally binding version is the Polish text.',
         sections: [
@@ -168,32 +275,116 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'These instructions apply to clients and users of the Salon Black & White website and booking system, and to people whose data may have been processed in connection with the salon’s Meta or Instagram integration.',
+                        text: 'These instructions apply to clients and users of the Salon Black & White website and booking system, regardless of how the account was created — through the registration form with an email address and password, or through external login (Google, Facebook or another available provider). They also apply to people whose data may have been processed in connection with the salon’s Meta or Instagram integration.',
                     },
                     {
                         type: 'p',
-                        text: 'The current Instagram integration displays media from the salon_bw business account. We do not use Instagram Login to create client accounts and we do not retrieve private messages, contacts or Instagram passwords.',
+                        text: 'The current Instagram integration only displays media from the salon_bw business account and is not a client login — its separate rules are described in section 7.',
                     },
                 ],
             },
             {
-                heading: '2. How do I submit a deletion request?',
+                heading: '2. What data does SalonBW store?',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'As part of your client account and your service history, the SalonBW panel may store the following categories of data:',
+                    },
+                    {
+                        type: 'list',
+                        ordered: false,
+                        items: [
+                            {
+                                lead: 'Account and profile data:',
+                                text: 'first name, surname, display name, email address, account role and a password stored only in hashed form.',
+                            },
+                            {
+                                lead: 'Contact and address data:',
+                                text: 'phone number, address, city and postal code.',
+                            },
+                            {
+                                lead: 'Additional profile data:',
+                                text: 'date of birth, gender, a description or note, and a profile photo (avatar).',
+                            },
+                            {
+                                lead: 'Consents and communication preferences:',
+                                text: 'GDPR and terms consents (with dates), marketing consents (SMS, WhatsApp, email), in-panel notification settings and a record of consent changes (audit trail).',
+                            },
+                            {
+                                lead: 'Visit and booking history:',
+                                text: 'appointment times, selected services, the assigned staff member, statuses, amounts, payment methods, discounts and tips.',
+                            },
+                            {
+                                lead: 'Notes, recommendations and formulas:',
+                                text: 'visit notes, aftercare recommendations and formulas or recipes (e.g. colouring) saved in the profile.',
+                            },
+                            {
+                                lead: 'Messages and reviews:',
+                                text: 'message threads between the client and the salon, and ratings and comments about visits.',
+                            },
+                            {
+                                lead: 'Loyalty programme:',
+                                text: 'points, accrual history and linked gift cards.',
+                            },
+                            {
+                                lead: 'Attachments:',
+                                text: 'photos in the client gallery and files attached to the profile.',
+                            },
+                            {
+                                lead: 'Billing data:',
+                                text: 'invoices, receipts and product sales records.',
+                            },
+                            {
+                                lead: 'Technical and security data:',
+                                text: 'session and refresh tokens, login-attempt records, event logs and push-notification subscription identifiers.',
+                            },
+                            {
+                                lead: 'Communication history:',
+                                text: 'logs of SMS and email messages sent and newsletter recipient records.',
+                            },
+                            {
+                                lead: 'External login identifiers:',
+                                text: 'your account identifier at the provider (e.g. Google or Facebook), if external login has been linked to the account — see section 3.',
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                heading: '3. Data copied at login through Google, Facebook or another provider',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'If you log in through Google, Facebook or another available provider, at first login we copy from your basic profile only: your email address, first name, surname and profile photo. We also store your account identifier at the provider (e.g. a Google or Facebook identifier) so we can recognise you at subsequent logins.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'External login uses only the basic profile scope (e.g. Google: “email” and “profile”; Facebook: “email” and “public_profile”). We do not retrieve or store provider access tokens, friend lists, private messages or passwords.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'The copied data becomes part of your SalonBW client account and is deleted on the same terms as the rest of your profile data (see sections 4 and 5).',
+                    },
+                ],
+            },
+            {
+                heading: '4. How do I submit an account or data deletion request?',
                 blocks: [
                     {
                         type: 'list',
                         ordered: true,
                         items: [
                             {
-                                text: `Send an email to ${CONTACT_EMAIL} with the subject “Data deletion – Meta/Instagram” or “Delete SalonBW account”.`,
+                                text: `Send an email to ${CONTACT_EMAIL} with the subject “Delete SalonBW account” or “Data deletion – Meta/Instagram”.`,
                             },
                             {
-                                text: 'State whether your request concerns your SalonBW client account, Meta/Instagram-related data, or both.',
+                                text: 'State what the request concerns: deletion of your entire SalonBW client account (regardless of how you registered), selected data, or Meta/Instagram-related data.',
                             },
                             {
-                                text: 'Provide the information needed to locate your account: your first and last name and the email address or telephone number used during registration. If your request concerns Meta/Instagram, you may also provide your Instagram username.',
+                                text: 'Provide the information needed to locate your account: your first and last name and the email address or telephone number used during registration or external login. If your request concerns the Meta/Instagram integration, you may also provide your Instagram username.',
                             },
                             {
-                                text: 'If possible, send the request from the address linked to your account. We may ask for additional identity verification, but never for your password, access token or Meta or Instagram login details.',
+                                text: 'If possible, send the request from the address linked to your account. We may ask for additional identity verification, but never for your password, access token or Google, Facebook, Meta or Instagram login details.',
                             },
                         ],
                     },
@@ -205,43 +396,83 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '3. What will we delete?',
+                heading: '5. What is deleted when the account is deleted?',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'After successful verification, we will delete or anonymise data that we are not required to retain, according to the scope of your request.',
+                        text: 'After successful verification, and to the extent we are not required to retain the data (see section 8), we will delete or anonymise:',
                     },
                     {
                         type: 'list',
                         ordered: false,
                         items: [
-                            { text: 'your SalonBW client profile and contact data,' },
-                            { text: 'marketing consents and communication settings,' },
                             {
-                                text: 'technical data or Meta/Instagram integration identifiers stored by Salon Black & White, if any exist,',
+                                text: 'the account and its profile, contact and address data,',
                             },
                             {
-                                text: 'copies of data obtained from Meta/Instagram and stored in our systems, if any exist and there is no obligation to retain them.',
+                                text: 'the profile photo and the photos and files stored in your profile,',
+                            },
+                            {
+                                text: 'consents, communication preferences and the related history of messages, reviews, notes and recommendations,',
+                            },
+                            {
+                                text: 'loyalty programme data linked to the account,',
+                            },
+                            {
+                                text: 'the link to your Google, Facebook or other provider account (we unlink the external identifiers) and the basic profile copies made at login,',
+                            },
+                            {
+                                text: 'technical data or Meta/Instagram integration identifiers stored by Salon Black & White, if any exist.',
                             },
                         ],
                     },
+                    {
+                        type: 'p',
+                        text: 'Deleting the account also revokes active SalonBW sessions and login tokens. After the request is fulfilled, using the booking system again requires creating a new account.',
+                    },
                 ],
             },
             {
-                heading: '4. Data we cannot delete immediately',
+                heading: '6. Disconnecting external login vs. deleting data',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'The right to erasure is not absolute. Some information may be restricted and retained for the period required by law, particularly for tax settlements, accounting records, handling legal claims, preventing abuse or demonstrating legal compliance.',
+                        text: 'Removing the app’s access in your Google, Facebook or Meta account settings blocks future login through that connection, but it does not automatically delete a separate client account or data previously stored in SalonBW systems. To delete that data, submit the request described in section 4.',
                     },
                     {
                         type: 'p',
-                        text: 'If any data must be retained, we will explain its scope, the legal basis and the expected retention period. Such data will not be used for marketing.',
+                        text: 'This also works the other way around: deleting your SalonBW account does not delete your account or data at Google, Facebook, Meta or Instagram. You manage that data directly in the relevant provider’s settings. Salon Black & White cannot delete data held exclusively on those services’ servers.',
                     },
                 ],
             },
             {
-                heading: '5. Response time and confirmation',
+                heading: '7. Instagram — gallery integration',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'The current Instagram integration only displays media from the salon_bw business account on our website. We do not use Instagram Login to create client accounts and we do not retrieve private messages, contacts or Instagram passwords.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'If in the future we enable login through Instagram or another provider, we will update this page and the Privacy Policy, and such login will be covered by the same data deletion rules as other providers.',
+                    },
+                ],
+            },
+            {
+                heading: '8. Data we cannot delete immediately',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'The right to erasure is not absolute. Some information may be restricted and retained for the period required by law, in particular: billing and accounting data (invoices, receipts, sales records) for the period required by tax law, and data necessary to establish, exercise or defend legal claims — until such claims become time-barred.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'We may also retain a minimal set of data to prevent abuse and to demonstrate that our actions comply with the law. If any data must be retained, we will explain its scope, the legal basis and the expected retention period. Such data will not be used for marketing and will be deleted once the required periods expire.',
+                    },
+                ],
+            },
+            {
+                heading: '9. Response time and confirmation',
                 blocks: [
                     {
                         type: 'p',
@@ -254,20 +485,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '6. Disconnecting the Meta or Instagram app',
-                blocks: [
-                    {
-                        type: 'p',
-                        text: 'You can separately remove the app’s access in your Meta or Instagram account settings. Disconnecting the app prevents future access through that connection, but it may not automatically delete a separate client account or data previously stored in SalonBW systems. To delete that data, submit the request described in section 2.',
-                    },
-                    {
-                        type: 'p',
-                        text: 'Content and data stored exclusively by Meta or Instagram, including your Instagram account, must be deleted or managed directly in the relevant service settings. Salon Black & White cannot delete data held exclusively on Meta servers.',
-                    },
-                ],
-            },
-            {
-                heading: '7. Request security',
+                heading: '10. Request security',
                 blocks: [
                     {
                         type: 'p',
@@ -276,11 +494,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '8. Controller and your rights',
+                heading: '11. Controller and your rights',
                 blocks: [
                     {
                         type: 'p',
-                        text: `The data controller is Salon Fryzjerski Black&White Aleksandra Bodora. For personal data matters, contact us at ${CONTACT_EMAIL}. Detailed information about data processing is available in our Privacy Policy. You also have the right to lodge a complaint with the President of the Polish Personal Data Protection Office.`,
+                        text: `The data controller is Salon Fryzjerski Black&White Aleksandra Bodora. For personal data matters, contact us at ${CONTACT_EMAIL}. Detailed information about data processing, including the categories of data and their retention periods, is available in our Privacy Policy. You also have the right to lodge a complaint with the President of the Polish Personal Data Protection Office.`,
                     },
                     {
                         type: 'link',
@@ -296,13 +514,13 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
     de: {
         metaTitle: 'Datenlöschung | Salon Black & White',
         metaDescription:
-            'Anleitung zur Löschung von Daten aus den Systemen von Salon Black & White und von Daten im Zusammenhang mit Meta- und Instagram-Integrationen.',
+            'So löschen Sie Ihr Salon-Black-&-White-Konto und Ihre Daten, einschließlich der bei der Anmeldung über Google oder Facebook kopierten Daten sowie der Daten aus Meta- und Instagram-Integrationen.',
         ogTitle: 'Datenlöschung — Salon Black & White',
         ogDescription:
-            'Erfahren Sie, wie Sie die Löschung von Daten aus den Systemen von Salon Black & White und aus Meta- und Instagram-Integrationen beantragen.',
+            'Erfahren Sie, wie Sie Ihr SalonBW-Konto und zugehörige Daten löschen, einschließlich der Daten aus der Google- oder Facebook-Anmeldung sowie aus Meta- und Instagram-Integrationen.',
         eyebrow: 'Datenschutz',
         h1: 'Anleitung zur Datenlöschung',
-        lead: 'Auf dieser Seite erklären wir, wie Sie die Löschung personenbezogener Daten beantragen können, die von Salon Black & White verarbeitet werden, einschließlich Daten im Zusammenhang mit unserer Nutzung von Meta- und Instagram-Diensten.',
+        lead: 'Auf dieser Seite erklären wir, wie Sie Ihr Kundenkonto bei Salon Black & White löschen und die Löschung der von uns verarbeiteten personenbezogenen Daten beantragen können — unabhängig davon, wie das Konto erstellt wurde, einschließlich der bei der Anmeldung über Google, Facebook oder einen anderen Anbieter kopierten Daten sowie der Daten im Zusammenhang mit unserer Nutzung von Meta- und Instagram-Diensten.',
         reviewNotice:
             'Die deutsche Fassung ist eine Übersetzung zur Erleichterung. Rechtlich verbindlich ist die polnische Fassung.',
         sections: [
@@ -311,32 +529,116 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Diese Anleitung gilt für Kundinnen und Kunden sowie Nutzer der Website und des Buchungssystems von Salon Black & White und für Personen, deren Daten im Zusammenhang mit der Meta- oder Instagram-Integration des Salons verarbeitet worden sein könnten.',
+                        text: 'Diese Anleitung gilt für Kundinnen und Kunden sowie Nutzer der Website und des Buchungssystems von Salon Black & White, unabhängig davon, wie das Konto erstellt wurde — über das Registrierungsformular mit E-Mail-Adresse und Passwort oder über eine externe Anmeldung (Google, Facebook oder ein anderer verfügbarer Anbieter). Sie gilt auch für Personen, deren Daten im Zusammenhang mit der Meta- oder Instagram-Integration des Salons verarbeitet worden sein könnten.',
                     },
                     {
                         type: 'p',
-                        text: 'Die aktuelle Instagram-Integration zeigt Medien des Geschäftskontos salon_bw an. Wir verwenden Instagram Login nicht zur Erstellung von Kundenkonten und rufen keine privaten Nachrichten, Kontakte oder Instagram-Passwörter ab.',
+                        text: 'Die aktuelle Instagram-Integration zeigt lediglich Medien des Geschäftskontos salon_bw an und ist keine Kundenanmeldung — ihre gesonderten Regeln beschreiben wir in Abschnitt 7.',
                     },
                 ],
             },
             {
-                heading: '2. Wie stelle ich einen Löschantrag?',
+                heading: '2. Welche Daten speichert SalonBW?',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Im Rahmen Ihres Kundenkontos und Ihrer Nutzungshistorie kann das SalonBW-Panel folgende Datenkategorien speichern:',
+                    },
+                    {
+                        type: 'list',
+                        ordered: false,
+                        items: [
+                            {
+                                lead: 'Konto- und Profildaten:',
+                                text: 'Vorname, Nachname, Anzeigename, E-Mail-Adresse, Kontorolle sowie ein ausschließlich als Hash gespeichertes Passwort.',
+                            },
+                            {
+                                lead: 'Kontakt- und Adressdaten:',
+                                text: 'Telefonnummer, Adresse, Stadt und Postleitzahl.',
+                            },
+                            {
+                                lead: 'Zusätzliche Profildaten:',
+                                text: 'Geburtsdatum, Geschlecht, eine Beschreibung oder Notiz sowie ein Profilbild (Avatar).',
+                            },
+                            {
+                                lead: 'Einwilligungen und Kommunikationseinstellungen:',
+                                text: 'DSGVO- und AGB-Einwilligungen (mit Datum), Marketingeinwilligungen (SMS, WhatsApp, E-Mail), Benachrichtigungseinstellungen im Panel sowie eine Aufzeichnung von Einwilligungsänderungen (Audit-Trail).',
+                            },
+                            {
+                                lead: 'Besuchs- und Buchungshistorie:',
+                                text: 'Termine, ausgewählte Leistungen, zugewiesene Mitarbeiterin, Status, Beträge, Zahlungsmethoden, Rabatte und Trinkgelder.',
+                            },
+                            {
+                                lead: 'Notizen, Empfehlungen und Rezepturen:',
+                                text: 'Besuchsnotizen, Nachsorgeempfehlungen sowie im Profil gespeicherte Formeln und Rezepturen (z. B. für Colorationen).',
+                            },
+                            {
+                                lead: 'Nachrichten und Bewertungen:',
+                                text: 'Nachrichtenverläufe zwischen Kunde und Salon sowie Bewertungen und Kommentare zu Besuchen.',
+                            },
+                            {
+                                lead: 'Treueprogramm:',
+                                text: 'Punkte, Gutschriftshistorie und verknüpfte Gutscheinkarten.',
+                            },
+                            {
+                                lead: 'Anhänge:',
+                                text: 'Fotos in der Kundengalerie und dem Profil beigefügte Dateien.',
+                            },
+                            {
+                                lead: 'Abrechnungsdaten:',
+                                text: 'Rechnungen, Quittungen und Verkaufsunterlagen zu Produkten.',
+                            },
+                            {
+                                lead: 'Technische und Sicherheitsdaten:',
+                                text: 'Sitzungs- und Aktualisierungstoken, Aufzeichnungen von Anmeldeversuchen, Ereignisprotokolle sowie Kennungen von Push-Benachrichtigungsabonnements.',
+                            },
+                            {
+                                lead: 'Kommunikationshistorie:',
+                                text: 'Protokolle gesendeter SMS- und E-Mail-Nachrichten sowie Aufzeichnungen von Newsletter-Empfängern.',
+                            },
+                            {
+                                lead: 'Kennungen der externen Anmeldung:',
+                                text: 'Ihre Kontokennung beim Anbieter (z. B. Google oder Facebook), sofern eine externe Anmeldung mit dem Konto verknüpft wurde — siehe Abschnitt 3.',
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                heading: '3. Bei der Anmeldung über Google, Facebook oder einen anderen Anbieter erhobene Daten',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Wenn Sie sich über Google, Facebook oder einen anderen verfügbaren Anbieter anmelden, kopieren wir bei der ersten Anmeldung aus Ihrem Basisprofil ausschließlich: Ihre E-Mail-Adresse, Ihren Vornamen, Ihren Nachnamen und Ihr Profilbild. Außerdem speichern wir Ihre Kontokennung beim Anbieter (z. B. eine Google- oder Facebook-Kennung), um Sie bei späteren Anmeldungen wiederzuerkennen.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Die externe Anmeldung nutzt nur den Basisprofil-Umfang (z. B. Google: „email” und „profile”; Facebook: „email” und „public_profile”). Wir rufen keine Zugriffstoken des Anbieters, Freundeslisten, privaten Nachrichten oder Passwörter ab und speichern diese nicht.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Die kopierten Daten werden Teil Ihres SalonBW-Kundenkontos und werden zu denselben Bedingungen gelöscht wie Ihre übrigen Profildaten (siehe Abschnitte 4 und 5).',
+                    },
+                ],
+            },
+            {
+                heading: '4. Wie stelle ich einen Antrag auf Konto- oder Datenlöschung?',
                 blocks: [
                     {
                         type: 'list',
                         ordered: true,
                         items: [
                             {
-                                text: `Senden Sie eine E-Mail an ${CONTACT_EMAIL} mit dem Betreff „Datenlöschung – Meta/Instagram” oder „SalonBW-Konto löschen”.`,
+                                text: `Senden Sie eine E-Mail an ${CONTACT_EMAIL} mit dem Betreff „SalonBW-Konto löschen” oder „Datenlöschung – Meta/Instagram”.`,
                             },
                             {
-                                text: 'Geben Sie an, ob Ihr Antrag das SalonBW-Kundenkonto, Meta-/Instagram-bezogene Daten oder beide Bereiche betrifft.',
+                                text: 'Geben Sie an, was der Antrag betrifft: die Löschung Ihres gesamten SalonBW-Kundenkontos (unabhängig von der Art der Registrierung), ausgewählter Daten oder Meta-/Instagram-bezogener Daten.',
                             },
                             {
-                                text: 'Geben Sie die zur Identifizierung des Kontos erforderlichen Daten an: Vor- und Nachname sowie die bei der Registrierung verwendete E-Mail-Adresse oder Telefonnummer. Betrifft der Antrag Meta/Instagram, können Sie zusätzlich Ihren Instagram-Benutzernamen angeben.',
+                                text: 'Geben Sie die zur Identifizierung des Kontos erforderlichen Daten an: Vor- und Nachname sowie die bei der Registrierung oder externen Anmeldung verwendete E-Mail-Adresse oder Telefonnummer. Betrifft der Antrag die Meta-/Instagram-Integration, können Sie zusätzlich Ihren Instagram-Benutzernamen angeben.',
                             },
                             {
-                                text: 'Senden Sie die Anfrage möglichst von der mit Ihrem Konto verknüpften Adresse. Wir können eine zusätzliche Identitätsbestätigung verlangen, jedoch niemals Ihr Passwort, Zugriffstoken oder Ihre Meta- bzw. Instagram-Anmeldedaten.',
+                                text: 'Senden Sie die Anfrage möglichst von der mit Ihrem Konto verknüpften Adresse. Wir können eine zusätzliche Identitätsbestätigung verlangen, jedoch niemals Ihr Passwort, Zugriffstoken oder Ihre Anmeldedaten für Google, Facebook, Meta oder Instagram.',
                             },
                         ],
                     },
@@ -348,43 +650,83 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '3. Was löschen wir?',
+                heading: '5. Was wird bei der Kontolöschung gelöscht?',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Nach erfolgreicher Überprüfung löschen oder anonymisieren wir entsprechend dem Umfang Ihres Antrags alle Daten, zu deren weiterer Speicherung wir nicht verpflichtet sind.',
+                        text: 'Nach erfolgreicher Überprüfung löschen oder anonymisieren wir, soweit wir nicht zur weiteren Aufbewahrung verpflichtet sind (siehe Abschnitt 8):',
                     },
                     {
                         type: 'list',
                         ordered: false,
                         items: [
-                            { text: 'Ihr SalonBW-Kundenprofil und Ihre Kontaktdaten,' },
-                            { text: 'Marketingeinwilligungen und Kommunikationseinstellungen,' },
                             {
-                                text: 'von Salon Black & White gespeicherte technische Daten oder Kennungen der Meta-/Instagram-Integration, sofern solche Daten vorhanden sind,',
+                                text: 'das Konto sowie die Profil-, Kontakt- und Adressdaten,',
                             },
                             {
-                                text: 'Kopien von aus Meta/Instagram bezogenen und in unseren Systemen gespeicherten Daten, sofern solche Daten vorhanden sind und keine Pflicht zur Aufbewahrung besteht.',
+                                text: 'das Profilbild sowie die in Ihrem Profil gespeicherten Fotos und Dateien,',
+                            },
+                            {
+                                text: 'Einwilligungen, Kommunikationseinstellungen und die zugehörige Historie von Nachrichten, Bewertungen, Notizen und Empfehlungen,',
+                            },
+                            {
+                                text: 'mit dem Konto verknüpfte Daten des Treueprogramms,',
+                            },
+                            {
+                                text: 'die Verknüpfung mit Ihrem Google-, Facebook- oder anderen Anbieterkonto (wir trennen die externen Kennungen) sowie die bei der Anmeldung kopierten Basisprofil-Daten,',
+                            },
+                            {
+                                text: 'von Salon Black & White gespeicherte technische Daten oder Kennungen der Meta-/Instagram-Integration, sofern solche Daten vorhanden sind.',
                             },
                         ],
                     },
+                    {
+                        type: 'p',
+                        text: 'Die Kontolöschung widerruft außerdem aktive SalonBW-Sitzungen und Anmeldetoken. Nach Erfüllung des Antrags ist für die weitere Nutzung des Buchungssystems die Erstellung eines neuen Kontos erforderlich.',
+                    },
                 ],
             },
             {
-                heading: '4. Daten, die wir nicht sofort löschen können',
+                heading: '6. Trennung der externen Anmeldung vs. Löschung der Daten',
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Das Recht auf Löschung gilt nicht uneingeschränkt. Bestimmte Informationen können für den gesetzlich vorgeschriebenen Zeitraum eingeschränkt und gespeichert werden, insbesondere für Steuerabrechnungen, Buchhaltungsunterlagen, die Bearbeitung von Rechtsansprüchen, die Verhinderung von Missbrauch oder den Nachweis der Rechtmäßigkeit unserer Tätigkeiten.',
+                        text: 'Das Entfernen des App-Zugriffs in den Einstellungen Ihres Google-, Facebook- oder Meta-Kontos verhindert die künftige Anmeldung über diese Verbindung, löscht jedoch nicht automatisch ein separates Kundenkonto oder zuvor in SalonBW-Systemen gespeicherte Daten. Um diese Daten zu löschen, stellen Sie den in Abschnitt 4 beschriebenen Antrag.',
                     },
                     {
                         type: 'p',
-                        text: 'Müssen Daten aufbewahrt werden, informieren wir Sie über deren Umfang, Rechtsgrundlage und voraussichtliche Speicherdauer. Diese Daten werden nicht für Marketingzwecke verwendet.',
+                        text: 'Dies gilt auch umgekehrt: Die Löschung Ihres SalonBW-Kontos löscht nicht Ihr Konto oder Ihre Daten bei Google, Facebook, Meta oder Instagram. Diese Daten verwalten Sie direkt in den Einstellungen des jeweiligen Anbieters. Salon Black & White kann keine Daten löschen, die ausschließlich auf den Servern dieser Dienste gespeichert sind.',
                     },
                 ],
             },
             {
-                heading: '5. Antwortfrist und Bestätigung',
+                heading: '7. Instagram — Galerie-Integration',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Die aktuelle Instagram-Integration zeigt auf unserer Website ausschließlich Medien des Geschäftskontos salon_bw an. Wir verwenden Instagram Login nicht zur Erstellung von Kundenkonten und rufen keine privaten Nachrichten, Kontakte oder Instagram-Passwörter ab.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Sollten wir künftig die Anmeldung über Instagram oder einen anderen Anbieter ermöglichen, aktualisieren wir diese Seite und die Datenschutzerklärung, und eine solche Anmeldung unterliegt denselben Löschregeln wie andere Anbieter.',
+                    },
+                ],
+            },
+            {
+                heading: '8. Daten, die wir nicht sofort löschen können',
+                blocks: [
+                    {
+                        type: 'p',
+                        text: 'Das Recht auf Löschung gilt nicht uneingeschränkt. Bestimmte Informationen können für den gesetzlich vorgeschriebenen Zeitraum eingeschränkt und aufbewahrt werden, insbesondere: Abrechnungs- und Buchhaltungsdaten (Rechnungen, Quittungen, Verkaufsunterlagen) für den steuerrechtlich vorgeschriebenen Zeitraum sowie Daten, die zur Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen erforderlich sind — bis zu deren Verjährung.',
+                    },
+                    {
+                        type: 'p',
+                        text: 'Wir können außerdem einen minimalen Datensatz aufbewahren, um Missbrauch vorzubeugen und die Rechtmäßigkeit unserer Tätigkeiten nachzuweisen. Müssen Daten aufbewahrt werden, informieren wir Sie über deren Umfang, Rechtsgrundlage und voraussichtliche Speicherdauer. Diese Daten werden nicht für Marketingzwecke verwendet und nach Ablauf der erforderlichen Fristen gelöscht.',
+                    },
+                ],
+            },
+            {
+                heading: '9. Antwortfrist und Bestätigung',
                 blocks: [
                     {
                         type: 'p',
@@ -397,20 +739,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '6. Trennung der Meta- oder Instagram-App',
-                blocks: [
-                    {
-                        type: 'p',
-                        text: 'Sie können den Zugriff der App separat in den Einstellungen Ihres Meta- oder Instagram-Kontos entfernen. Die Trennung verhindert den zukünftigen Zugriff über diese Verbindung, löscht jedoch nicht zwingend ein separates Kundenkonto oder zuvor in SalonBW-Systemen gespeicherte Daten. Um diese Daten zu löschen, stellen Sie den in Abschnitt 2 beschriebenen Antrag.',
-                    },
-                    {
-                        type: 'p',
-                        text: 'Inhalte und Daten, die ausschließlich von Meta oder Instagram gespeichert werden, einschließlich Ihres Instagram-Kontos, müssen direkt in den Einstellungen des jeweiligen Dienstes gelöscht oder verwaltet werden. Salon Black & White kann keine Daten löschen, die ausschließlich auf Meta-Servern gespeichert sind.',
-                    },
-                ],
-            },
-            {
-                heading: '7. Sicherheit des Antrags',
+                heading: '10. Sicherheit des Antrags',
                 blocks: [
                     {
                         type: 'p',
@@ -419,11 +748,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 ],
             },
             {
-                heading: '8. Verantwortlicher und Ihre Rechte',
+                heading: '11. Verantwortlicher und Ihre Rechte',
                 blocks: [
                     {
                         type: 'p',
-                        text: `Verantwortlicher ist Salon Fryzjerski Black&White Aleksandra Bodora. Bei Fragen zu personenbezogenen Daten kontaktieren Sie uns unter ${CONTACT_EMAIL}. Ausführliche Informationen zur Datenverarbeitung finden Sie in unserer Datenschutzerklärung. Sie haben außerdem das Recht, eine Beschwerde beim Präsidenten der polnischen Datenschutzbehörde einzureichen.`,
+                        text: `Verantwortlicher ist Salon Fryzjerski Black&White Aleksandra Bodora. Bei Fragen zu personenbezogenen Daten kontaktieren Sie uns unter ${CONTACT_EMAIL}. Ausführliche Informationen zur Datenverarbeitung, einschließlich der Datenkategorien und ihrer Speicherfristen, finden Sie in unserer Datenschutzerklärung. Sie haben außerdem das Recht, eine Beschwerde beim Präsidenten der polnischen Datenschutzbehörde einzureichen.`,
                     },
                     {
                         type: 'link',

--- a/apps/landing/src/i18n/dataDeletionContent.ts
+++ b/apps/landing/src/i18n/dataDeletionContent.ts
@@ -21,11 +21,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Instrukcja dotyczy klientów i użytkowników serwisu Salon Black & White oraz systemu rezerwacji, niezależnie od tego, w jaki sposób powstało konto — przez formularz rejestracji z adresem e-mail i hasłem, czy przez logowanie zewnętrzne (Google, Facebook lub inny dostępny dostawca). Dotyczy również osób, których dane mogły zostać przetworzone w związku z integracją salonu z usługami Meta lub Instagram.',
+                        text: 'Instrukcja dotyczy klientów i użytkowników serwisu Salon Black & White oraz systemu rezerwacji, niezależnie od tego, w jaki sposób powstało konto — przez formularz rejestracji z adresem e-mail i hasłem, czy przez logowanie zewnętrzne (Google, Facebook lub inny dostępny dostawca). Dane osobowe klientów przetwarzamy wyłącznie w naszym panelu (systemie CRM), a przy logowaniu zewnętrznym dodatkowo w zakresie podstawowego profilu pobranego od dostawcy logowania.',
                     },
                     {
                         type: 'p',
-                        text: 'Obecna integracja z Instagramem służy wyłącznie do wyświetlania mediów z firmowego konta salon_bw i nie jest logowaniem klienta — jej odrębne zasady opisujemy w punkcie 7.',
+                        text: 'Obowiązek udostępnienia tej instrukcji wynika z korzystania z logowania Meta (Facebook). Integracja z Instagramem to osobna sprawa — służy wyłącznie do prezentacji treści z naszego firmowego konta salon_bw na stronie i nie przetwarza danych osobowych klientów; jej odrębne zasady opisujemy w punkcie 7.',
                     },
                 ],
             },
@@ -124,7 +124,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                                 text: `Wyślij wiadomość na adres ${CONTACT_EMAIL} z tematem „Usunięcie konta SalonBW” albo „Usunięcie danych – Meta/Instagram”.`,
                             },
                             {
-                                text: 'Napisz, czego dotyczy żądanie: usunięcia całego konta klienta SalonBW (niezależnie od sposobu rejestracji), wybranych danych, czy danych związanych z Meta/Instagram.',
+                                text: 'Napisz, czego dotyczy żądanie: usunięcia całego konta klienta SalonBW (niezależnie od sposobu rejestracji), wybranych danych, odłączenia logowania Facebook/Google, albo — jeżeli wyświetlamy Twój publiczny komentarz lub polubienie przy naszych postach na Instagramie — zaprzestania jego prezentacji na stronie.',
                             },
                             {
                                 text: 'Podaj dane pozwalające odnaleźć konto: imię i nazwisko oraz adres e-mail lub numer telefonu użyty przy rejestracji albo logowaniu zewnętrznym. Jeżeli żądanie dotyczy integracji Meta/Instagram, możesz dodatkowo podać nazwę użytkownika Instagram.',
@@ -168,7 +168,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                                 text: 'powiązanie z kontem Google, Facebooka lub innego dostawcy (odłączamy identyfikatory zewnętrzne) oraz kopie podstawowego profilu skopiowane przy logowaniu,',
                             },
                             {
-                                text: 'dane techniczne lub identyfikatory integracji Meta/Instagram zapisane przez Salon Black & White, jeżeli takie dane istnieją.',
+                                text: 'ewentualne dane techniczne logowania Meta (Facebook) zapisane przez Salon Black & White. Galeria Instagram wyświetla wyłącznie nasze własne posty i nie przechowuje Twoich danych osobowych, więc nie zawiera danych klienta do usunięcia.',
                             },
                         ],
                     },
@@ -183,11 +183,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Odłączenie aplikacji w ustawieniach konta Google, Facebook lub Meta blokuje przyszłe logowanie tym połączeniem, ale nie usuwa automatycznie odrębnego konta klienta ani danych zapisanych wcześniej w systemie SalonBW. Aby usunąć te dane, złóż żądanie opisane w punkcie 4.',
+                        text: 'Jeżeli logowałeś się przez Facebooka lub Google, możesz odłączyć naszą aplikację w ustawieniach swojego konta (Facebook: Ustawienia → Aplikacje i witryny; Google: Konto → Bezpieczeństwo → Połączenia z aplikacjami). Odłączenie blokuje przyszłe logowanie tym połączeniem, ale nie usuwa automatycznie odrębnego konta klienta ani danych zapisanych wcześniej w systemie SalonBW. Aby usunąć te dane, złóż żądanie opisane w punkcie 4.',
                     },
                     {
                         type: 'p',
-                        text: 'Działa to również w drugą stronę: usunięcie konta SalonBW nie usuwa Twojego konta ani danych po stronie Google, Facebooka, Meta czy Instagrama. Tymi danymi zarządzasz bezpośrednio w ustawieniach danego dostawcy. Salon Black & White nie może usunąć danych przechowywanych wyłącznie na serwerach tych usług.',
+                        text: 'Galeria Instagram korzysta z naszego własnego, firmowego konta, więc zwykły odwiedzający nie ma tu nic „podłączonego”, co mógłby odłączyć. Działa to też w drugą stronę: usunięcie konta SalonBW nie usuwa Twojego konta ani danych po stronie Google, Facebooka, Meta czy Instagrama. Tymi danymi zarządzasz bezpośrednio w ustawieniach danego dostawcy, a Salon Black & White nie może usunąć danych przechowywanych wyłącznie na serwerach tych usług.',
                     },
                 ],
             },
@@ -196,7 +196,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Obecna integracja z Instagramem służy wyłącznie do wyświetlania na naszej stronie mediów z firmowego konta salon_bw. Nie używamy logowania przez Instagram do zakładania kont klientów i nie pobieramy prywatnych wiadomości, kontaktów ani haseł użytkowników Instagrama.',
+                        text: 'Integracja z Instagramem służy wyłącznie do prezentacji na naszej stronie treści z firmowego konta salon_bw — postów, a także możliwych publicznych polubień i komentarzy pod naszymi postami. Pobieramy jedynie media i podpisy z naszego własnego konta; nie używamy logowania przez Instagram, nie zakładamy kont klientów i nie budujemy z tej integracji profili klientów, nie pobieramy też prywatnych wiadomości, kontaktów ani haseł.',
+                    },
+                    {
+                        type: 'p',
+                        text: `Jeżeli wyświetlamy Twój publiczny komentarz lub polubienie widoczne przy naszych postach i chcesz, abyśmy przestali je prezentować na stronie, napisz do nas na adres ${CONTACT_EMAIL} albo usuń bądź ukryj tę treść bezpośrednio na Instagramie. Nie kopiujemy takich treści do systemu CRM ani nie łączymy ich z kontami klientów.`,
                     },
                     {
                         type: 'p',
@@ -275,11 +279,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'These instructions apply to clients and users of the Salon Black & White website and booking system, regardless of how the account was created — through the registration form with an email address and password, or through external login (Google, Facebook or another available provider). They also apply to people whose data may have been processed in connection with the salon’s Meta or Instagram integration.',
+                        text: 'These instructions apply to clients and users of the Salon Black & White website and booking system, regardless of how the account was created — through the registration form with an email address and password, or through external login (Google, Facebook or another available provider). We process clients’ personal data only in our panel (the CRM system) and, for external login, additionally the basic profile obtained from the login provider.',
                     },
                     {
                         type: 'p',
-                        text: 'The current Instagram integration only displays media from the salon_bw business account and is not a client login — its separate rules are described in section 7.',
+                        text: 'The obligation to publish these instructions arises from our use of Meta (Facebook) login. The Instagram integration is a separate matter — it only displays content from our salon_bw business account on the website and does not process clients’ personal data; its separate rules are described in section 7.',
                     },
                 ],
             },
@@ -378,7 +382,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                                 text: `Send an email to ${CONTACT_EMAIL} with the subject “Delete SalonBW account” or “Data deletion – Meta/Instagram”.`,
                             },
                             {
-                                text: 'State what the request concerns: deletion of your entire SalonBW client account (regardless of how you registered), selected data, or Meta/Instagram-related data.',
+                                text: 'State what the request concerns: deletion of your entire SalonBW client account (regardless of how you registered), selected data, disconnecting Facebook/Google login, or — if we display your public comment or like under our Instagram posts — that we stop showing it on the website.',
                             },
                             {
                                 text: 'Provide the information needed to locate your account: your first and last name and the email address or telephone number used during registration or external login. If your request concerns the Meta/Instagram integration, you may also provide your Instagram username.',
@@ -422,7 +426,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                                 text: 'the link to your Google, Facebook or other provider account (we unlink the external identifiers) and the basic profile copies made at login,',
                             },
                             {
-                                text: 'technical data or Meta/Instagram integration identifiers stored by Salon Black & White, if any exist.',
+                                text: 'any technical Meta (Facebook) login data stored by Salon Black & White. The Instagram gallery only displays our own posts and stores none of your personal data, so it contains no client data to delete.',
                             },
                         ],
                     },
@@ -437,11 +441,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Removing the app’s access in your Google, Facebook or Meta account settings blocks future login through that connection, but it does not automatically delete a separate client account or data previously stored in SalonBW systems. To delete that data, submit the request described in section 4.',
+                        text: 'If you logged in through Facebook or Google, you can disconnect our app in your account settings (Facebook: Settings → Apps and Websites; Google: Account → Security → Your connections to third-party apps). Disconnecting blocks future login through that connection, but it does not automatically delete a separate client account or data previously stored in SalonBW systems. To delete that data, submit the request described in section 4.',
                     },
                     {
                         type: 'p',
-                        text: 'This also works the other way around: deleting your SalonBW account does not delete your account or data at Google, Facebook, Meta or Instagram. You manage that data directly in the relevant provider’s settings. Salon Black & White cannot delete data held exclusively on those services’ servers.',
+                        text: 'The Instagram gallery uses our own business account, so an ordinary visitor has nothing “connected” here to disconnect. This also works the other way around: deleting your SalonBW account does not delete your account or data at Google, Facebook, Meta or Instagram. You manage that data directly in the relevant provider’s settings, and Salon Black & White cannot delete data held exclusively on those services’ servers.',
                     },
                 ],
             },
@@ -450,7 +454,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'The current Instagram integration only displays media from the salon_bw business account on our website. We do not use Instagram Login to create client accounts and we do not retrieve private messages, contacts or Instagram passwords.',
+                        text: 'The Instagram integration is used only to display content from our salon_bw business account on the website — posts, and possibly public likes and comments under our posts. We retrieve only media and captions from our own account; we do not use Instagram Login, do not create client accounts and do not build client profiles from this integration, nor do we retrieve private messages, contacts or passwords.',
+                    },
+                    {
+                        type: 'p',
+                        text: `If we display your public comment or like shown under our posts and you want us to stop showing it on the website, email us at ${CONTACT_EMAIL}, or delete or hide that content directly on Instagram. We do not copy such content into the CRM system or link it to client accounts.`,
                     },
                     {
                         type: 'p',
@@ -529,11 +537,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Diese Anleitung gilt für Kundinnen und Kunden sowie Nutzer der Website und des Buchungssystems von Salon Black & White, unabhängig davon, wie das Konto erstellt wurde — über das Registrierungsformular mit E-Mail-Adresse und Passwort oder über eine externe Anmeldung (Google, Facebook oder ein anderer verfügbarer Anbieter). Sie gilt auch für Personen, deren Daten im Zusammenhang mit der Meta- oder Instagram-Integration des Salons verarbeitet worden sein könnten.',
+                        text: 'Diese Anleitung gilt für Kundinnen und Kunden sowie Nutzer der Website und des Buchungssystems von Salon Black & White, unabhängig davon, wie das Konto erstellt wurde — über das Registrierungsformular mit E-Mail-Adresse und Passwort oder über eine externe Anmeldung (Google, Facebook oder ein anderer verfügbarer Anbieter). Personenbezogene Daten von Kunden verarbeiten wir ausschließlich in unserem Panel (dem CRM-System) und bei externer Anmeldung zusätzlich im Umfang des vom Anmeldeanbieter bezogenen Basisprofils.',
                     },
                     {
                         type: 'p',
-                        text: 'Die aktuelle Instagram-Integration zeigt lediglich Medien des Geschäftskontos salon_bw an und ist keine Kundenanmeldung — ihre gesonderten Regeln beschreiben wir in Abschnitt 7.',
+                        text: 'Die Pflicht zur Bereitstellung dieser Anleitung ergibt sich aus der Nutzung der Meta-(Facebook-)Anmeldung. Die Instagram-Integration ist eine gesonderte Sache — sie dient ausschließlich der Darstellung von Inhalten unseres Geschäftskontos salon_bw auf der Website und verarbeitet keine personenbezogenen Daten von Kunden; ihre gesonderten Regeln beschreiben wir in Abschnitt 7.',
                     },
                 ],
             },
@@ -632,7 +640,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                                 text: `Senden Sie eine E-Mail an ${CONTACT_EMAIL} mit dem Betreff „SalonBW-Konto löschen” oder „Datenlöschung – Meta/Instagram”.`,
                             },
                             {
-                                text: 'Geben Sie an, was der Antrag betrifft: die Löschung Ihres gesamten SalonBW-Kundenkontos (unabhängig von der Art der Registrierung), ausgewählter Daten oder Meta-/Instagram-bezogener Daten.',
+                                text: 'Geben Sie an, was der Antrag betrifft: die Löschung Ihres gesamten SalonBW-Kundenkontos (unabhängig von der Art der Registrierung), ausgewählter Daten, die Trennung der Facebook-/Google-Anmeldung oder — falls wir Ihren öffentlichen Kommentar oder Ihr „Gefällt mir” unter unseren Instagram-Beiträgen anzeigen — dass wir dessen Anzeige auf der Website einstellen.',
                             },
                             {
                                 text: 'Geben Sie die zur Identifizierung des Kontos erforderlichen Daten an: Vor- und Nachname sowie die bei der Registrierung oder externen Anmeldung verwendete E-Mail-Adresse oder Telefonnummer. Betrifft der Antrag die Meta-/Instagram-Integration, können Sie zusätzlich Ihren Instagram-Benutzernamen angeben.',
@@ -676,7 +684,7 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                                 text: 'die Verknüpfung mit Ihrem Google-, Facebook- oder anderen Anbieterkonto (wir trennen die externen Kennungen) sowie die bei der Anmeldung kopierten Basisprofil-Daten,',
                             },
                             {
-                                text: 'von Salon Black & White gespeicherte technische Daten oder Kennungen der Meta-/Instagram-Integration, sofern solche Daten vorhanden sind.',
+                                text: 'etwaige von Salon Black & White gespeicherte technische Daten der Meta-(Facebook-)Anmeldung. Die Instagram-Galerie zeigt ausschließlich unsere eigenen Beiträge an und speichert keine Ihrer personenbezogenen Daten, enthält also keine zu löschenden Kundendaten.',
                             },
                         ],
                     },
@@ -691,11 +699,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Das Entfernen des App-Zugriffs in den Einstellungen Ihres Google-, Facebook- oder Meta-Kontos verhindert die künftige Anmeldung über diese Verbindung, löscht jedoch nicht automatisch ein separates Kundenkonto oder zuvor in SalonBW-Systemen gespeicherte Daten. Um diese Daten zu löschen, stellen Sie den in Abschnitt 4 beschriebenen Antrag.',
+                        text: 'Wenn Sie sich über Facebook oder Google angemeldet haben, können Sie unsere App in den Einstellungen Ihres Kontos trennen (Facebook: Einstellungen → Apps und Websites; Google: Konto → Sicherheit → Ihre Verbindungen zu Drittanbieter-Apps). Die Trennung verhindert die künftige Anmeldung über diese Verbindung, löscht jedoch nicht automatisch ein separates Kundenkonto oder zuvor in SalonBW-Systemen gespeicherte Daten. Um diese Daten zu löschen, stellen Sie den in Abschnitt 4 beschriebenen Antrag.',
                     },
                     {
                         type: 'p',
-                        text: 'Dies gilt auch umgekehrt: Die Löschung Ihres SalonBW-Kontos löscht nicht Ihr Konto oder Ihre Daten bei Google, Facebook, Meta oder Instagram. Diese Daten verwalten Sie direkt in den Einstellungen des jeweiligen Anbieters. Salon Black & White kann keine Daten löschen, die ausschließlich auf den Servern dieser Dienste gespeichert sind.',
+                        text: 'Die Instagram-Galerie nutzt unser eigenes Geschäftskonto, sodass ein gewöhnlicher Besucher hier nichts „Verbundenes” zum Trennen hat. Dies gilt auch umgekehrt: Die Löschung Ihres SalonBW-Kontos löscht nicht Ihr Konto oder Ihre Daten bei Google, Facebook, Meta oder Instagram. Diese Daten verwalten Sie direkt in den Einstellungen des jeweiligen Anbieters, und Salon Black & White kann keine Daten löschen, die ausschließlich auf den Servern dieser Dienste gespeichert sind.',
                     },
                 ],
             },
@@ -704,7 +712,11 @@ export const DATA_DELETION: Record<Language, LegalDoc> = {
                 blocks: [
                     {
                         type: 'p',
-                        text: 'Die aktuelle Instagram-Integration zeigt auf unserer Website ausschließlich Medien des Geschäftskontos salon_bw an. Wir verwenden Instagram Login nicht zur Erstellung von Kundenkonten und rufen keine privaten Nachrichten, Kontakte oder Instagram-Passwörter ab.',
+                        text: 'Die Instagram-Integration dient ausschließlich der Darstellung von Inhalten unseres Geschäftskontos salon_bw auf der Website — Beiträge sowie möglicherweise öffentliche „Gefällt mir”-Angaben und Kommentare unter unseren Beiträgen. Wir rufen nur Medien und Bildunterschriften unseres eigenen Kontos ab; wir verwenden keine Instagram-Anmeldung, erstellen keine Kundenkonten und bilden aus dieser Integration keine Kundenprofile und rufen auch keine privaten Nachrichten, Kontakte oder Passwörter ab.',
+                    },
+                    {
+                        type: 'p',
+                        text: `Wenn wir Ihren öffentlichen Kommentar oder Ihr „Gefällt mir” unter unseren Beiträgen anzeigen und Sie möchten, dass wir die Anzeige auf der Website einstellen, schreiben Sie uns an ${CONTACT_EMAIL} oder löschen bzw. verbergen Sie diesen Inhalt direkt auf Instagram. Wir kopieren solche Inhalte nicht in das CRM-System und verknüpfen sie nicht mit Kundenkonten.`,
                     },
                     {
                         type: 'p',

--- a/apps/landing/src/i18n/legalContent.ts
+++ b/apps/landing/src/i18n/legalContent.ts
@@ -255,21 +255,55 @@ export const LEGAL: Record<
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Podczas rejestracji w naszym systemie rezerwacji oraz w trakcie realizacji usług zbieramy:',
+                            text: 'Podczas rejestracji w systemie rezerwacji oraz w trakcie realizacji usług w panelu SalonBW możemy przetwarzać następujące kategorie danych:',
                         },
                         {
                             type: 'list',
                             ordered: false,
                             items: [
-                                { text: 'Imię i nazwisko' },
                                 {
-                                    text: 'Numer telefonu komórkowego (niezbędny do potwierdzania i przypominania o wizytach)',
+                                    lead: 'Dane konta i profilu:',
+                                    text: 'imię, nazwisko, nazwa wyświetlana, adres e-mail (służący też do logowania), rola konta oraz hasło przechowywane wyłącznie w postaci zahaszowanej.',
                                 },
                                 {
-                                    text: 'Adres e-mail (do logowania w systemie CRM oraz komunikacji)',
+                                    lead: 'Dane kontaktowe i adresowe:',
+                                    text: 'numer telefonu (niezbędny do potwierdzania i przypominania o wizytach), adres, miasto i kod pocztowy.',
                                 },
                                 {
-                                    text: 'Zwyczaje i preferencje związane z usługami fryzjerskimi (tworzące historię zabiegów w profilu Klienta)',
+                                    lead: 'Dodatkowe dane profilu:',
+                                    text: 'data urodzenia, płeć, opis lub notatka oraz zdjęcie profilowe (awatar).',
+                                },
+                                {
+                                    lead: 'Zgody i preferencje komunikacji:',
+                                    text: 'zgody RODO i na regulamin (wraz z datami), zgody marketingowe (SMS, WhatsApp, e-mail), ustawienia powiadomień w panelu oraz zapis zmian zgód.',
+                                },
+                                {
+                                    lead: 'Historia wizyt i rezerwacji:',
+                                    text: 'terminy, wybrane usługi, przypisany pracownik, statusy, kwoty, metody płatności, rabaty i napiwki.',
+                                },
+                                {
+                                    lead: 'Notatki, zalecenia i receptury:',
+                                    text: 'notatki do wizyt, zalecenia pozabiegowe oraz formuły i receptury (np. koloryzacji) tworzące historię zabiegów w profilu Klienta.',
+                                },
+                                {
+                                    lead: 'Wiadomości i opinie:',
+                                    text: 'wątki wiadomości między Klientem a salonem oraz oceny i komentarze do wizyt.',
+                                },
+                                {
+                                    lead: 'Program lojalnościowy i rozliczenia:',
+                                    text: 'punkty, historia naliczeń, karty podarunkowe oraz dokumenty sprzedaży (faktury, paragony).',
+                                },
+                                {
+                                    lead: 'Załączniki:',
+                                    text: 'zdjęcia w galerii Klienta i pliki dołączone do profilu.',
+                                },
+                                {
+                                    lead: 'Dane techniczne, bezpieczeństwa i komunikacji:',
+                                    text: 'tokeny sesji i odświeżania, zapisy prób logowania, logi zdarzeń, identyfikatory subskrypcji powiadomień push oraz logi wysłanych wiadomości SMS i e-mail.',
+                                },
+                                {
+                                    lead: 'Identyfikatory logowania zewnętrznego:',
+                                    text: 'identyfikator konta u dostawcy (np. Google lub Facebook), jeżeli logowanie zewnętrzne zostało powiązane z kontem (patrz punkt 4).',
                                 },
                             ],
                         },
@@ -280,7 +314,24 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '4. Kto jest odbiorcą Państwa danych?',
+                    heading: '4. Logowanie przez Google, Facebooka lub innego dostawcę',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'Umożliwiamy zakładanie konta i logowanie przez dostawców zewnętrznych (Google, Facebook lub inny dostępny dostawca). W takim przypadku przy pierwszym logowaniu kopiujemy z Państwa podstawowego profilu wyłącznie: adres e-mail, imię, nazwisko oraz zdjęcie profilowe, a także zapisujemy identyfikator konta u dostawcy w celu rozpoznania przy kolejnych logowaniach.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Logowanie zewnętrzne korzysta jedynie z podstawowego zakresu profilu (np. Google: „email” i „profile”; Facebook: „email” i „public_profile”). Nie pobieramy i nie przechowujemy tokenów dostępu dostawcy, list znajomych, wiadomości prywatnych ani haseł. Podstawą prawną jest niezbędność do wykonania umowy o świadczenie usług elektronicznych (art. 6 ust. 1 lit. b RODO).',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Obecna integracja z Instagramem służy wyłącznie do wyświetlania mediów z firmowego konta salon_bw i nie jest logowaniem klienta. Zasady odłączania kont zewnętrznych i usuwania danych opisujemy w osobnej Instrukcji usuwania danych (/data-deletion).',
+                        },
+                    ],
+                },
+                {
+                    heading: '5. Kto jest odbiorcą Państwa danych?',
                     blocks: [
                         {
                             type: 'p',
@@ -308,7 +359,7 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '5. Prawa osób, których dane dotyczą',
+                    heading: '6. Prawa osób, których dane dotyczą',
                     blocks: [
                         {
                             type: 'p',
@@ -340,16 +391,20 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '6. Okres przechowywania danych',
+                    heading: '7. Okres przechowywania i usuwanie danych',
                     blocks: [
                         {
                             type: 'p',
                             text: 'Dane osobowe będą przechowywane przez okres niezbędny do świadczenia usług rezerwacji i prowadzenia konta w systemie, a po usunięciu konta — do momentu wejścia w życie przedawnienia ewentualnych roszczeń wynikających z umowy lub obowiązkowego czasu archiwizacji dokumentów księgowych przewidzianego przez prawo (zazwyczaj 5 lat).',
                         },
+                        {
+                            type: 'p',
+                            text: 'Prawo do usunięcia danych nie jest bezwzględne — część danych (np. rozliczeniowych, księgowych oraz niezbędnych do obrony roszczeń) możemy zachować przez wymagany przepisami okres, po którego upływie zostaną usunięte. Usunięcie konta odłącza również powiązane logowanie zewnętrzne (Google, Facebook lub inny dostawca) i unieważnia sesje w SalonBW; nie usuwa jednak danych po stronie tych dostawców. Szczegółowy tryb usunięcia konta i danych opisuje Instrukcja usuwania danych (/data-deletion).',
+                        },
                     ],
                 },
                 {
-                    heading: '7. Pliki Cookies',
+                    heading: '8. Pliki Cookies',
                     blocks: [
                         {
                             type: 'p',
@@ -575,21 +630,55 @@ export const LEGAL: Record<
                     blocks: [
                         {
                             type: 'p',
-                            text: 'During registration in our booking system and while providing services we collect:',
+                            text: 'During registration in our booking system and while providing services, the SalonBW panel may process the following categories of data:',
                         },
                         {
                             type: 'list',
                             ordered: false,
                             items: [
-                                { text: 'First name and surname' },
                                 {
-                                    text: 'Mobile phone number (required to confirm and remind about visits)',
+                                    lead: 'Account and profile data:',
+                                    text: 'first name, surname, display name, email address (also used for logging in), account role and a password stored only in hashed form.',
                                 },
                                 {
-                                    text: 'E-mail address (for logging in to the CRM system and for communication)',
+                                    lead: 'Contact and address data:',
+                                    text: 'phone number (required to confirm and remind about visits), address, city and postal code.',
                                 },
                                 {
-                                    text: 'Habits and preferences related to hairdressing services (forming the treatment history in the Client profile)',
+                                    lead: 'Additional profile data:',
+                                    text: 'date of birth, gender, a description or note, and a profile photo (avatar).',
+                                },
+                                {
+                                    lead: 'Consents and communication preferences:',
+                                    text: 'GDPR and terms consents (with dates), marketing consents (SMS, WhatsApp, email), in-panel notification settings and a record of consent changes.',
+                                },
+                                {
+                                    lead: 'Visit and booking history:',
+                                    text: 'appointment times, selected services, the assigned staff member, statuses, amounts, payment methods, discounts and tips.',
+                                },
+                                {
+                                    lead: 'Notes, recommendations and formulas:',
+                                    text: 'visit notes, aftercare recommendations and formulas or recipes (e.g. colouring) forming the treatment history in the Client profile.',
+                                },
+                                {
+                                    lead: 'Messages and reviews:',
+                                    text: 'message threads between the Client and the salon, and ratings and comments about visits.',
+                                },
+                                {
+                                    lead: 'Loyalty programme and billing:',
+                                    text: 'points, accrual history, gift cards and sales documents (invoices, receipts).',
+                                },
+                                {
+                                    lead: 'Attachments:',
+                                    text: 'photos in the Client gallery and files attached to the profile.',
+                                },
+                                {
+                                    lead: 'Technical, security and communication data:',
+                                    text: 'session and refresh tokens, login-attempt records, event logs, push-notification subscription identifiers and logs of SMS and email messages sent.',
+                                },
+                                {
+                                    lead: 'External login identifiers:',
+                                    text: 'your account identifier at the provider (e.g. Google or Facebook), if external login has been linked to the account (see section 4).',
                                 },
                             ],
                         },
@@ -600,7 +689,24 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '4. Who receives your data?',
+                    heading: '4. Login through Google, Facebook or another provider',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'We allow account creation and login through external providers (Google, Facebook or another available provider). In that case, at first login we copy from your basic profile only: your email address, first name, surname and profile photo, and we store your account identifier at the provider so we can recognise you at subsequent logins.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'External login uses only the basic profile scope (e.g. Google: “email” and “profile”; Facebook: “email” and “public_profile”). We do not retrieve or store provider access tokens, friend lists, private messages or passwords. The legal basis is necessity for the performance of the contract for electronic services (Art. 6(1)(b) GDPR).',
+                        },
+                        {
+                            type: 'p',
+                            text: 'The current Instagram integration only displays media from the salon_bw business account and is not a client login. The rules for disconnecting external accounts and deleting data are described in the separate Data deletion instructions (/data-deletion).',
+                        },
+                    ],
+                },
+                {
+                    heading: '5. Who receives your data?',
                     blocks: [
                         {
                             type: 'p',
@@ -628,7 +734,7 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '5. Rights of data subjects',
+                    heading: '6. Rights of data subjects',
                     blocks: [
                         {
                             type: 'p',
@@ -660,16 +766,20 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '6. Data retention period',
+                    heading: '7. Data retention and deletion',
                     blocks: [
                         {
                             type: 'p',
                             text: 'Personal data will be stored for the period necessary to provide booking services and maintain the account in the system and, after the account is deleted, until any claims arising from the contract become time-barred or until the mandatory period for archiving accounting documents required by law expires (usually 5 years).',
                         },
+                        {
+                            type: 'p',
+                            text: 'The right to erasure is not absolute — some data (e.g. billing, accounting and data needed to defend legal claims) may be retained for the period required by law and deleted once it expires. Deleting the account also unlinks any connected external login (Google, Facebook or another provider) and revokes SalonBW sessions; it does not, however, delete data held by those providers. The detailed procedure for deleting the account and data is described in the Data deletion instructions (/data-deletion).',
+                        },
                     ],
                 },
                 {
-                    heading: '7. Cookies',
+                    heading: '8. Cookies',
                     blocks: [
                         {
                             type: 'p',
@@ -895,21 +1005,55 @@ export const LEGAL: Record<
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Bei der Registrierung in unserem Buchungssystem und während der Leistungserbringung erheben wir:',
+                            text: 'Bei der Registrierung in unserem Buchungssystem und während der Leistungserbringung kann das SalonBW-Panel folgende Datenkategorien verarbeiten:',
                         },
                         {
                             type: 'list',
                             ordered: false,
                             items: [
-                                { text: 'Vor- und Nachname' },
                                 {
-                                    text: 'Mobiltelefonnummer (erforderlich zur Bestätigung und Erinnerung an Termine)',
+                                    lead: 'Konto- und Profildaten:',
+                                    text: 'Vorname, Nachname, Anzeigename, E-Mail-Adresse (auch für die Anmeldung), Kontorolle sowie ein ausschließlich als Hash gespeichertes Passwort.',
                                 },
                                 {
-                                    text: 'E-Mail-Adresse (für die Anmeldung im CRM-System und für die Kommunikation)',
+                                    lead: 'Kontakt- und Adressdaten:',
+                                    text: 'Telefonnummer (erforderlich zur Bestätigung und Erinnerung an Termine), Adresse, Stadt und Postleitzahl.',
                                 },
                                 {
-                                    text: 'Gewohnheiten und Vorlieben in Bezug auf Friseurleistungen (bilden die Behandlungshistorie im Kundenprofil)',
+                                    lead: 'Zusätzliche Profildaten:',
+                                    text: 'Geburtsdatum, Geschlecht, eine Beschreibung oder Notiz sowie ein Profilbild (Avatar).',
+                                },
+                                {
+                                    lead: 'Einwilligungen und Kommunikationseinstellungen:',
+                                    text: 'DSGVO- und AGB-Einwilligungen (mit Datum), Marketingeinwilligungen (SMS, WhatsApp, E-Mail), Benachrichtigungseinstellungen im Panel sowie eine Aufzeichnung von Einwilligungsänderungen.',
+                                },
+                                {
+                                    lead: 'Besuchs- und Buchungshistorie:',
+                                    text: 'Termine, ausgewählte Leistungen, zugewiesene Mitarbeiterin, Status, Beträge, Zahlungsmethoden, Rabatte und Trinkgelder.',
+                                },
+                                {
+                                    lead: 'Notizen, Empfehlungen und Rezepturen:',
+                                    text: 'Besuchsnotizen, Nachsorgeempfehlungen sowie Formeln und Rezepturen (z. B. für Colorationen), die die Behandlungshistorie im Kundenprofil bilden.',
+                                },
+                                {
+                                    lead: 'Nachrichten und Bewertungen:',
+                                    text: 'Nachrichtenverläufe zwischen Kunde und Salon sowie Bewertungen und Kommentare zu Besuchen.',
+                                },
+                                {
+                                    lead: 'Treueprogramm und Abrechnung:',
+                                    text: 'Punkte, Gutschriftshistorie, Gutscheinkarten und Verkaufsbelege (Rechnungen, Quittungen).',
+                                },
+                                {
+                                    lead: 'Anhänge:',
+                                    text: 'Fotos in der Kundengalerie und dem Profil beigefügte Dateien.',
+                                },
+                                {
+                                    lead: 'Technische, Sicherheits- und Kommunikationsdaten:',
+                                    text: 'Sitzungs- und Aktualisierungstoken, Aufzeichnungen von Anmeldeversuchen, Ereignisprotokolle, Kennungen von Push-Benachrichtigungsabonnements sowie Protokolle gesendeter SMS- und E-Mail-Nachrichten.',
+                                },
+                                {
+                                    lead: 'Kennungen der externen Anmeldung:',
+                                    text: 'Ihre Kontokennung beim Anbieter (z. B. Google oder Facebook), sofern eine externe Anmeldung mit dem Konto verknüpft wurde (siehe Abschnitt 4).',
                                 },
                             ],
                         },
@@ -920,7 +1064,24 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '4. Wer erhält Ihre Daten?',
+                    heading: '4. Anmeldung über Google, Facebook oder einen anderen Anbieter',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'Wir ermöglichen die Kontoerstellung und Anmeldung über externe Anbieter (Google, Facebook oder einen anderen verfügbaren Anbieter). In diesem Fall kopieren wir bei der ersten Anmeldung aus Ihrem Basisprofil ausschließlich: Ihre E-Mail-Adresse, Ihren Vornamen, Ihren Nachnamen und Ihr Profilbild und speichern Ihre Kontokennung beim Anbieter, um Sie bei späteren Anmeldungen wiederzuerkennen.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Die externe Anmeldung nutzt nur den Basisprofil-Umfang (z. B. Google: „email” und „profile”; Facebook: „email” und „public_profile”). Wir rufen keine Zugriffstoken des Anbieters, Freundeslisten, privaten Nachrichten oder Passwörter ab und speichern diese nicht. Rechtsgrundlage ist die Erforderlichkeit zur Erfüllung des Vertrags über elektronische Dienstleistungen (Art. 6 Abs. 1 lit. b DSGVO).',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Die aktuelle Instagram-Integration zeigt lediglich Medien des Geschäftskontos salon_bw an und ist keine Kundenanmeldung. Die Regeln zur Trennung externer Konten und zur Löschung von Daten sind in der gesonderten Anleitung zur Datenlöschung (/data-deletion) beschrieben.',
+                        },
+                    ],
+                },
+                {
+                    heading: '5. Wer erhält Ihre Daten?',
                     blocks: [
                         {
                             type: 'p',
@@ -948,7 +1109,7 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '5. Rechte der betroffenen Personen',
+                    heading: '6. Rechte der betroffenen Personen',
                     blocks: [
                         {
                             type: 'p',
@@ -980,16 +1141,20 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '6. Speicherdauer der Daten',
+                    heading: '7. Speicherdauer und Löschung der Daten',
                     blocks: [
                         {
                             type: 'p',
                             text: 'Personenbezogene Daten werden für den Zeitraum gespeichert, der für die Erbringung der Buchungsleistungen und die Kontoführung im System erforderlich ist, und nach Löschung des Kontos bis zum Eintritt der Verjährung etwaiger vertraglicher Ansprüche oder bis zum Ablauf der gesetzlich vorgeschriebenen Aufbewahrungsfrist für Buchhaltungsunterlagen (in der Regel 5 Jahre).',
                         },
+                        {
+                            type: 'p',
+                            text: 'Das Recht auf Löschung gilt nicht uneingeschränkt — bestimmte Daten (z. B. Abrechnungs-, Buchhaltungsdaten und zur Verteidigung von Rechtsansprüchen erforderliche Daten) können für den gesetzlich vorgeschriebenen Zeitraum aufbewahrt und nach dessen Ablauf gelöscht werden. Die Kontolöschung trennt außerdem eine verknüpfte externe Anmeldung (Google, Facebook oder ein anderer Anbieter) und widerruft SalonBW-Sitzungen; sie löscht jedoch keine Daten bei diesen Anbietern. Das genaue Verfahren zur Löschung des Kontos und der Daten ist in der Anleitung zur Datenlöschung (/data-deletion) beschrieben.',
+                        },
                     ],
                 },
                 {
-                    heading: '7. Cookies',
+                    heading: '8. Cookies',
                     blocks: [
                         {
                             type: 'p',

--- a/apps/landing/src/i18n/legalContent.ts
+++ b/apps/landing/src/i18n/legalContent.ts
@@ -99,7 +99,7 @@ export const LEGAL: Record<
                                 },
                                 {
                                     lead: 'Salon',
-                                    text: '– miejsce fizycznego świadczenia usług fryzjerskich zlokalizowane pod adresem ul. Mikołaja Kopernika 13, Radzionków.',
+                                    text: '– miejsce fizycznego świadczenia usług fryzjerskich zlokalizowane pod adresem ul. Webera 1a/13, 41-902 Bytom.',
                                 },
                             ],
                         },
@@ -215,7 +215,7 @@ export const LEGAL: Record<
                     blocks: [
                         {
                             type: 'p',
-                            text: `Administratorem Państwa danych osobowych jest Salon Fryzjerski Black&White Aleksandra Bodora z siedzibą w Radzionkowie (41-922), ul. Mikołaja Kopernika 13, NIP: 626 223 11 81, tel. +48 723 588 868. W sprawach związanych z ochroną danych osobowych prosimy o kontakt pod adresem e-mail: ${CONTACT_EMAIL}.`,
+                            text: `Administratorem Państwa danych osobowych jest Salon Fryzjerski Black&White Aleksandra Bodora z siedzibą w Radzionkowie (41-922), ul. Mikołaja Kopernika 13, NIP: 626 223 11 81, tel. +48 723 588 868. Usługi fryzjerskie świadczone są w salonie przy ul. Webera 1a/13, 41-902 Bytom. W sprawach związanych z ochroną danych osobowych prosimy o kontakt pod adresem e-mail: ${CONTACT_EMAIL}.`,
                         },
                     ],
                 },
@@ -519,7 +519,7 @@ export const LEGAL: Record<
                                 },
                                 {
                                     lead: 'Salon',
-                                    text: '– the place where hairdressing services are physically provided, located at ul. Mikołaja Kopernika 13, Radzionków.',
+                                    text: '– the place where hairdressing services are physically provided, located at ul. Webera 1a/13, 41-902 Bytom.',
                                 },
                             ],
                         },
@@ -637,7 +637,7 @@ export const LEGAL: Record<
                     blocks: [
                         {
                             type: 'p',
-                            text: `The controller of your personal data is Salon Fryzjerski Black&White Aleksandra Bodora, registered office in Radzionków (41-922), ul. Mikołaja Kopernika 13, NIP: 626 223 11 81, tel. +48 723 588 868. For matters relating to the protection of personal data, please contact us at: ${CONTACT_EMAIL}.`,
+                            text: `The controller of your personal data is Salon Fryzjerski Black&White Aleksandra Bodora, registered office in Radzionków (41-922), ul. Mikołaja Kopernika 13, NIP: 626 223 11 81, tel. +48 723 588 868. Hairdressing services are provided at the salon at ul. Webera 1a/13, 41-902 Bytom. For matters relating to the protection of personal data, please contact us at: ${CONTACT_EMAIL}.`,
                         },
                     ],
                 },
@@ -941,7 +941,7 @@ export const LEGAL: Record<
                                 },
                                 {
                                     lead: 'Salon',
-                                    text: '– der Ort der physischen Erbringung der Friseurleistungen, gelegen in der ul. Mikołaja Kopernika 13, Radzionków.',
+                                    text: '– der Ort der physischen Erbringung der Friseurleistungen, gelegen in der ul. Webera 1a/13, 41-902 Bytom.',
                                 },
                             ],
                         },
@@ -1059,7 +1059,7 @@ export const LEGAL: Record<
                     blocks: [
                         {
                             type: 'p',
-                            text: `Verantwortlicher für Ihre personenbezogenen Daten ist Salon Fryzjerski Black&White Aleksandra Bodora mit Sitz in Radzionków (41-922), ul. Mikołaja Kopernika 13, NIP: 626 223 11 81, Tel. +48 723 588 868. Bei Fragen zum Schutz personenbezogener Daten kontaktieren Sie uns bitte unter: ${CONTACT_EMAIL}.`,
+                            text: `Verantwortlicher für Ihre personenbezogenen Daten ist Salon Fryzjerski Black&White Aleksandra Bodora mit Sitz in Radzionków (41-922), ul. Mikołaja Kopernika 13, NIP: 626 223 11 81, Tel. +48 723 588 868. Die Friseurleistungen werden im Salon in der ul. Webera 1a/13, 41-902 Bytom erbracht. Bei Fragen zum Schutz personenbezogener Daten kontaktieren Sie uns bitte unter: ${CONTACT_EMAIL}.`,
                         },
                     ],
                 },

--- a/apps/landing/src/i18n/legalContent.ts
+++ b/apps/landing/src/i18n/legalContent.ts
@@ -444,6 +444,10 @@ export const LEGAL: Record<
                             type: 'p',
                             text: 'Prawo do usunięcia danych nie jest bezwzględne — część danych (np. rozliczeniowych, księgowych oraz niezbędnych do obrony roszczeń) możemy zachować przez wymagany przepisami okres, po którego upływie zostaną usunięte. Usunięcie konta odłącza również powiązane logowanie zewnętrzne (Google, Facebook lub inny dostawca) i unieważnia sesje w SalonBW; nie usuwa jednak danych po stronie tych dostawców. Szczegółowy tryb usunięcia konta i danych opisuje Instrukcja usuwania danych (/data-deletion).',
                         },
+                        {
+                            type: 'p',
+                            text: 'Dane usunięte z systemu mogą przez ograniczony czas (do około 14 dni) pozostawać w automatycznych kopiach zapasowych wykonywanych przez dostawcę hostingu, po czym są cyklicznie nadpisywane. Kopie zapasowe służą wyłącznie przywracaniu systemu po awarii i nie są wykorzystywane do bieżącego przetwarzania danych.',
+                        },
                     ],
                 },
                 {
@@ -866,6 +870,10 @@ export const LEGAL: Record<
                             type: 'p',
                             text: 'The right to erasure is not absolute — some data (e.g. billing, accounting and data needed to defend legal claims) may be retained for the period required by law and deleted once it expires. Deleting the account also unlinks any connected external login (Google, Facebook or another provider) and revokes SalonBW sessions; it does not, however, delete data held by those providers. The detailed procedure for deleting the account and data is described in the Data deletion instructions (/data-deletion).',
                         },
+                        {
+                            type: 'p',
+                            text: 'Data deleted from the system may remain for a limited time (up to approximately 14 days) in automatic backups made by the hosting provider, after which they are cyclically overwritten. Backups serve solely to restore the system after a failure and are not used for ongoing data processing.',
+                        },
                     ],
                 },
                 {
@@ -1287,6 +1295,10 @@ export const LEGAL: Record<
                         {
                             type: 'p',
                             text: 'Das Recht auf Löschung gilt nicht uneingeschränkt — bestimmte Daten (z. B. Abrechnungs-, Buchhaltungsdaten und zur Verteidigung von Rechtsansprüchen erforderliche Daten) können für den gesetzlich vorgeschriebenen Zeitraum aufbewahrt und nach dessen Ablauf gelöscht werden. Die Kontolöschung trennt außerdem eine verknüpfte externe Anmeldung (Google, Facebook oder ein anderer Anbieter) und widerruft SalonBW-Sitzungen; sie löscht jedoch keine Daten bei diesen Anbietern. Das genaue Verfahren zur Löschung des Kontos und der Daten ist in der Anleitung zur Datenlöschung (/data-deletion) beschrieben.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Aus dem System gelöschte Daten können für begrenzte Zeit (bis zu etwa 14 Tagen) in automatischen Sicherungskopien des Hosting-Anbieters verbleiben und werden anschließend zyklisch überschrieben. Sicherungskopien dienen ausschließlich der Systemwiederherstellung nach einem Ausfall und werden nicht für die laufende Datenverarbeitung verwendet.',
                         },
                     ],
                 },

--- a/apps/landing/src/i18n/legalContent.ts
+++ b/apps/landing/src/i18n/legalContent.ts
@@ -246,6 +246,10 @@ export const LEGAL: Record<
                                     lead: 'Marketing i Newsletter (za zgodą):',
                                     text: 'Przesyłanie informacji o promocjach, zniżkach i nowościach. Podstawa prawna: wyraźna, dobrowolna zgoda Użytkownika wyrażana podczas rejestracji lub w ustawieniach konta (art. 6 ust. 1 lit. a RODO).',
                                 },
+                                {
+                                    lead: 'Bezpieczne wykonanie zabiegu:',
+                                    text: 'jeżeli dobrowolnie przekażą nam Państwo informacje istotne dla bezpiecznego wykonania usługi (np. o alergiach lub przeciwwskazaniach), przetwarzamy je wyłącznie w tym celu. Podstawa prawna: wyraźna zgoda wyrażona poprzez dobrowolne podanie tych informacji (art. 9 ust. 2 lit. a RODO).',
+                                },
                             ],
                         },
                     ],
@@ -283,7 +287,7 @@ export const LEGAL: Record<
                                 },
                                 {
                                     lead: 'Notatki, zalecenia i receptury:',
-                                    text: 'notatki do wizyt, zalecenia pozabiegowe oraz formuły i receptury (np. koloryzacji) tworzące historię zabiegów w profilu Klienta.',
+                                    text: 'notatki do wizyt, zalecenia pozabiegowe oraz formuły i receptury (np. koloryzacji) tworzące historię zabiegów w profilu Klienta — w tym dobrowolnie podane informacje o alergiach lub przeciwwskazaniach do zabiegów.',
                                 },
                                 {
                                     lead: 'Wiadomości i opinie:',
@@ -331,21 +335,39 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '5. Kto jest odbiorcą Państwa danych?',
+                    heading: '5. Dane osób zapisywanych na wizytę telefonicznie lub na miejscu',
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Dla zapewnienia najwyższej jakości naszych usług, dane mogą być powierzane wyspecjalizowanym podmiotom współpracującym z Administratorem, w tym:',
+                            text: 'Jeżeli wizyta jest umawiana telefonicznie lub osobiście w Salonie, personel może wprowadzić do systemu CRM podstawowe dane potrzebne do obsługi rezerwacji: imię i nazwisko, numer telefonu oraz — opcjonalnie — adres e-mail i notatki dotyczące usługi. Dane te przetwarzamy na tych samych zasadach, co dane kont zakładanych samodzielnie (podstawa prawna: niezbędność do wykonania umowy, art. 6 ust. 1 lit. b RODO), a niniejsza Polityka pełni wobec tych osób funkcję informacyjną zgodnie z art. 14 RODO. Osobom tym przysługują wszystkie prawa opisane w punkcie 8.',
+                        },
+                    ],
+                },
+                {
+                    heading: '6. Kto jest odbiorcą Państwa danych?',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'Dla zapewnienia najwyższej jakości naszych usług, dane mogą być powierzane lub udostępniane wyspecjalizowanym podmiotom współpracującym z Administratorem — wyłącznie w zakresie niezbędnym do działania danej usługi:',
                         },
                         {
                             type: 'list',
                             ordered: false,
                             items: [
                                 {
-                                    text: 'Dostawcom usług hostingowych, na których serwerach działa serwis salon-bw.pl',
+                                    text: 'Dostawcy usług hostingowych, na którego serwerach w Polsce działają serwis salon-bw.pl i panel klienta (obecnie MyDevil)',
                                 },
                                 {
-                                    text: 'Operatorom bramek SMS oraz usług dostarczania e-maili (do celów wysyłania powiadomień)',
+                                    text: 'Operatorowi bramki SMS (SMSAPI) oraz dostawcom usług dostarczania e-maili — do wysyłki potwierdzeń i przypomnień o wizytach',
+                                },
+                                {
+                                    text: 'Meta Platforms — wyłącznie jeżeli korzystają Państwo z logowania przez Facebooka lub wybrali powiadomienia WhatsApp',
+                                },
+                                {
+                                    text: 'Google — wyłącznie jeżeli korzystają Państwo z logowania przez Google',
+                                },
+                                {
+                                    text: 'Dostawcom przeglądarkowych usług powiadomień push (np. Google, Apple, Mozilla) — wyłącznie jeżeli włączą Państwo powiadomienia push',
                                 },
                                 {
                                     text: 'Biuru rachunkowemu wspierającemu kwestie księgowe',
@@ -359,7 +381,20 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '6. Prawa osób, których dane dotyczą',
+                    heading: '7. Przekazywanie danych poza Europejski Obszar Gospodarczy',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'Co do zasady przetwarzamy dane na serwerach zlokalizowanych w Polsce. Jeżeli jednak korzystają Państwo z logowania przez Google lub Facebooka, z powiadomień WhatsApp albo z powiadomień push, dane niezbędne do działania tych usług mogą być przekazywane przez ich dostawców (Google, Meta) do państw trzecich, w tym do USA.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Takie przekazanie odbywa się na podstawie zabezpieczeń przewidzianych w RODO — decyzji Komisji Europejskiej stwierdzającej odpowiedni stopień ochrony (EU-U.S. Data Privacy Framework) lub standardowych klauzul umownych. Korzystanie z tych kanałów jest dobrowolne: konto można założyć i obsługiwać bez logowania zewnętrznego i bez tych kanałów powiadomień.',
+                        },
+                    ],
+                },
+                {
+                    heading: '8. Prawa osób, których dane dotyczą',
                     blocks: [
                         {
                             type: 'p',
@@ -376,6 +411,10 @@ export const LEGAL: Record<
                                     text: 'Usunięcia („prawo do bycia zapomnianym") lub ograniczenia przetwarzania,',
                                 },
                                 {
+                                    lead: 'Sprzeciwu',
+                                    text: 'wobec przetwarzania opartego na prawnie uzasadnionym interesie Administratora (art. 21 RODO),',
+                                },
+                                {
                                     lead: 'Przenoszenia danych',
                                     text: 'wprost ze swojego profilu klienta,',
                                 },
@@ -388,10 +427,14 @@ export const LEGAL: Record<
                                 },
                             ],
                         },
+                        {
+                            type: 'p',
+                            text: 'Nie podejmujemy decyzji opartych wyłącznie na zautomatyzowanym przetwarzaniu, w tym profilowaniu, które wywoływałyby wobec Państwa skutki prawne lub w podobny sposób istotnie na Państwa wpływały.',
+                        },
                     ],
                 },
                 {
-                    heading: '7. Okres przechowywania i usuwanie danych',
+                    heading: '9. Okres przechowywania i usuwanie danych',
                     blocks: [
                         {
                             type: 'p',
@@ -404,11 +447,15 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '8. Pliki Cookies',
+                    heading: '10. Pliki Cookies',
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Nasz serwis internetowy zbiera w sposób automatyczny wyłącznie informacje zawarte w plikach cookies. Są one wykorzystywane do utrzymywania sesji logowania w panelu, prawidłowego działania serwisu oraz w celach analitycznych.',
+                            text: 'Serwis wykorzystuje pliki cookies niezbędne do działania — w szczególności do utrzymania sesji logowania w panelu oraz zabezpieczenia formularzy (ochrona CSRF). Te pliki nie wymagają zgody i nie służą do śledzenia.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Analityczne pliki cookies (statystyki odwiedzin) uruchamiamy wyłącznie po wyrażeniu zgody w banerze zgód wyświetlanym przy pierwszej wizycie. Zgodę można w każdej chwili wycofać — zmieniając wybór w banerze lub usuwając pliki cookies w przeglądarce; odmowa lub wycofanie zgody powoduje usunięcie identyfikatorów analitycznych i nie ogranicza korzystania z serwisu.',
                         },
                     ],
                 },
@@ -621,6 +668,10 @@ export const LEGAL: Record<
                                     lead: 'Marketing and Newsletter (with consent):',
                                     text: 'sending information about promotions, discounts and news. Legal basis: the explicit, voluntary consent of the User given during registration or in account settings (Art. 6(1)(a) GDPR).',
                                 },
+                                {
+                                    lead: 'Safe performance of the treatment:',
+                                    text: 'if you voluntarily provide us with information relevant to performing the service safely (e.g. allergies or contraindications), we process it solely for that purpose. Legal basis: explicit consent expressed by voluntarily providing this information (Art. 9(2)(a) GDPR).',
+                                },
                             ],
                         },
                     ],
@@ -658,7 +709,7 @@ export const LEGAL: Record<
                                 },
                                 {
                                     lead: 'Notes, recommendations and formulas:',
-                                    text: 'visit notes, aftercare recommendations and formulas or recipes (e.g. colouring) forming the treatment history in the Client profile.',
+                                    text: 'visit notes, aftercare recommendations and formulas or recipes (e.g. colouring) forming the treatment history in the Client profile — including voluntarily provided information about allergies or contraindications to treatments.',
                                 },
                                 {
                                     lead: 'Messages and reviews:',
@@ -706,21 +757,39 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '5. Who receives your data?',
+                    heading: '5. Data of persons booked by phone or in person',
                     blocks: [
                         {
                             type: 'p',
-                            text: 'To ensure the highest quality of our services, data may be entrusted to specialised entities cooperating with the Controller, including:',
+                            text: 'If a visit is booked by phone or in person at the Salon, staff may enter into the CRM system the basic data needed to handle the booking: first and last name, phone number and — optionally — an email address and notes about the service. We process this data on the same terms as data of self-created accounts (legal basis: necessity for the performance of the contract, Art. 6(1)(b) GDPR), and this Policy serves as the information notice for those persons in accordance with Art. 14 GDPR. They have all the rights described in section 8.',
+                        },
+                    ],
+                },
+                {
+                    heading: '6. Who receives your data?',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'To ensure the highest quality of our services, data may be entrusted or disclosed to specialised entities cooperating with the Controller — solely to the extent necessary for the given service to work:',
                         },
                         {
                             type: 'list',
                             ordered: false,
                             items: [
                                 {
-                                    text: 'Hosting providers on whose servers the salon-bw.pl service runs',
+                                    text: 'The hosting provider on whose servers in Poland the salon-bw.pl service and the client panel run (currently MyDevil)',
                                 },
                                 {
-                                    text: 'SMS gateway operators and e-mail delivery services (for sending notifications)',
+                                    text: 'The SMS gateway operator (SMSAPI) and email delivery services — for sending visit confirmations and reminders',
+                                },
+                                {
+                                    text: 'Meta Platforms — only if you use Facebook login or have chosen WhatsApp notifications',
+                                },
+                                {
+                                    text: 'Google — only if you use Google login',
+                                },
+                                {
+                                    text: 'Browser push-notification service providers (e.g. Google, Apple, Mozilla) — only if you enable push notifications',
                                 },
                                 {
                                     text: 'An accounting office supporting bookkeeping matters',
@@ -734,7 +803,20 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '6. Rights of data subjects',
+                    heading: '7. Transfers of data outside the European Economic Area',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'As a rule, we process data on servers located in Poland. However, if you use Google or Facebook login, WhatsApp notifications or push notifications, the data necessary for those services to work may be transferred by their providers (Google, Meta) to third countries, including the USA.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Such transfers take place on the basis of safeguards provided for in the GDPR — a European Commission adequacy decision (the EU-U.S. Data Privacy Framework) or standard contractual clauses. Using these channels is voluntary: an account can be created and used without external login and without these notification channels.',
+                        },
+                    ],
+                },
+                {
+                    heading: '8. Rights of data subjects',
                     blocks: [
                         {
                             type: 'p',
@@ -751,6 +833,10 @@ export const LEGAL: Record<
                                     text: 'Erasure (the "right to be forgotten") or restriction of processing,',
                                 },
                                 {
+                                    lead: 'Object',
+                                    text: 'to processing based on the Controller’s legitimate interest (Art. 21 GDPR),',
+                                },
+                                {
                                     lead: 'Data portability',
                                     text: 'directly from your client profile,',
                                 },
@@ -763,10 +849,14 @@ export const LEGAL: Record<
                                 },
                             ],
                         },
+                        {
+                            type: 'p',
+                            text: 'We do not make decisions based solely on automated processing, including profiling, that would produce legal effects concerning you or similarly significantly affect you.',
+                        },
                     ],
                 },
                 {
-                    heading: '7. Data retention and deletion',
+                    heading: '9. Data retention and deletion',
                     blocks: [
                         {
                             type: 'p',
@@ -779,11 +869,15 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '8. Cookies',
+                    heading: '10. Cookies',
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Our website automatically collects only the information contained in cookies. They are used to maintain the login session in the panel, for the correct operation of the website and for analytical purposes.',
+                            text: 'The website uses cookies necessary for its operation — in particular to maintain the login session in the panel and to secure forms (CSRF protection). These cookies do not require consent and are not used for tracking.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Analytical cookies (visit statistics) are activated only after you give consent in the consent banner shown on your first visit. You can withdraw consent at any time — by changing your choice in the banner or deleting cookies in your browser; refusing or withdrawing consent removes the analytical identifiers and does not limit your use of the website.',
                         },
                     ],
                 },
@@ -996,6 +1090,10 @@ export const LEGAL: Record<
                                     lead: 'Marketing und Newsletter (mit Einwilligung):',
                                     text: 'Versand von Informationen über Aktionen, Rabatte und Neuigkeiten. Rechtsgrundlage: ausdrückliche, freiwillige Einwilligung des Nutzers bei der Registrierung oder in den Kontoeinstellungen (Art. 6 Abs. 1 lit. a DSGVO).',
                                 },
+                                {
+                                    lead: 'Sichere Durchführung der Behandlung:',
+                                    text: 'wenn Sie uns freiwillig Informationen mitteilen, die für die sichere Erbringung der Leistung relevant sind (z. B. Allergien oder Kontraindikationen), verarbeiten wir sie ausschließlich zu diesem Zweck. Rechtsgrundlage: ausdrückliche Einwilligung durch die freiwillige Angabe dieser Informationen (Art. 9 Abs. 2 lit. a DSGVO).',
+                                },
                             ],
                         },
                     ],
@@ -1033,7 +1131,7 @@ export const LEGAL: Record<
                                 },
                                 {
                                     lead: 'Notizen, Empfehlungen und Rezepturen:',
-                                    text: 'Besuchsnotizen, Nachsorgeempfehlungen sowie Formeln und Rezepturen (z. B. für Colorationen), die die Behandlungshistorie im Kundenprofil bilden.',
+                                    text: 'Besuchsnotizen, Nachsorgeempfehlungen sowie Formeln und Rezepturen (z. B. für Colorationen), die die Behandlungshistorie im Kundenprofil bilden — einschließlich freiwillig angegebener Informationen zu Allergien oder Kontraindikationen für Behandlungen.',
                                 },
                                 {
                                     lead: 'Nachrichten und Bewertungen:',
@@ -1081,21 +1179,39 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '5. Wer erhält Ihre Daten?',
+                    heading: '5. Daten von telefonisch oder vor Ort angemeldeten Personen',
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Um die höchste Qualität unserer Leistungen sicherzustellen, können Daten an spezialisierte, mit dem Verantwortlichen kooperierende Stellen weitergegeben werden, darunter:',
+                            text: 'Wird ein Termin telefonisch oder persönlich im Salon vereinbart, kann das Personal die für die Buchung erforderlichen Grunddaten in das CRM-System eintragen: Vor- und Nachname, Telefonnummer sowie — optional — E-Mail-Adresse und Notizen zur Leistung. Diese Daten verarbeiten wir zu denselben Bedingungen wie Daten selbst erstellter Konten (Rechtsgrundlage: Erforderlichkeit zur Vertragserfüllung, Art. 6 Abs. 1 lit. b DSGVO); diese Erklärung dient gegenüber diesen Personen als Information gemäß Art. 14 DSGVO. Ihnen stehen alle in Abschnitt 8 beschriebenen Rechte zu.',
+                        },
+                    ],
+                },
+                {
+                    heading: '6. Wer erhält Ihre Daten?',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'Um die höchste Qualität unserer Leistungen sicherzustellen, können Daten an spezialisierte, mit dem Verantwortlichen kooperierende Stellen weitergegeben oder offengelegt werden — ausschließlich in dem für den jeweiligen Dienst erforderlichen Umfang:',
                         },
                         {
                             type: 'list',
                             ordered: false,
                             items: [
                                 {
-                                    text: 'Hosting-Anbieter, auf deren Servern der Dienst salon-bw.pl läuft',
+                                    text: 'Der Hosting-Anbieter, auf dessen Servern in Polen der Dienst salon-bw.pl und das Kundenpanel laufen (derzeit MyDevil)',
                                 },
                                 {
-                                    text: 'Betreiber von SMS-Gateways und E-Mail-Zustelldiensten (zum Versand von Benachrichtigungen)',
+                                    text: 'Der SMS-Gateway-Betreiber (SMSAPI) und E-Mail-Zustelldienste — zum Versand von Terminbestätigungen und -erinnerungen',
+                                },
+                                {
+                                    text: 'Meta Platforms — nur wenn Sie die Facebook-Anmeldung nutzen oder WhatsApp-Benachrichtigungen gewählt haben',
+                                },
+                                {
+                                    text: 'Google — nur wenn Sie die Google-Anmeldung nutzen',
+                                },
+                                {
+                                    text: 'Anbieter von Browser-Push-Benachrichtigungsdiensten (z. B. Google, Apple, Mozilla) — nur wenn Sie Push-Benachrichtigungen aktivieren',
                                 },
                                 {
                                     text: 'Ein Buchhaltungsbüro zur Unterstützung buchhalterischer Angelegenheiten',
@@ -1109,7 +1225,20 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '6. Rechte der betroffenen Personen',
+                    heading: '7. Übermittlung von Daten außerhalb des Europäischen Wirtschaftsraums',
+                    blocks: [
+                        {
+                            type: 'p',
+                            text: 'Grundsätzlich verarbeiten wir Daten auf Servern in Polen. Wenn Sie jedoch die Google- oder Facebook-Anmeldung, WhatsApp-Benachrichtigungen oder Push-Benachrichtigungen nutzen, können die für diese Dienste erforderlichen Daten von deren Anbietern (Google, Meta) in Drittländer, einschließlich der USA, übermittelt werden.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Eine solche Übermittlung erfolgt auf Grundlage der in der DSGVO vorgesehenen Garantien — eines Angemessenheitsbeschlusses der Europäischen Kommission (EU-U.S. Data Privacy Framework) oder von Standardvertragsklauseln. Die Nutzung dieser Kanäle ist freiwillig: Ein Konto kann ohne externe Anmeldung und ohne diese Benachrichtigungskanäle erstellt und genutzt werden.',
+                        },
+                    ],
+                },
+                {
+                    heading: '8. Rechte der betroffenen Personen',
                     blocks: [
                         {
                             type: 'p',
@@ -1126,6 +1255,10 @@ export const LEGAL: Record<
                                     text: 'Löschung (das „Recht auf Vergessenwerden") oder Einschränkung der Verarbeitung,',
                                 },
                                 {
+                                    lead: 'Widerspruch',
+                                    text: 'gegen eine auf dem berechtigten Interesse des Verantwortlichen beruhende Verarbeitung (Art. 21 DSGVO),',
+                                },
+                                {
                                     lead: 'Datenübertragbarkeit',
                                     text: 'direkt aus Ihrem Kundenprofil,',
                                 },
@@ -1138,10 +1271,14 @@ export const LEGAL: Record<
                                 },
                             ],
                         },
+                        {
+                            type: 'p',
+                            text: 'Wir treffen keine ausschließlich auf automatisierter Verarbeitung — einschließlich Profiling — beruhenden Entscheidungen, die Ihnen gegenüber rechtliche Wirkung entfalten oder Sie in ähnlicher Weise erheblich beeinträchtigen würden.',
+                        },
                     ],
                 },
                 {
-                    heading: '7. Speicherdauer und Löschung der Daten',
+                    heading: '9. Speicherdauer und Löschung der Daten',
                     blocks: [
                         {
                             type: 'p',
@@ -1154,11 +1291,15 @@ export const LEGAL: Record<
                     ],
                 },
                 {
-                    heading: '8. Cookies',
+                    heading: '10. Cookies',
                     blocks: [
                         {
                             type: 'p',
-                            text: 'Unsere Website erfasst automatisch ausschließlich die in Cookies enthaltenen Informationen. Sie dienen der Aufrechterhaltung der Anmeldesitzung im Panel, dem ordnungsgemäßen Betrieb der Website und analytischen Zwecken.',
+                            text: 'Die Website verwendet für den Betrieb notwendige Cookies — insbesondere zur Aufrechterhaltung der Anmeldesitzung im Panel und zur Absicherung von Formularen (CSRF-Schutz). Diese Cookies erfordern keine Einwilligung und dienen nicht dem Tracking.',
+                        },
+                        {
+                            type: 'p',
+                            text: 'Analytische Cookies (Besuchsstatistiken) werden nur aktiviert, nachdem Sie im beim ersten Besuch angezeigten Einwilligungsbanner zugestimmt haben. Die Einwilligung können Sie jederzeit widerrufen — durch Änderung Ihrer Auswahl im Banner oder Löschen der Cookies im Browser; eine Ablehnung oder ein Widerruf entfernt die analytischen Kennungen und schränkt die Nutzung der Website nicht ein.',
                         },
                     ],
                 },


### PR DESCRIPTION
## Summary

The current `/data-deletion` page satisfies Meta's app-review requirement but is too narrow as a real data-deletion notice, and the Privacy Policy did not describe the actual data model. This PR makes both documents describe the same reality, grounded in the codebase — `user.entity.ts`, `social-auth.service.ts` (OAuth copies only email/first/last name/picture; provider tokens are **not** stored), the Google/Facebook strategies (basic scopes), the Instagram gallery route (`graph.instagram.com/me/media` — our own posts only, no client PII), and the real notification processors (`api.smsapi.pl`, Meta WhatsApp Business Cloud API, SMTP, web-push).

All three locales (pl/en/de) updated. PL remains the legally binding version; EN/DE keep the convenience-translation notice.

## Data-deletion page (`dataDeletionContent.ts`, 8 → 11 sections)

1. Who it's for — any client regardless of registration method; the Meta obligation stems from **Facebook login**, not the Instagram gallery
2. **What data SalonBW stores** — exact panel categories
3. **Data copied at Google/Facebook/other-provider login** — email, name, photo, provider id; basic scope only; no tokens/friends/messages/passwords
4. How to request account or data deletion
5. What deletion does — unlink external identifiers, revoke SalonBW sessions
6. Disconnecting Facebook/Google login (with where to revoke) ≠ deleting SalonBW data, and vice versa; the IG gallery is our own account, so a visitor has nothing linked to disconnect
7. **Instagram** — display-only of our salon_bw account (posts, possibly public likes/comments under our posts); nothing copied into CRM; how a person whose public comment/like we display can ask us to stop showing it
8. Data that can't be deleted immediately (billing/claims retention)
9. Response time and confirmation
10. Request security
11. Controller and user rights

Future providers phrased neutrally: *"Google, Facebook or another available provider."*

## Privacy Policy (`legalContent.ts`, 7 → 10 sections, full Art. 13/14 coverage)

1. Controller
2. Purposes + legal bases — incl. **safe treatment performance** for voluntarily provided allergy/contraindication info (Art. 9(2)(a))
3. **What data** — expanded category list matching the entities (incl. hashed password, consents audit trail, technical/security data, external login ids)
4. **External login** (Google/Facebook/other): copied fields, scopes, no token storage
5. **Clients booked by phone or in person** entered into the CRM by staff (Art. 14 notice)
6. **Recipients** completed: MyDevil hosting (PL), SMSAPI, email delivery, Meta (login + WhatsApp), Google (login), browser push providers, accounting — each scoped "only if you use that service"
7. **Third-country transfers** (Art. 13(1)(f)): Google/Meta channels may transfer to the USA under the EU-U.S. DPF / SCCs; all optional
8. Rights — incl. **Art. 21 objection** and a no-automated-decisions/no-profiling statement (Art. 13(2)(f))
9. Retention + deletion (erasure not absolute; session revocation; external-login unlink; link to `/data-deletion`)
10. **Cookies** — necessary (session/CSRF, no consent) vs analytics (consent-banner opt-in only, revocable)

## Tests

- `dataDeletionContent.test.ts`: 11 sections + Google/Facebook/session assertions across locales
- Full landing suite green; `eslint src` clean; `tsc --noEmit` clean

## Notes

- Rebased on `master` after #1463 (landing build fix), so `Frontend (public)` builds cleanly.
- Legal texts are drafted for professional legal review before final reliance (consistent with the existing "PL binding, EN/DE pending review" notice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)