### PR TITLE
fix(backend): align synthetic data with owner schedule

### DIFF
--- a/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
+++ b/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
@@ -143,6 +143,7 @@ function publicReport(report: SyntheticCommandReport): object {
             deleteCounts: report.plan.deleteCounts,
             createCounts: report.plan.createCounts,
             blockers: report.plan.blockers,
+            scheduleSummary: report.plan.scheduleSummary,
         },
         ...(report.mutationCounts
             ? { mutationCounts: report.mutationCounts }

--- a/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
+++ b/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
@@ -149,7 +149,21 @@ function publicReport(report: SyntheticCommandReport): object {
             ? { mutationCounts: report.mutationCounts }
             : {}),
         ...(report.insertCounts ? { insertCounts: report.insertCounts } : {}),
-        ...(report.verification ? { verification: report.verification } : {}),
+        ...(report.verification
+            ? {
+                  verification: {
+                      actual: report.verification.actual,
+                      expected: report.verification.expected,
+                      protectedAccountsPresent:
+                          report.verification.protectedAccountsPresent,
+                      remainingNonSyntheticClients:
+                          report.verification.remainingNonSyntheticClients,
+                      scheduleViolations:
+                          report.verification.scheduleViolations,
+                      blockers: report.verification.blockers,
+                  },
+              }
+            : {}),
     };
 }
 

--- a/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
+++ b/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
@@ -6,6 +6,7 @@ import { config as loadEnv } from 'dotenv';
 import { DataSource } from 'typeorm';
 import { parseSyntheticRunConfig } from '../src/database/synthetic-data/synthetic-data.config';
 import { generateSyntheticDataset } from '../src/database/synthetic-data/synthetic-data.dataset';
+import { summarizeSyntheticSchedule } from '../src/database/synthetic-data/synthetic-data.schedule';
 import {
     runSyntheticDataCommand,
     type SyntheticCommandReport,
@@ -16,9 +17,12 @@ import {
     buildSyntheticPlan,
     cleanupSyntheticData,
     insertSyntheticDataset,
+    loadSyntheticBaseContext,
+    loadSyntheticWorkingDays,
     resetOperationalData,
     verifySyntheticState,
 } from '../src/database/synthetic-data/synthetic-data.store';
+import { assertSyntheticScheduleValid } from '../src/database/synthetic-data/synthetic-data.validation';
 import type {
     FileMetadata,
     SyntheticRunConfig,
@@ -107,7 +111,11 @@ async function runCommand(
             anchorDate: new Date(),
             createPasswordHash: async () =>
                 bcrypt.hash(randomBytes(32).toString('hex'), 12),
+            loadSyntheticBaseContext,
+            loadSyntheticWorkingDays,
             generateDataset: generateSyntheticDataset,
+            assertSyntheticScheduleValid,
+            summarizeSyntheticSchedule,
             buildSyntheticPlan,
             assertProtectedAccounts,
             assertResetSchema,

--- a/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
+++ b/backend/salonbw-backend/scripts/synthetic-prelive-data.ts
@@ -17,8 +17,10 @@ import {
     buildSyntheticPlan,
     cleanupSyntheticData,
     insertSyntheticDataset,
+    loadSyntheticAppointmentDateRange,
     loadSyntheticBaseContext,
     loadSyntheticWorkingDays,
+    lockSyntheticSchedule,
     resetOperationalData,
     verifySyntheticState,
 } from '../src/database/synthetic-data/synthetic-data.store';
@@ -111,8 +113,10 @@ async function runCommand(
             anchorDate: new Date(),
             createPasswordHash: async () =>
                 bcrypt.hash(randomBytes(32).toString('hex'), 12),
+            loadSyntheticAppointmentDateRange,
             loadSyntheticBaseContext,
             loadSyntheticWorkingDays,
+            lockSyntheticSchedule,
             generateDataset: generateSyntheticDataset,
             assertSyntheticScheduleValid,
             summarizeSyntheticSchedule,

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.spec.ts
@@ -1,15 +1,74 @@
 import { generateSyntheticDataset } from './synthetic-data.dataset';
+import {
+    SYNTHETIC_FUTURE_DAYS,
+    SYNTHETIC_PAST_DAYS,
+    warsawDateKey,
+    warsawMinuteOfDay,
+} from './synthetic-data.schedule';
+import type {
+    DatasetInput,
+    SyntheticWorkingDay,
+    SyntheticWorkingRange,
+} from './synthetic-data.types';
 
-const input = {
-    anchorDate: new Date('2026-07-28T12:00:00+02:00'),
+function dateKeyAtOffset(date: string, offset: number): string {
+    const [year, month, day] = date.split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, day + offset))
+        .toISOString()
+        .slice(0, 10);
+}
+
+function horizonWorkingDays(
+    anchorDate: Date,
+    ranges: SyntheticWorkingRange[] = [
+        { startMinute: 9 * 60, endMinute: 17 * 60 },
+    ],
+): SyntheticWorkingDay[] {
+    const anchorDateKey = warsawDateKey(anchorDate);
+    return Array.from(
+        { length: SYNTHETIC_PAST_DAYS + SYNTHETIC_FUTURE_DAYS + 1 },
+        (_, index) => ({
+            date: dateKeyAtOffset(
+                anchorDateKey,
+                index - SYNTHETIC_PAST_DAYS,
+            ),
+            ranges: ranges.map((range) => ({ ...range })),
+        }),
+    );
+}
+
+function cloneInput(source: DatasetInput): DatasetInput {
+    return {
+        ...source,
+        anchorDate: new Date(source.anchorDate),
+        serviceIds: [...source.serviceIds],
+        workingDays: source.workingDays.map((day) => ({
+            date: day.date,
+            ranges: day.ranges.map((range) => ({ ...range })),
+        })),
+    };
+}
+
+const anchorDate = new Date('2026-07-28T12:00:00+02:00');
+const input: DatasetInput = {
+    anchorDate,
     ownerUserId: 7,
     serviceIds: [10, 11, 12],
+    workingDays: horizonWorkingDays(anchorDate),
+};
+const closedWednesdayAnchor = new Date('2026-07-29T12:00:00+02:00');
+const closedWednesdayInput: DatasetInput = {
+    ...input,
+    anchorDate: closedWednesdayAnchor,
+    workingDays: horizonWorkingDays(closedWednesdayAnchor).map((day) =>
+        day.date === '2026-07-29' ? { ...day, ranges: [] } : day,
+    ),
 };
 
 describe('generateSyntheticDataset', () => {
-    it('is deterministic for the same local day', () => {
-        expect(generateSyntheticDataset(input)).toEqual(
-            generateSyntheticDataset(input),
+    it('is deterministic for cloned schedule inputs', () => {
+        expect(generateSyntheticDataset(cloneInput(input))).toEqual(
+            generateSyntheticDataset(cloneInput(input)),
         );
     });
 
@@ -73,6 +132,107 @@ describe('generateSyntheticDataset', () => {
                 (appointment) =>
                     appointment.startTime.getTime() <
                     appointment.endTime.getTime(),
+            ),
+        ).toBe(true);
+    });
+
+    it('moves every in-progress visit off a closed anchor day', () => {
+        const data = generateSyntheticDataset(closedWednesdayInput);
+        expect(
+            data.appointments.some(
+                (visit) => warsawDateKey(visit.startTime) === '2026-07-29',
+            ),
+        ).toBe(false);
+        expect(
+            data.appointments.filter(
+                (visit) => visit.status === 'in_progress',
+            ),
+        ).toHaveLength(0);
+        expect(data.generationSummary.convertedInProgress).toBe(4);
+    });
+
+    it('preserves an in-progress visit when the anchor is inside working hours', () => {
+        const data = generateSyntheticDataset(input);
+
+        expect(
+            data.appointments.filter(
+                (visit) => visit.status === 'in_progress',
+            ).length,
+        ).toBeGreaterThan(0);
+    });
+
+    it('does not place any visit across a schedule break', () => {
+        const breakInput: DatasetInput = {
+            ...input,
+            workingDays: horizonWorkingDays(input.anchorDate, [
+                { startMinute: 9 * 60, endMinute: 12 * 60 },
+                { startMinute: 13 * 60, endMinute: 17 * 60 },
+            ]),
+        };
+        const data = generateSyntheticDataset(breakInput);
+
+        expect(
+            data.appointments.every((visit) => {
+                const start = warsawMinuteOfDay(visit.startTime);
+                const end = warsawMinuteOfDay(visit.endTime);
+                return start >= 13 * 60 || end <= 12 * 60;
+            }),
+        ).toBe(true);
+    });
+
+    it('uses an explicitly scheduled Sunday when future weekdays are closed', () => {
+        const sundayInput: DatasetInput = {
+            ...input,
+            workingDays: horizonWorkingDays(input.anchorDate, []).map((day) => {
+                const beforeAnchor = day.date < warsawDateKey(input.anchorDate);
+                const sunday =
+                    new Date(`${day.date}T12:00:00.000Z`).getUTCDay() === 0;
+                return beforeAnchor || sunday
+                    ? {
+                          ...day,
+                          ranges: [
+                              {
+                                  startMinute: 9 * 60,
+                                  endMinute: 17 * 60,
+                              },
+                          ],
+                      }
+                    : day;
+            }),
+        };
+        const data = generateSyntheticDataset(sundayInput);
+
+        expect(
+            data.appointments.some(
+                (visit) => warsawDateKey(visit.startTime) === '2026-08-02',
+            ),
+        ).toBe(true);
+    });
+
+    it('rejects a schedule without capacity', () => {
+        const closedInput: DatasetInput = {
+            ...input,
+            workingDays: horizonWorkingDays(input.anchorDate, []),
+        };
+
+        expect(() => generateSyntheticDataset(closedInput)).toThrow(
+            'SYNTHETIC_SCHEDULE_CAPACITY',
+        );
+    });
+
+    it('does not overlap owner appointment intervals', () => {
+        const intervals = generateSyntheticDataset(input).appointments
+            .map((appointment) => ({
+                startTime: appointment.startTime.getTime(),
+                endTime: appointment.endTime.getTime(),
+            }))
+            .sort((a, b) => a.startTime - b.startTime);
+
+        expect(
+            intervals.every(
+                (current, index) =>
+                    index === intervals.length - 1 ||
+                    current.endTime <= intervals[index + 1].startTime,
             ),
         ).toBe(true);
     });

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.spec.ts
@@ -28,10 +28,7 @@ function horizonWorkingDays(
     return Array.from(
         { length: SYNTHETIC_PAST_DAYS + SYNTHETIC_FUTURE_DAYS + 1 },
         (_, index) => ({
-            date: dateKeyAtOffset(
-                anchorDateKey,
-                index - SYNTHETIC_PAST_DAYS,
-            ),
+            date: dateKeyAtOffset(anchorDateKey, index - SYNTHETIC_PAST_DAYS),
             ranges: ranges.map((range) => ({ ...range })),
         }),
     );
@@ -47,6 +44,42 @@ function cloneInput(source: DatasetInput): DatasetInput {
             ranges: day.ranges.map((range) => ({ ...range })),
         })),
     };
+}
+
+function dstInput(anchorDate: Date, transitionDate: string): DatasetInput {
+    const anchorDateKey = warsawDateKey(anchorDate);
+    return {
+        anchorDate,
+        ownerUserId: 7,
+        serviceIds: [10, 11, 12],
+        workingDays: horizonWorkingDays(anchorDate, []).map((day) => {
+            if (day.date < anchorDateKey || day.date > transitionDate) {
+                return {
+                    ...day,
+                    ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+                };
+            }
+            if (day.date === transitionDate) {
+                return {
+                    ...day,
+                    ranges: [{ startMinute: 90, endMinute: 4 * 60 }],
+                };
+            }
+            return day;
+        }),
+    };
+}
+
+function expectDeclaredElapsedDurations(
+    data: ReturnType<typeof generateSyntheticDataset>,
+): void {
+    for (const appointment of data.appointments) {
+        const index = Number(appointment.key.split('-').at(-1)) - 1;
+        const declaredDurationMinutes = 30 + (index % 3) * 30;
+        expect(
+            appointment.endTime.getTime() - appointment.startTime.getTime(),
+        ).toBe(declaredDurationMinutes * 60_000);
+    }
 }
 
 const anchorDate = new Date('2026-07-28T12:00:00+02:00');
@@ -144,9 +177,7 @@ describe('generateSyntheticDataset', () => {
             ),
         ).toBe(false);
         expect(
-            data.appointments.filter(
-                (visit) => visit.status === 'in_progress',
-            ),
+            data.appointments.filter((visit) => visit.status === 'in_progress'),
         ).toHaveLength(0);
         expect(data.generationSummary.convertedInProgress).toBe(4);
     });
@@ -155,9 +186,8 @@ describe('generateSyntheticDataset', () => {
         const data = generateSyntheticDataset(input);
 
         expect(
-            data.appointments.filter(
-                (visit) => visit.status === 'in_progress',
-            ).length,
+            data.appointments.filter((visit) => visit.status === 'in_progress')
+                .length,
         ).toBeGreaterThan(0);
     });
 
@@ -221,8 +251,8 @@ describe('generateSyntheticDataset', () => {
     });
 
     it('does not overlap owner appointment intervals', () => {
-        const intervals = generateSyntheticDataset(input).appointments
-            .map((appointment) => ({
+        const intervals = generateSyntheticDataset(input)
+            .appointments.map((appointment) => ({
                 startTime: appointment.startTime.getTime(),
                 endTime: appointment.endTime.getTime(),
             }))
@@ -237,14 +267,40 @@ describe('generateSyntheticDataset', () => {
         ).toBe(true);
     });
 
+    it('skips nonexistent spring-gap candidates without changing elapsed duration', () => {
+        const data = generateSyntheticDataset(
+            dstInput(new Date('2026-03-28T23:30:00+01:00'), '2026-03-29'),
+        );
+
+        expect(
+            data.appointments.some(
+                (appointment) =>
+                    warsawDateKey(appointment.startTime) === '2026-03-29',
+            ),
+        ).toBe(true);
+        expectDeclaredElapsedDurations(data);
+    });
+
+    it('skips autumn-fold candidates with altered elapsed duration', () => {
+        const data = generateSyntheticDataset(
+            dstInput(new Date('2026-10-24T23:30:00+02:00'), '2026-10-25'),
+        );
+
+        expect(
+            data.appointments.some(
+                (appointment) =>
+                    warsawDateKey(appointment.startTime) === '2026-10-25',
+            ),
+        ).toBe(true);
+        expectDeclaredElapsedDurations(data);
+    });
+
     it('covers normal, low and zero product stock', () => {
         const data = generateSyntheticDataset(input);
 
         expect(data.products.some((p) => p.stock === 0)).toBe(true);
         expect(
-            data.products.some(
-                (p) => p.stock > 0 && p.stock < p.minQuantity,
-            ),
+            data.products.some((p) => p.stock > 0 && p.stock < p.minQuantity),
         ).toBe(true);
         expect(data.products.some((p) => p.stock >= p.minQuantity)).toBe(true);
     });

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.ts
@@ -7,8 +7,14 @@ import type {
     SyntheticProduct,
     SyntheticProductCategory,
     SyntheticSupplier,
+    SyntheticWorkingDay,
     SyntheticWarehouseDocument,
 } from './synthetic-data.types';
+import {
+    warsawDateAtMinute,
+    warsawDateKey,
+    warsawMinuteOfDay,
+} from './synthetic-data.schedule';
 
 const APPOINTMENT_STATUSES: SyntheticAppointmentStatus[] = [
     'scheduled',
@@ -20,27 +26,170 @@ const APPOINTMENT_STATUSES: SyntheticAppointmentStatus[] = [
     'online_pending',
     'rescheduled_pending',
 ];
+const PAST_APPOINTMENT_STATUSES = new Set<SyntheticAppointmentStatus>([
+    'cancelled',
+    'completed',
+    'no_show',
+]);
+const APPOINTMENT_GRID_MINUTES = 30;
 
 function localDayStart(value: Date): Date {
-    const result = new Date(value);
-    result.setHours(0, 0, 0, 0);
-    return result;
+    return warsawDateAtMinute(warsawDateKey(value), 0);
 }
 
-function appointmentDayOffset(
-    status: SyntheticAppointmentStatus,
-    index: number,
-): number {
-    switch (status) {
-        case 'completed':
-        case 'cancelled':
-        case 'no_show':
-            return -(1 + (index % 21));
-        case 'in_progress':
-            return 0;
-        default:
-            return 1 + (index % 14);
+interface AppointmentDraft {
+    key: string;
+    status: SyntheticAppointmentStatus;
+    durationMinutes: 30 | 60 | 90;
+    preferredOffset: number;
+}
+
+interface OccupiedInterval {
+    start: number;
+    end: number;
+}
+
+function dateOrdinal(date: string): number {
+    const [year, month, day] = date.split('-').map(Number);
+    return Date.UTC(year, month - 1, day);
+}
+
+function allocateAppointment(
+    draft: AppointmentDraft,
+    candidates: SyntheticWorkingDay[],
+    occupied: OccupiedInterval[],
+): { startTime: Date; endTime: Date } | null {
+    for (const candidate of candidates) {
+        const ranges = [...candidate.ranges].sort(
+            (a, b) =>
+                a.startMinute - b.startMinute || a.endMinute - b.endMinute,
+        );
+
+        for (const range of ranges) {
+            const firstMinute =
+                Math.ceil(range.startMinute / APPOINTMENT_GRID_MINUTES) *
+                APPOINTMENT_GRID_MINUTES;
+            for (
+                let startMinute = firstMinute;
+                startMinute + draft.durationMinutes <= range.endMinute;
+                startMinute += APPOINTMENT_GRID_MINUTES
+            ) {
+                const startTime = warsawDateAtMinute(
+                    candidate.date,
+                    startMinute,
+                );
+                const endTime = warsawDateAtMinute(
+                    candidate.date,
+                    startMinute + draft.durationMinutes,
+                );
+                const interval = {
+                    start: startTime.getTime(),
+                    end: endTime.getTime(),
+                };
+                if (
+                    occupied.some(
+                        (existing) =>
+                            interval.start < existing.end &&
+                            interval.end > existing.start,
+                    )
+                ) {
+                    continue;
+                }
+
+                occupied.push(interval);
+                return { startTime, endTime };
+            }
+        }
     }
+
+    return null;
+}
+
+function preferredPastCandidates(
+    draft: AppointmentDraft,
+    workingDays: SyntheticWorkingDay[],
+    anchorDateKey: string,
+): SyntheticWorkingDay[] {
+    const preferredOrdinal =
+        dateOrdinal(anchorDateKey) + draft.preferredOffset * 86_400_000;
+    return workingDays
+        .filter((day) => day.date < anchorDateKey)
+        .sort(
+            (a, b) =>
+                Math.abs(dateOrdinal(a.date) - preferredOrdinal) -
+                    Math.abs(dateOrdinal(b.date) - preferredOrdinal) ||
+                a.date.localeCompare(b.date),
+        );
+}
+
+function inProgressCandidate(
+    draft: AppointmentDraft,
+    workingDays: SyntheticWorkingDay[],
+    anchorDateKey: string,
+    anchorMinute: number,
+): SyntheticWorkingDay[] {
+    const anchorDay = workingDays.find((day) => day.date === anchorDateKey);
+    const range = anchorDay?.ranges.find(
+        (item) =>
+            item.startMinute <= anchorMinute && anchorMinute < item.endMinute,
+    );
+    if (!range) return [];
+
+    let startMinute =
+        Math.floor(anchorMinute / APPOINTMENT_GRID_MINUTES) *
+        APPOINTMENT_GRID_MINUTES;
+    while (
+        startMinute >= range.startMinute &&
+        (startMinute + draft.durationMinutes > range.endMinute ||
+            startMinute + draft.durationMinutes <= anchorMinute)
+    ) {
+        startMinute -= APPOINTMENT_GRID_MINUTES;
+    }
+    if (startMinute < range.startMinute) return [];
+
+    return [
+        {
+            date: anchorDateKey,
+            ranges: [
+                {
+                    startMinute,
+                    endMinute: startMinute + draft.durationMinutes,
+                },
+            ],
+        },
+    ];
+}
+
+function futureCandidates(
+    workingDays: SyntheticWorkingDay[],
+    anchorDateKey: string,
+    anchorMinute: number,
+): SyntheticWorkingDay[] {
+    const firstFutureMinute =
+        (Math.floor(anchorMinute / APPOINTMENT_GRID_MINUTES) + 1) *
+        APPOINTMENT_GRID_MINUTES;
+
+    return workingDays
+        .filter((day) => day.date >= anchorDateKey)
+        .sort((a, b) => a.date.localeCompare(b.date))
+        .map((day) =>
+            day.date === anchorDateKey
+                ? {
+                      ...day,
+                      ranges: day.ranges
+                          .map((range) => ({
+                              ...range,
+                              startMinute: Math.max(
+                                  range.startMinute,
+                                  firstFutureMinute,
+                              ),
+                          }))
+                          .filter(
+                              (range) => range.startMinute < range.endMinute,
+                          ),
+                  }
+                : day,
+        );
 }
 
 function createClients(): SyntheticClient[] {
@@ -70,32 +219,113 @@ function createClients(): SyntheticClient[] {
     });
 }
 
-function createAppointments(input: DatasetInput): SyntheticAppointment[] {
-    const anchor = localDayStart(input.anchorDate);
-
-    return Array.from({ length: 30 }, (_, index) => {
+function createAppointments(input: DatasetInput): {
+    appointments: SyntheticAppointment[];
+    convertedInProgress: number;
+} {
+    const drafts = Array.from({ length: 30 }, (_, index): AppointmentDraft => {
         const status =
             APPOINTMENT_STATUSES[index % APPOINTMENT_STATUSES.length];
-        const startTime = new Date(anchor);
-        startTime.setDate(
-            startTime.getDate() + appointmentDayOffset(status, index),
-        );
-        startTime.setHours(9 + (index % 8), (index % 2) * 30, 0, 0);
-        const durationMinutes = 30 + (index % 3) * 30;
-        const endTime = new Date(
-            startTime.getTime() + durationMinutes * 60_000,
-        );
-        const price = 60 + (index % 6) * 20;
-        const completed = status === 'completed';
-
+        const durationMinutes = (30 + (index % 3) * 30) as 30 | 60 | 90;
+        const preferredOffset = PAST_APPOINTMENT_STATUSES.has(status)
+            ? -(1 + (index % 21))
+            : status === 'in_progress'
+              ? 0
+              : 1 + (index % 14);
         return {
             key: `appointment-${String(index + 1).padStart(2, '0')}`,
+            status,
+            durationMinutes,
+            preferredOffset,
+        };
+    });
+    const anchorDateKey = warsawDateKey(input.anchorDate);
+    const anchorMinute = warsawMinuteOfDay(input.anchorDate);
+    const workingDays = input.workingDays.map((day) => ({
+        date: day.date,
+        ranges: day.ranges.map((range) => ({ ...range })),
+    }));
+    const occupied: OccupiedInterval[] = [];
+    const allocations = new Map<
+        string,
+        {
+            status: SyntheticAppointmentStatus;
+            startTime: Date;
+            endTime: Date;
+        }
+    >();
+    let convertedInProgress = 0;
+
+    for (const draft of drafts
+        .filter((item) => PAST_APPOINTMENT_STATUSES.has(item.status))
+        .sort((a, b) => a.key.localeCompare(b.key))) {
+        const allocation = allocateAppointment(
+            draft,
+            preferredPastCandidates(draft, workingDays, anchorDateKey),
+            occupied,
+        );
+        if (!allocation) throw new Error('SYNTHETIC_SCHEDULE_CAPACITY');
+        allocations.set(draft.key, { status: draft.status, ...allocation });
+    }
+
+    const futureDrafts = drafts
+        .filter(
+            (item) =>
+                !PAST_APPOINTMENT_STATUSES.has(item.status) &&
+                item.status !== 'in_progress',
+        )
+        .map((draft) => ({ ...draft }));
+    for (const draft of drafts
+        .filter((item) => item.status === 'in_progress')
+        .sort((a, b) => a.key.localeCompare(b.key))) {
+        const allocation = allocateAppointment(
+            draft,
+            inProgressCandidate(
+                draft,
+                workingDays,
+                anchorDateKey,
+                anchorMinute,
+            ),
+            occupied,
+        );
+        if (allocation) {
+            allocations.set(draft.key, {
+                status: draft.status,
+                ...allocation,
+            });
+        } else {
+            convertedInProgress += 1;
+            futureDrafts.push({ ...draft, status: 'confirmed' });
+        }
+    }
+
+    const futureDays = futureCandidates(
+        workingDays,
+        anchorDateKey,
+        anchorMinute,
+    );
+    for (const draft of futureDrafts.sort((a, b) =>
+        a.key.localeCompare(b.key),
+    )) {
+        const allocation = allocateAppointment(draft, futureDays, occupied);
+        if (!allocation) throw new Error('SYNTHETIC_SCHEDULE_CAPACITY');
+        allocations.set(draft.key, { status: draft.status, ...allocation });
+    }
+
+    const appointments = drafts.map((draft, index) => {
+        const allocation = allocations.get(draft.key);
+        if (!allocation) throw new Error('SYNTHETIC_SCHEDULE_CAPACITY');
+        const price = 60 + (index % 6) * 20;
+        const completed = allocation.status === 'completed';
+
+        return {
+            key: draft.key,
             clientKey: `client-${String((index % 12) + 1).padStart(2, '0')}`,
             employeeId: input.ownerUserId,
             serviceId: input.serviceIds[index % input.serviceIds.length],
-            status,
-            startTime,
-            endTime,
+            status: allocation.status,
+            startTime: allocation.startTime,
+            endTime: allocation.endTime,
             price,
             paidAmount: completed ? price : null,
             tipAmount: completed && index % 2 === 0 ? 10 : null,
@@ -104,6 +334,8 @@ function createAppointments(input: DatasetInput): SyntheticAppointment[] {
                 : null,
         };
     });
+
+    return { appointments, convertedInProgress };
 }
 
 function createProductCategories(): SyntheticProductCategory[] {
@@ -171,13 +403,16 @@ export function generateSyntheticDataset(
     const anchorDate = localDayStart(input.anchorDate);
     const products = createProducts();
     const productKeys = products.slice(0, 3).map((product) => product.key);
-    const appointments = createAppointments({ ...input, anchorDate });
+    const { appointments, convertedInProgress } = createAppointments(input);
     const completedAppointments = appointments.filter(
         (appointment) => appointment.status === 'completed',
     );
 
     return {
         anchorDate,
+        generationSummary: {
+            convertedInProgress,
+        },
         clients: createClients(),
         appointments,
         productCategories: createProductCategories(),

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.ts
@@ -74,14 +74,27 @@ function allocateAppointment(
                 startMinute + draft.durationMinutes <= range.endMinute;
                 startMinute += APPOINTMENT_GRID_MINUTES
             ) {
-                const startTime = warsawDateAtMinute(
-                    candidate.date,
-                    startMinute,
-                );
-                const endTime = warsawDateAtMinute(
-                    candidate.date,
-                    startMinute + draft.durationMinutes,
-                );
+                const endMinute = startMinute + draft.durationMinutes;
+                let startTime: Date;
+                let endTime: Date;
+                try {
+                    startTime = warsawDateAtMinute(candidate.date, startMinute);
+                    endTime = warsawDateAtMinute(candidate.date, endMinute);
+                    if (
+                        warsawDateKey(startTime) !== candidate.date ||
+                        warsawDateKey(endTime) !== candidate.date ||
+                        warsawMinuteOfDay(startTime) !== startMinute ||
+                        warsawMinuteOfDay(endTime) !== endMinute ||
+                        endTime.getTime() - startTime.getTime() !==
+                            draft.durationMinutes * 60_000 ||
+                        startMinute < range.startMinute ||
+                        endMinute > range.endMinute
+                    ) {
+                        continue;
+                    }
+                } catch {
+                    continue;
+                }
                 const interval = {
                     start: startTime.getTime(),
                     end: endTime.getTime(),

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.spec.ts
@@ -1,0 +1,204 @@
+import {
+    resolveSyntheticWorkingDays,
+    summarizeSyntheticSchedule,
+    warsawDateAtMinute,
+    warsawDateKey,
+    warsawMinuteOfDay,
+} from './synthetic-data.schedule';
+
+const anchorDate = new Date('2026-07-29T12:00:00+02:00');
+
+const timetable = {
+    id: 1,
+    validFrom: '2026-06-01',
+    validTo: null,
+    slots: [
+        {
+            dayOfWeek: 0,
+            startTime: '09:00',
+            endTime: '17:00',
+            isBreak: false,
+        },
+        {
+            dayOfWeek: 0,
+            startTime: '12:00',
+            endTime: '13:00',
+            isBreak: true,
+        },
+        {
+            dayOfWeek: 6,
+            startTime: '10:00',
+            endTime: '15:00',
+            isBreak: false,
+        },
+    ],
+};
+
+const input = {
+    anchorDate,
+    timetables: [timetable],
+    exceptions: [
+        {
+            timetableId: 1,
+            date: '2026-07-29',
+            type: 'day_off',
+            customStartTime: null,
+            customEndTime: null,
+        },
+        {
+            timetableId: 1,
+            date: '2026-07-30',
+            type: 'custom_hours',
+            customStartTime: '10:00',
+            customEndTime: '14:00',
+        },
+    ],
+};
+
+describe('resolveSyntheticWorkingDays', () => {
+    it('resolves working ranges, breaks, exceptions, and scheduled Sundays', () => {
+        const days = resolveSyntheticWorkingDays(input);
+        const byDate = new Map(days.map((day) => [day.date, day]));
+
+        expect(byDate.get('2026-07-27')?.ranges).toEqual([
+            { startMinute: 540, endMinute: 720 },
+            { startMinute: 780, endMinute: 1020 },
+        ]);
+        expect(byDate.get('2026-07-29')?.ranges).toEqual([]);
+        expect(byDate.get('2026-07-30')?.ranges).toEqual([
+            { startMinute: 600, endMinute: 840 },
+        ]);
+        expect(byDate.get('2026-08-02')?.ranges).toEqual([
+            { startMinute: 600, endMinute: 900 },
+        ]);
+    });
+
+    it('rejects a day without an applicable timetable', () => {
+        expect(() =>
+            resolveSyntheticWorkingDays({ ...input, timetables: [] }),
+        ).toThrow('SYNTHETIC_SCHEDULE_MISSING');
+    });
+
+    it('rejects invalid custom working hours', () => {
+        expect(() =>
+            resolveSyntheticWorkingDays({
+                ...input,
+                exceptions: [
+                    {
+                        ...input.exceptions[1],
+                        customEndTime: '10:00',
+                    },
+                ],
+            }),
+        ).toThrow('SYNTHETIC_SCHEDULE_CUSTOM_HOURS_INVALID');
+    });
+
+    it('rejects multiple exceptions for the selected timetable and day', () => {
+        expect(() =>
+            resolveSyntheticWorkingDays({
+                ...input,
+                exceptions: [
+                    input.exceptions[0],
+                    { ...input.exceptions[0] },
+                ],
+            }),
+        ).toThrow('SYNTHETIC_SCHEDULE_EXCEPTION_AMBIGUOUS');
+    });
+
+    it('rejects malformed timetable slots and unknown exception types', () => {
+        expect(() =>
+            resolveSyntheticWorkingDays({
+                ...input,
+                timetables: [
+                    {
+                        ...timetable,
+                        slots: [
+                            {
+                                ...timetable.slots[0],
+                                dayOfWeek: 7,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow('SYNTHETIC_SCHEDULE_DAY_OF_WEEK_INVALID');
+        expect(() =>
+            resolveSyntheticWorkingDays({
+                ...input,
+                timetables: [
+                    {
+                        ...timetable,
+                        slots: [
+                            {
+                                ...timetable.slots[0],
+                                startTime: '9:00',
+                            },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow('SYNTHETIC_SCHEDULE_TIME_INVALID');
+        expect(() =>
+            resolveSyntheticWorkingDays({
+                ...input,
+                timetables: [
+                    {
+                        ...timetable,
+                        slots: [
+                            {
+                                ...timetable.slots[0],
+                                endTime: '09:00',
+                            },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow('SYNTHETIC_SCHEDULE_RANGE_INVALID');
+        expect(() =>
+            resolveSyntheticWorkingDays({
+                ...input,
+                exceptions: [
+                    {
+                        ...input.exceptions[0],
+                        type: 'unrecognized',
+                    },
+                ],
+            }),
+        ).toThrow('SYNTHETIC_SCHEDULE_EXCEPTION_TYPE_INVALID');
+    });
+
+    it('summarizes the exact 35/60-day inclusive horizon', () => {
+        const days = resolveSyntheticWorkingDays(input);
+
+        expect(summarizeSyntheticSchedule(days)).toEqual({
+            rangeStart: '2026-06-24',
+            rangeEnd: '2026-09-27',
+            workingDays: expect.any(Number),
+            closedDays: expect.any(Number),
+        });
+        expect(new Set(days.map((day) => day.date)).size).toBe(96);
+    });
+
+    it('preserves Warsaw calendar dates and wall-clock minutes across DST', () => {
+        const date = '2026-03-29';
+        const minute = 10 * 60;
+        const instant = warsawDateAtMinute(date, minute);
+
+        expect(warsawDateKey(instant)).toBe(date);
+        expect(warsawMinuteOfDay(instant)).toBe(minute);
+        expect(
+            new Set(
+                resolveSyntheticWorkingDays({
+                    ...input,
+                    anchorDate: new Date('2026-03-29T12:00:00+02:00'),
+                    timetables: [
+                        {
+                            ...timetable,
+                            validFrom: '2026-01-01',
+                        },
+                    ],
+                }).map((day) => day.date),
+            ).size,
+        ).toBe(96);
+    });
+});

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.spec.ts
@@ -97,10 +97,7 @@ describe('resolveSyntheticWorkingDays', () => {
         expect(() =>
             resolveSyntheticWorkingDays({
                 ...input,
-                exceptions: [
-                    input.exceptions[0],
-                    { ...input.exceptions[0] },
-                ],
+                exceptions: [input.exceptions[0], { ...input.exceptions[0] }],
             }),
         ).toThrow('SYNTHETIC_SCHEDULE_EXCEPTION_AMBIGUOUS');
     });
@@ -165,6 +162,82 @@ describe('resolveSyntheticWorkingDays', () => {
                 ],
             }),
         ).toThrow('SYNTHETIC_SCHEDULE_EXCEPTION_TYPE_INVALID');
+    });
+
+    it('ignores malformed slots and custom hours on an older fully shadowed timetable', () => {
+        const days = resolveSyntheticWorkingDays({
+            anchorDate,
+            timetables: [
+                {
+                    id: 2,
+                    validFrom: '2026-01-01',
+                    validTo: null,
+                    slots: [
+                        {
+                            dayOfWeek: 3,
+                            startTime: '09:00',
+                            endTime: '17:00',
+                            isBreak: false,
+                        },
+                    ],
+                },
+                {
+                    id: 1,
+                    validFrom: '2025-01-01',
+                    validTo: null,
+                    slots: [
+                        {
+                            dayOfWeek: 7,
+                            startTime: 'invalid',
+                            endTime: 'invalid',
+                            isBreak: false,
+                        },
+                    ],
+                },
+            ],
+            exceptions: [
+                {
+                    timetableId: 1,
+                    date: '2026-07-30',
+                    type: 'custom_hours',
+                    customStartTime: '14:00',
+                    customEndTime: '10:00',
+                },
+            ],
+        });
+
+        expect(days.find((day) => day.date === '2026-07-30')?.ranges).toEqual([
+            { startMinute: 9 * 60, endMinute: 17 * 60 },
+        ]);
+    });
+
+    it('resolves an explicit persisted appointment range instead of the anchor horizon', () => {
+        const days = resolveSyntheticWorkingDays({
+            ...input,
+            anchorDate: new Date('2026-07-29T12:00:00+02:00'),
+            timetables: [
+                {
+                    ...timetable,
+                    validFrom: '2025-01-01',
+                },
+            ],
+            exceptions: [],
+            dateRange: {
+                rangeStart: '2025-12-20',
+                rangeEnd: '2025-12-22',
+            },
+        } as Parameters<typeof resolveSyntheticWorkingDays>[0] & {
+            dateRange: {
+                rangeStart: string;
+                rangeEnd: string;
+            };
+        });
+
+        expect(days.map((day) => day.date)).toEqual([
+            '2025-12-20',
+            '2025-12-21',
+            '2025-12-22',
+        ]);
     });
 
     it('summarizes the exact 35/60-day inclusive horizon', () => {

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.ts
@@ -1,0 +1,378 @@
+import {
+    SyntheticScheduleSummary,
+    SyntheticTimetableExceptionRecord,
+    SyntheticTimetableRecord,
+    SyntheticWorkingDay,
+    SyntheticWorkingRange,
+} from './synthetic-data.types';
+
+export const SYNTHETIC_PAST_DAYS = 35;
+export const SYNTHETIC_FUTURE_DAYS = 60;
+
+const SALON_TIME_ZONE = 'Europe/Warsaw';
+const CLOSED_EXCEPTION_TYPES = new Set([
+    'day_off',
+    'holiday',
+    'vacation',
+    'sick_leave',
+    'training',
+    'other',
+]);
+const VALID_EXCEPTION_TYPES = new Set([
+    ...CLOSED_EXCEPTION_TYPES,
+    'custom_hours',
+]);
+const WARSAW_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+    timeZone: SALON_TIME_ZONE,
+    weekday: 'short',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+});
+const ISO_WEEKDAY_INDEX: Record<string, number> = {
+    Mon: 0,
+    Tue: 1,
+    Wed: 2,
+    Thu: 3,
+    Fri: 4,
+    Sat: 5,
+    Sun: 6,
+};
+
+interface WarsawParts {
+    weekday: number;
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+}
+
+interface NormalizedTimetable extends SyntheticTimetableRecord {
+    validFromKey: string;
+    validToKey: string | null;
+}
+
+interface NormalizedException extends SyntheticTimetableExceptionRecord {
+    dateKey: string;
+}
+
+function scheduleError(code: string): Error {
+    return new Error(`SYNTHETIC_SCHEDULE_${code}`);
+}
+
+function formatWarsawParts(value: Date): WarsawParts {
+    const raw = Object.fromEntries(
+        WARSAW_FORMATTER.formatToParts(value)
+            .filter((part) => part.type !== 'literal')
+            .map((part) => [part.type, part.value]),
+    );
+    const weekday = ISO_WEEKDAY_INDEX[raw.weekday];
+
+    if (
+        weekday === undefined ||
+        !raw.year ||
+        !raw.month ||
+        !raw.day ||
+        !raw.hour ||
+        !raw.minute
+    ) {
+        throw scheduleError('WARSAW_FORMAT_INVALID');
+    }
+
+    return {
+        weekday,
+        year: Number(raw.year),
+        month: Number(raw.month),
+        day: Number(raw.day),
+        hour: Number(raw.hour),
+        minute: Number(raw.minute),
+    };
+}
+
+export function warsawDateKey(value: Date): string {
+    if (Number.isNaN(value.getTime())) {
+        throw scheduleError('DATE_INVALID');
+    }
+    const parts = formatWarsawParts(value);
+    return `${parts.year.toString().padStart(4, '0')}-${parts.month
+        .toString()
+        .padStart(2, '0')}-${parts.day.toString().padStart(2, '0')}`;
+}
+
+export function warsawMinuteOfDay(value: Date): number {
+    if (Number.isNaN(value.getTime())) {
+        throw scheduleError('DATE_INVALID');
+    }
+    const parts = formatWarsawParts(value);
+    return parts.hour * 60 + parts.minute;
+}
+
+function parseDateKey(value: string | Date): string {
+    if (value instanceof Date) return warsawDateKey(value);
+
+    const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (dateOnly) {
+        const parsed = new Date(`${value}T00:00:00.000Z`);
+        if (
+            Number.isNaN(parsed.getTime()) ||
+            parsed.toISOString().slice(0, 10) !== value
+        ) {
+            throw scheduleError('DATE_INVALID');
+        }
+        return value;
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) throw scheduleError('DATE_INVALID');
+    return warsawDateKey(parsed);
+}
+
+function parseTime(value: string, errorCode = 'TIME_INVALID'): number {
+    const match = /^(?:([01]\d|2[0-3]):([0-5]\d))(?::[0-5]\d)?$/.exec(value);
+    if (!match) throw scheduleError(errorCode);
+    return Number(match[1]) * 60 + Number(match[2]);
+}
+
+function assertSlot(slot: SyntheticTimetableRecord['slots'][number]): void {
+    if (
+        !Number.isInteger(slot.dayOfWeek) ||
+        slot.dayOfWeek < 0 ||
+        slot.dayOfWeek > 6
+    ) {
+        throw scheduleError('DAY_OF_WEEK_INVALID');
+    }
+    const start = parseTime(slot.startTime);
+    const end = parseTime(slot.endTime);
+    if (end <= start) throw scheduleError('RANGE_INVALID');
+}
+
+function normalizeTimetables(
+    timetables: SyntheticTimetableRecord[],
+): NormalizedTimetable[] {
+    return timetables.map((timetable) => {
+        timetable.slots.forEach(assertSlot);
+        const validFromKey = parseDateKey(timetable.validFrom);
+        const validToKey = timetable.validTo
+            ? parseDateKey(timetable.validTo)
+            : null;
+        if (validToKey && validToKey < validFromKey) {
+            throw scheduleError('VALIDITY_INVALID');
+        }
+        return { ...timetable, validFromKey, validToKey };
+    });
+}
+
+function normalizeExceptions(
+    exceptions: SyntheticTimetableExceptionRecord[],
+): NormalizedException[] {
+    return exceptions.map((exception) => {
+        if (!VALID_EXCEPTION_TYPES.has(exception.type)) {
+            throw scheduleError('EXCEPTION_TYPE_INVALID');
+        }
+        if (exception.type === 'custom_hours') {
+            try {
+                if (!exception.customStartTime || !exception.customEndTime) {
+                    throw scheduleError('CUSTOM_HOURS_INVALID');
+                }
+                const start = parseTime(
+                    exception.customStartTime,
+                    'CUSTOM_HOURS_INVALID',
+                );
+                const end = parseTime(
+                    exception.customEndTime,
+                    'CUSTOM_HOURS_INVALID',
+                );
+                if (end <= start) throw scheduleError('CUSTOM_HOURS_INVALID');
+            } catch (error) {
+                if (
+                    error instanceof Error &&
+                    error.message === 'SYNTHETIC_SCHEDULE_CUSTOM_HOURS_INVALID'
+                ) {
+                    throw error;
+                }
+                throw scheduleError('CUSTOM_HOURS_INVALID');
+            }
+        }
+        return { ...exception, dateKey: parseDateKey(exception.date) };
+    });
+}
+
+function dateKeyAtOffset(date: string, offset: number): string {
+    const [year, month, day] = date.split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, day + offset))
+        .toISOString()
+        .slice(0, 10);
+}
+
+function minuteRangesForSlots(
+    timetable: NormalizedTimetable,
+    weekday: number,
+    isBreak: boolean,
+): SyntheticWorkingRange[] {
+    return timetable.slots
+        .filter(
+            (slot) => slot.dayOfWeek === weekday && slot.isBreak === isBreak,
+        )
+        .map((slot) => ({
+            startMinute: parseTime(slot.startTime),
+            endMinute: parseTime(slot.endTime),
+        }));
+}
+
+function mergeRanges(ranges: SyntheticWorkingRange[]): SyntheticWorkingRange[] {
+    const merged: SyntheticWorkingRange[] = [];
+    for (const range of [...ranges].sort(
+        (a, b) => a.startMinute - b.startMinute || a.endMinute - b.endMinute,
+    )) {
+        const previous = merged.at(-1);
+        if (previous && range.startMinute <= previous.endMinute) {
+            previous.endMinute = Math.max(previous.endMinute, range.endMinute);
+        } else {
+            merged.push({ ...range });
+        }
+    }
+    return merged;
+}
+
+function subtractRange(
+    ranges: SyntheticWorkingRange[],
+    breakRange: SyntheticWorkingRange,
+): SyntheticWorkingRange[] {
+    return ranges.flatMap((range) => {
+        if (
+            breakRange.endMinute <= range.startMinute ||
+            breakRange.startMinute >= range.endMinute
+        ) {
+            return [range];
+        }
+        const remaining: SyntheticWorkingRange[] = [];
+        if (breakRange.startMinute > range.startMinute) {
+            remaining.push({
+                startMinute: range.startMinute,
+                endMinute: breakRange.startMinute,
+            });
+        }
+        if (breakRange.endMinute < range.endMinute) {
+            remaining.push({
+                startMinute: breakRange.endMinute,
+                endMinute: range.endMinute,
+            });
+        }
+        return remaining;
+    });
+}
+
+export function warsawDateAtMinute(date: string, minute: number): Date {
+    if (!Number.isInteger(minute) || minute < 0 || minute >= 24 * 60) {
+        throw scheduleError('MINUTE_INVALID');
+    }
+    const dateKey = parseDateKey(date);
+    const [year, month, day] = dateKey.split('-').map(Number);
+    const hour = Math.floor(minute / 60);
+    const minutePart = minute % 60;
+    const targetWallTime = Date.UTC(year, month - 1, day, hour, minutePart);
+    let guess = new Date(targetWallTime);
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+        const parts = formatWarsawParts(guess);
+        const formattedWallTime = Date.UTC(
+            parts.year,
+            parts.month - 1,
+            parts.day,
+            parts.hour,
+            parts.minute,
+        );
+        const correction = targetWallTime - formattedWallTime;
+        if (correction === 0) return guess;
+        guess = new Date(guess.getTime() + correction);
+    }
+
+    throw scheduleError('WARSAW_TIME_INVALID');
+}
+
+export function resolveSyntheticWorkingDays(input: {
+    anchorDate: Date;
+    timetables: SyntheticTimetableRecord[];
+    exceptions: SyntheticTimetableExceptionRecord[];
+}): SyntheticWorkingDay[] {
+    const timetables = normalizeTimetables(input.timetables);
+    const exceptions = normalizeExceptions(input.exceptions);
+    const anchorDateKey = warsawDateKey(input.anchorDate);
+    const days: SyntheticWorkingDay[] = [];
+
+    for (
+        let offset = -SYNTHETIC_PAST_DAYS;
+        offset <= SYNTHETIC_FUTURE_DAYS;
+        offset += 1
+    ) {
+        const date = dateKeyAtOffset(anchorDateKey, offset);
+        const applicable = timetables
+            .filter(
+                (timetable) =>
+                    timetable.validFromKey <= date &&
+                    (!timetable.validToKey || timetable.validToKey >= date),
+            )
+            .sort(
+                (a, b) =>
+                    b.validFromKey.localeCompare(a.validFromKey) || b.id - a.id,
+            )[0];
+        if (!applicable) throw scheduleError(`MISSING:${date}`);
+
+        const exception = exceptions.filter(
+            (item) =>
+                item.timetableId === applicable.id && item.dateKey === date,
+        );
+        if (exception.length > 1) {
+            throw scheduleError('EXCEPTION_AMBIGUOUS');
+        }
+        if (exception[0]) {
+            if (CLOSED_EXCEPTION_TYPES.has(exception[0].type)) {
+                days.push({ date, ranges: [] });
+                continue;
+            }
+            const startMinute = parseTime(
+                exception[0].customStartTime as string,
+                'CUSTOM_HOURS_INVALID',
+            );
+            const endMinute = parseTime(
+                exception[0].customEndTime as string,
+                'CUSTOM_HOURS_INVALID',
+            );
+            days.push({ date, ranges: [{ startMinute, endMinute }] });
+            continue;
+        }
+
+        const weekday = formatWarsawParts(
+            warsawDateAtMinute(date, 12 * 60),
+        ).weekday;
+        const working = mergeRanges(
+            minuteRangesForSlots(applicable, weekday, false),
+        );
+        const ranges = mergeRanges(
+            mergeRanges(minuteRangesForSlots(applicable, weekday, true)).reduce(
+                (remaining, breakRange) => subtractRange(remaining, breakRange),
+                working,
+            ),
+        );
+        days.push({ date, ranges });
+    }
+
+    return days;
+}
+
+export function summarizeSyntheticSchedule(
+    days: SyntheticWorkingDay[],
+): Omit<SyntheticScheduleSummary, 'convertedInProgress'> {
+    if (days.length === 0) throw scheduleError('SUMMARY_EMPTY');
+    const workingDays = days.filter((day) => day.ranges.length > 0).length;
+    return {
+        rangeStart: days[0].date,
+        rangeEnd: days.at(-1)!.date,
+        workingDays,
+        closedDays: days.length - workingDays,
+    };
+}

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.ts
@@ -1,4 +1,5 @@
 import {
+    SyntheticDateRange,
     SyntheticScheduleSummary,
     SyntheticTimetableExceptionRecord,
     SyntheticTimetableRecord,
@@ -154,7 +155,9 @@ function normalizeTimetables(
     timetables: SyntheticTimetableRecord[],
 ): NormalizedTimetable[] {
     return timetables.map((timetable) => {
-        timetable.slots.forEach(assertSlot);
+        if (!Number.isSafeInteger(timetable.id) || timetable.id <= 0) {
+            throw scheduleError('TIMETABLE_ID_INVALID');
+        }
         const validFromKey = parseDateKey(timetable.validFrom);
         const validToKey = timetable.validTo
             ? parseDateKey(timetable.validTo)
@@ -170,32 +173,11 @@ function normalizeExceptions(
     exceptions: SyntheticTimetableExceptionRecord[],
 ): NormalizedException[] {
     return exceptions.map((exception) => {
-        if (!VALID_EXCEPTION_TYPES.has(exception.type)) {
-            throw scheduleError('EXCEPTION_TYPE_INVALID');
-        }
-        if (exception.type === 'custom_hours') {
-            try {
-                if (!exception.customStartTime || !exception.customEndTime) {
-                    throw scheduleError('CUSTOM_HOURS_INVALID');
-                }
-                const start = parseTime(
-                    exception.customStartTime,
-                    'CUSTOM_HOURS_INVALID',
-                );
-                const end = parseTime(
-                    exception.customEndTime,
-                    'CUSTOM_HOURS_INVALID',
-                );
-                if (end <= start) throw scheduleError('CUSTOM_HOURS_INVALID');
-            } catch (error) {
-                if (
-                    error instanceof Error &&
-                    error.message === 'SYNTHETIC_SCHEDULE_CUSTOM_HOURS_INVALID'
-                ) {
-                    throw error;
-                }
-                throw scheduleError('CUSTOM_HOURS_INVALID');
-            }
+        if (
+            !Number.isSafeInteger(exception.timetableId) ||
+            exception.timetableId <= 0
+        ) {
+            throw scheduleError('TIMETABLE_ID_INVALID');
         }
         return { ...exception, dateKey: parseDateKey(exception.date) };
     });
@@ -266,6 +248,41 @@ function subtractRange(
     });
 }
 
+function rangesForSelectedException(
+    exception: NormalizedException,
+): SyntheticWorkingRange[] {
+    if (!VALID_EXCEPTION_TYPES.has(exception.type)) {
+        throw scheduleError('EXCEPTION_TYPE_INVALID');
+    }
+    if (CLOSED_EXCEPTION_TYPES.has(exception.type)) return [];
+    if (!exception.customStartTime || !exception.customEndTime) {
+        throw scheduleError('CUSTOM_HOURS_INVALID');
+    }
+
+    try {
+        const startMinute = parseTime(
+            exception.customStartTime,
+            'CUSTOM_HOURS_INVALID',
+        );
+        const endMinute = parseTime(
+            exception.customEndTime,
+            'CUSTOM_HOURS_INVALID',
+        );
+        if (endMinute <= startMinute) {
+            throw scheduleError('CUSTOM_HOURS_INVALID');
+        }
+        return [{ startMinute, endMinute }];
+    } catch (error) {
+        if (
+            error instanceof Error &&
+            error.message === 'SYNTHETIC_SCHEDULE_CUSTOM_HOURS_INVALID'
+        ) {
+            throw error;
+        }
+        throw scheduleError('CUSTOM_HOURS_INVALID');
+    }
+}
+
 export function warsawDateAtMinute(date: string, minute: number): Date {
     if (!Number.isInteger(minute) || minute < 0 || minute >= 24 * 60) {
         throw scheduleError('MINUTE_INVALID');
@@ -296,20 +313,27 @@ export function warsawDateAtMinute(date: string, minute: number): Date {
 
 export function resolveSyntheticWorkingDays(input: {
     anchorDate: Date;
+    dateRange?: SyntheticDateRange;
     timetables: SyntheticTimetableRecord[];
     exceptions: SyntheticTimetableExceptionRecord[];
 }): SyntheticWorkingDay[] {
     const timetables = normalizeTimetables(input.timetables);
     const exceptions = normalizeExceptions(input.exceptions);
     const anchorDateKey = warsawDateKey(input.anchorDate);
+    const rangeStart = input.dateRange
+        ? parseDateKey(input.dateRange.rangeStart)
+        : dateKeyAtOffset(anchorDateKey, -SYNTHETIC_PAST_DAYS);
+    const rangeEnd = input.dateRange
+        ? parseDateKey(input.dateRange.rangeEnd)
+        : dateKeyAtOffset(anchorDateKey, SYNTHETIC_FUTURE_DAYS);
+    if (rangeEnd < rangeStart) throw scheduleError('DATE_RANGE_INVALID');
     const days: SyntheticWorkingDay[] = [];
 
     for (
-        let offset = -SYNTHETIC_PAST_DAYS;
-        offset <= SYNTHETIC_FUTURE_DAYS;
-        offset += 1
+        let date = rangeStart;
+        date <= rangeEnd;
+        date = dateKeyAtOffset(date, 1)
     ) {
-        const date = dateKeyAtOffset(anchorDateKey, offset);
         const applicable = timetables
             .filter(
                 (timetable) =>
@@ -321,6 +345,7 @@ export function resolveSyntheticWorkingDays(input: {
                     b.validFromKey.localeCompare(a.validFromKey) || b.id - a.id,
             )[0];
         if (!applicable) throw scheduleError(`MISSING:${date}`);
+        applicable.slots.forEach(assertSlot);
 
         const exception = exceptions.filter(
             (item) =>
@@ -330,19 +355,10 @@ export function resolveSyntheticWorkingDays(input: {
             throw scheduleError('EXCEPTION_AMBIGUOUS');
         }
         if (exception[0]) {
-            if (CLOSED_EXCEPTION_TYPES.has(exception[0].type)) {
-                days.push({ date, ranges: [] });
-                continue;
-            }
-            const startMinute = parseTime(
-                exception[0].customStartTime as string,
-                'CUSTOM_HOURS_INVALID',
-            );
-            const endMinute = parseTime(
-                exception[0].customEndTime as string,
-                'CUSTOM_HOURS_INVALID',
-            );
-            days.push({ date, ranges: [{ startMinute, endMinute }] });
+            days.push({
+                date,
+                ranges: rangesForSelectedException(exception[0]),
+            });
             continue;
         }
 

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.spec.ts
@@ -98,16 +98,39 @@ const workingDays: SyntheticWorkingDay[] = Array.from(
         ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
     }),
 );
+const persistedRange = {
+    rangeStart: '2026-06-24',
+    rangeEnd: '2026-09-27',
+};
 
 function createHarness(callOrder?: string[]) {
     const queryRunner = {
         connect: jest.fn().mockImplementation(async () => {
             callOrder?.push('connect');
         }),
-        release: jest.fn().mockResolvedValue(undefined),
-        startTransaction: jest.fn().mockResolvedValue(undefined),
-        commitTransaction: jest.fn().mockResolvedValue(undefined),
-        rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+        query: jest.fn().mockImplementation(async (sql: string) => {
+            if (sql.trim().toUpperCase() === 'SET TRANSACTION READ ONLY') {
+                callOrder?.push('set-transaction-read-only');
+            }
+        }),
+        release: jest.fn().mockImplementation(async () => {
+            callOrder?.push('release');
+        }),
+        startTransaction: jest
+            .fn()
+            .mockImplementation(async (isolation?: string) => {
+                callOrder?.push(
+                    isolation
+                        ? `start-transaction:${isolation}`
+                        : 'start-transaction',
+                );
+            }),
+        commitTransaction: jest.fn().mockImplementation(async () => {
+            callOrder?.push('commit');
+        }),
+        rollbackTransaction: jest.fn().mockImplementation(async () => {
+            callOrder?.push('rollback');
+        }),
     } as unknown as QueryRunner;
     const dataset = {
         anchorDate: new Date('2026-07-28T00:00:00+02:00'),
@@ -126,7 +149,19 @@ function createHarness(callOrder?: string[]) {
             createQueryRunner: jest.fn().mockReturnValue(queryRunner),
         } as unknown as DataSource,
         anchorDate: new Date('2026-07-28T12:00:00+02:00'),
-        createPasswordHash: jest.fn().mockResolvedValue('synthetic-hash'),
+        createPasswordHash: jest.fn().mockImplementation(async () => {
+            callOrder?.push('create-password-hash');
+            return 'synthetic-hash';
+        }),
+        loadSyntheticAppointmentDateRange: jest
+            .fn()
+            .mockImplementation(async () => {
+                callOrder?.push('load-appointment-date-range');
+                return persistedRange;
+            }),
+        lockSyntheticSchedule: jest.fn().mockImplementation(async () => {
+            callOrder?.push('lock-schedule');
+        }),
         loadSyntheticBaseContext: jest.fn().mockImplementation(async () => {
             callOrder?.push('load-base-context');
             return context;
@@ -157,22 +192,30 @@ function createHarness(callOrder?: string[]) {
         }),
         assertProtectedAccounts: jest.fn().mockImplementation((input) => {
             callOrder?.push(
-                input === context
-                    ? 'assert-base-context'
-                    : 'assert-built-plan',
+                input === context ? 'assert-base-context' : 'assert-built-plan',
             );
         }),
-        assertResetSchema: jest.fn().mockResolvedValue(undefined),
-        resetOperationalData: jest
-            .fn()
-            .mockResolvedValue({ users: 2, appointments: 3 }),
-        insertSyntheticDataset: jest
-            .fn()
-            .mockResolvedValue(plan.createCounts),
-        verifySyntheticState: jest.fn().mockResolvedValue(verification),
+        assertResetSchema: jest.fn().mockImplementation(async () => {
+            callOrder?.push('assert-reset-schema');
+        }),
+        resetOperationalData: jest.fn().mockImplementation(async () => {
+            callOrder?.push('reset-operational-data');
+            return { users: 2, appointments: 3 };
+        }),
+        insertSyntheticDataset: jest.fn().mockImplementation(async () => {
+            callOrder?.push('insert-dataset');
+            return plan.createCounts;
+        }),
+        verifySyntheticState: jest.fn().mockImplementation(async () => {
+            callOrder?.push('verify-state');
+            return verification;
+        }),
         cleanupSyntheticData: jest
             .fn()
             .mockResolvedValue({ users: 12, appointments: 30 }),
+    } as unknown as SyntheticDataDependencies & {
+        loadSyntheticAppointmentDateRange: jest.Mock;
+        lockSyntheticSchedule: jest.Mock;
     };
 
     return { queryRunner, deps };
@@ -195,6 +238,7 @@ describe('synthetic data service', () => {
             'summarize-schedule',
             'build-plan',
             'assert-built-plan',
+            'release',
         ]);
     });
 
@@ -254,6 +298,81 @@ describe('synthetic data service', () => {
         expect(queryRunner.release).toHaveBeenCalledTimes(1);
     });
 
+    it('locks, reloads, regenerates, and verifies apply in transaction order', async () => {
+        const callOrder: string[] = [];
+        const { deps } = createHarness(callOrder);
+
+        await runSyntheticDataCommand(deps, configs.apply);
+
+        expect(callOrder).toEqual([
+            'connect',
+            'load-base-context',
+            'assert-base-context',
+            'load-working-days',
+            'generate-dataset',
+            'validate-schedule',
+            'summarize-schedule',
+            'build-plan',
+            'assert-built-plan',
+            'assert-reset-schema',
+            'start-transaction',
+            'lock-schedule',
+            'load-base-context',
+            'assert-base-context',
+            'load-working-days',
+            'generate-dataset',
+            'validate-schedule',
+            'summarize-schedule',
+            'build-plan',
+            'assert-built-plan',
+            'reset-operational-data',
+            'create-password-hash',
+            'insert-dataset',
+            'verify-state',
+            'commit',
+            'release',
+        ]);
+    });
+
+    it('returns the locked apply plan instead of the stale preflight plan', async () => {
+        const { deps } = createHarness();
+        const lockedPlan: SyntheticPlan = {
+            ...plan,
+            deleteCounts: {
+                ...plan.deleteCounts,
+                appointments: 99,
+            },
+            scheduleSummary: {
+                ...plan.scheduleSummary!,
+                convertedInProgress: 3,
+            },
+        };
+        (deps.buildSyntheticPlan as jest.Mock)
+            .mockResolvedValueOnce(plan)
+            .mockResolvedValueOnce(lockedPlan);
+
+        const report = await runSyntheticDataCommand(deps, configs.apply);
+
+        expect(report.plan).toBe(lockedPlan);
+    });
+
+    it('rolls back when locked schedule validation fails before reset', async () => {
+        const { queryRunner, deps } = createHarness();
+        (deps.assertSyntheticScheduleValid as jest.Mock)
+            .mockImplementationOnce(() => undefined)
+            .mockImplementationOnce(() => {
+                throw new Error('SYNTHETIC_SCHEDULE_LOCKED_INVALID');
+            });
+
+        await expect(
+            runSyntheticDataCommand(deps, configs.apply),
+        ).rejects.toThrow('SYNTHETIC_SCHEDULE_LOCKED_INVALID');
+        expect(deps.lockSyntheticSchedule).toHaveBeenCalledTimes(1);
+        expect(deps.resetOperationalData).not.toHaveBeenCalled();
+        expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+        expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
+    });
+
     it('rolls back when inserted database rows violate the schedule', async () => {
         const { queryRunner, deps } = createHarness();
         const scheduleBlockerVerification: SyntheticVerificationReport = {
@@ -267,10 +386,7 @@ describe('synthetic data service', () => {
                 _expected,
                 _protectedUserIds,
                 scheduleContext,
-            ) =>
-                scheduleContext
-                    ? scheduleBlockerVerification
-                    : verification,
+            ) => (scheduleContext ? scheduleBlockerVerification : verification),
         );
 
         await expect(
@@ -290,7 +406,8 @@ describe('synthetic data service', () => {
             (deps.insertSyntheticDataset as jest.Mock).mock
                 .invocationCallOrder[0],
         ).toBeLessThan(
-            (deps.verifySyntheticState as jest.Mock).mock.invocationCallOrder[0],
+            (deps.verifySyntheticState as jest.Mock).mock
+                .invocationCallOrder[0],
         );
         expect(queryRunner.startTransaction).toHaveBeenCalledTimes(1);
         expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
@@ -298,15 +415,75 @@ describe('synthetic data service', () => {
         expect(queryRunner.release).toHaveBeenCalledTimes(1);
     });
 
-    it('runs verify without a transaction or writes', async () => {
-        const { queryRunner, deps } = createHarness();
+    it('runs standalone verify in one repeatable-read read-only snapshot', async () => {
+        const callOrder: string[] = [];
+        const { queryRunner, deps } = createHarness(callOrder);
 
         const report = await runSyntheticDataCommand(deps, configs.verify);
 
         expect(report.verification).toEqual(verification);
-        expect(queryRunner.startTransaction).not.toHaveBeenCalled();
+        expect(queryRunner.startTransaction).toHaveBeenCalledWith(
+            'REPEATABLE READ',
+        );
+        expect(queryRunner.query).toHaveBeenCalledWith(
+            'SET TRANSACTION READ ONLY',
+        );
+        expect(deps.loadSyntheticAppointmentDateRange).toHaveBeenCalledWith(
+            queryRunner,
+        );
+        expect(deps.loadSyntheticWorkingDays).toHaveBeenCalledWith(
+            queryRunner,
+            context.ownerUserId,
+            deps.anchorDate,
+            persistedRange,
+        );
+        expect(deps.generateDataset).not.toHaveBeenCalled();
+        expect(deps.verifySyntheticState).toHaveBeenCalledWith(
+            queryRunner,
+            plan.createCounts,
+            plan.protectedUserIds,
+            {
+                ownerUserId: context.ownerUserId,
+                anchorDate: deps.anchorDate,
+                workingDays,
+                validateStatusTime: false,
+            },
+        );
         expect(deps.verifySyntheticState).toHaveBeenCalledTimes(1);
         expect(deps.resetOperationalData).not.toHaveBeenCalled();
+        expect(deps.insertSyntheticDataset).not.toHaveBeenCalled();
+        expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
+        expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
+        expect(callOrder).toEqual([
+            'connect',
+            'start-transaction:REPEATABLE READ',
+            'set-transaction-read-only',
+            'load-base-context',
+            'assert-base-context',
+            'load-appointment-date-range',
+            'load-working-days',
+            'build-plan',
+            'assert-built-plan',
+            'verify-state',
+            'commit',
+            'release',
+        ]);
+    });
+
+    it('rolls back the standalone verify snapshot on schedule load failure', async () => {
+        const { queryRunner, deps } = createHarness();
+        (deps.loadSyntheticWorkingDays as jest.Mock).mockRejectedValue(
+            new Error('SYNTHETIC_SCHEDULE_SNAPSHOT_FAILED'),
+        );
+
+        await expect(
+            runSyntheticDataCommand(deps, configs.verify),
+        ).rejects.toThrow('SYNTHETIC_SCHEDULE_SNAPSHOT_FAILED');
+        expect(queryRunner.startTransaction).toHaveBeenCalledWith(
+            'REPEATABLE READ',
+        );
+        expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+        expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
     });
 
     it('cleans only synthetic records in a transaction', async () => {

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.spec.ts
@@ -1,9 +1,11 @@
 import type { DataSource, QueryRunner } from 'typeorm';
 import type {
+    SyntheticBaseContext,
     SyntheticDataset,
     SyntheticPlan,
     SyntheticRunConfig,
     SyntheticVerificationReport,
+    SyntheticWorkingDay,
 } from './synthetic-data.types';
 import {
     runSyntheticDataCommand,
@@ -30,6 +32,22 @@ const plan: SyntheticPlan = {
         warehouseDocuments: 5,
     },
     blockers: [],
+    scheduleSummary: {
+        rangeStart: '2026-06-24',
+        rangeEnd: '2026-09-27',
+        workingDays: 96,
+        closedDays: 0,
+        convertedInProgress: 4,
+    },
+};
+
+const context: SyntheticBaseContext = {
+    protectedUserIds: plan.protectedUserIds,
+    protectedAdminPresent: plan.protectedAdminPresent,
+    protectedCiClientPresent: plan.protectedCiClientPresent,
+    ownerUserId: plan.ownerUserId,
+    serviceIds: plan.serviceIds,
+    blockers: [],
 };
 
 const verification: SyntheticVerificationReport = {
@@ -37,6 +55,7 @@ const verification: SyntheticVerificationReport = {
     expected: plan.createCounts as SyntheticVerificationReport['expected'],
     protectedAccountsPresent: 2,
     remainingNonSyntheticClients: 0,
+    scheduleViolations: 0,
     blockers: [],
 };
 
@@ -65,15 +84,34 @@ const configs: Record<SyntheticRunConfig['mode'], SyntheticRunConfig> = {
     },
 };
 
-function createHarness() {
+function dateKeyAtOffset(date: string, offset: number): string {
+    const [year, month, day] = date.split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, day + offset))
+        .toISOString()
+        .slice(0, 10);
+}
+
+const workingDays: SyntheticWorkingDay[] = Array.from(
+    { length: 96 },
+    (_, index) => ({
+        date: dateKeyAtOffset('2026-06-24', index),
+        ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+    }),
+);
+
+function createHarness(callOrder?: string[]) {
     const queryRunner = {
-        connect: jest.fn().mockResolvedValue(undefined),
+        connect: jest.fn().mockImplementation(async () => {
+            callOrder?.push('connect');
+        }),
         release: jest.fn().mockResolvedValue(undefined),
         startTransaction: jest.fn().mockResolvedValue(undefined),
         commitTransaction: jest.fn().mockResolvedValue(undefined),
         rollbackTransaction: jest.fn().mockResolvedValue(undefined),
     } as unknown as QueryRunner;
     const dataset = {
+        anchorDate: new Date('2026-07-28T00:00:00+02:00'),
+        generationSummary: { convertedInProgress: 4 },
         clients: Array(12),
         appointments: Array(30),
         products: Array(12),
@@ -89,9 +127,41 @@ function createHarness() {
         } as unknown as DataSource,
         anchorDate: new Date('2026-07-28T12:00:00+02:00'),
         createPasswordHash: jest.fn().mockResolvedValue('synthetic-hash'),
-        generateDataset: jest.fn().mockReturnValue(dataset),
-        buildSyntheticPlan: jest.fn().mockResolvedValue(plan),
-        assertProtectedAccounts: jest.fn(),
+        loadSyntheticBaseContext: jest.fn().mockImplementation(async () => {
+            callOrder?.push('load-base-context');
+            return context;
+        }),
+        loadSyntheticWorkingDays: jest.fn().mockImplementation(async () => {
+            callOrder?.push('load-working-days');
+            return workingDays;
+        }),
+        generateDataset: jest.fn().mockImplementation(() => {
+            callOrder?.push('generate-dataset');
+            return dataset;
+        }),
+        assertSyntheticScheduleValid: jest.fn().mockImplementation(() => {
+            callOrder?.push('validate-schedule');
+        }),
+        summarizeSyntheticSchedule: jest.fn().mockImplementation(() => {
+            callOrder?.push('summarize-schedule');
+            return {
+                rangeStart: '2026-06-24',
+                rangeEnd: '2026-09-27',
+                workingDays: 96,
+                closedDays: 0,
+            };
+        }),
+        buildSyntheticPlan: jest.fn().mockImplementation(async () => {
+            callOrder?.push('build-plan');
+            return plan;
+        }),
+        assertProtectedAccounts: jest.fn().mockImplementation((input) => {
+            callOrder?.push(
+                input === context
+                    ? 'assert-base-context'
+                    : 'assert-built-plan',
+            );
+        }),
         assertResetSchema: jest.fn().mockResolvedValue(undefined),
         resetOperationalData: jest
             .fn()
@@ -109,6 +179,25 @@ function createHarness() {
 }
 
 describe('synthetic data service', () => {
+    it('loads and validates the schedule before building a plan', async () => {
+        const callOrder: string[] = [];
+        const { deps } = createHarness(callOrder);
+
+        await runSyntheticDataCommand(deps, configs.plan);
+
+        expect(callOrder).toEqual([
+            'connect',
+            'load-base-context',
+            'assert-base-context',
+            'load-working-days',
+            'generate-dataset',
+            'validate-schedule',
+            'summarize-schedule',
+            'build-plan',
+            'assert-built-plan',
+        ]);
+    });
+
     it('never starts a transaction or writes for plan', async () => {
         const { queryRunner, deps } = createHarness();
 
@@ -130,6 +219,22 @@ describe('synthetic data service', () => {
         ).resolves.toMatchObject({ mode: 'plan' });
     });
 
+    it('does not start a transaction when schedule validation fails', async () => {
+        const { queryRunner, deps } = createHarness();
+        (deps.assertSyntheticScheduleValid as jest.Mock).mockImplementation(
+            () => {
+                throw new Error('SYNTHETIC_SCHEDULE_OUTSIDE_WORKING_HOURS');
+            },
+        );
+
+        await expect(
+            runSyntheticDataCommand(deps, configs.apply),
+        ).rejects.toThrow('SYNTHETIC_SCHEDULE_OUTSIDE_WORKING_HOURS');
+        expect(queryRunner.startTransaction).not.toHaveBeenCalled();
+        expect(deps.resetOperationalData).not.toHaveBeenCalled();
+        expect(deps.insertSyntheticDataset).not.toHaveBeenCalled();
+    });
+
     it('commits apply only after successful verification', async () => {
         const { queryRunner, deps } = createHarness();
 
@@ -149,15 +254,44 @@ describe('synthetic data service', () => {
         expect(queryRunner.release).toHaveBeenCalledTimes(1);
     });
 
-    it('rolls back when insert verification fails', async () => {
+    it('rolls back when inserted database rows violate the schedule', async () => {
         const { queryRunner, deps } = createHarness();
-        (deps.verifySyntheticState as jest.Mock).mockRejectedValue(
-            new Error('count mismatch'),
+        const scheduleBlockerVerification: SyntheticVerificationReport = {
+            ...verification,
+            scheduleViolations: 1,
+            blockers: ['SYNTHETIC_SCHEDULE_OUTSIDE_WORKING_HOURS'],
+        };
+        (deps.verifySyntheticState as jest.Mock).mockImplementation(
+            async (
+                _queryRunner,
+                _expected,
+                _protectedUserIds,
+                scheduleContext,
+            ) =>
+                scheduleContext
+                    ? scheduleBlockerVerification
+                    : verification,
         );
 
         await expect(
             runSyntheticDataCommand(deps, configs.apply),
-        ).rejects.toThrow('count mismatch');
+        ).rejects.toThrow('SYNTHETIC_SCHEDULE_OUTSIDE_WORKING_HOURS');
+        expect(deps.verifySyntheticState).toHaveBeenCalledWith(
+            queryRunner,
+            plan.createCounts,
+            plan.protectedUserIds,
+            {
+                ownerUserId: context.ownerUserId,
+                anchorDate: deps.anchorDate,
+                workingDays,
+            },
+        );
+        expect(
+            (deps.insertSyntheticDataset as jest.Mock).mock
+                .invocationCallOrder[0],
+        ).toBeLessThan(
+            (deps.verifySyntheticState as jest.Mock).mock.invocationCallOrder[0],
+        );
         expect(queryRunner.startTransaction).toHaveBeenCalledTimes(1);
         expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
         expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
@@ -199,6 +333,8 @@ describe('synthetic data service', () => {
         const report = await runSyntheticDataCommand(deps, configs.cleanup);
 
         expect(report.mode).toBe('cleanup');
+        expect(deps.loadSyntheticWorkingDays).not.toHaveBeenCalled();
+        expect(deps.generateDataset).not.toHaveBeenCalled();
         expect(deps.cleanupSyntheticData).toHaveBeenCalledTimes(1);
         expect(deps.resetOperationalData).not.toHaveBeenCalled();
         expect(deps.insertSyntheticDataset).not.toHaveBeenCalled();

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.ts
@@ -1,24 +1,42 @@
 import type { DataSource, QueryRunner } from 'typeorm';
 import type {
     DatasetInput,
+    SyntheticBaseContext,
     SyntheticDataset,
     SyntheticPlan,
     SyntheticRunConfig,
+    SyntheticScheduleSummary,
+    SyntheticScheduleValidationInput,
     SyntheticVerificationExpected,
     SyntheticVerificationReport,
+    SyntheticWorkingDay,
 } from './synthetic-data.types';
 
 export interface SyntheticDataDependencies {
     dataSource: Pick<DataSource, 'createQueryRunner'>;
     anchorDate: Date;
     createPasswordHash(): Promise<string>;
-    generateDataset(input: DatasetInput): SyntheticDataset;
-    buildSyntheticPlan(
+    loadSyntheticBaseContext(
         queryRunner: QueryRunner,
         protectedEmails: string[],
-        dataset: SyntheticDataset,
+    ): Promise<SyntheticBaseContext>;
+    loadSyntheticWorkingDays(
+        queryRunner: QueryRunner,
+        ownerUserId: number,
+        anchorDate: Date,
+    ): Promise<SyntheticWorkingDay[]>;
+    generateDataset(input: DatasetInput): SyntheticDataset;
+    assertSyntheticScheduleValid(input: SyntheticScheduleValidationInput): void;
+    summarizeSyntheticSchedule(
+        workingDays: SyntheticWorkingDay[],
+    ): Omit<SyntheticScheduleSummary, 'convertedInProgress'>;
+    buildSyntheticPlan(
+        queryRunner: QueryRunner,
+        context: SyntheticBaseContext,
+        dataset: SyntheticDataset | null,
+        scheduleSummary?: SyntheticScheduleSummary,
     ): Promise<SyntheticPlan>;
-    assertProtectedAccounts(plan: SyntheticPlan): void;
+    assertProtectedAccounts(input: SyntheticBaseContext | SyntheticPlan): void;
     assertResetSchema(
         queryRunner: QueryRunner,
         protectedUserIds: number[],
@@ -36,6 +54,11 @@ export interface SyntheticDataDependencies {
         queryRunner: QueryRunner,
         expected: SyntheticVerificationExpected,
         protectedUserIds: number[],
+        scheduleContext?: {
+            ownerUserId: number;
+            anchorDate: Date;
+            workingDays: SyntheticWorkingDay[];
+        },
     ): Promise<SyntheticVerificationReport>;
     cleanupSyntheticData(
         queryRunner: QueryRunner,
@@ -94,50 +117,26 @@ export async function runSyntheticDataCommand(
 
     try {
         await queryRunner.connect();
-        const manifest = dependencies.generateDataset({
-            anchorDate: dependencies.anchorDate,
-            ownerUserId: 1,
-            serviceIds: [1],
-        });
-        const plan = await dependencies.buildSyntheticPlan(
+        const context = await dependencies.loadSyntheticBaseContext(
             queryRunner,
             config.protectedEmails,
-            manifest,
         );
-        dependencies.assertProtectedAccounts(plan);
+        dependencies.assertProtectedAccounts(context);
 
-        if (config.mode === 'plan') {
-            return { mode: config.mode, plan };
-        }
-
-        const ownerUserId = plan.ownerUserId;
-        if (!ownerUserId) {
-            throw new Error('Protected owner account is missing');
-        }
-        const dataset = dependencies.generateDataset({
-            anchorDate: dependencies.anchorDate,
-            ownerUserId,
-            serviceIds: plan.serviceIds,
-        });
-
-        if (config.mode === 'verify') {
-            const verification = await dependencies.verifySyntheticState(
+        if (config.mode === 'cleanup') {
+            const plan = await dependencies.buildSyntheticPlan(
                 queryRunner,
-                expectedFromDataset(dataset),
+                context,
+                null,
+            );
+            dependencies.assertProtectedAccounts(plan);
+            await dependencies.assertResetSchema(
+                queryRunner,
                 plan.protectedUserIds,
             );
-            assertVerification(verification);
-            return { mode: config.mode, plan, verification };
-        }
+            await queryRunner.startTransaction();
 
-        await dependencies.assertResetSchema(
-            queryRunner,
-            plan.protectedUserIds,
-        );
-        await queryRunner.startTransaction();
-
-        try {
-            if (config.mode === 'cleanup') {
+            try {
                 const mutationCounts =
                     await dependencies.cleanupSyntheticData(queryRunner);
                 const verification = await dependencies.verifySyntheticState(
@@ -153,8 +152,73 @@ export async function runSyntheticDataCommand(
                     mutationCounts,
                     verification,
                 };
+            } catch (error) {
+                await rollbackIfActive(queryRunner);
+                throw error;
             }
+        }
 
+        const ownerUserId = context.ownerUserId;
+        if (!ownerUserId) {
+            throw new Error('Protected owner account is missing');
+        }
+        const workingDays = await dependencies.loadSyntheticWorkingDays(
+            queryRunner,
+            ownerUserId,
+            dependencies.anchorDate,
+        );
+        const dataset = dependencies.generateDataset({
+            anchorDate: dependencies.anchorDate,
+            ownerUserId,
+            serviceIds: context.serviceIds,
+            workingDays,
+        });
+        dependencies.assertSyntheticScheduleValid({
+            appointments: dataset.appointments,
+            workingDays,
+            ownerUserId,
+            anchorDate: dependencies.anchorDate,
+        });
+        const scheduleSummary = {
+            ...dependencies.summarizeSyntheticSchedule(workingDays),
+            convertedInProgress: dataset.generationSummary.convertedInProgress,
+        };
+        const plan = await dependencies.buildSyntheticPlan(
+            queryRunner,
+            context,
+            dataset,
+            scheduleSummary,
+        );
+        dependencies.assertProtectedAccounts(plan);
+
+        if (config.mode === 'plan') {
+            return { mode: config.mode, plan };
+        }
+
+        const scheduleContext = {
+            ownerUserId,
+            anchorDate: dependencies.anchorDate,
+            workingDays,
+        };
+
+        if (config.mode === 'verify') {
+            const verification = await dependencies.verifySyntheticState(
+                queryRunner,
+                expectedFromDataset(dataset),
+                plan.protectedUserIds,
+                scheduleContext,
+            );
+            assertVerification(verification);
+            return { mode: config.mode, plan, verification };
+        }
+
+        await dependencies.assertResetSchema(
+            queryRunner,
+            plan.protectedUserIds,
+        );
+        await queryRunner.startTransaction();
+
+        try {
             const mutationCounts = await dependencies.resetOperationalData(
                 queryRunner,
                 plan.protectedUserIds,
@@ -169,6 +233,7 @@ export async function runSyntheticDataCommand(
                 queryRunner,
                 expectedFromDataset(dataset),
                 plan.protectedUserIds,
+                scheduleContext,
             );
             assertVerification(verification);
             await queryRunner.commitTransaction();

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.ts
@@ -2,6 +2,7 @@ import type { DataSource, QueryRunner } from 'typeorm';
 import type {
     DatasetInput,
     SyntheticBaseContext,
+    SyntheticDateRange,
     SyntheticDataset,
     SyntheticPlan,
     SyntheticRunConfig,
@@ -9,6 +10,7 @@ import type {
     SyntheticScheduleValidationInput,
     SyntheticVerificationExpected,
     SyntheticVerificationReport,
+    SyntheticVerificationScheduleContext,
     SyntheticWorkingDay,
 } from './synthetic-data.types';
 
@@ -16,6 +18,9 @@ export interface SyntheticDataDependencies {
     dataSource: Pick<DataSource, 'createQueryRunner'>;
     anchorDate: Date;
     createPasswordHash(): Promise<string>;
+    loadSyntheticAppointmentDateRange(
+        queryRunner: QueryRunner,
+    ): Promise<SyntheticDateRange | null>;
     loadSyntheticBaseContext(
         queryRunner: QueryRunner,
         protectedEmails: string[],
@@ -24,7 +29,9 @@ export interface SyntheticDataDependencies {
         queryRunner: QueryRunner,
         ownerUserId: number,
         anchorDate: Date,
+        dateRange?: SyntheticDateRange,
     ): Promise<SyntheticWorkingDay[]>;
+    lockSyntheticSchedule(queryRunner: QueryRunner): Promise<void>;
     generateDataset(input: DatasetInput): SyntheticDataset;
     assertSyntheticScheduleValid(input: SyntheticScheduleValidationInput): void;
     summarizeSyntheticSchedule(
@@ -33,7 +40,7 @@ export interface SyntheticDataDependencies {
     buildSyntheticPlan(
         queryRunner: QueryRunner,
         context: SyntheticBaseContext,
-        dataset: SyntheticDataset | null,
+        expectedCreateCounts: SyntheticVerificationExpected,
         scheduleSummary?: SyntheticScheduleSummary,
     ): Promise<SyntheticPlan>;
     assertProtectedAccounts(input: SyntheticBaseContext | SyntheticPlan): void;
@@ -54,11 +61,7 @@ export interface SyntheticDataDependencies {
         queryRunner: QueryRunner,
         expected: SyntheticVerificationExpected,
         protectedUserIds: number[],
-        scheduleContext?: {
-            ownerUserId: number;
-            anchorDate: Date;
-            workingDays: SyntheticWorkingDay[];
-        },
+        scheduleContext?: SyntheticVerificationScheduleContext,
     ): Promise<SyntheticVerificationReport>;
     cleanupSyntheticData(
         queryRunner: QueryRunner,
@@ -78,6 +81,12 @@ const EMPTY_EXPECTED: SyntheticVerificationExpected = {
     appointments: 0,
     products: 0,
     warehouseDocuments: 0,
+};
+const EXPECTED_SYNTHETIC_STATE: SyntheticVerificationExpected = {
+    clients: 12,
+    appointments: 30,
+    products: 12,
+    warehouseDocuments: 5,
 };
 
 function expectedFromDataset(
@@ -109,6 +118,107 @@ async function rollbackIfActive(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.rollbackTransaction();
 }
 
+interface PreparedSyntheticData {
+    context: SyntheticBaseContext;
+    ownerUserId: number;
+    workingDays: SyntheticWorkingDay[];
+    dataset: SyntheticDataset;
+    plan: SyntheticPlan;
+}
+
+async function prepareSyntheticData(
+    dependencies: SyntheticDataDependencies,
+    queryRunner: QueryRunner,
+    context: SyntheticBaseContext,
+): Promise<PreparedSyntheticData> {
+    const ownerUserId = context.ownerUserId;
+    if (!ownerUserId) {
+        throw new Error('Protected owner account is missing');
+    }
+    const workingDays = await dependencies.loadSyntheticWorkingDays(
+        queryRunner,
+        ownerUserId,
+        dependencies.anchorDate,
+    );
+    const dataset = dependencies.generateDataset({
+        anchorDate: dependencies.anchorDate,
+        ownerUserId,
+        serviceIds: context.serviceIds,
+        workingDays,
+    });
+    dependencies.assertSyntheticScheduleValid({
+        appointments: dataset.appointments,
+        workingDays,
+        ownerUserId,
+        anchorDate: dependencies.anchorDate,
+    });
+    const scheduleSummary = {
+        ...dependencies.summarizeSyntheticSchedule(workingDays),
+        convertedInProgress: dataset.generationSummary.convertedInProgress,
+    };
+    const plan = await dependencies.buildSyntheticPlan(
+        queryRunner,
+        context,
+        expectedFromDataset(dataset),
+        scheduleSummary,
+    );
+    dependencies.assertProtectedAccounts(plan);
+    return { context, ownerUserId, workingDays, dataset, plan };
+}
+
+async function runStandaloneVerify(
+    dependencies: SyntheticDataDependencies,
+    queryRunner: QueryRunner,
+    config: SyntheticRunConfig,
+): Promise<SyntheticCommandReport> {
+    await queryRunner.startTransaction('REPEATABLE READ');
+    try {
+        await queryRunner.query('SET TRANSACTION READ ONLY');
+        const context = await dependencies.loadSyntheticBaseContext(
+            queryRunner,
+            config.protectedEmails,
+        );
+        dependencies.assertProtectedAccounts(context);
+        const ownerUserId = context.ownerUserId;
+        if (!ownerUserId) {
+            throw new Error('Protected owner account is missing');
+        }
+        const dateRange =
+            await dependencies.loadSyntheticAppointmentDateRange(queryRunner);
+        const workingDays = dateRange
+            ? await dependencies.loadSyntheticWorkingDays(
+                  queryRunner,
+                  ownerUserId,
+                  dependencies.anchorDate,
+                  dateRange,
+              )
+            : [];
+        const plan = await dependencies.buildSyntheticPlan(
+            queryRunner,
+            context,
+            EXPECTED_SYNTHETIC_STATE,
+        );
+        dependencies.assertProtectedAccounts(plan);
+        const verification = await dependencies.verifySyntheticState(
+            queryRunner,
+            EXPECTED_SYNTHETIC_STATE,
+            plan.protectedUserIds,
+            {
+                ownerUserId,
+                anchorDate: dependencies.anchorDate,
+                workingDays,
+                validateStatusTime: false,
+            },
+        );
+        assertVerification(verification);
+        await queryRunner.commitTransaction();
+        return { mode: config.mode, plan, verification };
+    } catch (error) {
+        await rollbackIfActive(queryRunner);
+        throw error;
+    }
+}
+
 export async function runSyntheticDataCommand(
     dependencies: SyntheticDataDependencies,
     config: SyntheticRunConfig,
@@ -117,6 +227,10 @@ export async function runSyntheticDataCommand(
 
     try {
         await queryRunner.connect();
+        if (config.mode === 'verify') {
+            return await runStandaloneVerify(dependencies, queryRunner, config);
+        }
+
         const context = await dependencies.loadSyntheticBaseContext(
             queryRunner,
             config.protectedEmails,
@@ -127,7 +241,7 @@ export async function runSyntheticDataCommand(
             const plan = await dependencies.buildSyntheticPlan(
                 queryRunner,
                 context,
-                null,
+                EMPTY_EXPECTED,
             );
             dependencies.assertProtectedAccounts(plan);
             await dependencies.assertResetSchema(
@@ -158,88 +272,62 @@ export async function runSyntheticDataCommand(
             }
         }
 
-        const ownerUserId = context.ownerUserId;
-        if (!ownerUserId) {
-            throw new Error('Protected owner account is missing');
-        }
-        const workingDays = await dependencies.loadSyntheticWorkingDays(
-            queryRunner,
-            ownerUserId,
-            dependencies.anchorDate,
-        );
-        const dataset = dependencies.generateDataset({
-            anchorDate: dependencies.anchorDate,
-            ownerUserId,
-            serviceIds: context.serviceIds,
-            workingDays,
-        });
-        dependencies.assertSyntheticScheduleValid({
-            appointments: dataset.appointments,
-            workingDays,
-            ownerUserId,
-            anchorDate: dependencies.anchorDate,
-        });
-        const scheduleSummary = {
-            ...dependencies.summarizeSyntheticSchedule(workingDays),
-            convertedInProgress: dataset.generationSummary.convertedInProgress,
-        };
-        const plan = await dependencies.buildSyntheticPlan(
+        const preflight = await prepareSyntheticData(
+            dependencies,
             queryRunner,
             context,
-            dataset,
-            scheduleSummary,
         );
-        dependencies.assertProtectedAccounts(plan);
 
         if (config.mode === 'plan') {
-            return { mode: config.mode, plan };
-        }
-
-        const scheduleContext = {
-            ownerUserId,
-            anchorDate: dependencies.anchorDate,
-            workingDays,
-        };
-
-        if (config.mode === 'verify') {
-            const verification = await dependencies.verifySyntheticState(
-                queryRunner,
-                expectedFromDataset(dataset),
-                plan.protectedUserIds,
-                scheduleContext,
-            );
-            assertVerification(verification);
-            return { mode: config.mode, plan, verification };
+            return { mode: config.mode, plan: preflight.plan };
         }
 
         await dependencies.assertResetSchema(
             queryRunner,
-            plan.protectedUserIds,
+            preflight.plan.protectedUserIds,
         );
         await queryRunner.startTransaction();
 
         try {
+            await dependencies.lockSyntheticSchedule(queryRunner);
+            const lockedContext = await dependencies.loadSyntheticBaseContext(
+                queryRunner,
+                config.protectedEmails,
+            );
+            dependencies.assertProtectedAccounts(lockedContext);
+            const locked = await prepareSyntheticData(
+                dependencies,
+                queryRunner,
+                lockedContext,
+            );
             const mutationCounts = await dependencies.resetOperationalData(
                 queryRunner,
-                plan.protectedUserIds,
+                locked.plan.protectedUserIds,
             );
             const clientPasswordHash = await dependencies.createPasswordHash();
             const insertCounts = await dependencies.insertSyntheticDataset(
                 queryRunner,
-                dataset,
-                { ownerUserId, clientPasswordHash },
+                locked.dataset,
+                {
+                    ownerUserId: locked.ownerUserId,
+                    clientPasswordHash,
+                },
             );
             const verification = await dependencies.verifySyntheticState(
                 queryRunner,
-                expectedFromDataset(dataset),
-                plan.protectedUserIds,
-                scheduleContext,
+                expectedFromDataset(locked.dataset),
+                locked.plan.protectedUserIds,
+                {
+                    ownerUserId: locked.ownerUserId,
+                    anchorDate: dependencies.anchorDate,
+                    workingDays: locked.workingDays,
+                },
             );
             assertVerification(verification);
             await queryRunner.commitTransaction();
             return {
                 mode: config.mode,
-                plan,
+                plan: locked.plan,
                 mutationCounts,
                 insertCounts,
                 verification,

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.spec.ts
@@ -1,20 +1,39 @@
 import type { QueryRunner } from 'typeorm';
 import { generateSyntheticDataset } from './synthetic-data.dataset';
 import {
+    SYNTHETIC_FUTURE_DAYS,
+    SYNTHETIC_PAST_DAYS,
+} from './synthetic-data.schedule';
+import {
     assertProtectedAccounts,
     buildSyntheticPlan,
     cleanupSyntheticData,
     insertSyntheticDataset,
+    loadSyntheticBaseContext,
+    loadSyntheticWorkingDays,
     RESET_GROUPS,
     resetOperationalData,
     assertResetSchema,
     verifySyntheticState,
 } from './synthetic-data.store';
 
+const anchorDate = new Date('2026-07-28T12:00:00+02:00');
+const workingDays = Array.from(
+    { length: SYNTHETIC_PAST_DAYS + SYNTHETIC_FUTURE_DAYS + 1 },
+    (_, index) => {
+        const date = new Date('2026-07-28T12:00:00.000Z');
+        date.setUTCDate(date.getUTCDate() + index - SYNTHETIC_PAST_DAYS);
+        return {
+            date: date.toISOString().slice(0, 10),
+            ranges: [{ startMinute: 8 * 60, endMinute: 20 * 60 }],
+        };
+    },
+);
 const dataset = generateSyntheticDataset({
-    anchorDate: new Date('2026-07-28T12:00:00+02:00'),
+    anchorDate,
     ownerUserId: 7,
     serviceIds: [10, 11, 12],
+    workingDays,
 });
 
 function queryRunnerWithResults(results: unknown[]): QueryRunner {
@@ -43,11 +62,17 @@ describe('synthetic-data store plan', () => {
             ],
         ]);
 
-        const plan = await buildSyntheticPlan(
-            runner,
-            ['owner@example.invalid', 'ci@example.invalid'],
-            dataset,
-        );
+        const context = await loadSyntheticBaseContext(runner, [
+            'owner@example.invalid',
+            'ci@example.invalid',
+        ]);
+        const plan = await buildSyntheticPlan(runner, context, dataset, {
+            rangeStart: '2026-06-23',
+            rangeEnd: '2026-09-26',
+            workingDays: 96,
+            closedDays: 0,
+            convertedInProgress: 0,
+        });
 
         const sqlStatements = (runner.query as jest.Mock).mock.calls.map(
             ([sql]) => String(sql).trim().toUpperCase(),
@@ -57,6 +82,7 @@ describe('synthetic-data store plan', () => {
                 (sql) => sql.startsWith('SELECT') || sql.startsWith('WITH'),
             ),
         ).toBe(true);
+        expect(context.ownerUserId).toBe(7);
         expect(plan.protectedUserIds).toEqual([7, 20]);
         expect(plan.ownerUserId).toBe(7);
         expect(plan.serviceIds).toEqual([10, 11, 12]);
@@ -68,7 +94,64 @@ describe('synthetic-data store plan', () => {
         });
         expect(plan.createCounts.clients).toBe(12);
         expect(plan.createCounts.appointments).toBe(30);
+        expect(plan.scheduleSummary?.workingDays).toBe(96);
         expect(JSON.stringify(plan)).not.toContain('@');
+    });
+
+    it('loads overlapping timetable slots and exceptions with read-only SQL', async () => {
+        const timetableRows = Array.from({ length: 7 }, (_, dayOfWeek) => ({
+            id: 31,
+            validFrom: '2026-01-01',
+            validTo: null,
+            dayOfWeek,
+            startTime: '09:00:00',
+            endTime: '17:00:00',
+            isBreak: false,
+        }));
+        const runner = queryRunnerWithResults([
+            timetableRows,
+            [
+                {
+                    timetableId: 31,
+                    date: '2026-07-29',
+                    type: 'day_off',
+                    customStartTime: null,
+                    customEndTime: null,
+                },
+            ],
+        ]);
+
+        const loadedWorkingDays = await loadSyntheticWorkingDays(
+            runner,
+            7,
+            new Date('2026-07-29T12:00:00+02:00'),
+        );
+
+        expect(
+            loadedWorkingDays.find((day) => day.date === '2026-07-29')?.ranges,
+        ).toEqual([]);
+        expect((runner.query as jest.Mock).mock.calls).toHaveLength(2);
+        expect(
+            (runner.query as jest.Mock).mock.calls.every(([sql]) =>
+                /^(SELECT|WITH)/.test(String(sql).trim().toUpperCase()),
+            ),
+        ).toBe(true);
+        expect((runner.query as jest.Mock).mock.calls[0]?.[1]).toEqual([
+            7,
+            '2026-06-24',
+            '2026-09-27',
+        ]);
+        expect((runner.query as jest.Mock).mock.calls[1]?.[1]).toEqual([
+            [31],
+            '2026-06-24',
+            '2026-09-27',
+        ]);
+        const selectedColumns = (runner.query as jest.Mock).mock.calls
+            .map(([sql]) => String(sql).split(/\bFROM\b/i)[0])
+            .join(' ');
+        expect(selectedColumns).not.toMatch(
+            /"name"|"description"|"title"|"reason"|"email"/i,
+        );
     });
 
     it('reports missing protected roles as blockers', async () => {
@@ -85,17 +168,58 @@ describe('synthetic-data store plan', () => {
             ],
         ]);
 
-        const plan = await buildSyntheticPlan(
-            runner,
-            ['missing-admin@example.invalid', 'ci@example.invalid'],
-            dataset,
-        );
+        const context = await loadSyntheticBaseContext(runner, [
+            'missing-admin@example.invalid',
+            'ci@example.invalid',
+        ]);
+        const plan = await buildSyntheticPlan(runner, context, dataset);
 
         expect(plan.protectedAdminPresent).toBe(false);
         expect(plan.blockers).toContain('Protected admin account is missing');
         expect(() => assertProtectedAccounts(plan)).toThrow(
             'Protected admin account is missing',
         );
+    });
+
+    it('builds cleanup counts without a schedule summary', async () => {
+        const runner = queryRunnerWithResults([
+            [
+                {
+                    clients: '4',
+                    appointments: '11',
+                    products: '822',
+                    warehouseDocuments: '7',
+                    unprotectedPrivileged: '0',
+                },
+            ],
+        ]);
+
+        const plan = await buildSyntheticPlan(
+            runner,
+            {
+                protectedUserIds: [7, 20],
+                protectedAdminPresent: true,
+                protectedCiClientPresent: true,
+                ownerUserId: 7,
+                serviceIds: [10, 11, 12],
+                blockers: [],
+            },
+            null,
+        );
+
+        expect(plan.deleteCounts).toEqual({
+            clients: 4,
+            appointments: 11,
+            products: 822,
+            warehouseDocuments: 7,
+        });
+        expect(plan.createCounts).toEqual({
+            clients: 0,
+            appointments: 0,
+            products: 0,
+            warehouseDocuments: 0,
+        });
+        expect(plan).not.toHaveProperty('scheduleSummary');
     });
 
     it('keeps a versioned explicit reset registry', () => {
@@ -140,9 +264,7 @@ describe('synthetic-data store plan', () => {
         expect(logIndex).toBeLessThan(userIndex);
         expect(sql[logIndex]).toContain(`log."userId" = client."id"`);
         expect(sql[logIndex]).toContain(`client."role" = 'client'`);
-        expect(sql[logIndex]).toContain(
-            `NOT (client."id" = ANY($1::int[]))`,
-        );
+        expect(sql[logIndex]).toContain(`NOT (client."id" = ANY($1::int[]))`);
         expect(calls[logIndex]?.[1]).toEqual([[7, 20]]);
         expect(counts.logs).toBe(1);
 
@@ -207,13 +329,13 @@ describe('synthetic-data store plan', () => {
             (runner.query as jest.Mock).mock.calls,
         );
         expect(serializedCalls).not.toContain('@salon-bw.pl');
-        expect(serializedCalls).toContain('synthetic.client.01@example.invalid');
+        expect(serializedCalls).toContain(
+            'synthetic.client.01@example.invalid',
+        );
         expect(serializedCalls).toContain('SYNTH-001');
 
-        const stocktakingCall = (
-            runner.query as jest.Mock
-        ).mock.calls.find(([sql]) =>
-            String(sql).includes('INSERT INTO "stocktakings"'),
+        const stocktakingCall = (runner.query as jest.Mock).mock.calls.find(
+            ([sql]) => String(sql).includes('INSERT INTO "stocktakings"'),
         );
         expect(String(stocktakingCall?.[0])).toContain(
             `$3, $3, $4, now(), now())`,
@@ -226,7 +348,7 @@ describe('synthetic-data store plan', () => {
         ]);
     });
 
-    it('returns a redacted verification report and count blockers', async () => {
+    it('returns count and actual database schedule blockers without PII', async () => {
         const runner = queryRunnerWithResults([
             [
                 {
@@ -236,6 +358,15 @@ describe('synthetic-data store plan', () => {
                     warehouseDocuments: '5',
                     protectedAccountsPresent: '2',
                     remainingNonSyntheticClients: '0',
+                },
+            ],
+            [
+                {
+                    id: 44,
+                    employeeId: 7,
+                    status: 'confirmed',
+                    startTime: new Date('2026-07-29T18:00:00+02:00'),
+                    endTime: new Date('2026-07-29T19:00:00+02:00'),
                 },
             ],
         ]);
@@ -249,13 +380,84 @@ describe('synthetic-data store plan', () => {
                 warehouseDocuments: 5,
             },
             [7, 20],
+            {
+                ownerUserId: 7,
+                anchorDate,
+                workingDays: [
+                    {
+                        date: '2026-07-29',
+                        ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+                    },
+                ],
+            },
         );
 
         expect(report.actual.products).toBe(11);
         expect(report.blockers).toContain(
             'products count mismatch: expected 12, got 11',
         );
+        expect(report.scheduleViolations).toBe(1);
+        expect(report.blockers).toContain(
+            'db-appointment-44:SYNTHETIC_APPOINTMENT_OUTSIDE_SCHEDULE',
+        );
+        const appointmentSelect = String(
+            (runner.query as jest.Mock).mock.calls[1]?.[0],
+        ).split(/\bFROM\b/i)[0];
+        expect(appointmentSelect).toContain('a."id"');
+        expect(appointmentSelect).toContain('a."employeeId"');
+        expect(appointmentSelect).toContain('a."status"');
+        expect(appointmentSelect).toContain('a."startTime"');
+        expect(appointmentSelect).toContain('a."endTime"');
+        expect(appointmentSelect).not.toMatch(/email|name|client/i);
         expect(JSON.stringify(report)).not.toContain('@');
+    });
+
+    it('requires schedule context when synthetic appointments are expected', async () => {
+        const runner = queryRunnerWithResults([]);
+
+        await expect(
+            verifySyntheticState(
+                runner,
+                {
+                    clients: 12,
+                    appointments: 30,
+                    products: 12,
+                    warehouseDocuments: 5,
+                },
+                [7, 20],
+            ),
+        ).rejects.toThrow('SYNTHETIC_SCHEDULE_CONTEXT_REQUIRED');
+        expect(runner.query).not.toHaveBeenCalled();
+    });
+
+    it('allows cleanup verification without schedule context', async () => {
+        const runner = queryRunnerWithResults([
+            [
+                {
+                    clients: '0',
+                    appointments: '0',
+                    products: '0',
+                    warehouseDocuments: '0',
+                    protectedAccountsPresent: '2',
+                    remainingNonSyntheticClients: '0',
+                },
+            ],
+            [],
+        ]);
+
+        const report = await verifySyntheticState(
+            runner,
+            {
+                clients: 0,
+                appointments: 0,
+                products: 0,
+                warehouseDocuments: 0,
+            },
+            [7, 20],
+        );
+
+        expect(report.scheduleViolations).toBe(0);
+        expect(report.blockers).toEqual([]);
     });
 
     it('reports every foreign key outside the explicit reset boundary', async () => {

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.spec.ts
@@ -9,8 +9,10 @@ import {
     buildSyntheticPlan,
     cleanupSyntheticData,
     insertSyntheticDataset,
+    loadSyntheticAppointmentDateRange,
     loadSyntheticBaseContext,
     loadSyntheticWorkingDays,
+    lockSyntheticSchedule,
     RESET_GROUPS,
     resetOperationalData,
     assertResetSchema,
@@ -35,6 +37,17 @@ const dataset = generateSyntheticDataset({
     serviceIds: [10, 11, 12],
     workingDays,
 });
+const expectedCounts = {
+    clients: dataset.clients.length,
+    appointments: dataset.appointments.length,
+    products: dataset.products.length,
+    warehouseDocuments:
+        dataset.deliveries.length +
+        dataset.orders.length +
+        dataset.sales.length +
+        dataset.usages.length +
+        dataset.stocktakings.length,
+};
 
 function queryRunnerWithResults(results: unknown[]): QueryRunner {
     return {
@@ -66,7 +79,7 @@ describe('synthetic-data store plan', () => {
             'owner@example.invalid',
             'ci@example.invalid',
         ]);
-        const plan = await buildSyntheticPlan(runner, context, dataset, {
+        const plan = await buildSyntheticPlan(runner, context, expectedCounts, {
             rangeStart: '2026-06-23',
             rangeEnd: '2026-09-26',
             workingDays: 96,
@@ -154,6 +167,82 @@ describe('synthetic-data store plan', () => {
         );
     });
 
+    it('loads the actual persisted synthetic appointment date range without PII', async () => {
+        const runner = queryRunnerWithResults([
+            [
+                {
+                    rangeStart: new Date('2025-12-20T09:00:00+01:00'),
+                    rangeEnd: new Date('2026-01-05T17:00:00+01:00'),
+                },
+            ],
+        ]);
+
+        await expect(
+            loadSyntheticAppointmentDateRange(runner),
+        ).resolves.toEqual({
+            rangeStart: '2025-12-20',
+            rangeEnd: '2026-01-05',
+        });
+        const sql = String((runner.query as jest.Mock).mock.calls[0]?.[0]);
+        expect(sql.trim().toUpperCase()).toMatch(/^SELECT/);
+        expect(sql.split(/\bFROM\b/i)[0]).not.toMatch(/email|name|client/i);
+    });
+
+    it('loads schedule rows for an explicit persisted range instead of the current anchor horizon', async () => {
+        const timetableRows = Array.from({ length: 7 }, (_, dayOfWeek) => ({
+            id: 31,
+            validFrom: '2025-01-01',
+            validTo: null,
+            dayOfWeek,
+            startTime: '09:00:00',
+            endTime: '17:00:00',
+            isBreak: false,
+        }));
+        const runner = queryRunnerWithResults([timetableRows, []]);
+        const persistedRange = {
+            rangeStart: '2025-12-20',
+            rangeEnd: '2025-12-22',
+        };
+
+        const days = await loadSyntheticWorkingDays(
+            runner,
+            7,
+            anchorDate,
+            persistedRange,
+        );
+
+        expect(days.map((day) => day.date)).toEqual([
+            '2025-12-20',
+            '2025-12-21',
+            '2025-12-22',
+        ]);
+        expect((runner.query as jest.Mock).mock.calls[0]?.[1]).toEqual([
+            7,
+            persistedRange.rangeStart,
+            persistedRange.rangeEnd,
+        ]);
+        expect((runner.query as jest.Mock).mock.calls[1]?.[1]).toEqual([
+            [31],
+            persistedRange.rangeStart,
+            persistedRange.rangeEnd,
+        ]);
+    });
+
+    it('acquires one static write-excluding lock for every schedule table', async () => {
+        const runner = {
+            query: jest.fn().mockResolvedValue(undefined),
+        } as unknown as QueryRunner;
+
+        await lockSyntheticSchedule(runner);
+
+        expect(runner.query).toHaveBeenCalledTimes(1);
+        const [sql, parameters] = (runner.query as jest.Mock).mock.calls[0];
+        expect(String(sql).replace(/\s+/g, ' ').trim()).toBe(
+            'LOCK TABLE "timetables", "timetable_slots", "timetable_exceptions" IN SHARE MODE',
+        );
+        expect(parameters).toBeUndefined();
+    });
+
     it('reports missing protected roles as blockers', async () => {
         const runner = queryRunnerWithResults([
             [{ id: 20, role: 'client' }],
@@ -172,7 +261,7 @@ describe('synthetic-data store plan', () => {
             'missing-admin@example.invalid',
             'ci@example.invalid',
         ]);
-        const plan = await buildSyntheticPlan(runner, context, dataset);
+        const plan = await buildSyntheticPlan(runner, context, expectedCounts);
 
         expect(plan.protectedAdminPresent).toBe(false);
         expect(plan.blockers).toContain('Protected admin account is missing');
@@ -204,7 +293,12 @@ describe('synthetic-data store plan', () => {
                 serviceIds: [10, 11, 12],
                 blockers: [],
             },
-            null,
+            {
+                clients: 0,
+                appointments: 0,
+                products: 0,
+                warehouseDocuments: 0,
+            },
         );
 
         expect(plan.deleteCounts).toEqual({
@@ -428,6 +522,50 @@ describe('synthetic-data store plan', () => {
             ),
         ).rejects.toThrow('SYNTHETIC_SCHEDULE_CONTEXT_REQUIRED');
         expect(runner.query).not.toHaveBeenCalled();
+    });
+
+    it('keeps persisted confirmed visits valid after their original anchor passes', async () => {
+        const runner = queryRunnerWithResults([
+            [
+                {
+                    clients: '12',
+                    appointments: '30',
+                    products: '12',
+                    warehouseDocuments: '5',
+                    protectedAccountsPresent: '2',
+                    remainingNonSyntheticClients: '0',
+                },
+            ],
+            [
+                {
+                    id: 44,
+                    employeeId: 7,
+                    status: 'confirmed',
+                    startTime: new Date('2026-07-30T09:00:00+02:00'),
+                    endTime: new Date('2026-07-30T10:00:00+02:00'),
+                },
+            ],
+        ]);
+
+        const report = await verifySyntheticState(
+            runner,
+            expectedCounts,
+            [7, 20],
+            {
+                ownerUserId: 7,
+                anchorDate: new Date('2026-08-01T12:00:00+02:00'),
+                workingDays: [
+                    {
+                        date: '2026-07-30',
+                        ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+                    },
+                ],
+                validateStatusTime: false,
+            },
+        );
+
+        expect(report.scheduleViolations).toBe(0);
+        expect(report.blockers).toEqual([]);
     });
 
     it('allows cleanup verification without schedule context', async () => {

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts
@@ -1,10 +1,24 @@
 import type { QueryRunner } from 'typeorm';
 import type {
+    SyntheticAppointmentStatus,
+    SyntheticAppointmentWindow,
+    SyntheticBaseContext,
     SyntheticDataset,
     SyntheticPlan,
+    SyntheticScheduleSummary,
+    SyntheticTimetableExceptionRecord,
+    SyntheticTimetableRecord,
     SyntheticVerificationExpected,
     SyntheticVerificationReport,
+    SyntheticWorkingDay,
 } from './synthetic-data.types';
+import {
+    resolveSyntheticWorkingDays,
+    SYNTHETIC_FUTURE_DAYS,
+    SYNTHETIC_PAST_DAYS,
+    warsawDateKey,
+} from './synthetic-data.schedule';
+import { collectSyntheticScheduleViolations } from './synthetic-data.validation';
 
 export const RESET_GROUPS = {
     appointmentChildren: [
@@ -71,6 +85,24 @@ interface CountRow {
 interface VerificationRow extends CountRow {
     protectedAccountsPresent?: string | number;
     remainingNonSyntheticClients?: string | number;
+}
+
+interface TimetableSlotRow {
+    id: number;
+    validFrom: string | Date;
+    validTo: string | Date | null;
+    dayOfWeek: number | null;
+    startTime: string | null;
+    endTime: string | null;
+    isBreak: boolean | null;
+}
+
+interface SyntheticAppointmentRow {
+    id: number;
+    employeeId: number;
+    status: SyntheticAppointmentStatus;
+    startTime: Date;
+    endTime: Date;
 }
 
 interface ForeignKeyRow {
@@ -177,11 +209,10 @@ function asCount(value: string | number | undefined): number {
     return count;
 }
 
-export async function buildSyntheticPlan(
+export async function loadSyntheticBaseContext(
     queryRunner: QueryRunner,
     protectedEmails: string[],
-    dataset: SyntheticDataset,
-): Promise<SyntheticPlan> {
+): Promise<SyntheticBaseContext> {
     const protectedUsers = (await queryRunner.query(
         `SELECT "id", "role"
          FROM "users"
@@ -195,22 +226,6 @@ export async function buildSyntheticPlan(
          ORDER BY "id"
          LIMIT 3`,
     )) as IdRow[];
-    const [rawCounts = {}] = (await queryRunner.query(
-        `SELECT
-            (SELECT count(*) FROM "users"
-             WHERE "role" = 'client' AND NOT ("id" = ANY($1::int[]))) AS "clients",
-            (SELECT count(*) FROM "appointments") AS "appointments",
-            (SELECT count(*) FROM "products") AS "products",
-            ((SELECT count(*) FROM "deliveries")
-             + (SELECT count(*) FROM "stocktakings")
-             + (SELECT count(*) FROM "warehouse_orders")
-             + (SELECT count(*) FROM "warehouse_sales")
-             + (SELECT count(*) FROM "warehouse_usages")) AS "warehouseDocuments",
-            (SELECT count(*) FROM "users"
-             WHERE "role" IN ('admin', 'employee')
-               AND NOT ("id" = ANY($1::int[]))) AS "unprotectedPrivileged"`,
-        [protectedUsers.map((user) => user.id)],
-    )) as CountRow[];
 
     const protectedAdmin = protectedUsers.find((user) => user.role === 'admin');
     const protectedClient = protectedUsers.find(
@@ -231,9 +246,6 @@ export async function buildSyntheticPlan(
     if (serviceIds.length === 0) {
         blockers.push('No services are available for synthetic appointments');
     }
-    if (asCount(rawCounts.unprotectedPrivileged) > 0) {
-        blockers.push('Unprotected privileged accounts require review');
-    }
 
     return {
         protectedUserIds: protectedUsers.map((user) => user.id),
@@ -241,6 +253,116 @@ export async function buildSyntheticPlan(
         protectedCiClientPresent: Boolean(protectedClient),
         ownerUserId: protectedAdmin?.id ?? null,
         serviceIds,
+        blockers,
+    };
+}
+
+function dateKeyAtOffset(date: string, offset: number): string {
+    const [year, month, day] = date.split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, day + offset))
+        .toISOString()
+        .slice(0, 10);
+}
+
+export async function loadSyntheticWorkingDays(
+    queryRunner: QueryRunner,
+    ownerUserId: number,
+    anchorDate: Date,
+): Promise<SyntheticWorkingDay[]> {
+    const anchorDateKey = warsawDateKey(anchorDate);
+    const rangeStart = dateKeyAtOffset(anchorDateKey, -SYNTHETIC_PAST_DAYS);
+    const rangeEnd = dateKeyAtOffset(anchorDateKey, SYNTHETIC_FUTURE_DAYS);
+    const slotRows = (await queryRunner.query(
+        `SELECT t."id", t."validFrom", t."validTo",
+                s."dayOfWeek", s."startTime", s."endTime", s."isBreak"
+         FROM "timetables" t
+         LEFT JOIN "timetable_slots" s ON s."timetableId" = t."id"
+         WHERE t."employeeId" = $1
+           AND t."isActive" = true
+           AND t."validFrom" <= $3
+           AND (t."validTo" IS NULL OR t."validTo" >= $2)
+         ORDER BY t."validFrom" DESC, t."id" DESC, s."id" ASC`,
+        [ownerUserId, rangeStart, rangeEnd],
+    )) as TimetableSlotRow[];
+
+    const timetablesById = new Map<number, SyntheticTimetableRecord>();
+    for (const row of slotRows) {
+        let timetable = timetablesById.get(row.id);
+        if (!timetable) {
+            timetable = {
+                id: row.id,
+                validFrom: row.validFrom,
+                validTo: row.validTo,
+                slots: [],
+            };
+            timetablesById.set(row.id, timetable);
+        }
+        if (
+            row.dayOfWeek !== null &&
+            row.startTime !== null &&
+            row.endTime !== null &&
+            row.isBreak !== null
+        ) {
+            timetable.slots.push({
+                dayOfWeek: row.dayOfWeek,
+                startTime: row.startTime,
+                endTime: row.endTime,
+                isBreak: row.isBreak,
+            });
+        }
+    }
+
+    const timetables = [...timetablesById.values()];
+    const exceptions = (await queryRunner.query(
+        `SELECT e."timetableId", e."date", e."type",
+                e."customStartTime", e."customEndTime"
+         FROM "timetable_exceptions" e
+         WHERE e."timetableId" = ANY($1::int[])
+           AND e."date" BETWEEN $2 AND $3
+         ORDER BY e."date", e."id"`,
+        [timetables.map((timetable) => timetable.id), rangeStart, rangeEnd],
+    )) as SyntheticTimetableExceptionRecord[];
+
+    return resolveSyntheticWorkingDays({
+        anchorDate,
+        timetables,
+        exceptions,
+    });
+}
+
+export async function buildSyntheticPlan(
+    queryRunner: QueryRunner,
+    context: SyntheticBaseContext,
+    dataset: SyntheticDataset | null,
+    scheduleSummary?: SyntheticScheduleSummary,
+): Promise<SyntheticPlan> {
+    const [rawCounts = {}] = (await queryRunner.query(
+        `SELECT
+            (SELECT count(*) FROM "users"
+             WHERE "role" = 'client' AND NOT ("id" = ANY($1::int[]))) AS "clients",
+            (SELECT count(*) FROM "appointments") AS "appointments",
+            (SELECT count(*) FROM "products") AS "products",
+            ((SELECT count(*) FROM "deliveries")
+             + (SELECT count(*) FROM "stocktakings")
+             + (SELECT count(*) FROM "warehouse_orders")
+             + (SELECT count(*) FROM "warehouse_sales")
+             + (SELECT count(*) FROM "warehouse_usages")) AS "warehouseDocuments",
+            (SELECT count(*) FROM "users"
+             WHERE "role" IN ('admin', 'employee')
+               AND NOT ("id" = ANY($1::int[]))) AS "unprotectedPrivileged"`,
+        [context.protectedUserIds],
+    )) as CountRow[];
+    const blockers = [...context.blockers];
+    if (asCount(rawCounts.unprotectedPrivileged) > 0) {
+        blockers.push('Unprotected privileged accounts require review');
+    }
+
+    return {
+        protectedUserIds: context.protectedUserIds,
+        protectedAdminPresent: context.protectedAdminPresent,
+        protectedCiClientPresent: context.protectedCiClientPresent,
+        ownerUserId: context.ownerUserId,
+        serviceIds: context.serviceIds,
         deleteCounts: {
             clients: asCount(rawCounts.clients),
             appointments: asCount(rawCounts.appointments),
@@ -248,17 +370,19 @@ export async function buildSyntheticPlan(
             warehouseDocuments: asCount(rawCounts.warehouseDocuments),
         },
         createCounts: {
-            clients: dataset.clients.length,
-            appointments: dataset.appointments.length,
-            products: dataset.products.length,
-            warehouseDocuments:
-                dataset.deliveries.length +
-                dataset.orders.length +
-                dataset.sales.length +
-                dataset.usages.length +
-                dataset.stocktakings.length,
+            clients: dataset?.clients.length ?? 0,
+            appointments: dataset?.appointments.length ?? 0,
+            products: dataset?.products.length ?? 0,
+            warehouseDocuments: dataset
+                ? dataset.deliveries.length +
+                  dataset.orders.length +
+                  dataset.sales.length +
+                  dataset.usages.length +
+                  dataset.stocktakings.length
+                : 0,
         },
         blockers,
+        ...(dataset && scheduleSummary ? { scheduleSummary } : {}),
     };
 }
 
@@ -371,7 +495,16 @@ export async function verifySyntheticState(
     queryRunner: QueryRunner,
     expected: SyntheticVerificationExpected,
     protectedUserIds: number[],
+    scheduleContext?: {
+        ownerUserId: number;
+        anchorDate: Date;
+        workingDays: SyntheticWorkingDay[];
+    },
 ): Promise<SyntheticVerificationReport> {
+    if (expected.appointments > 0 && !scheduleContext) {
+        throw new Error('SYNTHETIC_SCHEDULE_CONTEXT_REQUIRED');
+    }
+
     const [row = {}] = (await queryRunner.query(
         `SELECT
             (SELECT count(*) FROM "users"
@@ -404,6 +537,14 @@ export async function verifySyntheticState(
                 AS "remainingNonSyntheticClients"`,
         [protectedUserIds],
     )) as VerificationRow[];
+    const appointmentRows = (await queryRunner.query(
+        `SELECT a."id", a."employeeId", a."status",
+                a."startTime", a."endTime"
+         FROM "appointments" a
+         JOIN "users" u ON u."id" = a."clientId"
+         WHERE u."email" LIKE 'synthetic.client.%@example.invalid'
+         ORDER BY a."id"`,
+    )) as SyntheticAppointmentRow[];
 
     const actual = {
         clients: asCount(row.clients),
@@ -432,12 +573,31 @@ export async function verifySyntheticState(
     if (remainingNonSyntheticClients > 0) {
         blockers.push('Non-synthetic client accounts remain');
     }
+    const appointments: SyntheticAppointmentWindow[] = appointmentRows.map(
+        (appointment) => ({
+            key: `db-appointment-${appointment.id}`,
+            employeeId: appointment.employeeId,
+            status: appointment.status,
+            startTime: appointment.startTime,
+            endTime: appointment.endTime,
+        }),
+    );
+    const scheduleBlockers = scheduleContext
+        ? collectSyntheticScheduleViolations({
+              appointments,
+              workingDays: scheduleContext.workingDays,
+              ownerUserId: scheduleContext.ownerUserId,
+              anchorDate: scheduleContext.anchorDate,
+          })
+        : [];
+    blockers.push(...scheduleBlockers);
 
     return {
         actual,
         expected,
         protectedAccountsPresent,
         remainingNonSyntheticClients,
+        scheduleViolations: scheduleBlockers.length,
         blockers,
     };
 }

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts
@@ -4,12 +4,14 @@ import type {
     SyntheticAppointmentWindow,
     SyntheticBaseContext,
     SyntheticDataset,
+    SyntheticDateRange,
     SyntheticPlan,
     SyntheticScheduleSummary,
     SyntheticTimetableExceptionRecord,
     SyntheticTimetableRecord,
     SyntheticVerificationExpected,
     SyntheticVerificationReport,
+    SyntheticVerificationScheduleContext,
     SyntheticWorkingDay,
 } from './synthetic-data.types';
 import {
@@ -103,6 +105,11 @@ interface SyntheticAppointmentRow {
     status: SyntheticAppointmentStatus;
     startTime: Date;
     endTime: Date;
+}
+
+interface SyntheticAppointmentDateRangeRow {
+    rangeStart: string | Date | null;
+    rangeEnd: string | Date | null;
 }
 
 interface ForeignKeyRow {
@@ -264,14 +271,47 @@ function dateKeyAtOffset(date: string, offset: number): string {
         .slice(0, 10);
 }
 
+function persistedDateKey(value: string | Date | null): string | null {
+    if (value === null) return null;
+    const parsed = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        throw new Error('SYNTHETIC_APPOINTMENT_DATE_RANGE_INVALID');
+    }
+    return warsawDateKey(parsed);
+}
+
+export async function loadSyntheticAppointmentDateRange(
+    queryRunner: QueryRunner,
+): Promise<SyntheticDateRange | null> {
+    const [row] = (await queryRunner.query(
+        `SELECT min(a."startTime") AS "rangeStart",
+                max(a."endTime") AS "rangeEnd"
+         FROM "appointments" a
+         JOIN "users" u ON u."id" = a."clientId"
+         WHERE u."email" LIKE 'synthetic.client.%@example.invalid'`,
+    )) as SyntheticAppointmentDateRangeRow[];
+    const rangeStart = persistedDateKey(row?.rangeStart ?? null);
+    const rangeEnd = persistedDateKey(row?.rangeEnd ?? null);
+    if (rangeStart === null && rangeEnd === null) return null;
+    if (rangeStart === null || rangeEnd === null || rangeEnd < rangeStart) {
+        throw new Error('SYNTHETIC_APPOINTMENT_DATE_RANGE_INVALID');
+    }
+    return { rangeStart, rangeEnd };
+}
+
 export async function loadSyntheticWorkingDays(
     queryRunner: QueryRunner,
     ownerUserId: number,
     anchorDate: Date,
+    dateRange?: SyntheticDateRange,
 ): Promise<SyntheticWorkingDay[]> {
     const anchorDateKey = warsawDateKey(anchorDate);
-    const rangeStart = dateKeyAtOffset(anchorDateKey, -SYNTHETIC_PAST_DAYS);
-    const rangeEnd = dateKeyAtOffset(anchorDateKey, SYNTHETIC_FUTURE_DAYS);
+    const rangeStart =
+        dateRange?.rangeStart ??
+        dateKeyAtOffset(anchorDateKey, -SYNTHETIC_PAST_DAYS);
+    const rangeEnd =
+        dateRange?.rangeEnd ??
+        dateKeyAtOffset(anchorDateKey, SYNTHETIC_FUTURE_DAYS);
     const slotRows = (await queryRunner.query(
         `SELECT t."id", t."validFrom", t."validTo",
                 s."dayOfWeek", s."startTime", s."endTime", s."isBreak"
@@ -325,15 +365,24 @@ export async function loadSyntheticWorkingDays(
 
     return resolveSyntheticWorkingDays({
         anchorDate,
+        ...(dateRange ? { dateRange } : {}),
         timetables,
         exceptions,
     });
 }
 
+export async function lockSyntheticSchedule(
+    queryRunner: QueryRunner,
+): Promise<void> {
+    await queryRunner.query(
+        `LOCK TABLE "timetables", "timetable_slots", "timetable_exceptions" IN SHARE MODE`,
+    );
+}
+
 export async function buildSyntheticPlan(
     queryRunner: QueryRunner,
     context: SyntheticBaseContext,
-    dataset: SyntheticDataset | null,
+    expectedCreateCounts: SyntheticVerificationExpected,
     scheduleSummary?: SyntheticScheduleSummary,
 ): Promise<SyntheticPlan> {
     const [rawCounts = {}] = (await queryRunner.query(
@@ -370,19 +419,15 @@ export async function buildSyntheticPlan(
             warehouseDocuments: asCount(rawCounts.warehouseDocuments),
         },
         createCounts: {
-            clients: dataset?.clients.length ?? 0,
-            appointments: dataset?.appointments.length ?? 0,
-            products: dataset?.products.length ?? 0,
-            warehouseDocuments: dataset
-                ? dataset.deliveries.length +
-                  dataset.orders.length +
-                  dataset.sales.length +
-                  dataset.usages.length +
-                  dataset.stocktakings.length
-                : 0,
+            clients: asCount(expectedCreateCounts.clients),
+            appointments: asCount(expectedCreateCounts.appointments),
+            products: asCount(expectedCreateCounts.products),
+            warehouseDocuments: asCount(
+                expectedCreateCounts.warehouseDocuments,
+            ),
         },
         blockers,
-        ...(dataset && scheduleSummary ? { scheduleSummary } : {}),
+        ...(scheduleSummary ? { scheduleSummary } : {}),
     };
 }
 
@@ -497,11 +542,7 @@ export async function verifySyntheticState(
     queryRunner: QueryRunner,
     expected: SyntheticVerificationExpected,
     protectedUserIds: number[],
-    scheduleContext?: {
-        ownerUserId: number;
-        anchorDate: Date;
-        workingDays: SyntheticWorkingDay[];
-    },
+    scheduleContext?: SyntheticVerificationScheduleContext,
 ): Promise<SyntheticVerificationReport> {
     if (expected.appointments > 0 && !scheduleContext) {
         throw new Error('SYNTHETIC_SCHEDULE_CONTEXT_REQUIRED');
@@ -590,6 +631,7 @@ export async function verifySyntheticState(
               workingDays: scheduleContext.workingDays,
               ownerUserId: scheduleContext.ownerUserId,
               anchorDate: scheduleContext.anchorDate,
+              validateStatusTime: scheduleContext.validateStatusTime,
           })
         : [];
     blockers.push(...scheduleBlockers);

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts
@@ -386,9 +386,11 @@ export async function buildSyntheticPlan(
     };
 }
 
-export function assertProtectedAccounts(plan: SyntheticPlan): void {
-    if (plan.blockers.length > 0) {
-        throw new Error(plan.blockers.join('; '));
+export function assertProtectedAccounts(
+    input: SyntheticBaseContext | SyntheticPlan,
+): void {
+    if (input.blockers.length > 0) {
+        throw new Error(input.blockers.join('; '));
     }
 }
 

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
@@ -19,6 +19,44 @@ export interface DatasetInput {
     serviceIds: number[];
 }
 
+export interface SyntheticWorkingRange {
+    startMinute: number;
+    endMinute: number;
+}
+
+export interface SyntheticWorkingDay {
+    date: string;
+    ranges: SyntheticWorkingRange[];
+}
+
+export interface SyntheticScheduleSummary {
+    rangeStart: string;
+    rangeEnd: string;
+    workingDays: number;
+    closedDays: number;
+    convertedInProgress: number;
+}
+
+export interface SyntheticTimetableRecord {
+    id: number;
+    validFrom: string | Date;
+    validTo: string | Date | null;
+    slots: Array<{
+        dayOfWeek: number;
+        startTime: string;
+        endTime: string;
+        isBreak: boolean;
+    }>;
+}
+
+export interface SyntheticTimetableExceptionRecord {
+    timetableId: number;
+    date: string | Date;
+    type: string;
+    customStartTime: string | null;
+    customEndTime: string | null;
+}
+
 export type SyntheticAppointmentStatus =
     | 'scheduled'
     | 'confirmed'

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
@@ -34,6 +34,21 @@ export interface SyntheticWorkingDay {
     ranges: SyntheticWorkingRange[];
 }
 
+export interface SyntheticAppointmentWindow {
+    key: string;
+    employeeId: number;
+    status: SyntheticAppointmentStatus;
+    startTime: Date;
+    endTime: Date;
+}
+
+export interface SyntheticScheduleValidationInput {
+    appointments: SyntheticAppointmentWindow[];
+    workingDays: SyntheticWorkingDay[];
+    ownerUserId: number;
+    anchorDate: Date;
+}
+
 export interface SyntheticScheduleSummary {
     rangeStart: string;
     rangeEnd: string;
@@ -90,14 +105,9 @@ export interface SyntheticClient {
     origin?: string;
 }
 
-export interface SyntheticAppointment {
-    key: string;
+export interface SyntheticAppointment extends SyntheticAppointmentWindow {
     clientKey: string;
-    employeeId: number;
     serviceId: number;
-    status: SyntheticAppointmentStatus;
-    startTime: Date;
-    endTime: Date;
     price: number;
     paidAmount: number | null;
     tipAmount: number | null;

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
@@ -34,6 +34,11 @@ export interface SyntheticWorkingDay {
     ranges: SyntheticWorkingRange[];
 }
 
+export interface SyntheticDateRange {
+    rangeStart: string;
+    rangeEnd: string;
+}
+
 export interface SyntheticAppointmentWindow {
     key: string;
     employeeId: number;
@@ -47,6 +52,7 @@ export interface SyntheticScheduleValidationInput {
     workingDays: SyntheticWorkingDay[];
     ownerUserId: number;
     anchorDate: Date;
+    validateStatusTime?: boolean;
 }
 
 export interface SyntheticScheduleSummary {
@@ -227,4 +233,11 @@ export interface SyntheticVerificationReport {
     remainingNonSyntheticClients: number;
     scheduleViolations: number;
     blockers: string[];
+}
+
+export interface SyntheticVerificationScheduleContext {
+    ownerUserId: number;
+    anchorDate: Date;
+    workingDays: SyntheticWorkingDay[];
+    validateStatusTime?: boolean;
 }

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
@@ -13,10 +13,15 @@ export interface SyntheticRunConfig {
     reportJson: boolean;
 }
 
+export interface SyntheticGenerationSummary {
+    convertedInProgress: number;
+}
+
 export interface DatasetInput {
     anchorDate: Date;
     ownerUserId: number;
     serviceIds: number[];
+    workingDays: SyntheticWorkingDay[];
 }
 
 export interface SyntheticWorkingRange {
@@ -160,6 +165,7 @@ export interface SyntheticRecipeItem {
 
 export interface SyntheticDataset {
     anchorDate: Date;
+    generationSummary: SyntheticGenerationSummary;
     clients: SyntheticClient[];
     appointments: SyntheticAppointment[];
     productCategories: SyntheticProductCategory[];

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts
@@ -192,6 +192,15 @@ export interface SyntheticDataset {
     recipeItems: SyntheticRecipeItem[];
 }
 
+export interface SyntheticBaseContext {
+    protectedUserIds: number[];
+    protectedAdminPresent: boolean;
+    protectedCiClientPresent: boolean;
+    ownerUserId: number | null;
+    serviceIds: number[];
+    blockers: string[];
+}
+
 export interface SyntheticPlan {
     protectedUserIds: number[];
     protectedAdminPresent: boolean;
@@ -201,6 +210,7 @@ export interface SyntheticPlan {
     deleteCounts: Record<string, number>;
     createCounts: Record<string, number>;
     blockers: string[];
+    scheduleSummary?: SyntheticScheduleSummary;
 }
 
 export interface SyntheticVerificationExpected {
@@ -215,5 +225,6 @@ export interface SyntheticVerificationReport {
     expected: SyntheticVerificationExpected;
     protectedAccountsPresent: number;
     remainingNonSyntheticClients: number;
+    scheduleViolations: number;
     blockers: string[];
 }

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
@@ -109,6 +109,70 @@ describe('synthetic schedule validation', () => {
         );
     });
 
+    it('allows in-progress status when the anchor is in that working-day range but outside the appointment', () => {
+        const inProgress = validInput();
+        inProgress.anchorDate = new Date('2026-07-29T12:00:00+02:00');
+        inProgress.workingDays.unshift({
+            date: '2026-07-29',
+            ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+        });
+        inProgress.appointments[0] = {
+            ...inProgress.appointments[0],
+            status: 'in_progress',
+            startTime: new Date('2026-07-29T09:00:00+02:00'),
+            endTime: new Date('2026-07-29T10:00:00+02:00'),
+        };
+
+        expect(collectSyntheticScheduleViolations(inProgress)).toEqual([]);
+    });
+
+    it('allows in-progress status when the anchor equals the working-range start', () => {
+        const inProgressAtRangeStart = validInput();
+        inProgressAtRangeStart.anchorDate = new Date(
+            '2026-07-29T09:00:00+02:00',
+        );
+        inProgressAtRangeStart.workingDays.unshift({
+            date: '2026-07-29',
+            ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+        });
+        inProgressAtRangeStart.appointments[0] = {
+            ...inProgressAtRangeStart.appointments[0],
+            status: 'in_progress',
+            startTime: new Date('2026-07-29T13:00:00+02:00'),
+            endTime: new Date('2026-07-29T14:00:00+02:00'),
+        };
+
+        expect(
+            collectSyntheticScheduleViolations(inProgressAtRangeStart),
+        ).toEqual([]);
+    });
+
+    it('allows an appointment ending at a working-range boundary', () => {
+        const atRangeBoundary = validInput();
+        atRangeBoundary.appointments[0].startTime = new Date(
+            '2026-07-30T16:00:00+02:00',
+        );
+        atRangeBoundary.appointments[0].endTime = new Date(
+            '2026-07-30T17:00:00+02:00',
+        );
+
+        expect(collectSyntheticScheduleViolations(atRangeBoundary)).toEqual([]);
+    });
+
+    it('rejects an appointment ending after a range boundary by seconds', () => {
+        const secondsOverrun = validInput();
+        secondsOverrun.appointments[0].startTime = new Date(
+            '2026-07-30T16:00:00+02:00',
+        );
+        secondsOverrun.appointments[0].endTime = new Date(
+            '2026-07-30T17:00:30+02:00',
+        );
+
+        expect(collectSyntheticScheduleViolations(secondsOverrun)).toContain(
+            'appointment-01:SYNTHETIC_APPOINTMENT_TIME_INVALID',
+        );
+    });
+
     it('accepts a valid appointment schedule', () => {
         expect(() => assertSyntheticScheduleValid(validInput())).not.toThrow();
     });

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
@@ -1,0 +1,115 @@
+import {
+    assertSyntheticScheduleValid,
+    collectSyntheticScheduleViolations,
+} from './synthetic-data.validation';
+import { SyntheticScheduleValidationInput } from './synthetic-data.types';
+
+const anchorDate = new Date('2026-07-29T12:00:00+02:00');
+
+function validInput(): SyntheticScheduleValidationInput {
+    return {
+        appointments: [
+            {
+                key: 'appointment-01',
+                employeeId: 7,
+                status: 'confirmed',
+                startTime: new Date('2026-07-30T09:00:00+02:00'),
+                endTime: new Date('2026-07-30T10:00:00+02:00'),
+            },
+        ],
+        workingDays: [
+            {
+                date: '2026-07-28',
+                ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+            },
+            {
+                date: '2026-07-30',
+                ranges: [
+                    { startMinute: 9 * 60, endMinute: 12 * 60 },
+                    { startMinute: 13 * 60, endMinute: 17 * 60 },
+                ],
+            },
+        ],
+        ownerUserId: 7,
+        anchorDate,
+    };
+}
+
+describe('synthetic schedule validation', () => {
+    it('reports an appointment outside working hours', () => {
+        const outsideHours = validInput();
+        outsideHours.appointments[0].startTime = new Date(
+            '2026-07-30T08:30:00+02:00',
+        );
+
+        expect(collectSyntheticScheduleViolations(outsideHours)).toContain(
+            'appointment-01:SYNTHETIC_APPOINTMENT_OUTSIDE_SCHEDULE',
+        );
+    });
+
+    it('reports an appointment during a working-day break', () => {
+        const duringBreak = validInput();
+        duringBreak.appointments[0].startTime = new Date(
+            '2026-07-30T12:00:00+02:00',
+        );
+        duringBreak.appointments[0].endTime = new Date(
+            '2026-07-30T13:00:00+02:00',
+        );
+
+        expect(collectSyntheticScheduleViolations(duringBreak)).toContain(
+            'appointment-01:SYNTHETIC_APPOINTMENT_OUTSIDE_SCHEDULE',
+        );
+    });
+
+    it('reports the later appointment when owner intervals overlap', () => {
+        const overlap = validInput();
+        overlap.appointments.push({
+            ...overlap.appointments[0],
+            key: 'appointment-02',
+            startTime: new Date('2026-07-30T09:30:00+02:00'),
+            endTime: new Date('2026-07-30T10:30:00+02:00'),
+        });
+
+        expect(collectSyntheticScheduleViolations(overlap)).toContain(
+            'appointment-02:SYNTHETIC_APPOINTMENT_OVERLAP',
+        );
+    });
+
+    it('reports an appointment assigned to another employee', () => {
+        const wrongEmployee = validInput();
+        wrongEmployee.appointments[0].employeeId = 8;
+
+        expect(collectSyntheticScheduleViolations(wrongEmployee)).toContain(
+            'appointment-01:SYNTHETIC_APPOINTMENT_EMPLOYEE',
+        );
+    });
+
+    it('reports a missing working-day entry', () => {
+        const missingDay = validInput();
+        missingDay.workingDays = missingDay.workingDays.filter(
+            (day) => day.date !== '2026-07-30',
+        );
+
+        expect(collectSyntheticScheduleViolations(missingDay)).toContain(
+            'appointment-01:SYNTHETIC_APPOINTMENT_SCHEDULE_DAY_MISSING',
+        );
+    });
+
+    it('reports a confirmed appointment before the anchor', () => {
+        const pastConfirmed = validInput();
+        pastConfirmed.appointments[0].startTime = new Date(
+            '2026-07-28T09:00:00+02:00',
+        );
+        pastConfirmed.appointments[0].endTime = new Date(
+            '2026-07-28T10:00:00+02:00',
+        );
+
+        expect(collectSyntheticScheduleViolations(pastConfirmed)).toContain(
+            'appointment-01:SYNTHETIC_APPOINTMENT_STATUS_TIME',
+        );
+    });
+
+    it('accepts a valid appointment schedule', () => {
+        expect(() => assertSyntheticScheduleValid(validInput())).not.toThrow();
+    });
+});

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
@@ -109,6 +109,25 @@ describe('synthetic schedule validation', () => {
         );
     });
 
+    it('skips only time-relative status checks for persisted standalone verification', () => {
+        const persistedAfterAnchor = {
+            ...validInput(),
+            anchorDate: new Date('2026-08-01T12:00:00+02:00'),
+            validateStatusTime: false,
+        } as SyntheticScheduleValidationInput & {
+            validateStatusTime: boolean;
+        };
+
+        expect(
+            collectSyntheticScheduleViolations(persistedAfterAnchor),
+        ).toEqual([]);
+
+        persistedAfterAnchor.appointments[0].employeeId = 8;
+        expect(
+            collectSyntheticScheduleViolations(persistedAfterAnchor),
+        ).toEqual(['appointment-01:SYNTHETIC_APPOINTMENT_EMPLOYEE']);
+    });
+
     it('allows in-progress status when the anchor is in that working-day range but outside the appointment', () => {
         const inProgress = validInput();
         inProgress.anchorDate = new Date('2026-07-29T12:00:00+02:00');

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
@@ -147,6 +147,22 @@ describe('synthetic schedule validation', () => {
         ).toEqual([]);
     });
 
+    it('reports in-progress status when the appointment Warsaw date differs from the anchor date', () => {
+        const inProgressOnAnotherDay = validInput();
+        inProgressOnAnotherDay.anchorDate = new Date(
+            '2026-07-29T12:00:00+02:00',
+        );
+        inProgressOnAnotherDay.workingDays.unshift({
+            date: '2026-07-29',
+            ranges: [{ startMinute: 9 * 60, endMinute: 17 * 60 }],
+        });
+        inProgressOnAnotherDay.appointments[0].status = 'in_progress';
+
+        expect(
+            collectSyntheticScheduleViolations(inProgressOnAnotherDay),
+        ).toContain('appointment-01:SYNTHETIC_APPOINTMENT_STATUS_TIME');
+    });
+
     it('allows an appointment ending at a working-range boundary', () => {
         const atRangeBoundary = validInput();
         atRangeBoundary.appointments[0].startTime = new Date(
@@ -159,6 +175,20 @@ describe('synthetic schedule validation', () => {
         expect(collectSyntheticScheduleViolations(atRangeBoundary)).toEqual([]);
     });
 
+    it('allows an appointment with seconds wholly inside a working range', () => {
+        const secondsWithinRange = validInput();
+        secondsWithinRange.appointments[0].startTime = new Date(
+            '2026-07-30T09:00:30+02:00',
+        );
+        secondsWithinRange.appointments[0].endTime = new Date(
+            '2026-07-30T10:00:30+02:00',
+        );
+
+        expect(collectSyntheticScheduleViolations(secondsWithinRange)).toEqual(
+            [],
+        );
+    });
+
     it('rejects an appointment ending after a range boundary by seconds', () => {
         const secondsOverrun = validInput();
         secondsOverrun.appointments[0].startTime = new Date(
@@ -169,7 +199,7 @@ describe('synthetic schedule validation', () => {
         );
 
         expect(collectSyntheticScheduleViolations(secondsOverrun)).toContain(
-            'appointment-01:SYNTHETIC_APPOINTMENT_TIME_INVALID',
+            'appointment-01:SYNTHETIC_APPOINTMENT_OUTSIDE_SCHEDULE',
         );
     });
 

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
@@ -1,0 +1,171 @@
+import {
+    SyntheticAppointmentStatus,
+    SyntheticAppointmentWindow,
+    SyntheticScheduleValidationInput,
+    SyntheticWorkingDay,
+} from './synthetic-data.types';
+import { warsawDateKey, warsawMinuteOfDay } from './synthetic-data.schedule';
+
+const HISTORICAL_STATUSES = new Set<SyntheticAppointmentStatus>([
+    'cancelled',
+    'completed',
+    'no_show',
+]);
+
+function violation(key: string, code: string): string {
+    return `${key}:${code}`;
+}
+
+function hasFiniteTime(value: Date): boolean {
+    return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+function hasWorkingRange(
+    day: SyntheticWorkingDay,
+    startMinute: number,
+    endMinute: number,
+): boolean {
+    return day.ranges.some(
+        (range) =>
+            range.startMinute <= startMinute && endMinute <= range.endMinute,
+    );
+}
+
+function hasAnchorWorkingRange(
+    workingDays: SyntheticWorkingDay[],
+    anchorDate: Date,
+): boolean {
+    const anchorDateKey = warsawDateKey(anchorDate);
+    const anchorDays = workingDays.filter((day) => day.date === anchorDateKey);
+    const anchorMinute = warsawMinuteOfDay(anchorDate);
+
+    return (
+        anchorDays.length === 1 &&
+        anchorDays[0].ranges.some(
+            (range) =>
+                range.startMinute <= anchorMinute &&
+                anchorMinute < range.endMinute,
+        )
+    );
+}
+
+function hasValidStatusTime(
+    appointment: SyntheticAppointmentWindow,
+    anchorDate: Date,
+    anchorWorkingRange: boolean,
+): boolean {
+    const start = appointment.startTime.getTime();
+    const end = appointment.endTime.getTime();
+    const anchor = anchorDate.getTime();
+
+    if (HISTORICAL_STATUSES.has(appointment.status)) return end < anchor;
+    if (appointment.status === 'in_progress') {
+        return start <= anchor && anchor < end && anchorWorkingRange;
+    }
+    return start > anchor;
+}
+
+export function collectSyntheticScheduleViolations(
+    input: SyntheticScheduleValidationInput,
+): string[] {
+    const violations: string[] = [];
+    const validIntervals: SyntheticAppointmentWindow[] = [];
+    const anchorWorkingRange = hasFiniteTime(input.anchorDate)
+        ? hasAnchorWorkingRange(input.workingDays, input.anchorDate)
+        : false;
+
+    for (const appointment of input.appointments) {
+        if (
+            !hasFiniteTime(appointment.startTime) ||
+            !hasFiniteTime(appointment.endTime) ||
+            appointment.startTime >= appointment.endTime
+        ) {
+            violations.push(
+                violation(
+                    appointment.key,
+                    'SYNTHETIC_APPOINTMENT_TIME_INVALID',
+                ),
+            );
+            continue;
+        }
+
+        if (appointment.employeeId !== input.ownerUserId) {
+            violations.push(
+                violation(appointment.key, 'SYNTHETIC_APPOINTMENT_EMPLOYEE'),
+            );
+        }
+
+        const appointmentDateKey = warsawDateKey(appointment.startTime);
+        const appointmentDays = input.workingDays.filter(
+            (day) => day.date === appointmentDateKey,
+        );
+        if (appointmentDays.length === 0) {
+            violations.push(
+                violation(
+                    appointment.key,
+                    'SYNTHETIC_APPOINTMENT_SCHEDULE_DAY_MISSING',
+                ),
+            );
+        } else if (appointmentDays.length > 1) {
+            violations.push(
+                violation(
+                    appointment.key,
+                    'SYNTHETIC_APPOINTMENT_SCHEDULE_DAY_AMBIGUOUS',
+                ),
+            );
+        } else if (
+            warsawDateKey(appointment.endTime) !== appointmentDateKey ||
+            !hasWorkingRange(
+                appointmentDays[0],
+                warsawMinuteOfDay(appointment.startTime),
+                warsawMinuteOfDay(appointment.endTime),
+            )
+        ) {
+            violations.push(
+                violation(
+                    appointment.key,
+                    'SYNTHETIC_APPOINTMENT_OUTSIDE_SCHEDULE',
+                ),
+            );
+        }
+
+        if (
+            !hasFiniteTime(input.anchorDate) ||
+            !hasValidStatusTime(
+                appointment,
+                input.anchorDate,
+                anchorWorkingRange,
+            )
+        ) {
+            violations.push(
+                violation(appointment.key, 'SYNTHETIC_APPOINTMENT_STATUS_TIME'),
+            );
+        }
+
+        validIntervals.push(appointment);
+    }
+
+    let latestEnd = Number.NEGATIVE_INFINITY;
+    for (const appointment of validIntervals.sort(
+        (left, right) =>
+            left.startTime.getTime() - right.startTime.getTime() ||
+            left.endTime.getTime() - right.endTime.getTime() ||
+            left.key.localeCompare(right.key),
+    )) {
+        if (appointment.startTime.getTime() < latestEnd) {
+            violations.push(
+                violation(appointment.key, 'SYNTHETIC_APPOINTMENT_OVERLAP'),
+            );
+        }
+        latestEnd = Math.max(latestEnd, appointment.endTime.getTime());
+    }
+
+    return violations;
+}
+
+export function assertSyntheticScheduleValid(
+    input: SyntheticScheduleValidationInput,
+): void {
+    const violations = collectSyntheticScheduleViolations(input);
+    if (violations.length > 0) throw new Error(violations.join(', '));
+}

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
@@ -20,6 +20,10 @@ function hasFiniteTime(value: Date): boolean {
     return value instanceof Date && Number.isFinite(value.getTime());
 }
 
+function hasExactMinute(value: Date): boolean {
+    return value.getSeconds() === 0 && value.getMilliseconds() === 0;
+}
+
 function hasWorkingRange(
     day: SyntheticWorkingDay,
     startMinute: number,
@@ -54,15 +58,12 @@ function hasValidStatusTime(
     anchorDate: Date,
     anchorWorkingRange: boolean,
 ): boolean {
-    const start = appointment.startTime.getTime();
     const end = appointment.endTime.getTime();
     const anchor = anchorDate.getTime();
 
     if (HISTORICAL_STATUSES.has(appointment.status)) return end < anchor;
-    if (appointment.status === 'in_progress') {
-        return start <= anchor && anchor < end && anchorWorkingRange;
-    }
-    return start > anchor;
+    if (appointment.status === 'in_progress') return anchorWorkingRange;
+    return appointment.startTime.getTime() > anchor;
 }
 
 export function collectSyntheticScheduleViolations(
@@ -78,6 +79,8 @@ export function collectSyntheticScheduleViolations(
         if (
             !hasFiniteTime(appointment.startTime) ||
             !hasFiniteTime(appointment.endTime) ||
+            !hasExactMinute(appointment.startTime) ||
+            !hasExactMinute(appointment.endTime) ||
             appointment.startTime >= appointment.endTime
         ) {
             violations.push(

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
@@ -140,12 +140,13 @@ export function collectSyntheticScheduleViolations(
         }
 
         if (
-            !hasFiniteTime(input.anchorDate) ||
-            !hasValidStatusTime(
-                appointment,
-                input.anchorDate,
-                anchorWorkingRange,
-            )
+            input.validateStatusTime !== false &&
+            (!hasFiniteTime(input.anchorDate) ||
+                !hasValidStatusTime(
+                    appointment,
+                    input.anchorDate,
+                    anchorWorkingRange,
+                ))
         ) {
             violations.push(
                 violation(appointment.key, 'SYNTHETIC_APPOINTMENT_STATUS_TIME'),

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts
@@ -20,8 +20,12 @@ function hasFiniteTime(value: Date): boolean {
     return value instanceof Date && Number.isFinite(value.getTime());
 }
 
-function hasExactMinute(value: Date): boolean {
-    return value.getSeconds() === 0 && value.getMilliseconds() === 0;
+function warsawPreciseMinuteOfDay(value: Date): number {
+    return (
+        warsawMinuteOfDay(value) +
+        value.getSeconds() / 60 +
+        value.getMilliseconds() / 60_000
+    );
 }
 
 function hasWorkingRange(
@@ -62,7 +66,12 @@ function hasValidStatusTime(
     const anchor = anchorDate.getTime();
 
     if (HISTORICAL_STATUSES.has(appointment.status)) return end < anchor;
-    if (appointment.status === 'in_progress') return anchorWorkingRange;
+    if (appointment.status === 'in_progress') {
+        return (
+            warsawDateKey(appointment.startTime) ===
+                warsawDateKey(anchorDate) && anchorWorkingRange
+        );
+    }
     return appointment.startTime.getTime() > anchor;
 }
 
@@ -79,8 +88,6 @@ export function collectSyntheticScheduleViolations(
         if (
             !hasFiniteTime(appointment.startTime) ||
             !hasFiniteTime(appointment.endTime) ||
-            !hasExactMinute(appointment.startTime) ||
-            !hasExactMinute(appointment.endTime) ||
             appointment.startTime >= appointment.endTime
         ) {
             violations.push(
@@ -120,8 +127,8 @@ export function collectSyntheticScheduleViolations(
             warsawDateKey(appointment.endTime) !== appointmentDateKey ||
             !hasWorkingRange(
                 appointmentDays[0],
-                warsawMinuteOfDay(appointment.startTime),
-                warsawMinuteOfDay(appointment.endTime),
+                warsawPreciseMinuteOfDay(appointment.startTime),
+                warsawPreciseMinuteOfDay(appointment.endTime),
             )
         ) {
             violations.push(

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts
@@ -3,6 +3,7 @@ import {
     main,
     type SyntheticDataCliDependencies,
 } from '../../../scripts/synthetic-prelive-data';
+import type { SyntheticCommandReport } from './synthetic-data.service';
 
 function createHarness() {
     const dataSource = {
@@ -11,47 +12,58 @@ function createHarness() {
     } as unknown as DataSource;
     const output: string[] = [];
     const errors: string[] = [];
+    const reportFixture = {
+        mode: 'plan',
+        plan: {
+            protectedUserIds: [7, 20],
+            protectedAdminPresent: true,
+            protectedCiClientPresent: true,
+            ownerUserId: 7,
+            serviceIds: [10],
+            deleteCounts: { clients: 4 },
+            createCounts: { clients: 12 },
+            blockers: [],
+            scheduleSummary: {
+                rangeStart: '2026-06-24',
+                rangeEnd: '2026-09-27',
+                workingDays: 54,
+                closedDays: 42,
+                convertedInProgress: 4,
+            },
+            rawTimetableSentinel: {
+                label: 'timetable-plan-sentinel',
+                startTime: '09:15',
+                identity: 'plan-owner@example.invalid',
+            },
+        },
+        verification: {
+            actual: {
+                clients: 12,
+                appointments: 30,
+                products: 12,
+                warehouseDocuments: 5,
+            },
+            expected: {
+                clients: 12,
+                appointments: 30,
+                products: 12,
+                warehouseDocuments: 5,
+            },
+            protectedAccountsPresent: 2,
+            remainingNonSyntheticClients: 0,
+            scheduleViolations: 0,
+            blockers: [],
+            rawTimetableSentinel: {
+                label: 'timetable-verification-sentinel',
+                startTime: '18:45',
+                identity: 'verification-owner@example.invalid',
+            },
+        },
+    } as unknown as SyntheticCommandReport;
     const dependencies: SyntheticDataCliDependencies = {
         createDataSource: jest.fn().mockReturnValue(dataSource),
         getFileMetadata: jest.fn().mockReturnValue(null),
-        runCommand: jest.fn().mockResolvedValue({
-            mode: 'plan',
-            plan: {
-                protectedUserIds: [7, 20],
-                protectedAdminPresent: true,
-                protectedCiClientPresent: true,
-                ownerUserId: 7,
-                serviceIds: [10],
-                deleteCounts: { clients: 4 },
-                createCounts: { clients: 12 },
-                blockers: [],
-                scheduleSummary: {
-                    rangeStart: '2026-06-24',
-                    rangeEnd: '2026-09-27',
-                    workingDays: 54,
-                    closedDays: 42,
-                    convertedInProgress: 4,
-                },
-            },
-            verification: {
-                actual: {
-                    clients: 12,
-                    appointments: 30,
-                    products: 12,
-                    warehouseDocuments: 5,
-                },
-                expected: {
-                    clients: 12,
-                    appointments: 30,
-                    products: 12,
-                    warehouseDocuments: 5,
-                },
-                protectedAccountsPresent: 2,
-                remainingNonSyntheticClients: 0,
-                scheduleViolations: 0,
-                blockers: [],
-            },
-        }),
+        runCommand: jest.fn().mockResolvedValue(reportFixture),
         writeOutput: (value) => output.push(value),
         writeError: (value) => errors.push(value),
     };
@@ -84,7 +96,7 @@ describe('synthetic pre-live data CLI', () => {
 
         const serialized = output.join('');
         const publicReport = JSON.parse(serialized) as {
-            plan: {
+            plan: Record<string, unknown> & {
                 scheduleSummary: {
                     rangeStart: string;
                     rangeEnd: string;
@@ -93,9 +105,27 @@ describe('synthetic pre-live data CLI', () => {
                     convertedInProgress: number;
                 };
             };
-            verification: { scheduleViolations: number };
+            verification: Record<string, unknown> & {
+                scheduleViolations: number;
+            };
         };
         expect(serialized).toContain('"clients": 12');
+        expect(Object.keys(publicReport.plan).sort()).toEqual([
+            'blockers',
+            'createCounts',
+            'deleteCounts',
+            'protectedAdminPresent',
+            'protectedCiClientPresent',
+            'scheduleSummary',
+        ]);
+        expect(Object.keys(publicReport.verification).sort()).toEqual([
+            'actual',
+            'blockers',
+            'expected',
+            'protectedAccountsPresent',
+            'remainingNonSyntheticClients',
+            'scheduleViolations',
+        ]);
         expect(publicReport.plan.scheduleSummary).toEqual({
             rangeStart: '2026-06-24',
             rangeEnd: '2026-09-27',
@@ -105,7 +135,12 @@ describe('synthetic pre-live data CLI', () => {
         });
         expect(publicReport.verification.scheduleViolations).toBe(0);
         expect(serialized).not.toMatch(/\b(?:[01]\d|2[0-3]):[0-5]\d\b/);
+        expect(serialized).not.toContain('rawTimetableSentinel');
         expect(serialized).not.toContain('owner@example.invalid');
+        expect(serialized).not.toContain('plan-owner@example.invalid');
+        expect(serialized).not.toContain('verification-owner@example.invalid');
+        expect(serialized).not.toContain('timetable-plan-sentinel');
+        expect(serialized).not.toContain('timetable-verification-sentinel');
         expect(serialized).not.toContain('timetable');
     });
 

--- a/backend/salonbw-backend/src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts
+++ b/backend/salonbw-backend/src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts
@@ -25,6 +25,31 @@ function createHarness() {
                 deleteCounts: { clients: 4 },
                 createCounts: { clients: 12 },
                 blockers: [],
+                scheduleSummary: {
+                    rangeStart: '2026-06-24',
+                    rangeEnd: '2026-09-27',
+                    workingDays: 54,
+                    closedDays: 42,
+                    convertedInProgress: 4,
+                },
+            },
+            verification: {
+                actual: {
+                    clients: 12,
+                    appointments: 30,
+                    products: 12,
+                    warehouseDocuments: 5,
+                },
+                expected: {
+                    clients: 12,
+                    appointments: 30,
+                    products: 12,
+                    warehouseDocuments: 5,
+                },
+                protectedAccountsPresent: 2,
+                remainingNonSyntheticClients: 0,
+                scheduleViolations: 0,
+                blockers: [],
             },
         }),
         writeOutput: (value) => output.push(value),
@@ -48,7 +73,7 @@ describe('synthetic pre-live data CLI', () => {
         expect(dataSource.destroy).toHaveBeenCalledTimes(1);
     });
 
-    it('outputs count JSON without protected e-mail addresses', async () => {
+    it('outputs aggregate schedule counts without timetable details or identities', async () => {
         const { dependencies, output } = createHarness();
 
         await main(
@@ -57,8 +82,31 @@ describe('synthetic pre-live data CLI', () => {
             dependencies,
         );
 
-        expect(output.join('')).toContain('"clients": 12');
-        expect(output.join('')).not.toContain('owner@example.invalid');
+        const serialized = output.join('');
+        const publicReport = JSON.parse(serialized) as {
+            plan: {
+                scheduleSummary: {
+                    rangeStart: string;
+                    rangeEnd: string;
+                    workingDays: number;
+                    closedDays: number;
+                    convertedInProgress: number;
+                };
+            };
+            verification: { scheduleViolations: number };
+        };
+        expect(serialized).toContain('"clients": 12');
+        expect(publicReport.plan.scheduleSummary).toEqual({
+            rangeStart: '2026-06-24',
+            rangeEnd: '2026-09-27',
+            workingDays: 54,
+            closedDays: 42,
+            convertedInProgress: 4,
+        });
+        expect(publicReport.verification.scheduleViolations).toBe(0);
+        expect(serialized).not.toMatch(/\b(?:[01]\d|2[0-3]):[0-5]\d\b/);
+        expect(serialized).not.toContain('owner@example.invalid');
+        expect(serialized).not.toContain('timetable');
     });
 
     it('returns one and redacts identities and connection credentials', async () => {

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -40,13 +40,13 @@ syntetyczne, alert rezerwacji dociera, a błędy produkcyjne trafiają do Sentry
 
 ## Ostatnio zrobione
 
-- **Zatwierdzony projekt zgodności datasetu z grafikiem Oli** (2026-07-29):
-  źródłem prawdy są regularne godziny, przerwy i wyjątki aktywnego grafiku;
-  dzień wolny nie może zawierać syntetycznych wizyt, a niedozwolone
-  `in_progress` zostaną przeniesione jako przyszłe `confirmed`. Projekt
-  przewiduje niezależną walidację przed transakcją. Zapisano szczegółowy,
-  sześcioczęściowy plan implementacji test-first; kod i dane produkcyjne nie
-  zostały jeszcze zmienione.
+- **Zgodność generatora datasetu z grafikiem Oli zaimplementowana lokalnie**
+  (2026-07-29): aktywny grafik jest jedynym źródłem prawdy, `custom_hours`
+  zastępuje cały dzień bez dziedziczenia tygodniowych przerw, a niedozwolone
+  `in_progress` są przenoszone jako przyszłe `confirmed`. Generator i
+  niezależna walidacja działają przed transakcją, a raport CLI ujawnia tylko
+  agregaty grafiku. Nie wykonano deployu ani żadnej operacji na produkcyjnej
+  bazie.
 - **Faza B rozpoczęta — UAT start dnia i kalendarza** (2026-07-29): produkcyjny
   preflight API/db/panel/landing jest zielony; logowanie administracyjne,
   pulpit, liczniki, widoki Dzień/Tydzień/Miesiąc, bezpośredni widok Recepcja
@@ -108,10 +108,10 @@ syntetyczne, alert rezerwacji dociera, a błędy produkcyjne trafiają do Sentry
 
 ## Następny krok (konkretnie)
 
-1. Wykonać zaakceptowany plan implementacji test-first dla zgodności generatora
-   syntetycznego z grafikiem Oli. Po zielonym CI/deployu wykonać odczytowy
-   `plan`; mutacja nadal wymaga osobnej zgody, świeżego `pg_dump` i
-   pojedynczego `apply`.
+1. Po finalnym przeglądzie całej gałęzi wdrożyć kod, a następnie wykonać
+   wyłącznie odczytowy produkcyjny `synthetic:data:plan`. Nie wykonywać
+   automatycznego resetu: jedno `apply` wymaga późniejszej, osobnej zgody
+   ownera i świeżego `pg_dump`.
 2. Następnie dokończyć **fazę B: UAT** wg `docs/UAT_PLAN.md`: wykonać oznaczony
    przepływ umówienie → finalizacja → magazyn → statystyki.
 3. Osobny follow-up: responsywność szerokich tabel/formularzy oraz wymaganie

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -43,10 +43,11 @@ syntetyczne, alert rezerwacji dociera, a błędy produkcyjne trafiają do Sentry
 - **Zgodność generatora datasetu z grafikiem Oli zaimplementowana lokalnie**
   (2026-07-29): aktywny grafik jest jedynym źródłem prawdy, `custom_hours`
   zastępuje cały dzień bez dziedziczenia tygodniowych przerw, a niedozwolone
-  `in_progress` są przenoszone jako przyszłe `confirmed`. Generator i
-  niezależna walidacja działają przed transakcją, a raport CLI ujawnia tylko
-  agregaty grafiku. Nie wykonano deployu ani żadnej operacji na produkcyjnej
-  bazie.
+  `in_progress` są przenoszone jako przyszłe `confirmed`. `apply` wykonuje
+  preflight, a następnie ponownie generuje i rygorystycznie waliduje dataset w
+  transakcji z blokadą tabel grafiku; samodzielny `verify` używa spójnego
+  snapshotu tylko do odczytu. Raport CLI ujawnia wyłącznie agregaty grafiku.
+  Nie wykonano deployu ani żadnej operacji na produkcyjnej bazie.
 - **Faza B rozpoczęta — UAT start dnia i kalendarza** (2026-07-29): produkcyjny
   preflight API/db/panel/landing jest zielony; logowanie administracyjne,
   pulpit, liczniki, widoki Dzień/Tydzień/Miesiąc, bezpośredni widok Recepcja
@@ -78,8 +79,11 @@ syntetyczne, alert rezerwacji dociera, a błędy produkcyjne trafiają do Sentry
   przypisanych do 5 resetowanych klientów; pozostałe logi zachowano. Utworzono
   dataset bez PII i realnych cen: 12 klientów, 30 wizyt, 12 produktów i 5
   dokumentów. `verify`: 2 chronione konta, 0 niesyntetycznych klientów,
-  0 blockerów. `/healthz` jest zielone, a regresja Playwright
-  `30443911725` przeszła 23/23 testy.
+  0 blockerów w ówczesnej kontroli liczności/FK. Produkcyjny schedule-aware
+  `verify` jest nadal oczekiwany jako fail-closed na znanych środowych
+  wizytach, dopóki nie zostanie osobno zatwierdzone poprawione `apply`.
+  `/healthz` jest zielone, a regresja Playwright `30443911725` przeszła 23/23
+  testy.
 - **Naprawiony deploy statyków frontendu** (master `5a7a38a9`, run
   `30401261957`): wielocommitowy push nie jest już mylony z force-pushem,
   ekstrakcja ma rollback i retencję jednej poprzedniej generacji assetów.

--- a/docs/SYNTHETIC_PRELIVE_DATA.md
+++ b/docs/SYNTHETIC_PRELIVE_DATA.md
@@ -9,6 +9,18 @@ danych osobowych zestawu syntetycznego.
 Narzędzie nie jest migracją TypeORM i nie uruchamia się podczas deployu.
 Każde użycie jest osobną, audytowalną operacją operatorską.
 
+## Źródło prawdy dla wizyt
+
+Jedynym źródłem prawdy są regularne godziny, przerwy i wyjątki aktywnego
+grafiku Oli. Generator nie używa godzin oddziału ani zakodowanych dni tygodnia
+jako fallbacku. Wyjątek `custom_hours` zastępuje cały dany dzień i nie
+dziedziczy tygodniowych przerw.
+
+`scheduleSummary.convertedInProgress` oznacza liczbę planowanych wizyt
+`in_progress`, których nie można było umieścić w aktywnym zakresie pracy dnia
+kotwicy. Generator przenosi je do przyszłego dozwolonego zakresu i zmienia ich
+status na `confirmed`.
+
 ## Zakres
 
 `apply` zachowuje:
@@ -43,6 +55,13 @@ pnpm synthetic:data:plan
 pnpm synthetic:data:verify
 ```
 
+Obie komendy są tylko do odczytu: nie rozpoczynają transakcji i nie zmieniają
+danych. Publiczny raport pokazuje agregaty `plan.scheduleSummary` oraz
+`verification.scheduleViolations`; nie zawiera surowych godzin, rekordów
+grafiku ani danych osobowych. `verify` może zakończyć się błędem, jeżeli
+istniejący dataset narusza grafik — to blokada bezpieczeństwa, nie sygnał do
+automatycznego `apply`.
+
 Operacje zapisujące mają cztery niezależne bramki:
 
 1. `SYNTHETIC_DATA_ALLOWED=true`;
@@ -68,6 +87,20 @@ pnpm synthetic:data:verify
 Analogicznie `pnpm synthetic:data:cleanup -- ...` usuwa tylko dataset
 syntetyczny, ale wymaga tych samych bramek i backupu.
 
+Workflow `Deploy (MyDevil)` nigdy nie uruchamia `synthetic:data:apply`.
+Po wdrożeniu kodu operator najpierw wykonuje wyłącznie odczytowy `plan` i
+przedstawia raport ownerowi. Pojedynczy zapis produkcyjny ma obowiązkową,
+nierozłączną kolejność:
+
+1. świeża, jawna zgoda ownera na ten przebieg;
+2. świeży `pg_dump` oraz potwierdzenie, że jest niepustym plikiem regularnym
+   młodszym niż 30 minut;
+3. dokładnie jedno `synthetic:data:apply`;
+4. `synthetic:data:verify` z wymaganiem `scheduleViolations = 0`;
+5. kontrola `/healthz`;
+6. kontrola zamkniętego dnia i reprezentatywnego dnia pracy w kalendarzu;
+7. ponowna rotacja tymczasowego hasła bazy.
+
 ## Kontrole i rollback
 
 - `plan` i `verify` nie rozpoczynają transakcji i niczego nie zapisują.
@@ -79,8 +112,9 @@ syntetyczny, ale wymaga tych samych bramek i backupu.
   używają zarezerwowanej domeny `.invalid`.
 
 Po błędzie nie ponawiaj `apply` automatycznie. Zachowaj raport, sprawdź schemat
-i wykonaj ponownie `plan`. Restore z dumpa jest procedurą awaryjną i wymaga
-osobnej decyzji operatorskiej.
+i wykonaj ponownie `plan`. Każdy kolejny `apply` wymaga nowej zgody ownera i
+nowego dumpa. Restore z dumpa jest procedurą awaryjną i wymaga osobnej decyzji
+operatorskiej.
 
 ## Status
 

--- a/docs/SYNTHETIC_PRELIVE_DATA.md
+++ b/docs/SYNTHETIC_PRELIVE_DATA.md
@@ -33,7 +33,9 @@ Usuwa dane operacyjne klientów, wizyty i ich zależności oraz magazyn, po czym
 tworzy:
 
 - 12 klientów `synthetic.client.XX@example.invalid`, bez telefonów i zgód;
-- 30 wizyt obejmujących wszystkie statusy;
+- 30 wizyt obejmujących reprezentatywne statusy; `in_progress` może nie
+  wystąpić, gdy dzień kotwicy jest zamknięty albo uruchomienie wypada poza
+  godzinami pracy;
 - 4 kategorie, 12 produktów i 2 dostawców z markerami `SYNTHETIC`/`SYNTH-`;
 - dostawę, zamówienie, sprzedaż, zużycie i inwentaryzację;
 - reprezentatywne prowizje, opinie, lojalność i recepturę usługi.
@@ -55,12 +57,17 @@ pnpm synthetic:data:plan
 pnpm synthetic:data:verify
 ```
 
-Obie komendy są tylko do odczytu: nie rozpoczynają transakcji i nie zmieniają
-danych. Publiczny raport pokazuje agregaty `plan.scheduleSummary` oraz
-`verification.scheduleViolations`; nie zawiera surowych godzin, rekordów
-grafiku ani danych osobowych. `verify` może zakończyć się błędem, jeżeli
-istniejący dataset narusza grafik — to blokada bezpieczeństwa, nie sygnał do
-automatycznego `apply`.
+Obie komendy są tylko do odczytu i nie zmieniają danych. `plan` nie rozpoczyna
+transakcji. `verify` obejmuje kontekst, rzeczywisty zakres dat zapisanych
+wizyt, grafik, liczności i okna wizyt jedną transakcją
+`REPEATABLE READ READ ONLY`, dzięki czemu raport nie miesza kilku stanów bazy.
+`plan` pokazuje agregat `plan.scheduleSummary`, a `verify` raportuje
+`verification.scheduleViolations`; publiczny JSON nie zawiera surowych godzin,
+rekordów grafiku ani danych osobowych. Samodzielny `verify` nie klasyfikuje
+ponownie zapisanych statusów względem nowej chwili uruchomienia, ale nadal
+sprawdza daty, pracownika, pełne zawarcie w grafiku i brak nakładania. Może
+zakończyć się błędem, jeżeli istniejący dataset narusza grafik — to blokada
+bezpieczeństwa, nie sygnał do automatycznego `apply`.
 
 Operacje zapisujące mają cztery niezależne bramki:
 
@@ -103,8 +110,12 @@ nierozłączną kolejność:
 
 ## Kontrole i rollback
 
-- `plan` i `verify` nie rozpoczynają transakcji i niczego nie zapisują.
-- `apply` wykonuje reset, seed i weryfikację w jednej transakcji.
+- `plan` niczego nie zapisuje; `verify` używa wyłącznie odczytowej transakcji
+  i również niczego nie zapisuje.
+- `apply` wykonuje preflight, a następnie w transakcji blokuje zapis do tabel
+  grafiku, ponownie odczytuje grafik, regeneruje i rygorystycznie waliduje
+  dataset; reset, seed i poweryfikacyjna kontrola używają tego zablokowanego
+  planu.
 - Rozbieżna liczność, brak chronionego konta albo nieoczekiwany klucz obcy
   powoduje rollback.
 - Raport CLI nie zawiera adresów chronionych kont ani danych logowania.
@@ -119,7 +130,10 @@ operatorskiej.
 ## Status
 
 E4.2 zakończono 2026-07-29. Po świeżym dumpie i zatwierdzeniu wykonano
-transakcyjny reset oraz seed. Niezależne `verify` potwierdziło 12 klientów,
+transakcyjny reset oraz seed. Ówczesne `verify` potwierdziło 12 klientów,
 30 wizyt, 12 produktów, 5 dokumentów magazynowych, oba chronione konta,
-0 pozostałych niesyntetycznych klientów i 0 blockerów. Zrzut Versum nadal
-pozostaje offline i nie został zaimportowany.
+0 pozostałych niesyntetycznych klientów i 0 blockerów, ale była to wcześniejsza
+kontrola liczności/FK, sprzed walidacji grafiku. Produkcyjny, schedule-aware
+`verify` pozostaje do wykonania po deployu kodu i ma oczekiwanie fail-closed na
+znanych środowych wizytach, dopóki owner nie zatwierdzi poprawionego `apply`.
+Zrzut Versum nadal pozostaje offline i nie został zaimportowany.

--- a/docs/journal/2026-07-29-synthetic-schedule-implementation.md
+++ b/docs/journal/2026-07-29-synthetic-schedule-implementation.md
@@ -2,9 +2,9 @@
 
 - **Data:** 2026-07-29
 - **Agent:** Codex
-- **Commit(y):** ten commit, `docs: document schedule-aware synthetic data`;
-  poprzedzające commity implementacyjne `1eebc82d`, `ef08dd8c`, `029c6003`,
-  `e5341485`, `78073921`, `028abe0d`, `9a95a67d`
+- **Commit(y):** `1eebc82d`, `ef08dd8c`, `029c6003`, `e5341485`,
+  `78073921`, `028abe0d`, `9a95a67d`, `c3e8554f`, `1f91b81d` oraz ten finalny
+  commit naprawczy (`fix(backend): harden schedule-aware synthetic data`)
 - **PR:** brak
 
 ## Finding
@@ -15,6 +15,13 @@ według własnych offsetów zamiast aktywnego grafiku ownera. Ten etap nie
 odczytywał ponownie produkcji; finding pochodzi z wcześniejszego,
 udokumentowanego UAT.
 
+Finalny przegląd całej gałęzi wykazał ponadto cztery problemy bezpieczeństwa:
+samodzielny `verify` starzał poprawne statusy względem nowej chwili i budował
+grafik wyłącznie wokół nowej kotwicy; konwersja czasu mogła rzucić wyjątek w
+luce DST albo zmienić czas trwania podczas fold; błędny starszy grafik blokował
+poprawny nowszy; oraz odczyty `verify` i grafik używany przez `apply` nie
+tworzyły spójnego snapshotu.
+
 ## Change
 
 - Aktywny grafik Oli — regularne zakresy, przerwy i wyjątki — jest jedynym
@@ -24,20 +31,43 @@ udokumentowanego UAT.
   przerw.
 - Generator alokuje wizyty tylko w dozwolonych zakresach, nie nakłada ich na
   siebie i przenosi niedozwolone `in_progress` do przyszłości jako `confirmed`.
-- Niezależny validator działa przed transakcją; `apply` dodatkowo weryfikuje
-  zapisane wiersze przed commitem i wykonuje rollback po blockerze.
+- Kandydaci w luce/fold DST są pomijani, jeśli konwersja ścienna jest
+  niepoprawna, zmienia deklarowany czas 30/60/90 minut albo przenosi endpoint
+  poza ten sam lokalny zakres; brak dalszej pojemności daje stabilny blocker.
+- Resolver najpierw wybiera obowiązujący grafik po `validFrom`/`id`, a dopiero
+  potem waliduje jego sloty i wyjątek wybranej daty. Błędny, całkowicie
+  przesłonięty starszy rekord nie blokuje nowszego grafiku.
+- Samodzielny `verify` używa jednej transakcji
+  `REPEATABLE READ READ ONLY`, pobiera rzeczywisty zakres dat zapisanych
+  wizyt i pomija wyłącznie klasyfikację statusu względem nowej chwili. Nadal
+  sprawdza daty, pracownika, zawarcie w grafiku i kolizje.
+- `apply` zachowuje preflight, po czym w transakcji blokuje zapisy do trzech
+  tabel grafiku, ponownie odczytuje kontekst/grafik, regeneruje i rygorystycznie
+  waliduje dataset. Reset, insert i weryfikacja używają zablokowanego planu;
+  błąd grafiku, walidacji albo weryfikacji wykonuje rollback.
 - CLI zachowuje kompatybilny raport liczności, dodaje wyłącznie agregat
   `plan.scheduleSummary` i raportuje `verification.scheduleViolations`.
   Nie ujawnia surowych godzin, rekordów grafiku ani danych osobowych.
 - Dokumentacja operatorska rozdziela odczytowe `plan`/`verify` od pojedynczego,
   jawnie zatwierdzonego `apply`.
 
-Zmienione w Task 6:
+Zmienione w finalnej fali naprawczej:
 
 - `backend/salonbw-backend/scripts/synthetic-prelive-data.ts`
-- `backend/salonbw-backend/src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.ts`
+  i `.spec.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.ts`
+  i `.spec.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-data.service.ts`
+  i `.spec.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts`
+  i `.spec.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts`
+  i `.spec.ts`
 - `docs/SYNTHETIC_PRELIVE_DATA.md`
 - `docs/PROJECT_STATE.md`
+- `docs/superpowers/plans/2026-07-29-synthetic-schedule-alignment.md`
 - `docs/journal/2026-07-29-synthetic-schedule-implementation.md`
 
 ## Fail-first evidence
@@ -60,28 +90,33 @@ Wszystkie komendy Jest uruchamiano bez zbędnego, samodzielnego separatora
   suite integracyjnych: `63/63`.
 - **Task 6:** publiczny JSON pomijał `plan.scheduleSummary`; `1 suite`,
   `1 failed`, `3 passed`, `4 total`. GREEN: `1 suite`, `4/4`.
+- **Finalna fala — resolver/alokator/validator:** regresje statusu persistent,
+  jawnego zakresu dat, shadowed timetable oraz gap/fold DST dały RED:
+  `3 failed suites`, `5 failed`, `34 passed`, `39 total`. Po zmianie GREEN:
+  `3/3 suites`, `39/39`.
+- **Finalna fala — store/service:** brak loadera rzeczywistego zakresu,
+  blokad grafiku, spójnej transakcji `verify` i regeneracji `apply` pod blokadą
+  dał RED: `2 failed suites`, `13 failed`, `20 passed`, `33 total`. Po zmianie
+  store/service/CLI: GREEN `3/3 suites`, `37/37`.
+- **Finalny zestaw celowany:** `6/6 suites`, `76/76 tests`, `0` snapshotów.
 
 ## Validation
 
 - `pnpm --filter salonbw-backend test --runInBand`: exit `0`; `42/42` suite,
-  `319/319` testów, `0` snapshotów, `12.087 s`. Zastane testy ścieżek błędu
+  `332/332` testów, `0` snapshotów, `11.897 s`. Zastane testy ścieżek błędu
   wypisały oczekiwane logi WhatsApp i kontrolera klientów; nie było porażki.
 - `pnpm --filter salonbw-backend typecheck`: exit `0`; TypeScript bez błędów.
 - `pnpm --filter salonbw-backend lint`: exit `0`; `0 errors`, `176 warnings`.
   Są to zastane ostrzeżenia. Wbudowane `--fix` zmieniło mechanicznie pliki poza
-  zakresem; wszystkie te zmiany cofnięto, zachowując wyłącznie pięć plików
-  Task 6.
+  zakresem; wszystkie te zmiany cofnięto, zachowując wyłącznie pliki finalnej
+  fali.
 - `pnpm --dir backend/salonbw-backend exec eslint
-  scripts/synthetic-prelive-data.ts`: exit `0`, bez outputu.
+  <zmienione pliki produkcyjne i skrypt CLI>`: exit `0`, bez outputu.
 - `pnpm --dir backend/salonbw-backend exec prettier --check
-  scripts/synthetic-prelive-data.ts
-  src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts`: exit `0`;
-  oba pliki zgodne.
+  <12 zmienionych plików TypeScript>`: exit `0`; wszystkie zgodne.
 - `pnpm --filter salonbw-backend build`: exit `0`; `nest build`.
-- `git diff --check`: exit `0`, bez outputu.
-- `scripts/handoff-check.sh` przed commitem: exit `1`, ponieważ skrypt sprawdza
-  wyłącznie `origin/master...HEAD` i nie widzi poprawnych dokumentów w working
-  tree. Po commicie: exit `0`,
+- `git diff --check`: exit `0`, bez outputu po zmianach kodu i dokumentacji.
+- `scripts/handoff-check.sh`: exit `0`;
   `handoff-check: OK — praca jest przekazywalna.`.
 
 Nie uruchomiono żadnej komendy syntetycznych danych ani nie uzyskano dostępu do

--- a/docs/journal/2026-07-29-synthetic-schedule-implementation.md
+++ b/docs/journal/2026-07-29-synthetic-schedule-implementation.md
@@ -1,0 +1,103 @@
+# Zgodność syntetycznych wizyt z grafikiem
+
+- **Data:** 2026-07-29
+- **Agent:** Codex
+- **Commit(y):** ten commit, `docs: document schedule-aware synthetic data`;
+  poprzedzające commity implementacyjne `1eebc82d`, `ef08dd8c`, `029c6003`,
+  `e5341485`, `78073921`, `028abe0d`, `9a95a67d`
+- **PR:** brak
+
+## Finding
+
+Podczas produkcyjnego UAT kalendarza znaleziono syntetyczne wizyty w środę,
+mimo że widok poprawnie oznaczał salon jako zamknięty. Generator układał wizyty
+według własnych offsetów zamiast aktywnego grafiku ownera. Ten etap nie
+odczytywał ponownie produkcji; finding pochodzi z wcześniejszego,
+udokumentowanego UAT.
+
+## Change
+
+- Aktywny grafik Oli — regularne zakresy, przerwy i wyjątki — jest jedynym
+  źródłem prawdy dla syntetycznych wizyt. Nie ma fallbacku do godzin oddziału
+  ani zakodowanych dni tygodnia.
+- `custom_hours` całkowicie zastępuje dany dzień i nie dziedziczy tygodniowych
+  przerw.
+- Generator alokuje wizyty tylko w dozwolonych zakresach, nie nakłada ich na
+  siebie i przenosi niedozwolone `in_progress` do przyszłości jako `confirmed`.
+- Niezależny validator działa przed transakcją; `apply` dodatkowo weryfikuje
+  zapisane wiersze przed commitem i wykonuje rollback po blockerze.
+- CLI zachowuje kompatybilny raport liczności, dodaje wyłącznie agregat
+  `plan.scheduleSummary` i raportuje `verification.scheduleViolations`.
+  Nie ujawnia surowych godzin, rekordów grafiku ani danych osobowych.
+- Dokumentacja operatorska rozdziela odczytowe `plan`/`verify` od pojedynczego,
+  jawnie zatwierdzonego `apply`.
+
+Zmienione w Task 6:
+
+- `backend/salonbw-backend/scripts/synthetic-prelive-data.ts`
+- `backend/salonbw-backend/src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts`
+- `docs/SYNTHETIC_PRELIVE_DATA.md`
+- `docs/PROJECT_STATE.md`
+- `docs/journal/2026-07-29-synthetic-schedule-implementation.md`
+
+## Fail-first evidence
+
+Wszystkie komendy Jest uruchamiano bez zbędnego, samodzielnego separatora
+`--`.
+
+- **Task 1:** brak modułu resolvera; `1 failed suite`. GREEN: `1 suite`,
+  `7/7 tests`.
+- **Task 2:** stary generator ignorował grafik, przerwy, pojemność i kolizje;
+  `1 suite`, `5 failed`, `9 passed`, `14 total`. GREEN: `14/14`.
+- **Task 3:** brak niezależnego validatora; `1 failed suite`. Dwie późniejsze
+  rundy regresyjne wykazały po `3 failed` przy `11` i `13` testach. Final
+  GREEN: `13/13`.
+- **Task 4:** brak loaderów i weryfikacji grafiku; `1 suite`, `7 failed`,
+  `10 passed`, `17 total`. GREEN: `17/17`.
+- **Task 5:** brak walidacji przed transakcją i błędna ścieżka cleanup;
+  `1 suite`, `4 failed`, `4 passed`, `8 total`. Mutacja kontrolna wywołania
+  weryfikacji po insercie dała `1 failed`, `7 passed`. Final GREEN dla sześciu
+  suite integracyjnych: `63/63`.
+- **Task 6:** publiczny JSON pomijał `plan.scheduleSummary`; `1 suite`,
+  `1 failed`, `3 passed`, `4 total`. GREEN: `1 suite`, `4/4`.
+
+## Validation
+
+- `pnpm --filter salonbw-backend test --runInBand`: exit `0`; `42/42` suite,
+  `319/319` testów, `0` snapshotów, `12.087 s`. Zastane testy ścieżek błędu
+  wypisały oczekiwane logi WhatsApp i kontrolera klientów; nie było porażki.
+- `pnpm --filter salonbw-backend typecheck`: exit `0`; TypeScript bez błędów.
+- `pnpm --filter salonbw-backend lint`: exit `0`; `0 errors`, `176 warnings`.
+  Są to zastane ostrzeżenia. Wbudowane `--fix` zmieniło mechanicznie pliki poza
+  zakresem; wszystkie te zmiany cofnięto, zachowując wyłącznie pięć plików
+  Task 6.
+- `pnpm --dir backend/salonbw-backend exec eslint
+  scripts/synthetic-prelive-data.ts`: exit `0`, bez outputu.
+- `pnpm --dir backend/salonbw-backend exec prettier --check
+  scripts/synthetic-prelive-data.ts
+  src/database/synthetic-data/synthetic-prelive-data.cli.spec.ts`: exit `0`;
+  oba pliki zgodne.
+- `pnpm --filter salonbw-backend build`: exit `0`; `nest build`.
+- `git diff --check`: exit `0`, bez outputu.
+- `scripts/handoff-check.sh` przed commitem: exit `1`, ponieważ skrypt sprawdza
+  wyłącznie `origin/master...HEAD` i nie widzi poprawnych dokumentów w working
+  tree. Po commicie: exit `0`,
+  `handoff-check: OK — praca jest przekazywalna.`.
+
+Nie uruchomiono żadnej komendy syntetycznych danych ani nie uzyskano dostępu do
+produkcyjnej bazy. Nie wykonano `plan`, `verify`, `apply` ani `cleanup`.
+
+## Rollout
+
+Nie wykonano pushu, monitoringu CI/deployu ani produkcyjnego `plan`/`verify`.
+Kroki 7–8 planu są jawnie odroczone i należą do controllera po finalnym
+przeglądzie całej gałęzi. To nie jest zakończony rollout.
+
+## Follow-up
+
+Controller wykonuje finalny przegląd całej gałęzi i deploy kodu. Następna
+operacja produkcyjna to wyłącznie odczytowy `synthetic:data:plan` oraz
+przedstawienie agregatowego raportu ownerowi. Dopiero nowa, osobna zgoda ownera
+i świeży, zweryfikowany `pg_dump` mogą otworzyć dokładnie jedno `apply`, po
+którym wymagane są `verify`, `/healthz`, kontrola kalendarza i ponowna rotacja
+hasła bazy.

--- a/docs/superpowers/plans/2026-07-29-synthetic-schedule-alignment.md
+++ b/docs/superpowers/plans/2026-07-29-synthetic-schedule-alignment.md
@@ -147,7 +147,7 @@ expect(byDate.get('2026-08-02')?.ranges).toEqual([
 Run:
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.schedule.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.schedule.spec.ts --runInBand
 ```
 
 Expected: FAIL because `synthetic-data.schedule.ts` and its exports do not
@@ -230,7 +230,7 @@ expect(summarizeSyntheticSchedule(days)).toEqual({
 - [ ] **Step 5: Run GREEN and commit**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.schedule.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.schedule.spec.ts --runInBand
 git add backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.schedule.spec.ts
@@ -291,7 +291,7 @@ it('moves every in-progress visit off a closed anchor day', () => {
 - [ ] **Step 2: Run the focused test and verify RED**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.dataset.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.dataset.spec.ts --runInBand
 ```
 
 Expected: FAIL because `workingDays` and `generationSummary` are not handled.
@@ -351,7 +351,7 @@ Add exact assertions that:
 - [ ] **Step 5: Run GREEN and commit**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.dataset.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.dataset.spec.ts --runInBand
 git add backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.dataset.spec.ts
@@ -409,7 +409,7 @@ expect(collectSyntheticScheduleViolations(wrongEmployee)).toContain(
 - [ ] **Step 2: Run tests and verify RED**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.validation.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.validation.spec.ts --runInBand
 ```
 
 Expected: FAIL because the validation module does not exist.
@@ -453,7 +453,7 @@ expect(() => assertSyntheticScheduleValid(validInput)).not.toThrow();
 - [ ] **Step 5: Run GREEN and commit**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.validation.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.validation.spec.ts --runInBand
 git add backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.validation.spec.ts
@@ -512,7 +512,7 @@ expect(
 - [ ] **Step 2: Run store tests and verify RED**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.store.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.store.spec.ts --runInBand
 ```
 
 Expected: FAIL because the new store functions do not exist.
@@ -602,7 +602,7 @@ count without schedule context.
 - [ ] **Step 6: Run GREEN and commit**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.store.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.store.spec.ts --runInBand
 git add backend/salonbw-backend/src/database/synthetic-data/synthetic-data.types.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.ts \
   backend/salonbw-backend/src/database/synthetic-data/synthetic-data.store.spec.ts
@@ -660,7 +660,7 @@ blocker and assert `rollbackTransaction` is called once while
 - [ ] **Step 2: Run service tests and verify RED**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-data.service.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-data.service.spec.ts --runInBand
 ```
 
 Expected: FAIL on the old dependency contract and old call order.
@@ -724,7 +724,7 @@ Remove the obsolete dummy manifest path using `ownerUserId: 1`.
 - [ ] **Step 5: Run service, store and dataset suites**
 
 ```bash
-pnpm --filter salonbw-backend test -- \
+pnpm --filter salonbw-backend test \
   synthetic-data.service.spec.ts \
   synthetic-data.store.spec.ts \
   synthetic-data.dataset.spec.ts \
@@ -786,7 +786,7 @@ expect(serialized).not.toContain('timetable');
 - [ ] **Step 2: Run the CLI test and verify RED**
 
 ```bash
-pnpm --filter salonbw-backend test -- synthetic-prelive-data.cli.spec.ts --runInBand
+pnpm --filter salonbw-backend test synthetic-prelive-data.cli.spec.ts --runInBand
 ```
 
 Expected: FAIL because `publicReport` does not expose `scheduleSummary`.
@@ -813,7 +813,7 @@ Update `docs/SYNTHETIC_PRELIVE_DATA.md` with:
 - [ ] **Step 4: Run full backend validation**
 
 ```bash
-pnpm --filter salonbw-backend test -- --runInBand
+pnpm --filter salonbw-backend test --runInBand
 pnpm --filter salonbw-backend typecheck
 pnpm --filter salonbw-backend lint
 pnpm --filter salonbw-backend build


### PR DESCRIPTION
## Summary
- Syntetyczne wizyty powstają wyłącznie w godzinach aktywnego grafiku ownera (regularne sloty, przerwy, wyjątki) — usuwa wizyty in_progress w środę mimo zamkniętego salonu (finding z UAT 2026-07-29).
- Niedozwolone `in_progress` na dzień kotwicy konwertowane do przyszłego `confirmed`.
- Niezależny walidator sprawdza manifest przed transakcją i rzeczywiste rekordy po insercie (`plan`/`verify` read-only, `apply` w jednej transakcji z rollbackiem).
- Finalna fala hardeningu: `verify` używa realnego zakresu dat + transakcji `REPEATABLE READ READ ONLY`; obsługa luki/foldu DST; poprawny wybór grafiku po `validFrom`/`id`; `apply` blokuje tabele grafiku (`SHARE MODE`) i ponownie odczytuje/waliduje pod blokadą przed resetem+insertem.

## Test plan
- [x] `pnpm --filter salonbw-backend test --runInBand` — 42/42 suite, 332/332 testów
- [x] `pnpm --filter salonbw-backend typecheck` — czyste
- [x] `pnpm --filter salonbw-backend lint` — 0 błędów, 176 przedistniejących ostrzeżeń
- [x] `pnpm --filter salonbw-backend build`
- [x] `scripts/handoff-check.sh`
- [ ] Po merge: `pnpm synthetic:data:plan` (read-only) na produkcji, zaprezentowanie raportu ownerowi
- [ ] Osobna zgoda ownera + świeży `pg_dump` przed pojedynczym `synthetic:data:apply`

Nie wykonano żadnej komendy synthetic-data ani nie uzyskano dostępu do produkcyjnej bazy w tej sesji.