### PR TITLE
Fix landing build: resolve relative API base for server-side content fetch (#1462)

### DIFF
--- a/apps/landing/src/__tests__/contentApi.test.ts
+++ b/apps/landing/src/__tests__/contentApi.test.ts
@@ -2,6 +2,7 @@ import {
     getContentSection,
     getFounderMessage,
     getSalonGallery,
+    resolveApiBaseUrl,
 } from '@/utils/contentApi';
 import { SALON_GALLERY } from '@/config/content';
 
@@ -63,5 +64,55 @@ describe('contentApi', () => {
     it('keeps the salon gallery as explicit static content', async () => {
         await expect(getSalonGallery()).resolves.toBe(SALON_GALLERY);
         expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    describe('resolveApiBaseUrl (regression for #1462)', () => {
+        const originalProxy = process.env.API_PROXY_URL;
+        const originalBase = process.env.API_BASE_URL;
+
+        afterEach(() => {
+            if (originalProxy === undefined) delete process.env.API_PROXY_URL;
+            else process.env.API_PROXY_URL = originalProxy;
+            if (originalBase === undefined) delete process.env.API_BASE_URL;
+            else process.env.API_BASE_URL = originalBase;
+        });
+
+        it('maps a relative "/api" base to the absolute proxy origin on the server (SSG/ISR)', () => {
+            delete process.env.API_PROXY_URL;
+            delete process.env.API_BASE_URL;
+            // The Next.js rewrite strips the leading /api segment, so the
+            // server-side equivalent of "/api" is the proxy target root.
+            expect(resolveApiBaseUrl('/api', true)).toBe(
+                'https://api.salon-bw.pl',
+            );
+        });
+
+        it('honours API_PROXY_URL when mapping a relative base on the server', () => {
+            process.env.API_PROXY_URL = 'https://staging-api.example.com/';
+            expect(resolveApiBaseUrl('/api', true)).toBe(
+                'https://staging-api.example.com',
+            );
+        });
+
+        it('preserves extra path segments after /api', () => {
+            delete process.env.API_PROXY_URL;
+            delete process.env.API_BASE_URL;
+            expect(resolveApiBaseUrl('/api/v2', true)).toBe(
+                'https://api.salon-bw.pl/v2',
+            );
+        });
+
+        it('keeps a relative base as-is in the browser', () => {
+            expect(resolveApiBaseUrl('/api', false)).toBe('/api');
+        });
+
+        it('passes an already-absolute base through unchanged', () => {
+            expect(resolveApiBaseUrl('http://localhost', true)).toBe(
+                'http://localhost',
+            );
+            expect(resolveApiBaseUrl('https://api.salon-bw.pl', false)).toBe(
+                'https://api.salon-bw.pl',
+            );
+        });
     });
 });

--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -6,7 +6,12 @@ import { jsonLd, absUrl } from '@/utils/seo';
 import Link from 'next/link';
 import PublicLayout from '@/components/PublicLayout';
 import { trackEvent } from '@/utils/analytics';
-import { BUSINESS_INFO, SALON_GALLERY, SEO_META } from '@/config/content';
+import {
+    BUSINESS_INFO,
+    FOUNDER_MESSAGE,
+    SALON_GALLERY,
+    SEO_META,
+} from '@/config/content';
 import translations from '@/i18n/translations';
 import { useLanguage } from '@/contexts/LanguageContext';
 import SplitHero from '@/components/SplitHero';
@@ -354,11 +359,23 @@ export default function HomePage({ founder, galleryImages }: HomePageProps) {
 }
 
 export const getStaticProps: GetStaticProps<HomePageProps> = async () => {
-    const founder = await getFounderMessage();
+    // The CMS section is optional: if the API is unreachable at build/ISR time
+    // (or the section isn't seeded), fall back to the bundled local content so
+    // the page still renders instead of failing the whole build.
+    let founder: FounderData;
+    try {
+        founder = (await getFounderMessage()) as unknown as FounderData;
+    } catch (err) {
+        console.warn(
+            '[home] Falling back to local founder message content:',
+            err instanceof Error ? err.message : err,
+        );
+        founder = FOUNDER_MESSAGE as unknown as FounderData;
+    }
 
     return {
         props: {
-            founder: founder as unknown as FounderData,
+            founder,
             galleryImages: SALON_GALLERY as unknown as GalleryImage[],
         },
         revalidate: 3600,

--- a/apps/landing/src/utils/contentApi.ts
+++ b/apps/landing/src/utils/contentApi.ts
@@ -4,10 +4,54 @@
 
 import * as localConfig from '@/config/content';
 
-const API_BASE_URL =
+const RAW_API_BASE_URL =
     process.env.NEXT_PUBLIC_API_URL ||
     process.env.API_BASE_URL ||
     'https://api.salon-bw.pl';
+
+function isAbsoluteUrl(value: string): boolean {
+    return /^https?:\/\//i.test(value);
+}
+
+/**
+ * Resolve the API base URL for a fetch.
+ *
+ * In the browser a relative base such as "/api" is valid (it resolves against
+ * the current origin and is proxied to the backend by the Next.js rewrite).
+ * On the server — including build-time static generation (SSG/ISR) — Node's
+ * `fetch` cannot parse a relative URL, so we must turn it into an absolute one.
+ *
+ * The rewrite maps `/api/:path*` → `${API_PROXY_URL}/:path*` (it strips the
+ * leading `/api` segment), so server-side we mirror that: replace the relative
+ * base with the proxy target origin.
+ *
+ * Exported (and parameterised) so the server-side branch is unit-testable
+ * without having to remove `window` from the jsdom test environment.
+ */
+export function resolveApiBaseUrl(
+    base: string = RAW_API_BASE_URL,
+    isServer: boolean = typeof window === 'undefined',
+): string {
+    if (isAbsoluteUrl(base)) {
+        return base;
+    }
+    // Relative base (e.g. "/api"): usable as-is only in the browser.
+    if (!isServer) {
+        return base;
+    }
+    // Server-side: build an absolute origin equivalent to the Next.js rewrite.
+    const target = (
+        process.env.API_PROXY_URL ||
+        process.env.API_BASE_URL ||
+        'https://api.salon-bw.pl'
+    ).replace(/\/$/, '');
+    const origin = isAbsoluteUrl(target) ? target : 'https://api.salon-bw.pl';
+    // The rewrite strips a leading "/api" segment; anything else is preserved.
+    const remainder = base.replace(/^\/api(?=\/|$)/, '');
+    return `${origin}${remainder}`;
+}
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 export interface ContentSection {
     id: number;


### PR DESCRIPTION
Fixes #1462.

## Problem

`Frontend (public)` failed on `next build` while prerendering the home page `/`:

```
[TypeError: Failed to parse URL from /api/content/sections/founder_message]
  code: 'ERR_INVALID_URL'
```

CI sets a **relative** `NEXT_PUBLIC_API_URL=/api`. In the browser that's fine (proxied by the Next.js rewrite), but during static generation Node's `fetch` can't parse a relative URL, so the CMS fetch for the `founder_message` section threw and aborted the export.

## Fix

Two complementary changes:

1. **`contentApi.ts` — `resolveApiBaseUrl()`**
   On the server (build/SSR/ISR) a relative base is mapped to the absolute proxy target origin, mirroring the rewrite `/api/:path* → ${API_PROXY_URL}/:path*` (which strips the leading `/api` segment). In the browser a relative base is kept as-is. Exported and parameterised (`base`, `isServer`) so both branches are unit-testable without removing `window` from jsdom.

2. **`index.tsx` `getStaticProps` — graceful fallback**
   If the CMS fetch throws (unreachable API, unseeded section), fall back to the bundled local `FOUNDER_MESSAGE` so a build can't be broken by a transient API issue. `contentApi` keeps its existing strict "throw on bad response" contract (the caller decides the fallback), so the existing `contentApi` tests are unchanged.

## Tests

- 5 new `resolveApiBaseUrl` cases: server `/api` → absolute origin, `API_PROXY_URL` override, extra path segments preserved, browser passthrough, absolute-URL passthrough.
- Existing `contentApi` behaviour (strict reject on 404, snake_case key, static gallery) untouched.

## Verification

- `NEXT_PUBLIC_API_URL=/api pnpm run build` now prerenders `/` successfully (previously the failing step).
- `eslint src` clean, `tsc --noEmit` clean, full landing suite **51 tests passing**.

## Scope

Split out from #1461 (data-deletion / privacy expansion) so that PR stays focused on legal docs. This one is purely the build fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3C8mcqLsByRe3ZYuJ6vrS)_