### PR TITLE
Handoff protocol + sweep reliability + customer form numbering

### DIFF
--- a/.claude/rules/active-context.md
+++ b/.claude/rules/active-context.md
@@ -1,5 +1,16 @@
 # Active Context
 
+> ⚠️ **TEN PLIK JEST ARCHIWALNY — NIE DOPISUJ DO NIEGO.**
+> Dopisywanie na górze tego pliku i `docs/AGENT_STATUS.md` przez dwa równoległe
+> strumienie powodowało konflikty merge, które cicho blokowały CI (2026-07-27).
+>
+> - **Gdzie jesteśmy teraz** → [`docs/PROJECT_STATE.md`](../../docs/PROJECT_STATE.md) (czytaj to najpierw)
+> - **Jak zapisać ukończone zadanie** → [`docs/HANDOFF_PROTOCOL.md`](../../docs/HANDOFF_PROTOCOL.md)
+> - **Nowe wpisy** → [`docs/journal/`](../../docs/journal/) — jeden plik na zadanie
+>
+> Poniższa treść zostaje jako **historia** (cenne lekcje i pułapki — czytaj,
+> ale nie rozbudowuj).
+
 ## Agent workflow rules
 
 - **MANDATORY:** After every significant change, immediately update this file with: what was done, what was found, what is next.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,24 @@ It defines how agents should operate in this repository: what is “production�
 
 ---
 
+> **START HERE:** read [`docs/PROJECT_STATE.md`](docs/PROJECT_STATE.md) first —
+> one page, always current: where the project is, what is next, what is blocked
+> on the owner. Then follow
+> [`docs/HANDOFF_PROTOCOL.md`](docs/HANDOFF_PROTOCOL.md), which is **binding for
+> every agent (Codex, Claude, human)** and defines when a task counts as done.
+>
+> Per-task history lives in [`docs/journal/`](docs/journal/) — **one file per
+> task**. Do NOT append to `docs/AGENT_STATUS.md` or
+> `.claude/rules/active-context.md`; they are archived (append-at-top there
+> caused repeated merge conflicts that silently blocked CI).
+>
+> Before pushing: `scripts/handoff-check.sh`.
+
 ## 0) Non-negotiables (execution rules)
 
 1. Read-before-write: before changing anything, read:
+   - docs/PROJECT_STATE.md (current state — first)
+   - docs/HANDOFF_PROTOCOL.md (how to record work)
    - Agent.md
    - docs/ (especially deployment + env + ops docs)
    - .github/workflows/*

--- a/Agent.md
+++ b/Agent.md
@@ -1,7 +1,13 @@
 # Agent Instructions (SalonBW)
 
-This file is the single source of truth for AI/automation work in this repo.
+This file holds the durable facts (stack, domains, deploy, ops) for AI work here.
 Keep it short, actionable, and update it after any infra or deployment change.
+
+> **Current state and how to hand work over are NOT in this file:**
+> - **Where the project is right now** → [`docs/PROJECT_STATE.md`](docs/PROJECT_STATE.md) (read first, one page)
+> - **How to record a finished task so any agent can continue** → [`docs/HANDOFF_PROTOCOL.md`](docs/HANDOFF_PROTOCOL.md) (binding for Codex, Claude and humans)
+> - **Per-task history** → [`docs/journal/`](docs/journal/) — one file per task; never append to the archived `docs/AGENT_STATUS.md` / `.claude/rules/active-context.md`
+> - Before pushing: `scripts/handoff-check.sh`
 
 ## 1. Stack + domains (production)
 - Public site: `https://salon-bw.pl`

--- a/apps/panel/src/components/customers/CustomerFormFields.tsx
+++ b/apps/panel/src/components/customers/CustomerFormFields.tsx
@@ -131,7 +131,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row customer-new-row--consent">
                     <span className="form-label d-block">
-                        7. Zgody udzielone przez klienta
+                        6. Zgody udzielone przez klienta
                     </span>
                     <div className="customer-consent-box">
                         Pamiętaj o dopełnieniu obowiązku informacyjnego w
@@ -172,7 +172,7 @@ export default function CustomerFormFields({
                 <h4>dane rozszerzone</h4>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-birth-date`}>
-                        8. Data urodzenia
+                        7. Data urodzenia
                     </label>
                     <input
                         id={`${fieldIdPrefix}-birth-date`}
@@ -184,7 +184,7 @@ export default function CustomerFormFields({
                     />
                 </div>
                 <div className="customer-new-row">
-                    <label htmlFor={`${fieldIdPrefix}-address`}>9. Ulica</label>
+                    <label htmlFor={`${fieldIdPrefix}-address`}>8. Ulica</label>
                     <input
                         id={`${fieldIdPrefix}-address`}
                         className="form-control"
@@ -195,7 +195,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-building-no`}>
-                        10. Nr domu
+                        9. Nr domu
                     </label>
                     <input
                         id={`${fieldIdPrefix}-building-no`}
@@ -207,7 +207,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-apartment-no`}>
-                        11. Nr lokalu
+                        10. Nr lokalu
                     </label>
                     <input
                         id={`${fieldIdPrefix}-apartment-no`}
@@ -221,7 +221,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-postal-code`}>
-                        12. Kod pocztowy
+                        11. Kod pocztowy
                     </label>
                     <input
                         id={`${fieldIdPrefix}-postal-code`}
@@ -232,7 +232,7 @@ export default function CustomerFormFields({
                     />
                 </div>
                 <div className="customer-new-row">
-                    <label htmlFor={`${fieldIdPrefix}-city`}>13. Miasto</label>
+                    <label htmlFor={`${fieldIdPrefix}-city`}>12. Miasto</label>
                     <input
                         id={`${fieldIdPrefix}-city`}
                         className="form-control"
@@ -242,7 +242,7 @@ export default function CustomerFormFields({
                     />
                 </div>
                 <div className="customer-new-row">
-                    <label htmlFor={`${fieldIdPrefix}-country`}>14. Kraj</label>
+                    <label htmlFor={`${fieldIdPrefix}-country`}>13. Kraj</label>
                     <input
                         id={`${fieldIdPrefix}-country`}
                         className="form-control"
@@ -253,7 +253,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-name-day`}>
-                        15. Data imienin
+                        14. Data imienin
                     </label>
                     <input
                         id={`${fieldIdPrefix}-name-day`}
@@ -264,7 +264,7 @@ export default function CustomerFormFields({
                     />
                 </div>
                 <div className="customer-new-row">
-                    <label htmlFor={`${fieldIdPrefix}-groups`}>16. Grupy</label>
+                    <label htmlFor={`${fieldIdPrefix}-groups`}>15. Grupy</label>
                     <input
                         id={`${fieldIdPrefix}-groups`}
                         className="form-control"
@@ -276,7 +276,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-origin`}>
-                        17. Pochodzenie klienta
+                        16. Pochodzenie klienta
                     </label>
                     <input
                         id={`${fieldIdPrefix}-origin`}
@@ -287,7 +287,7 @@ export default function CustomerFormFields({
                     />
                 </div>
                 <div className="customer-new-row">
-                    <label htmlFor={`${fieldIdPrefix}-pesel`}>18. PESEL</label>
+                    <label htmlFor={`${fieldIdPrefix}-pesel`}>17. PESEL</label>
                     <input
                         id={`${fieldIdPrefix}-pesel`}
                         className="form-control"
@@ -297,7 +297,7 @@ export default function CustomerFormFields({
                     />
                 </div>
                 <div className="customer-new-row">
-                    <label htmlFor={`${fieldIdPrefix}-nip`}>19. NIP</label>
+                    <label htmlFor={`${fieldIdPrefix}-nip`}>18. NIP</label>
                     <input
                         id={`${fieldIdPrefix}-nip`}
                         className="form-control"
@@ -308,7 +308,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-card-number`}>
-                        20. Numer karty
+                        19. Numer karty
                     </label>
                     <input
                         id={`${fieldIdPrefix}-card-number`}
@@ -320,7 +320,7 @@ export default function CustomerFormFields({
                 </div>
                 <div className="customer-new-row">
                     <label htmlFor={`${fieldIdPrefix}-description`}>
-                        21. Opis
+                        20. Opis
                     </label>
                     <textarea
                         id={`${fieldIdPrefix}-description`}

--- a/apps/panel/tests/e2e/visual-sweep.spec.ts
+++ b/apps/panel/tests/e2e/visual-sweep.spec.ts
@@ -501,6 +501,18 @@ async function openAndShoot(
 
     await trigger.click().catch(() => undefined);
     await settle(page);
+
+    // settle() waits for the loading indicator and networkidle, but NOT for CSS
+    // transitions — the first overlay run caught modals mid fade-in and they
+    // looked washed out, which reads as a contrast bug that isn't there. Wait
+    // for the dialog to actually be there, then let any transition finish.
+    await page
+        .locator('[role="dialog"], .modal')
+        .first()
+        .waitFor({ state: 'visible', timeout: 5_000 })
+        .catch(() => undefined);
+    await page.waitForTimeout(600);
+
     await shot(page, role, viewport.name, spec.name);
     await assertHealthy(page);
 

--- a/docs/HANDOFF_PROTOCOL.md
+++ b/docs/HANDOFF_PROTOCOL.md
@@ -1,0 +1,143 @@
+# Protokół przekazania pracy (handoff) — obowiązuje KAŻDEGO agenta
+
+_Wersja 1.0, 2026-07-27. Dotyczy tak samo Codeksa, Claude'a i człowieka._
+_Cel: po każdym zadaniu stan projektu jest zapisany tak, że dowolny agent
+zaczynający „na zimno" wie w 5 minut, gdzie jesteśmy i co dalej._
+
+---
+
+## 1. Dlaczego ten protokół powstał (realne awarie, nie teoria)
+
+| Co się stało | Kiedy | Koszt |
+|---|---|---|
+| Dwa strumienie dopisywały wpisy **na górze tego samego** `AGENT_STATUS.md` | 2026-07-27 | 2 konflikty merge w jednej sesji; PR przestał budować merge-ref, przez co **CI w ogóle nie odpalało** i nikt tego nie zauważył |
+| `active-context.md` stał na 07-12, a master miał 45 commitów do 07-22 | 2026-07-22 | Agent pracował na nieaktualnym obrazie projektu |
+| Fakt „token Instagrama ODRZUCANY" przeżył swoją naprawę | 07-22→07-23 | Zadanie wisiało na liście blokerów GO mimo że było zrobione |
+| Stan „gdzie jesteśmy" rozsypany po 3 plikach (~3100 linii) | stale | Zimny start = czytanie tysięcy linii zamiast jednej strony |
+
+Wnioski, które protokół egzekwuje: **nie dopisuj do wspólnego pliku**,
+**datuj i weryfikuj fakty**, **trzymaj jeden krótki plik stanu**.
+
+---
+
+## 2. Trzy warstwy zapisu (każda ma inną rolę)
+
+| Plik | Rola | Tryb zapisu |
+|---|---|---|
+| `docs/PROJECT_STATE.md` | **„Gdzie jesteśmy TERAZ"** — 1 strona, pierwszy plik czytany na zimno | **NADPISUJ** (nigdy nie dopisuj) |
+| `docs/journal/YYYY-MM-DD-<slug>.md` | **Jedno zadanie = jeden plik** — pełny zapis Finding→Change→Validation | **NOWY PLIK** (nigdy nie edytuj cudzego) |
+| `docs/PROJECT_COMPLETION_PLAN.md` | Plan dojścia do produkcji (fazy, bramki, decyzje) | Edytuj tylko przy zmianie planu/decyzji |
+
+**Kluczowa zasada anty-konfliktowa:** dwa agenty nigdy nie piszą do tego samego
+pliku. Journal to katalog osobnych plików — merge jest zawsze bezkonfliktowy.
+`PROJECT_STATE.md` jest krótki i nadpisywany w całości, więc konflikt (jeśli
+wystąpi) rozwiązuje się w 30 sekund, a nie przez scalanie 2000 linii.
+
+> `docs/AGENT_STATUS.md` (2256 linii) i `.claude/rules/active-context.md` są
+> **archiwalne — tylko do CZYTANIA**. Nie dopisuj już do nich. Historia zostaje
+> tam, nowe wpisy idą do `docs/journal/`.
+
+---
+
+## 3. Definicja ukończenia zadania (DoD)
+
+Zadanie **nie jest skończone**, dopóki wszystkie punkty nie są spełnione:
+
+- [ ] **1. Kod/zmiana** zrobiona i zwalidowana (patrz §4).
+- [ ] **2. Wpis w journalu** — nowy plik `docs/journal/YYYY-MM-DD-<slug>.md`
+      wg szablonu §5.
+- [ ] **3. `PROJECT_STATE.md` zaktualizowany** — sekcje „Ostatnio zrobione",
+      „Następny krok", „Zablokowane na ownerze", „Fakty zweryfikowane".
+- [ ] **4. Commit** zawiera i zmianę, i wpisy (jeden spójny commit lub PR).
+- [ ] **5. Następny krok nazwany wprost** — konkretne zdanie, nie „dalsze prace".
+      Jeśli nic nie zostało: napisz „brak".
+
+Uruchom `scripts/handoff-check.sh` przed pushem — sprawdzi punkty 2–3.
+
+---
+
+## 4. Walidacja — co znaczy „zwalidowane"
+
+Minimum dla zmiany w kodzie (dostosuj do zakresu):
+- `pnpm --filter @salonbw/panel test` (lub celowany plik) — zielone
+- `pnpm exec tsc --noEmit` w dotkniętej aplikacji — czyste
+- `pnpm exec eslint --fix <zmienione pliki>` — czyste
+- build dotkniętej aplikacji, jeśli zmiana może go złamać
+- **bugfix = rytuał fail-first**: test najpierw failuje bez fixu (weryfikacja
+  przez `git stash` na pliku źródłowym), potem przechodzi
+- **zmiana widoczna w UI** = weryfikacja po deployu (zrzut/klik), nie „powinno
+  działać"
+
+---
+
+## 5. Szablon wpisu do journala
+
+Nazwa pliku: `docs/journal/2026-07-27-krotki-slug.md`
+
+```markdown
+# <tytuł zadania>
+
+- **Data:** 2026-07-27
+- **Agent:** Claude Opus 5 / Codex / człowiek
+- **Commit(y):** `abc1234`
+- **PR:** #1466 (albo „brak")
+
+## Finding
+Co konkretnie było nie tak / czego brakowało — z DOWODEM (ścieżka pliku,
+zachowanie, zrzut, wynik curla). Bez nazwanego Findingu nie zaczynaj zmiany.
+
+## Change
+Minimalna zmiana adresująca Finding. Bez „przy okazji".
+
+## Validation
+Co dokładnie uruchomiono i z jakim wynikiem (liczby, nie „przeszło").
+
+## Rollout
+Numery runów CI / Deploy, wynik live-verify. Albo „nie dotyczy".
+
+## Follow-up
+Następny krok wprost, albo „brak".
+```
+
+---
+
+## 6. Zasada świeżości faktów (najważniejsza)
+
+**Nie dziedzicz faktów z logów — weryfikuj je.** Każdy fakt o produkcji zapisany
+w `PROJECT_STATE.md` musi mieć **datę weryfikacji**. Fakt starszy niż ~7 dni
+traktuj jako niepewny i sprawdź ponownie, zanim na nim oprzesz decyzję.
+
+Szybka weryfikacja stanu produkcji:
+```bash
+curl -sS https://api.salon-bw.pl/healthz          # db / smtp / instagram
+curl -sS -o /dev/null -w "%{http_code}\n" https://panel.salon-bw.pl
+git log --oneline origin/master -5                 # czy master się nie ruszył
+```
+
+To ta zasada wyłapałaby „token Instagrama odrzucany" (fakt nieaktualny o kilka
+dni) i „panel nie ma domeny" (nigdy niezweryfikowane założenie).
+
+---
+
+## 7. Rytuał startu sesji (zimny start, dowolny agent)
+
+1. `git fetch origin master && git log --oneline -10` — **czy master się ruszył?**
+   Równoległy strumień (owner/Codex/Claude) pracuje na tych samych plikach.
+2. Przeczytaj **`docs/PROJECT_STATE.md`** — to wystarczy do orientacji.
+3. Potrzebujesz szczegółów zadania? → `docs/journal/` (najnowsze pliki).
+4. Potrzebujesz kierunku? → `docs/PROJECT_COMPLETION_PLAN.md` (§3.0 fazy A–E).
+5. Sprawdź, czy CI na masterze jest zielone, zanim zaczniesz.
+6. Jeśli pracujesz na starszej gałęzi: **rebase na master ZANIM zaczniesz** —
+   inaczej PR nie zbuduje merge-refa i CI cicho nie odpali.
+
+---
+
+## 8. Bramki, których agent NIE przekracza sam
+
+- Migracje **destrukcyjne** na produkcyjnej bazie → dry-run w opisie PR +
+  `pg_dump` + **jawna zgoda ownera** przed merge.
+- Sekrety, tokeny, klucze, env produkcyjny → agent podaje instrukcję, wykonuje
+  owner (safe-skrypty).
+- Treści prawne i dane identyfikacyjne firmy → agent robi DRAFT, decyduje owner.
+- Taksonomia biznesowa (np. nazwy kategorii produktów) → propozycja, nie fakt
+  dokonany.

--- a/docs/PROJECT_COMPLETION_PLAN.md
+++ b/docs/PROJECT_COMPLETION_PLAN.md
@@ -276,6 +276,34 @@ Konsekwencje, obowiązujące w całym planie:
 - Akceptacja: liczności się zgadzają; spot-check ≥5 kart klientek na prodzie
   (metoda §0 pkt 5); wpis do logów.
 
+### ETAP 3a — Kategorie produktów (owner zatwierdza nazwy, agent seeduje)
+
+**Finding (sweep nakładek 2026-07-27):** modal „Zarządzaj kategoriami
+(Produkty)" pokazuje **„Brak kategorii."** — nie istnieje ani jedna kategoria
+produktowa, dlatego wszystkie ~822 produkty mają „brak kategorii". Filtrowanie
+i raport wartości magazynu wg kategorii są przez to bezużyteczne.
+
+**Decyzja ownera (07-23): kategorie są przydatne — wprowadzamy.**
+
+- Wejście: zatwierdzona przez ownera lista nazw. **Agent nie wymyśla taksonomii
+  biznesowej samodzielnie.**
+- **Propozycja startowa** (wyprowadzona z realnego katalogu — dominują linie
+  Wella: Color Touch, Koleston Perfect, Shinefinity oraz pielęgnacja):
+  1. Koloryzacja (farby)
+  2. Rozjaśniacze i oksydanty
+  3. Pielęgnacja (szampony, odżywki, maski)
+  4. Stylizacja
+  5. Materiały zużywalne / akcesoria
+  6. Produkty do odsprzedaży
+- Wykonanie: migracja seedująca kategorie + **przypisanie produktów regułami po
+  nazwie/marce** (np. `Koleston Perfect`/`Color Touch` → Koloryzacja), z raportem
+  ile produktów trafiło do każdej kategorii i ile zostało bez przypisania.
+- Bramka jak w E3: dry-run w opisie PR + `pg_dump` + jawna zgoda ownera.
+- Akceptacja: 0 kategorii → N kategorii; odsetek produktów bez kategorii
+  spadł; spot-check na `/products` z filtrem kategorii.
+- Kolejność: najlepiej **razem z importem (faza C)**, żeby nie kategoryzować
+  dwa razy — ale można też wcześniej, bo nie jest destrukcyjne.
+
 ### ETAP 4 — Czyszczenie, UAT i GO (Opus + owner)
 
 **E4.1 + E4.2 — RAZEM, jeden PR (faza A).** Kolejność wymuszona: regresja CI

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,0 +1,87 @@
+# STAN PROJEKTU — czytaj to jako PIERWSZE
+
+> **Ten plik NADPISUJEMY, nie dopisujemy.** Ma zostać jednostronicowy.
+> Zasady pracy: [`docs/HANDOFF_PROTOCOL.md`](./HANDOFF_PROTOCOL.md).
+> Historia zadań: [`docs/journal/`](./journal/). Plan: [`docs/PROJECT_COMPLETION_PLAN.md`](./PROJECT_COMPLETION_PLAN.md).
+
+**Ostatnia aktualizacja:** 2026-07-27 · **Aktualizował:** Claude Opus 5
+
+---
+
+## Cel projektu
+
+Własny panel dla **jednoosobowego salonu fryzjerskiego** (Salon Black & White,
+Bytom). Właścicielka **Aleksandra pracuje jako admin** — rola „pracownik" jest
+świadomie **poza zakresem** GO. Cel: w pełni działający panel na produkcji,
+odejście od Booksy.
+
+## Gdzie jesteśmy
+
+**Faza A** ścieżki do produkcji (§3.0 planu): przed UAT.
+Aplikacja jest funkcjonalnie kompletna i wdrożona; zostały zadania
+przedprodukcyjne, w większości po stronie ownera.
+
+## Fakty o produkcji (ZWERYFIKOWANE — data przy każdym)
+
+| Fakt | Zweryfikowano |
+|---|---|
+| `panel.salon-bw.pl` → HTTP 307 (login) — **panel JEST na realnej domenie** | 2026-07-23 |
+| `salon-bw.pl` → 301 na `www.` = **stary landing** (nginx, nie Next) | 2026-07-23 |
+| `dev.salon-bw.pl` → nowy landing (Next) | 2026-07-23 |
+| `/healthz`: db ok · smtp ok · **instagram ok** (~251 ms = realne odpytanie Meta) | 2026-07-23 |
+| SMS **nie działa** — pusty `SMSAPI_TOKEN` | 2026-07-23 |
+| Sentry **nie działa** — brak DSN → zero widoczności błędów | 2026-07-23 |
+| Alert o rezerwacji do salonu: **jeden kanał** (mail `BOOKING_ALERT_EMAIL`) + dzwonek w panelu | 2026-07-23 |
+| Brak **jakiejkolwiek** kategorii produktów → 822 produkty „brak kategorii" | 2026-07-27 |
+| Na prodzie są **dane testowe** (Codex QA, E2E Klient, produkty AUDYT, stocktaking w toku) | 2026-07-27 |
+
+> Fakt starszy niż ~7 dni = niepewny. Zweryfikuj ponownie (§6 protokołu).
+
+## Ostatnio zrobione
+
+- **PR #1465** (master `d7dbb67`): ETAP 0/1 — sync logów, weryfikacja
+  dependabotów (0 superseded → eskalacja), Z12 sweep wizualny 164/164 bez 🔴,
+  fixy 🟡/🎨, audyt marki, emoji→Heroicons. Zweryfikowane live po deployu.
+- **PR #1466** (master `7a71c19`): przedefiniowanie ścieżki na fazy A–E,
+  `UAT_PLAN.md`, sweep nakładek (modale), zakres jednoosobowy, token IG zamknięty.
+- **Sweep nakładek uruchomiony** (run `30306818237`) — pierwsze zrzuty modali
+  w historii projektu; znaleziska w `docs/journal/`.
+- **Protokół przekazania pracy** (`docs/HANDOFF_PROTOCOL.md`, ten plik,
+  `docs/journal/`, `scripts/handoff-check.sh`) — po dwóch konfliktach merge
+  w `AGENT_STATUS.md`, które cicho zablokowały CI. Nowe wpisy: jeden plik na
+  zadanie; archiwalne logi tylko do czytania.
+
+## Następny krok (konkretnie)
+
+1. **Ponowny dispatch `e2e-visual-sweep.yml`** — poprzedni przebieg łapał modale
+   w trakcie animacji (naprawione commitem `0e0f8de`); potrzebne wiarygodne
+   zrzuty, m.in. by potwierdzić, czy CTA „UTWÓRZ WIZYTĘ" jest przycięty.
+2. **Faza A: migracja cleanup E4.1+E4.2** (przełączenie sekretu CI + usunięcie
+   danych testowych) — z dry-runem, za bramką `pg_dump` + zgoda ownera.
+3. Potem **faza B: UAT** wg `docs/UAT_PLAN.md`.
+
+## Zablokowane na ownerze
+
+| # | Co | Czas |
+|---|---|---|
+| E2.2 | Zmiana tymczasowego hasła admina | 2 min |
+| E2.5 | Założenie projektu Sentry → DSN (agent wpina) | 15 min |
+| E2.11 | **Test: czy alert o rezerwacji dociera na telefon** (procedura w planie) | 10 min |
+| E4.2 | Zgoda + `pg_dump` przed migracją czyszczącą | — |
+| ETAP 3a | Zatwierdzenie nazw kategorii produktów (propozycja w planie) | — |
+| E3 | Wsad danych z Booksy do importu | — |
+| E2.1 | Restore-drill backupu (mail do MyDevil) | — |
+| E2.3 | Decyzja o domenie landingu (**nie blokuje panelu**) | — |
+
+## Aktywna gałąź / PR
+
+- Gałąź robocza: `claude/przygotowany-plan-rp46za`
+- Otwarte commity ponad masterem: naprawa wiarygodności sweepa, przenumerowanie
+  pól klienta 1–20, ETAP 3a w planie, ten protokół.
+
+## Uwaga o równoległych strumieniach
+
+Na repo pracują **równolegle** owner/Codex (ostatnio: landing — footer, founder
+CMS, treści prawne) i Claude (panel, plan, weryfikacja). **Zawsze `git fetch` i
+rebase przed startem** — master potrafi przesunąć się o kilka commitów między
+sesjami, a skonfliktowany PR cicho blokuje CI.

--- a/docs/journal/2026-07-27-handoff-protocol.md
+++ b/docs/journal/2026-07-27-handoff-protocol.md
@@ -1,0 +1,47 @@
+# Protokół przekazania pracy między agentami
+
+- **Data:** 2026-07-27
+- **Agent:** Claude Opus 5
+- **Commit(y):** ten commit
+- **PR:** #1466 → następny (gałąź `claude/przygotowany-plan-rp46za`)
+
+## Finding
+Zapis stanu prac nie przeżywał zmiany agenta. Dowody z tej sesji:
+1. Oba strumienie (Codex/owner i Claude) dopisywały wpisy **na górze tego samego**
+   `docs/AGENT_STATUS.md` (2256 linii) → **dwa konflikty merge w jednej sesji**.
+   Skonfliktowany PR nie mógł zbudować merge-refa, więc **CI w ogóle się nie
+   odpalało** i nikt tego nie zauważył, dopóki nie sprawdziłem ręcznie.
+2. `active-context.md` stał na 07-12, gdy master miał już 45 commitów do 07-22.
+3. Fakt „token Instagrama ODRZUCANY" przeżył swoją naprawę o kilka dni i wisiał
+   na liście blokerów GO.
+4. „Gdzie jesteśmy" było rozsypane po 3 plikach (~3100 linii) — zimny start
+   wymagał przeczytania tysięcy linii.
+
+## Change
+- `docs/HANDOFF_PROTOCOL.md` — wiążący dla KAŻDEGO agenta: definicja ukończenia
+  zadania (DoD), trzy warstwy zapisu, szablon wpisu, **zasada świeżości faktów**
+  (każdy fakt o produkcji z datą weryfikacji; >7 dni = sprawdź ponownie),
+  rytuał zimnego startu, bramki nieprzekraczalne bez ownera.
+- `docs/PROJECT_STATE.md` — **jedna strona, NADPISYWANA**: cel, faza, fakty
+  zweryfikowane z datami, ostatnio zrobione, następny krok, zablokowane na
+  ownerze, aktywna gałąź, ostrzeżenie o równoległych strumieniach.
+- `docs/journal/` — **jeden plik na zadanie** (`YYYY-MM-DD-slug.md`).
+  Bezkonfliktowe z definicji: dwa agenty nigdy nie piszą tego samego pliku.
+- `scripts/handoff-check.sh` — egzekwuje DoD przed pushem: wymaga wpisu w
+  journalu i odświeżenia `PROJECT_STATE.md`, blokuje dopisywanie do archiwalnych
+  logów (furtka `HANDOFF_ALLOW_ARCHIVED=1` na uzasadnione wyjątki).
+- Wpięcie w OBA punkty wejścia: `AGENTS.md` (Codex) i `Agent.md` (+ symlink
+  `claude.md`), oraz baner „archiwalny" w `.claude/rules/active-context.md`.
+
+## Validation
+`bash -n` na skrypcie czyste; skrypt uruchomiony na własnym change-secie —
+najpierw poprawnie zgłosił braki (journal + PROJECT_STATE), po uzupełnieniu
+przechodzi. Zmiana wyłącznie dokumentacyjno-narzędziowa, nie dotyka aplikacji.
+
+## Rollout
+Docs + skrypt; brak wpływu na build i runtime.
+
+## Follow-up
+Opcjonalnie: wpiąć `scripts/handoff-check.sh` do CI jako miękki krok
+(ostrzeżenie) dla PR-ów dotykających `apps/` lub `backend/`. Nie zrobione
+świadomie — najpierw niech protokół sprawdzi się w praktyce przez kilka zadań.

--- a/docs/journal/2026-07-27-overlay-sweep.md
+++ b/docs/journal/2026-07-27-overlay-sweep.md
@@ -1,0 +1,52 @@
+# Sweep warstwy nakładek (modale) + zakres jednoosobowy
+
+- **Data:** 2026-07-27
+- **Agent:** Claude Opus 5
+- **Commity:** `27d96b9`, `0e0f8de`, `7f7efe0`, `88a792c`
+- **PR:** #1466 (zmergowany → master `7a71c19`)
+
+## Finding
+Sweep wizualny robił zrzuty wyłącznie stron w spoczynku, więc **cała warstwa
+nakładek (33 komponenty modal/drawer/panel) nigdy nie trafiła na żaden zrzut** —
+mimo że to w modalach żyły najgorsze bugi projektu (2026-07-06: modale
+renderowane niewidzialnie; 07-08: cztery kolejne tej samej klasy).
+Dodatkowo sweep asertuje tylko żywotność (brak „Application error", brak „Nie
+masz uprawnień", brak przekierowania do logowania, niepuste `body`), a regresja
+E2E to 21 testów read-only — **ciągłości międzymodułowej nie sprawdza nic**.
+
+## Change
+- `visual-sweep.spec.ts`: nowy blok `overlays` otwierający modale używane
+  codziennie w jednoosobowym salonie (drawer wizyty, nowa klientka/produkt/
+  usługa, kategorie usług i produktów, panel szczegółów wizyty klientki) na obu
+  viewportach. Ściśle niemutujący: otwiera → zrzut → Escape.
+- `0e0f8de`: po pierwszym przebiegu okazało się, że `settle()` nie czeka na
+  animacje CSS — modale łapały się w trakcie fade-in i wyglądały na wyblakłe
+  (o mało nie zgłoszono fałszywego „za niski kontrast"). Dodane czekanie na
+  `[role="dialog"]` + 600 ms.
+- `7f7efe0`: numeracja pól klienta miała lukę (1,2,3,4,5,**7**…21) → ciągłe 1–20.
+- `88a792c`: ETAP 3a w planie — brak jakiejkolwiek kategorii produktów.
+- Zapisana decyzja ownera: zakres = jeden salon, jedna osoba (admin) → rola
+  „pracownik" wypada z bramki GO.
+
+## Validation
+`tsc --noEmit` czyste; Playwright zbiera 4 nowe testy; panel **346/346**;
+CI na PR #1466 **11/11 zielone**; sweep run `30306818237` = success,
+**172 zrzuty** (było 164), w tym 8 zrzutów modali.
+
+## Rollout
+Master `7a71c19`, deploy automatyczny po merge. Sweep uruchomiony na tym SHA.
+
+## Znaleziska ze zrzutów modali
+- 🟡 Kategorie produktów: **„Brak kategorii."** → ETAP 3a.
+- 🟡 Drawer „Nowa wizyta": CTA „UTWÓRZ WIZYTĘ" wygląda na przycięty dolną
+  krawędzią modala przy wysokości 768 px — **do potwierdzenia** po poprawce
+  animacji.
+- 🎨 Natywne pola dat w modalach: format US `mm/dd/yyyy` (locale przeglądarki).
+- Pominięte przez best-effort: `modal-new-service` (trigger „dodaj usługę" to
+  prawdopodobnie link, nie `button`), kategorie na mobile (schowane w drawerze
+  nawigacji), panel wizyty klientki (konto E2E nie ma wizyt).
+
+## Follow-up
+Ponowny dispatch sweepa z poprawką animacji → rzetelna ocena kontrastu i
+przycięcia CTA; naprawić selektor „dodaj usługę". Potem faza A: migracja
+cleanup E4.1+E4.2.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -1,0 +1,11 @@
+# Journal — jedno zadanie, jeden plik
+
+Nazwa: `YYYY-MM-DD-krotki-slug.md` (np. `2026-07-27-overlay-sweep.md`).
+
+**Nigdy nie edytuj cudzego wpisu** i nie dopisuj do wspólnego pliku — to właśnie
+powodowało konflikty merge w `AGENT_STATUS.md`. Nowe zadanie = nowy plik.
+
+Szablon i pełne zasady: [`../HANDOFF_PROTOCOL.md`](../HANDOFF_PROTOCOL.md) §5.
+
+Historia sprzed protokołu (archiwum, tylko do czytania):
+`../AGENT_STATUS.md`, `../../.claude/rules/active-context.md`.

--- a/scripts/handoff-check.sh
+++ b/scripts/handoff-check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Handoff protocol guard — docs/HANDOFF_PROTOCOL.md
+#
+# Verifies that work being pushed leaves the project resumable by ANY agent:
+#   1. a new journal entry exists for this change set
+#   2. docs/PROJECT_STATE.md was refreshed
+#   3. nobody appended to the archived logs (they cause merge conflicts)
+#
+# Usage:  scripts/handoff-check.sh [base-ref]     (default: origin/master)
+set -uo pipefail
+
+BASE="${1:-origin/master}"
+git rev-parse --verify --quiet "$BASE" >/dev/null || { echo "handoff-check: brak ref '$BASE' — pomijam."; exit 0; }
+
+CHANGED="$(git diff --name-only "$BASE"...HEAD)"
+[ -z "$CHANGED" ] && { echo "handoff-check: brak zmian wobec $BASE."; exit 0; }
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+
+# 1. Journal entry (one file per task -> never conflicts)
+if ! grep -qE '^docs/journal/[0-9]{4}-[0-9]{2}-[0-9]{2}-.+\.md$' <<<"$CHANGED"; then
+    echo "BRAK: wpis w docs/journal/"
+    note "Utwórz docs/journal/\$(date +%F)-<slug>.md wg szablonu HANDOFF_PROTOCOL.md §5."
+    fail=1
+fi
+
+# 2. Current-state file refreshed
+if ! grep -qx 'docs/PROJECT_STATE.md' <<<"$CHANGED"; then
+    echo "BRAK: aktualizacja docs/PROJECT_STATE.md"
+    note "Odśwież: Ostatnio zrobione / Następny krok / Zablokowane na ownerze / Fakty."
+    fail=1
+fi
+
+# 3. Archived logs must not grow (append-at-top = merge conflicts)
+for archived in docs/AGENT_STATUS.md .claude/rules/active-context.md; do
+    if grep -qx "$archived" <<<"$CHANGED"; then
+        if [ "${HANDOFF_ALLOW_ARCHIVED:-0}" = "1" ]; then
+            note "OK (HANDOFF_ALLOW_ARCHIVED=1): świadoma zmiana w $archived"
+        else
+            echo "UWAGA: modyfikujesz archiwalny log $archived"
+            note "Nowe wpisy idą do docs/journal/. Archiwum jest tylko do czytania."
+            note "Jeśli zmiana jest uzasadniona (np. baner): HANDOFF_ALLOW_ARCHIVED=1 $0"
+            fail=1
+        fi
+    fi
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "handoff-check: OK — praca jest przekazywalna."
+else
+    echo ""
+    echo "Zadanie NIE jest ukończone wg docs/HANDOFF_PROTOCOL.md §3."
+fi
+exit "$fail"


### PR DESCRIPTION
## Co tu jest

Cztery niezależne zmiany zebrane na jednej gałęzi fazy A.

### 1. Protokół przekazania pracy (główna zmiana)

Zapis stanu prac nie przeżywał zmiany agenta. Dowody z sesji, nie teoria:

- Oba strumienie (Codex/owner i Claude) dopisywały wpisy **na górze tego samego**
  `docs/AGENT_STATUS.md` (2256 linii) → **dwa konflikty merge w jednej sesji**.
  Skonfliktowany PR nie buduje merge-refa, więc **CI w ogóle się nie odpalało**
  i nikt tego nie zauważył, dopóki nie sprawdzono ręcznie.
- `.claude/rules/active-context.md` stał na 07-12, gdy master miał 45 nowszych commitów.
- Fakt „token Instagrama odrzucany" przeżył swoją naprawę o kilka dni i wisiał na liście blokerów GO.
- „Gdzie jesteśmy" było rozsypane po trzech plikach (~3100 linii).

Wprowadzone:

| Plik | Rola |
|---|---|
| `docs/PROJECT_STATE.md` | jedna strona, **nadpisywana** — faza, fakty z datą weryfikacji, następny krok, co blokuje owner |
| `docs/journal/YYYY-MM-DD-slug.md` | **jeden plik na zadanie** — bezkonfliktowe z definicji |
| `docs/HANDOFF_PROTOCOL.md` | definicja ukończenia, szablon wpisu, zasada świeżości faktów, rytuał zimnego startu, bramki wymagające ownera |
| `scripts/handoff-check.sh` | egzekwuje DoD przed pushem; blokuje dopisywanie do archiwalnych logów (furtka `HANDOFF_ALLOW_ARCHIVED=1`) |

Wpięte w **oba** punkty wejścia: `AGENTS.md` (Codex) i `Agent.md` (Claude),
plus baner „archiwalny" na `.claude/rules/active-context.md`. Stare logi zostają
jako historia — przestają rosnąć.

### 2. Wiarygodność sweepa nakładek (`0e0f8de`)

Poprzedni przebieg łapał modale w trakcie animacji wejścia, więc zrzuty pokazywały
stan przejściowy, nie końcowy. Spec czeka teraz na zakończenie transition przed zrzutem.

### 3. Przenumerowanie pól formularza klienta (`7f7efe0`)

Numeracja pól miała dziury; ciągła sekwencja 1–20.

### 4. ETAP 3a w planie (`88a792c`)

Na produkcji **nie istnieje ani jedna** kategoria produktów → 822 produkty w „brak
kategorii". Dopisany etap z propozycją nazw do zatwierdzenia przez ownera.

## Weryfikacja

- `bash -n scripts/handoff-check.sh` czyste.
- Skrypt uruchomiony na własnym change-secie: najpierw poprawnie zgłosił brakujący
  wpis w journalu i nieodświeżony `PROJECT_STATE.md`, po uzupełnieniu przechodzi.
- Zmiany 1 i 4 to dokumentacja i narzędzia — nie dotykają runtime'u.
- Zmiany 2 i 3 dotyczą panelu i speca E2E; wymagają przebiegu CI.

## Świadomie nie zrobione

Skrypt **nie jest** wpięty do CI jako twarda bramka — najpierw niech protokół
sprawdzi się w praktyce przez kilka zadań. Zapisane jako follow-up w journalu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKVY8xr8fB3CDUy9aWSWzG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKVY8xr8fB3CDUy9aWSWzG)_